### PR TITLE
refactor(api): move BMI registration to canonical bootstrap

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,11 @@ _LOCAL_EXPORTS: dict[str, tuple[str, str]] = {
     "build_nutrition_targets": ("core.recommendations", "build_nutrition_targets"),
     # Expose metrics_endpoint for patch-based tests (patch("app.metrics"))
     "metrics": ("app.bootstrap.metrics", "metrics_endpoint"),
+    # BMI router ownership lives in app.main; these remain compatibility attrs.
+    "FEATURE_BMI_PRO_ENABLED": ("app.main", "FEATURE_BMI_PRO_ENABLED"),
+    "bmi_router": ("app.main", "bmi_router"),
+    "bmi_pro_router": ("app.main", "bmi_pro_router"),
+    "bmi_pro_legacy_alias_router": ("app.main", "bmi_pro_legacy_alias_router"),
 }
 
 
@@ -129,6 +134,10 @@ __all__ = [
     "resolve_attr",
     "make_weekly_menu",
     "build_nutrition_targets",
+    "FEATURE_BMI_PRO_ENABLED",
+    "bmi_router",
+    "bmi_pro_router",
+    "bmi_pro_legacy_alias_router",
     "MATPLOTLIB_AVAILABLE",
     "generate_bmi_visualization",
 ]

--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,7 @@ from app.routers.admin_operations import (
     router as admin_operations_router,
 )
 from app.routers.bmi_compat import BMI_COMPAT_ROUTE_SPECS, router as bmi_compat_router
+from app.routers.bmi_registration import BmiRouteRegistration, register_bmi_routes
 from app.routers.billing import register_billing_routes
 from app.routers.cbt_insight import router as cbt_insight_router
 from app.routers.feedback import router as feedback_router
@@ -75,6 +76,14 @@ VIP_MODULE_ENABLED: bool = bool(getattr(_legacy_module, "VIP_MODULE_ENABLED", Fa
 vip_router: APIRouter | None = getattr(_legacy_module, "vip_router", None)
 pro_router: APIRouter | None = getattr(_legacy_module, "pro_router", None)
 premium_week_router: APIRouter | None = getattr(_legacy_module, "premium_week_router", None)
+FEATURE_BMI_PRO_ENABLED: bool = bool(getattr(_legacy_module, "FEATURE_BMI_PRO_ENABLED", False))
+bmi_router: APIRouter | None = getattr(_legacy_module, "bmi_router", None)
+bmi_pro_router: APIRouter | None = getattr(_legacy_module, "bmi_pro_router", None)
+bmi_pro_legacy_alias_router: APIRouter | None = getattr(
+    _legacy_module,
+    "bmi_pro_legacy_alias_router",
+    None,
+)
 
 _WS_ROUTE_PATHS: tuple[str, str] = ("/api/v1/pro/ws", "/ws")
 _FEEDBACK_ROUTE_PATH: str = "/api/v1/feedback/rag"
@@ -837,6 +846,23 @@ def _register_paid_tier_routes(target_app: FastAPI) -> None:
     _mirror_paid_tier_registration_attrs(registered_pro_router, registered_premium_week_router)
 
 
+def _mirror_bmi_registration_attrs(registration: BmiRouteRegistration) -> None:
+    global FEATURE_BMI_PRO_ENABLED, bmi_router, bmi_pro_router, bmi_pro_legacy_alias_router
+
+    FEATURE_BMI_PRO_ENABLED = registration.feature_bmi_pro_enabled
+    bmi_router = registration.bmi_router
+    bmi_pro_router = registration.bmi_pro_router
+    bmi_pro_legacy_alias_router = registration.bmi_pro_legacy_alias_router
+    _legacy_module.FEATURE_BMI_PRO_ENABLED = registration.feature_bmi_pro_enabled
+    _legacy_module.bmi_router = registration.bmi_router
+    _legacy_module.bmi_pro_router = registration.bmi_pro_router
+    _legacy_module.bmi_pro_legacy_alias_router = registration.bmi_pro_legacy_alias_router
+
+
+def _register_bmi_routes(target_app: FastAPI) -> None:
+    _mirror_bmi_registration_attrs(register_bmi_routes(target_app))
+
+
 def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     """Apply canonical additive bootstrap to the provided FastAPI instance.
 
@@ -896,6 +922,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _include_legal_router_if_needed(app)
     _include_favicon_router_if_needed(app)
     _include_admin_operations_router_if_needed(app)
+    _register_bmi_routes(app)
     _include_bmi_compat_router_if_needed(app)
     _include_plan_export_routers_if_needed(app)
     _include_shoplist_export_router_if_needed(app)

--- a/app/routers/bmi_registration.py
+++ b/app/routers/bmi_registration.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+"""Canonical BMI route registration."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from fastapi.routing import APIRouter, APIRoute
+
+from app.bootstrap.route_family import (
+    RouteMemberContract,
+    ensure_route_family_registered,
+    route_member_contracts_from_router,
+)
+from app.middleware.api_tiers import require_pro_tier
+from app.utils.feature_flags import _is_truthy
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+__all__ = [
+    "BMI_PRO_LEGACY_ALIAS_ROUTE_SPECS",
+    "BMI_PRO_ROUTE_SPECS",
+    "BMI_ROUTE_SPECS",
+    "BmiRouteRegistration",
+    "is_bmi_pro_enabled",
+    "register_bmi_routes",
+]
+
+BMI_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (("/api/v1/bmi/calculate", "POST", True),)
+BMI_PRO_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/pro/bmi", "POST", True),
+    ("/api/v1/pro/bmi/calculate", "POST", True),
+)
+BMI_PRO_LEGACY_ALIAS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/bmi/pro", "POST", True),
+)
+_FRAMEWORK_METHODS = frozenset({"HEAD", "OPTIONS"})
+
+
+@dataclass(frozen=True, slots=True)
+class BmiRouteRegistration:
+    """Routers registered by canonical BMI bootstrap."""
+
+    bmi_router: APIRouter
+    bmi_pro_router: APIRouter | None
+    bmi_pro_legacy_alias_router: APIRouter | None
+    feature_bmi_pro_enabled: bool
+
+
+def is_bmi_pro_enabled() -> bool:
+    """Return whether BMI Pro routes should be registered."""
+
+    raw_value = os.getenv("FEATURE_BMI_PRO_ENABLED")
+    return bool(_is_truthy(raw_value)) if raw_value is not None else False
+
+
+def _route_members_for_routers(
+    family_name: str,
+    routers: tuple[APIRouter, ...],
+    *,
+    extra_required_dependencies: tuple[Callable[..., object], ...] = (),
+) -> tuple[RouteMemberContract, ...]:
+    return tuple(
+        member
+        for router in routers
+        for member in route_member_contracts_from_router(
+            family_name,
+            router,
+            extra_required_dependencies=extra_required_dependencies,
+        )
+    )
+
+
+def _require_exact_router_family(
+    family_name: str,
+    router: object,
+    module_name: str,
+    specs: tuple[tuple[str, str, bool], ...],
+) -> APIRouter:
+    if not isinstance(router, APIRouter) or not router.routes:
+        raise RuntimeError(
+            f"{family_name} router from {module_name} must be a non-empty APIRouter."
+        )
+
+    expected = {(path, method.upper()): include for path, method, include in specs}
+    actual: dict[tuple[str, str], APIRoute] = {}
+    for route in router.routes:
+        if not isinstance(route, APIRoute):
+            raise RuntimeError(f"{family_name} router does not define the expected route family.")
+
+        methods = {
+            str(method).upper()
+            for method in (route.methods or set())
+            if str(method).upper() not in _FRAMEWORK_METHODS
+        }
+        if len(methods) != 1:
+            raise RuntimeError(f"{family_name} router does not define the expected route family.")
+        method = next(iter(methods))
+        key = (str(route.path), method)
+        if key in actual:
+            raise RuntimeError(f"{family_name} router does not define the expected route family.")
+        actual[key] = route
+
+    if set(actual) != set(expected):
+        raise RuntimeError(f"{family_name} router does not define the expected route family.")
+
+    for key, include_in_schema in expected.items():
+        if actual[key].include_in_schema is not include_in_schema:
+            raise RuntimeError(f"{family_name} router does not preserve OpenAPI visibility.")
+
+    return router
+
+
+def register_bmi_routes(app: "FastAPI") -> BmiRouteRegistration:
+    """Register BMI route families with the FastAPI application."""
+
+    cached = getattr(app.state, "_cached_bmi_route_registration", None)
+    if getattr(app.state, "_bmi_routes_registered", False) and isinstance(
+        cached,
+        BmiRouteRegistration,
+    ):
+        return cached
+
+    from app.routers.bmi import router as bmi_router_imported
+
+    bmi_router = _require_exact_router_family(
+        "BMI",
+        bmi_router_imported,
+        "app.routers.bmi",
+        BMI_ROUTE_SPECS,
+    )
+    ensure_route_family_registered(
+        app,
+        family_name="BMI",
+        routers=(bmi_router,),
+        members=route_member_contracts_from_router("BMI", bmi_router),
+    )
+
+    bmi_pro_router: APIRouter | None = None
+    bmi_pro_legacy_alias_router: APIRouter | None = None
+    feature_bmi_pro_enabled = is_bmi_pro_enabled()
+    if feature_bmi_pro_enabled:
+        from app.routers.bmi_pro import router as bmi_pro_router_imported
+        from app.routers.bmi_pro_legacy_alias import (
+            router as bmi_pro_legacy_alias_router_imported,
+        )
+
+        bmi_pro_router = _require_exact_router_family(
+            "BMI Pro",
+            bmi_pro_router_imported,
+            "app.routers.bmi_pro",
+            BMI_PRO_ROUTE_SPECS,
+        )
+        bmi_pro_legacy_alias_router = _require_exact_router_family(
+            "BMI Pro legacy alias",
+            bmi_pro_legacy_alias_router_imported,
+            "app.routers.bmi_pro_legacy_alias",
+            BMI_PRO_LEGACY_ALIAS_ROUTE_SPECS,
+        )
+        bmi_pro_routers = (bmi_pro_router, bmi_pro_legacy_alias_router)
+        ensure_route_family_registered(
+            app,
+            family_name="BMI Pro",
+            routers=bmi_pro_routers,
+            members=_route_members_for_routers(
+                "BMI Pro",
+                bmi_pro_routers,
+                extra_required_dependencies=(require_pro_tier,),
+            ),
+        )
+
+    registration = BmiRouteRegistration(
+        bmi_router=bmi_router,
+        bmi_pro_router=bmi_pro_router,
+        bmi_pro_legacy_alias_router=bmi_pro_legacy_alias_router,
+        feature_bmi_pro_enabled=feature_bmi_pro_enabled,
+    )
+    app.state._bmi_routes_registered = True
+    app.state._cached_bmi_route_registration = registration
+    return registration

--- a/app/routers/bmi_registration.py
+++ b/app/routers/bmi_registration.py
@@ -41,6 +41,12 @@ BMI_PRO_LEGACY_ALIAS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
 _FRAMEWORK_METHODS = frozenset({"HEAD", "OPTIONS"})
 
 
+def _format_route_keys(route_keys: set[tuple[str, str]]) -> str:
+    if not route_keys:
+        return "none"
+    return ", ".join(f"{method} {path}" for path, method in sorted(route_keys))
+
+
 @dataclass(frozen=True, slots=True)
 class BmiRouteRegistration:
     """Routers registered by canonical BMI bootstrap."""
@@ -90,7 +96,10 @@ def _require_exact_router_family(
     actual: dict[tuple[str, str], APIRoute] = {}
     for route in router.routes:
         if not isinstance(route, APIRoute):
-            raise RuntimeError(f"{family_name} router does not define the expected route family.")
+            raise RuntimeError(
+                f"{family_name} router from {module_name} contains "
+                f"{type(route).__name__}; expected APIRoute-only members."
+            )
 
         methods = {
             str(method).upper()
@@ -98,25 +107,47 @@ def _require_exact_router_family(
             if str(method).upper() not in _FRAMEWORK_METHODS
         }
         if len(methods) != 1:
-            raise RuntimeError(f"{family_name} router does not define the expected route family.")
+            raise RuntimeError(
+                f"{family_name} router from {module_name} route {route.path} exposes "
+                f"methods {sorted(methods)}; expected exactly one non-framework method."
+            )
         method = next(iter(methods))
         key = (str(route.path), method)
         if key in actual:
-            raise RuntimeError(f"{family_name} router does not define the expected route family.")
+            raise RuntimeError(
+                f"{family_name} router from {module_name} defines duplicate route "
+                f"{method} {route.path}."
+            )
         actual[key] = route
 
-    if set(actual) != set(expected):
-        raise RuntimeError(f"{family_name} router does not define the expected route family.")
+    actual_keys = set(actual)
+    expected_keys = set(expected)
+    if actual_keys != expected_keys:
+        raise RuntimeError(
+            f"{family_name} router from {module_name} route family mismatch: "
+            f"missing {_format_route_keys(expected_keys - actual_keys)}; "
+            f"unexpected {_format_route_keys(actual_keys - expected_keys)}."
+        )
 
     for key, include_in_schema in expected.items():
         if actual[key].include_in_schema is not include_in_schema:
-            raise RuntimeError(f"{family_name} router does not preserve OpenAPI visibility.")
+            path, method = key
+            raise RuntimeError(
+                f"{family_name} router from {module_name} route {method} {path} has "
+                f"include_in_schema={actual[key].include_in_schema}; expected "
+                f"include_in_schema={include_in_schema}."
+            )
 
     return router
 
 
 def register_bmi_routes(app: "FastAPI") -> BmiRouteRegistration:
-    """Register BMI route families with the FastAPI application."""
+    """Register BMI route families with the FastAPI application.
+
+    Registration is idempotent per app instance. The first call evaluates
+    `FEATURE_BMI_PRO_ENABLED` and caches the registered router set on
+    `app.state`; use a fresh app/process when that environment flag changes.
+    """
 
     cached = getattr(app.state, "_cached_bmi_route_registration", None)
     if getattr(app.state, "_bmi_routes_registered", False) and isinstance(

--- a/app/routers/bmi_registration.py
+++ b/app/routers/bmi_registration.py
@@ -42,6 +42,8 @@ _FRAMEWORK_METHODS = frozenset({"HEAD", "OPTIONS"})
 
 
 def _format_route_keys(route_keys: set[tuple[str, str]]) -> str:
+    """Format route keys for diagnostic error messages."""
+
     if not route_keys:
         return "none"
     return ", ".join(f"{method} {path}" for path, method in sorted(route_keys))
@@ -70,6 +72,8 @@ def _route_members_for_routers(
     *,
     extra_required_dependencies: tuple[Callable[..., object], ...] = (),
 ) -> tuple[RouteMemberContract, ...]:
+    """Build route-family member contracts from one or more source routers."""
+
     return tuple(
         member
         for router in routers
@@ -87,6 +91,8 @@ def _require_exact_router_family(
     module_name: str,
     specs: tuple[tuple[str, str, bool], ...],
 ) -> APIRouter:
+    """Validate an imported BMI router against its canonical route specs."""
+
     if not isinstance(router, APIRouter) or not router.routes:
         raise RuntimeError(
             f"{family_name} router from {module_name} must be a non-empty APIRouter."

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -183,12 +183,15 @@ Evidence:
 
 ### Conditional routers: Bodyfat / BMI Pro / Business
 
-Anchor (stable): `legacy_app.py -> feature-flag gated routers (BMI Pro, Business) + optional bodyfat`
+Anchor (stable): `app/main.py -> app/routers/bmi_registration.py` owns BMI route registration; `legacy_app.py` remains a compatibility seam for direct-call shims and mirrored attrs.
 
-Evidence: `legacy_app.py:5226-5248`
+Evidence:
+- `app/main.py -> ensure_canonical_app_bootstrap()`
+- `app/routers/bmi_registration.py -> register_bmi_routes()`
 
 - Bodyfat: included if router factory is available (`get_bodyfat_router`)
-- BMI Pro: included only if `FEATURE_BMI_PRO_ENABLED` is truthy
+- BMI Free: canonical `/api/v1/bmi/calculate` is registered by `app/main.py` via `app/routers/bmi_registration.py`
+- BMI Pro: registered by `app/main.py` via `app/routers/bmi_registration.py`, included only if `FEATURE_BMI_PRO_ENABLED` is truthy
   - canonical: `/api/v1/pro/bmi`
   - legacy alias: `/api/v1/bmi/pro`
 - Business: included only if `BUSINESS_MODULE_ENABLED` is truthy

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -248,10 +248,10 @@ Not merge-ready yet.
 Required before merge:
 
 - [ ] Current-head GitHub CI passes for the pushed head.
-- [x] Post-open role passes completed:
+- [ ] Post-open role passes completed:
   `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- [x] Codex Security diff scan/finding discovery run.
-- [x] `pulseplate-pr-review` run; advisory large-diff-risk dispositioned.
+- [ ] Codex Security diff scan/finding discovery run.
+- [ ] `pulseplate-pr-review` run; advisory large-diff-risk dispositioned.
 - [ ] CodeRabbit, Sourcery, Cubic, and human review comments inspected and all
   actionables fixed or dispositioned.
 - [ ] PR body mirrors this fixed-mapping artifact.

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -56,13 +56,20 @@ below before merge readiness.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#pullrequestreview-4560935403 -> 6124584665aec4f6118f960f3787cdfbb8e34a42
+Disposition: FIXED
+Commit: 6124584665aec4f6118f960f3787cdfbb8e34a42
+Evidence: `app/routers/bmi_registration.py` now reports concrete route-family mismatches, duplicate keys, unsupported route types, method-shape problems, and `include_in_schema` drift; its docstring also documents per-app first-call feature-flag caching. `tests/test_bmi_registration_router_coverage.py` verifies unexpected source-route diagnostics. Focused pytest, `make openapi-check`, `make validate-changed`, `pre-commit run --all-files`, and Phase2 gates passed.
 
 ## Implementation Commits
 
 - `71873aae9` - moves BMI route registration to canonical bootstrap, preserves
   compatibility exports, removes legacy BMI ownership, tightens the legacy
   growth guard, and adds focused route/bootstrap/security tests.
+- `0e568f870` - adds PR #2016 fixed-mapping governance artifact.
+- `13ebb7fb8` - aligns PR #2016 mapping artifact with Phase2 parser contract.
+- `612458466` - fixes Sourcery review feedback by making BMI registration guard
+  failures diagnostic and documenting first-call feature flag caching.
 
 ## Premortem Findings
 
@@ -148,6 +155,14 @@ Passed locally on head `71873aae9`:
 - Pre-push hooks during `git push -u origin codex/move-bmi-registration-to-canonical-bootstrap`:
   changed-files mypy, pip-audit, backend tests, full-repo Bandit, and Docker
   build test.
+
+After Sourcery review remediation `612458466`:
+
+- `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_bmi_registration_router_coverage.py`
+- `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_bmi_registration_router_coverage.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_bmi_calculate_endpoint.py tests/test_bmi_pro_api.py tests/test_bmi_pro_endpoint_errors.py tests/test_bmi_pro_missing_hip.py tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_bola_contract_pack.py tests/test_paid_route_guards.py`
+- `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" make openapi-check`
+- `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" PREPUSH_DEBUG=1 make validate-changed`
+- `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" pre-commit run --all-files`
 
 Current-head CI is pending at mapping creation.
 

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -56,19 +56,19 @@ below before merge readiness.
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#pullrequestreview-4560935403 -> 6124584665aec4f6118f960f3787cdfbb8e34a42
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#pullrequestreview-4560935403 -> 3301be7d65a171c9cc029930ff9f73cec58a3b16
 Disposition: FIXED
-Commit: 6124584665aec4f6118f960f3787cdfbb8e34a42
+Commit: 3301be7d65a171c9cc029930ff9f73cec58a3b16
 Evidence: `app/routers/bmi_registration.py` now reports concrete route-family mismatches, duplicate keys, unsupported route types, method-shape problems, and `include_in_schema` drift; its docstring also documents per-app first-call feature-flag caching. `tests/test_bmi_registration_router_coverage.py` verifies unexpected source-route diagnostics. Focused pytest, `make openapi-check`, `make validate-changed`, `pre-commit run --all-files`, and Phase2 gates passed.
 
 ## Implementation Commits
 
-- `71873aae9` - moves BMI route registration to canonical bootstrap, preserves
+- `ba1eabf3d` - moves BMI route registration to canonical bootstrap, preserves
   compatibility exports, removes legacy BMI ownership, tightens the legacy
   growth guard, and adds focused route/bootstrap/security tests.
-- `0e568f870` - adds PR #2016 fixed-mapping governance artifact.
-- `13ebb7fb8` - aligns PR #2016 mapping artifact with Phase2 parser contract.
-- `612458466` - fixes Sourcery review feedback by making BMI registration guard
+- `761e2637a` - adds PR #2016 fixed-mapping governance artifact.
+- `614c37f0c` - aligns PR #2016 mapping artifact with Phase2 parser contract.
+- `3301be7d6` - fixes Sourcery review feedback by making BMI registration guard
   failures diagnostic and documenting first-call feature flag caching.
 
 ## Premortem Findings
@@ -78,7 +78,7 @@ Disposition: FIXED
 Finding: `PM-BMI-001` - validation could be too narrow for a route ownership
 move.
 
-Commit: `71873aae9`
+Commit: `ba1eabf3d`
 
 Evidence: focused BMI/bootstrap/security pytest bundle, route inventory proof,
 `make openapi-check`, `make validate-changed`, `pre-commit run --all-files`,
@@ -89,7 +89,7 @@ Disposition: FIXED
 Finding: `PM-BMI-002` - duplicate or lost BMI route guard could alter runtime
 behavior.
 
-Commit: `71873aae9`
+Commit: `ba1eabf3d`
 
 Evidence: `tests/test_bmi_registration_router_coverage.py` covers exact
 enabled/disabled route inventory, duplicate/foreign route rejection, partial Pro
@@ -114,7 +114,7 @@ Reason: This PR intentionally proves route ownership through canonical
 - Runner mode: `oracle_only_governance_reviewer`
 - Contribution kind: `oracle_review`
 - Co-author required: yes
-- Co-author trailer included in implementation commit `71873aae9`:
+- Co-author trailer included in implementation commit `ba1eabf3d`:
   `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
 - Oracles passed:
   - `python3 -m pytest -q tests/test_bmi_registration_router_coverage.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_bmi_calculate_endpoint.py tests/test_bmi_pro_api.py tests/test_bmi_pro_endpoint_errors.py tests/test_bmi_pro_missing_hip.py tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_bola_contract_pack.py tests/test_paid_route_guards.py`
@@ -145,7 +145,7 @@ Rejected Runner context:
   per-app BMI registration, no BMI compatibility route conflicts, and parser
   contract validity.
 - PASS: `security-auditor` found no current-head security actionables on
-  `a4aa36c11048cdf3f33fea16ae92433bbe88c26f`; the Sourcery delta only adds
+  `b045a55a3deeaedd880d713c646cc41f83ba068e`; the Sourcery delta only adds
   diagnostic messages, a docstring, a focused test, and mapping evidence.
 
 ## Codex Security Diff Scan / Finding Discovery
@@ -182,7 +182,7 @@ change is included.
 Full local `make verify` was not run under the operator-approved machine-heavy
 exception. Current-head GitHub CI remains the full-suite signal.
 
-Passed locally on head `71873aae9`:
+Passed locally before the dependency-stack rebase:
 
 - `python3 scripts/orchestration/check_preflight.py`
 - `python3 scripts/orchestration/check_agent_consistency.py`
@@ -203,13 +203,31 @@ Passed locally on head `71873aae9`:
   changed-files mypy, pip-audit, backend tests, full-repo Bandit, and Docker
   build test.
 
-After Sourcery review remediation `612458466`:
+After Sourcery review remediation `3301be7d6`:
 
 - `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_bmi_registration_router_coverage.py`
 - `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_bmi_registration_router_coverage.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_bmi_calculate_endpoint.py tests/test_bmi_pro_api.py tests/test_bmi_pro_endpoint_errors.py tests/test_bmi_pro_missing_hip.py tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_bola_contract_pack.py tests/test_paid_route_guards.py`
 - `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" make openapi-check`
 - `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" PREPUSH_DEBUG=1 make validate-changed`
 - `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" pre-commit run --all-files`
+
+After dependency-stack rebase onto `220139000`:
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `python3 scripts/ci/check_legacy_growth_guard.py`
+- `FEATURE_BMI_PRO_ENABLED=0` canonical BMI family proof: exactly
+  `POST /api/v1/bmi/calculate`; pre-existing legacy compatibility endpoints
+  `/bmi`, `/api/v1/bmi`, and `/legacy/bmi-calculator` remain preserved and out
+  of this PR's removal scope.
+- `FEATURE_BMI_PRO_ENABLED=1` canonical BMI/BMI Pro family proof: exactly
+  `POST /api/v1/bmi/calculate`, `POST /api/v1/pro/bmi`,
+  `POST /api/v1/pro/bmi/calculate`, and `POST /api/v1/bmi/pro`; Pro routes are
+  guarded by `require_pro_tier`; the legacy alias remains deprecated and keeps
+  migration metadata.
+- `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_bmi_registration_router_coverage.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_bmi_calculate_endpoint.py tests/test_bmi_pro_api.py tests/test_bmi_pro_endpoint_errors.py tests/test_bmi_pro_missing_hip.py tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_bola_contract_pack.py tests/test_paid_route_guards.py`
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make openapi-check`
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
 
 Current-head CI is pending at mapping creation.
 

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -306,17 +306,35 @@ commit. New current-head CI is pending at mapping update.
 
 ## Merge Readiness
 
-Not merge-ready yet.
+Final merge-readiness pass completed with the documented operator-approved
+machine-heavy local `make verify` exception. Full-suite truth is current-head
+GitHub CI; local validation used the PR-scoped narrow gates recorded above.
 
-Required before merge:
-
-- [ ] Current-head GitHub CI passes for the pushed head.
-- [ ] Post-open role passes completed:
+- [x] Current-head GitHub CI passes for the pushed head.
+- [x] Post-open role passes completed:
   `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- [ ] Codex Security diff scan/finding discovery run.
-- [ ] `pulseplate-pr-review` run; advisory large-diff-risk dispositioned.
-- [ ] CodeRabbit, Sourcery, Cubic, and human review comments inspected and all
+- [x] Codex Security diff scan/finding discovery run.
+- [x] `pulseplate-pr-review` run; advisory large-diff-risk dispositioned.
+- [x] CodeRabbit, Sourcery, Cubic, and human review comments inspected and all
   actionables fixed or dispositioned.
-- [ ] PR body mirrors this fixed-mapping artifact.
-- [ ] Strict merge-readiness checks pass with the documented machine-heavy
+- [x] PR body mirrors this fixed-mapping artifact.
+- [x] Strict merge-readiness checks pass with the documented machine-heavy
   exception.
+
+Final readiness evidence:
+
+- Current-head CI passed for the BMI/backend lane: `test-pr (3.13)`,
+  `coverage-pr`, `diff-coverage`, `codecov/patch`, `lint`, `security`,
+  `security-scan`, `OpenAPI sync`, `build`, CodeQL, PR body Phase2 gates,
+  merge-readiness gate, docs/governance guards, and PR automation.
+- Expected skips/neutral checks were limited to untouched specialized lanes
+  such as iOS, feature/main coverage lanes, publish, Trivy, Sourcery review, and
+  Cubic.
+- `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 2016 --require-auth`
+  passed: all resolved review threads have Disposition + proof and
+  commit-after-comment evidence.
+- `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 2016 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
+  passed.
+- CodeRabbit, Sourcery, Cubic, Codecov, and human review surfaces were inspected
+  before this final pass; all current-PR actionables were fixed or dispositioned
+  above.

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -61,6 +61,11 @@ Disposition: FIXED
 Commit: 3301be7d65a171c9cc029930ff9f73cec58a3b16
 Evidence: `app/routers/bmi_registration.py` now reports concrete route-family mismatches, duplicate keys, unsupported route types, method-shape problems, and `include_in_schema` drift; its docstring also documents per-app first-call feature-flag caching. `tests/test_bmi_registration_router_coverage.py` verifies unexpected source-route diagnostics. Focused pytest, `make openapi-check`, `make validate-changed`, `pre-commit run --all-files`, and Phase2 gates passed.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#discussion_r3469821502 -> 42978e28e086aee0c007f71da44276b801ba87b6
+Disposition: FIXED
+Commit: 42978e28e086aee0c007f71da44276b801ba87b6
+Evidence: `docs/review/PR_2016_FIXED_MAPPING.md` keeps merge-readiness gate checklist items unchecked until final merge readiness while preserving completed-work evidence in prose above. `git diff --check`, `check_preflight.py`, and commit hooks passed.
+
 ## Implementation Commits
 
 - `ba1eabf3d` - moves BMI route registration to canonical bootstrap, preserves
@@ -70,6 +75,8 @@ Evidence: `app/routers/bmi_registration.py` now reports concrete route-family mi
 - `614c37f0c` - aligns PR #2016 mapping artifact with Phase2 parser contract.
 - `3301be7d6` - fixes Sourcery review feedback by making BMI registration guard
   failures diagnostic and documenting first-call feature flag caching.
+- `42978e28e` - keeps PR #2016 merge-readiness gate checkboxes unchecked until
+  the final merge-readiness pass.
 
 ## Premortem Findings
 

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -47,6 +47,8 @@ frontend/iOS change, dependency update, deprecated-endpoint removal, or root
 
 - [x] Discussion-thread pass completed at PR open
 - [x] Fixed in commit mapping initialized
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 No review threads existed at PR open. Any later CodeRabbit, Sourcery, Cubic,
 Codex Security, human, or role-agent actionable must be fixed or dispositioned
@@ -54,7 +56,7 @@ below before merge readiness.
 
 ## Fixed in Commit Mapping
 
-No review threads existed at PR open.
+- No actionable review comments
 
 ## Implementation Commits
 

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -61,6 +61,7 @@ Disposition: FIXED
 Commit: 3301be7d65a171c9cc029930ff9f73cec58a3b16
 Evidence: `app/routers/bmi_registration.py` now reports concrete route-family mismatches, duplicate keys, unsupported route types, method-shape problems, and `include_in_schema` drift; its docstring also documents per-app first-call feature-flag caching. `tests/test_bmi_registration_router_coverage.py` verifies unexpected source-route diagnostics. Focused pytest, `make openapi-check`, `make validate-changed`, `pre-commit run --all-files`, and Phase2 gates passed.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#pullrequestreview-4565385286 -> 42978e28e086aee0c007f71da44276b801ba87b6
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#discussion_r3469821502 -> 42978e28e086aee0c007f71da44276b801ba87b6
 Disposition: FIXED
 Commit: 42978e28e086aee0c007f71da44276b801ba87b6

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -78,6 +78,11 @@ Commit: 5e2e125a5cd733c96b1f3715d98f2a85c853d20b
 Evidence: `app/routers/bmi_registration.py` now documents the BMI registration helper functions used by the production route-family registrar. The PR body mirror also adds related-PR context and a split-justification section for the description-shape advisory. Focused pytest and selected-suite coverage proof passed after the docstring change.
 Reason: The remaining CodeRabbit docstring-coverage framing is advisory for test/helper surfaces, not a repo gate. PulsePlate tests do not require per-test docstrings; adding broad test docstrings would reduce signal without improving the runtime BMI contract.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#pullrequestreview-4566649513 -> d2748ac9b109bfedaf74b7e3c6360f4eab04602c
+Disposition: FIXED
+Commit: d2748ac9b109bfedaf74b7e3c6360f4eab04602c
+Evidence: `tests/test_bmi_registration_router_coverage.py` no longer duplicates the router-validation regex assertions now owned by the CI-selected `tests/test_main_paywall_bootstrap.py` suite. Focused pytest across both BMI test files and selected-suite coverage proof passed after the de-duplication.
+
 ## Implementation Commits
 
 - `ba1eabf3d` - moves BMI route registration to canonical bootstrap, preserves
@@ -96,6 +101,8 @@ Reason: The remaining CodeRabbit docstring-coverage framing is advisory for test
   uses the branch coverage evidence.
 - `5e2e125a5` - documents BMI registration production helpers in response to
   CodeRabbit's advisory docstring-coverage warning.
+- `d2748ac9b` - removes duplicate BMI registrar guard assertions from the
+  dedicated coverage file after CodeRabbit's final nitpick.
 
 ## Premortem Findings
 
@@ -291,8 +298,18 @@ After CodeRabbit advisory docstring remediation `5e2e125a5`:
 - `git diff --check`
 - Commit hooks passed for `5e2e125a5`.
 
-Current-head CI passed at `ff7c6d335` before the CodeRabbit advisory docstring
-commit. New current-head CI is pending at mapping update.
+After CodeRabbit duplicate-test nitpick remediation `d2748ac9b`:
+
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_main_paywall_bootstrap.py tests/test_bmi_registration_router_coverage.py`
+- `COVERAGE_FILE=/tmp/pr2016_coverage_bmi_ci_selected_after_dedupe /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m coverage run --source=app.routers.bmi_registration -m pytest -q tests/test_main_paywall_bootstrap.py`
+- `COVERAGE_FILE=/tmp/pr2016_coverage_bmi_ci_selected_after_dedupe /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m coverage report -m app/routers/bmi_registration.py`
+  - Result: `app/routers/bmi_registration.py` `100.00%` line and branch
+    coverage from the CI-selected `tests/test_main_paywall_bootstrap.py` suite.
+- `git diff --check`
+- Commit hooks passed for `d2748ac9b`.
+
+Current-head CI must pass after this final CodeRabbit nitpick remediation before
+merge.
 
 ## Security Notes
 

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -72,6 +72,12 @@ Disposition: FIXED
 Commit: 68c1d4d6ecee59a1d01af7d00def0197df9ff4e0
 Evidence: `tests/test_bmi_registration_router_coverage.py` now covers the BMI registration guard branches Codecov reported for `app/routers/bmi_registration.py`: non-`APIRoute` members, multi-method source routes, duplicate source routes, and `include_in_schema` drift. Focused coverage proof reports `100.00%` line and branch coverage for the file; `make validate-changed`, `pre-commit run --all-files`, `git diff --check`, and commit hooks passed.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#issuecomment-4787837121 -> 5e2e125a5cd733c96b1f3715d98f2a85c853d20b
+Disposition: FIXED
+Commit: 5e2e125a5cd733c96b1f3715d98f2a85c853d20b
+Evidence: `app/routers/bmi_registration.py` now documents the BMI registration helper functions used by the production route-family registrar. The PR body mirror also adds related-PR context and a split-justification section for the description-shape advisory. Focused pytest and selected-suite coverage proof passed after the docstring change.
+Reason: The remaining CodeRabbit docstring-coverage framing is advisory for test/helper surfaces, not a repo gate. PulsePlate tests do not require per-test docstrings; adding broad test docstrings would reduce signal without improving the runtime BMI contract.
+
 ## Implementation Commits
 
 - `ba1eabf3d` - moves BMI route registration to canonical bootstrap, preserves
@@ -88,6 +94,8 @@ Evidence: `tests/test_bmi_registration_router_coverage.py` now covers the BMI re
 - `855738ce7` - moves BMI registration coverage proof into the CI-selected
   `tests/test_main_paywall_bootstrap.py` suite so current-head `diff-coverage`
   uses the branch coverage evidence.
+- `5e2e125a5` - documents BMI registration production helpers in response to
+  CodeRabbit's advisory docstring-coverage warning.
 
 ## Premortem Findings
 
@@ -273,7 +281,18 @@ After CI-selected diff-coverage remediation `855738ce7`:
 - `git diff --check`
 - Commit hooks passed for `855738ce7`.
 
-Current-head CI is pending at mapping update.
+After CodeRabbit advisory docstring remediation `5e2e125a5`:
+
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_main_paywall_bootstrap.py tests/test_bmi_registration_router_coverage.py`
+- `COVERAGE_FILE=/tmp/pr2016_coverage_bmi_ci_selected_after_docstrings /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m coverage run --source=app.routers.bmi_registration -m pytest -q tests/test_main_paywall_bootstrap.py`
+- `COVERAGE_FILE=/tmp/pr2016_coverage_bmi_ci_selected_after_docstrings /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m coverage report -m app/routers/bmi_registration.py`
+  - Result: `app/routers/bmi_registration.py` `100.00%` line and branch
+    coverage from the CI-selected `tests/test_main_paywall_bootstrap.py` suite.
+- `git diff --check`
+- Commit hooks passed for `5e2e125a5`.
+
+Current-head CI passed at `ff7c6d335` before the CodeRabbit advisory docstring
+commit. New current-head CI is pending at mapping update.
 
 ## Security Notes
 

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -130,6 +130,53 @@ Rejected Runner context:
 - `make validate-changed` was rerun and passed in the real worktree, where the
   shared repo `.venv` is intentionally available.
 
+## Post-Open Review Evidence
+
+- PASS: post-open packet
+  `artifacts/orchestration/task_packets/b9100128481b.json`.
+- PASS: dispatch manifest from
+  `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/b9100128481b.json --mode runtime --pretty`.
+- PASS: mandatory post-open role order executed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- PASS: `qa-engineer-agent` found no current-PR QA actionables and reran
+  focused route inventory, `make validate-changed`, `make openapi-check`, and
+  Phase2 gates.
+- PASS: `bug-hunter` found no current-PR regressions; it confirmed idempotent
+  per-app BMI registration, no BMI compatibility route conflicts, and parser
+  contract validity.
+- PASS: `security-auditor` found no current-head security actionables on
+  `a4aa36c11048cdf3f33fea16ae92433bbe88c26f`; the Sourcery delta only adds
+  diagnostic messages, a docstring, a focused test, and mapping evidence.
+
+## Codex Security Diff Scan / Finding Discovery
+
+- Artifact:
+  `artifacts/security_lab/pr_2016_bmi_bootstrap/diff_security_scan.md`
+- Scope: `origin/main...HEAD`.
+- Result: no reportable findings.
+- Evidence: static pattern scan found no added subprocess, `# nosec`, hardcoded
+  secret assignment, `eval`, or `exec` in changed files; route exposure and tier
+  guard behavior are covered by focused tests, route inventory proof, and
+  pre-push Bandit.
+
+## PulsePlate PR Review Disposition
+
+Finding: `large-diff-risk` advisory from `pulseplate-pr-review`.
+
+Disposition: NOT-A-BUG
+
+Evidence: the diff is intentionally concentrated in one narrow BMI route
+ownership lane, with production changes limited to canonical registration,
+compatibility exports, and the legacy-growth guard. `make validate-changed`
+selected the relevant new/changed Python tests and passed; focused BMI,
+security/auth tier, OpenAPI, pre-commit, pre-push, Experiment Runner, and
+post-open role passes also passed.
+
+Reason: The line-count threshold is crossed by focused tests and the canonical
+review artifact, not by broad unrelated production scope. No bodyfat, FoodDB,
+AI, frontend/iOS, dependency, deprecated-endpoint removal, or root-process-rule
+change is included.
+
 ## Local Validation
 
 Full local `make verify` was not run under the operator-approved machine-heavy
@@ -183,10 +230,10 @@ Not merge-ready yet.
 Required before merge:
 
 - [ ] Current-head GitHub CI passes for the pushed head.
-- [ ] Post-open role passes completed:
+- [x] Post-open role passes completed:
   `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- [ ] Codex Security diff scan/finding discovery run if available.
-- [ ] `pulseplate-pr-review` passed.
+- [x] Codex Security diff scan/finding discovery run.
+- [x] `pulseplate-pr-review` run; advisory large-diff-risk dispositioned.
 - [ ] CodeRabbit, Sourcery, Cubic, and human review comments inspected and all
   actionables fixed or dispositioned.
 - [ ] PR body mirrors this fixed-mapping artifact.

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -67,6 +67,11 @@ Disposition: FIXED
 Commit: 42978e28e086aee0c007f71da44276b801ba87b6
 Evidence: `docs/review/PR_2016_FIXED_MAPPING.md` keeps merge-readiness gate checklist items unchecked until final merge readiness while preserving completed-work evidence in prose above. `git diff --check`, `check_preflight.py`, and commit hooks passed.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#issuecomment-4793153666 -> 68c1d4d6ecee59a1d01af7d00def0197df9ff4e0
+Disposition: FIXED
+Commit: 68c1d4d6ecee59a1d01af7d00def0197df9ff4e0
+Evidence: `tests/test_bmi_registration_router_coverage.py` now covers the BMI registration guard branches Codecov reported for `app/routers/bmi_registration.py`: non-`APIRoute` members, multi-method source routes, duplicate source routes, and `include_in_schema` drift. Focused coverage proof reports `100.00%` line and branch coverage for the file; `make validate-changed`, `pre-commit run --all-files`, `git diff --check`, and commit hooks passed.
+
 ## Implementation Commits
 
 - `ba1eabf3d` - moves BMI route registration to canonical bootstrap, preserves
@@ -78,6 +83,8 @@ Evidence: `docs/review/PR_2016_FIXED_MAPPING.md` keeps merge-readiness gate chec
   failures diagnostic and documenting first-call feature flag caching.
 - `42978e28e` - keeps PR #2016 merge-readiness gate checkboxes unchecked until
   the final merge-readiness pass.
+- `68c1d4d6e` - covers BMI registration guard drift branches reported by
+  Codecov and proves 100% focused coverage for the canonical registrar.
 
 ## Premortem Findings
 
@@ -236,6 +243,16 @@ After dependency-stack rebase onto `220139000`:
 - `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_bmi_registration_router_coverage.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_bmi_calculate_endpoint.py tests/test_bmi_pro_api.py tests/test_bmi_pro_endpoint_errors.py tests/test_bmi_pro_missing_hip.py tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_bola_contract_pack.py tests/test_paid_route_guards.py`
 - `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make openapi-check`
 - `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+
+After Codecov patch-coverage remediation `68c1d4d6e`:
+
+- `COVERAGE_FILE=/tmp/pr2016_coverage_bmi_current PYTHONPATH=. VIP_MODULE_ENABLED=true APP_ENV=test ENVIRONMENT=test FEATURE_PREMIUM_NUTRITION=true API_KEY=test_key /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m coverage run --source=app.routers.bmi_registration -m pytest -q tests/test_bmi_registration_router_coverage.py`
+- `COVERAGE_FILE=/tmp/pr2016_coverage_bmi_current /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m coverage report -m app/routers/bmi_registration.py`
+  - Result: `app/routers/bmi_registration.py` `100.00%` line and branch
+    coverage.
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files`
+- `git diff --check`
 
 Current-head CI is pending at mapping creation.
 

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -85,6 +85,9 @@ Evidence: `tests/test_bmi_registration_router_coverage.py` now covers the BMI re
   the final merge-readiness pass.
 - `68c1d4d6e` - covers BMI registration guard drift branches reported by
   Codecov and proves 100% focused coverage for the canonical registrar.
+- `855738ce7` - moves BMI registration coverage proof into the CI-selected
+  `tests/test_main_paywall_bootstrap.py` suite so current-head `diff-coverage`
+  uses the branch coverage evidence.
 
 ## Premortem Findings
 
@@ -254,7 +257,23 @@ After Codecov patch-coverage remediation `68c1d4d6e`:
 - `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files`
 - `git diff --check`
 
-Current-head CI is pending at mapping creation.
+After CI-selected diff-coverage remediation `855738ce7`:
+
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_main_paywall_bootstrap.py tests/test_bmi_registration_router_coverage.py`
+- `COVERAGE_FILE=/tmp/pr2016_coverage_bmi_ci_selected /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m coverage run --source=app.routers.bmi_registration -m pytest -q tests/test_main_paywall_bootstrap.py`
+- `COVERAGE_FILE=/tmp/pr2016_coverage_bmi_ci_selected /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m coverage report -m app/routers/bmi_registration.py`
+  - Result: `app/routers/bmi_registration.py` `100.00%` line and branch
+    coverage from the CI-selected `tests/test_main_paywall_bootstrap.py` suite.
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/orchestration/check_preflight.py`
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/orchestration/check_agent_consistency.py`
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/ci/check_legacy_growth_guard.py`
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make openapi-check`
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python pre-commit run --all-files`
+- `git diff --check`
+- Commit hooks passed for `855738ce7`.
+
+Current-head CI is pending at mapping update.
 
 ## Security Notes
 

--- a/docs/review/PR_2016_FIXED_MAPPING.md
+++ b/docs/review/PR_2016_FIXED_MAPPING.md
@@ -1,0 +1,177 @@
+# PR #2016 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016
+
+Branch: `codex/move-bmi-registration-to-canonical-bootstrap`
+
+## Summary
+
+This PR moves BMI route registration ownership from `legacy_app.py` into the
+canonical `app/main.py` bootstrap path without changing public BMI behavior.
+Free BMI remains always registered. BMI Pro and the deprecated legacy BMI Pro
+alias remain registered only when `FEATURE_BMI_PRO_ENABLED` is truthy.
+
+## Scope
+
+- Add `app/routers/bmi_registration.py` as the canonical BMI route-family
+  registrar.
+- Register BMI routes from `app/main.py` through
+  `ensure_route_family_registered(...)` and
+  `route_member_contracts_from_router(...)`.
+- Remove BMI router imports and BMI `include_router(...)` calls from
+  `legacy_app.py`.
+- Preserve compatibility exports for `FEATURE_BMI_PRO_ENABLED`, `bmi_router`,
+  `bmi_pro_router`, and `bmi_pro_legacy_alias_router`.
+- Tighten `check_legacy_growth_guard.py` and tests so BMI ownership cannot move
+  back into `legacy_app.py`.
+- Add focused tests for canonical ownership, route inventory, duplicate guards,
+  Pro tier dependency, deprecated alias metadata, and OpenAPI stability.
+
+## Out Of Scope
+
+No BMI math/schema changes, bodyfat work, FoodDB work, AI/runtime work,
+frontend/iOS change, dependency update, deprecated-endpoint removal, or root
+`AGENTS.md` process-rule edit.
+
+## Lane Start Provenance
+
+- Base branch: `main`
+- Start head: `827eee384a4fd7fa9e80b993d503b3183a6312db`
+- Packet: `artifacts/orchestration/task_packets/68028055c67e.json`
+- Dispatch manifest:
+  `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/68028055c67e.json --mode runtime --implementation-owner bug-hunter --implementation-owner qa-engineer-agent --implementation-owner security-auditor --pretty`
+- Pre-implementation role order executed:
+  `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed at PR open
+- [x] Fixed in commit mapping initialized
+
+No review threads existed at PR open. Any later CodeRabbit, Sourcery, Cubic,
+Codex Security, human, or role-agent actionable must be fixed or dispositioned
+below before merge readiness.
+
+## Fixed in Commit Mapping
+
+No review threads existed at PR open.
+
+## Implementation Commits
+
+- `71873aae9` - moves BMI route registration to canonical bootstrap, preserves
+  compatibility exports, removes legacy BMI ownership, tightens the legacy
+  growth guard, and adds focused route/bootstrap/security tests.
+
+## Premortem Findings
+
+Disposition: FIXED
+
+Finding: `PM-BMI-001` - validation could be too narrow for a route ownership
+move.
+
+Commit: `71873aae9`
+
+Evidence: focused BMI/bootstrap/security pytest bundle, route inventory proof,
+`make openapi-check`, `make validate-changed`, `pre-commit run --all-files`,
+and pre-push hooks passed.
+
+Disposition: FIXED
+
+Finding: `PM-BMI-002` - duplicate or lost BMI route guard could alter runtime
+behavior.
+
+Commit: `71873aae9`
+
+Evidence: `tests/test_bmi_registration_router_coverage.py` covers exact
+enabled/disabled route inventory, duplicate/foreign route rejection, partial Pro
+family rejection, and unguarded Pro route rejection.
+
+Disposition: NOT-A-BUG
+
+Finding: canonical app ownership assumption.
+
+Evidence: `app/main.py` calls the canonical BMI registrar during
+`ensure_canonical_app_bootstrap(...)`; direct `legacy_app.py` construction is
+compatibility surface only and no longer owns BMI router registration.
+
+Reason: This PR intentionally proves route ownership through canonical
+`app.main:app`, which is the backend runtime route owner.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/exp-fb358458ae4e.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-fb358458ae4e.json`
+- Status: accepted
+- Runner mode: `oracle_only_governance_reviewer`
+- Contribution kind: `oracle_review`
+- Co-author required: yes
+- Co-author trailer included in implementation commit `71873aae9`:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+- Oracles passed:
+  - `python3 -m pytest -q tests/test_bmi_registration_router_coverage.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_bmi_calculate_endpoint.py tests/test_bmi_pro_api.py tests/test_bmi_pro_endpoint_errors.py tests/test_bmi_pro_missing_hip.py tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_bola_contract_pack.py tests/test_paid_route_guards.py`
+  - `make openapi-check`
+  - `python3 scripts/ci/check_legacy_growth_guard.py`
+
+Rejected Runner context:
+
+- `artifacts/orchestration/experiments/results/exp-98bd49dad8d8.json` was
+  rejected because the temporary sandbox checkout could not resolve the shared
+  repo `.venv` for `make validate-changed`.
+- This rejection is not used as readiness evidence.
+- `make validate-changed` was rerun and passed in the real worktree, where the
+  shared repo `.venv` is intentionally available.
+
+## Local Validation
+
+Full local `make verify` was not run under the operator-approved machine-heavy
+exception. Current-head GitHub CI remains the full-suite signal.
+
+Passed locally on head `71873aae9`:
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `python3 scripts/ci/check_legacy_growth_guard.py`
+- `git diff --check origin/main...HEAD`
+- `FEATURE_BMI_PRO_ENABLED=0` route inventory proof: exactly
+  `POST /api/v1/bmi/calculate` for the BMI route-family set.
+- `FEATURE_BMI_PRO_ENABLED=1` route inventory proof: exactly
+  `POST /api/v1/bmi/calculate`, `POST /api/v1/pro/bmi`,
+  `POST /api/v1/pro/bmi/calculate`, and `POST /api/v1/bmi/pro`; Pro routes are
+  guarded by `require_pro_tier`; the legacy alias remains deprecated and keeps
+  migration metadata.
+- `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_bmi_registration_router_coverage.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_bmi_calculate_endpoint.py tests/test_bmi_pro_api.py tests/test_bmi_pro_endpoint_errors.py tests/test_bmi_pro_missing_hip.py tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_bola_contract_pack.py tests/test_paid_route_guards.py`
+- `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" make openapi-check`
+- `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" PREPUSH_DEBUG=1 make validate-changed`
+- `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" pre-commit run --all-files`
+- Pre-push hooks during `git push -u origin codex/move-bmi-registration-to-canonical-bootstrap`:
+  changed-files mypy, pip-audit, backend tests, full-repo Bandit, and Docker
+  build test.
+
+Current-head CI is pending at mapping creation.
+
+## Security Notes
+
+- Free BMI calculation remains unguarded/free.
+- BMI Pro canonical routes and the deprecated legacy BMI Pro alias remain behind
+  `require_pro_tier` when enabled.
+- Duplicate FastAPI method/path registration is guarded by the canonical route
+  family helper and focused tests.
+- This PR does not touch secrets, token handling, billing, deploy, migrations,
+  or LLM endpoints.
+
+## Merge Readiness
+
+Not merge-ready yet.
+
+Required before merge:
+
+- [ ] Current-head GitHub CI passes for the pushed head.
+- [ ] Post-open role passes completed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [ ] Codex Security diff scan/finding discovery run if available.
+- [ ] `pulseplate-pr-review` passed.
+- [ ] CodeRabbit, Sourcery, Cubic, and human review comments inspected and all
+  actionables fixed or dispositioned.
+- [ ] PR body mirrors this fixed-mapping artifact.
+- [ ] Strict merge-readiness checks pass with the documented machine-heavy
+  exception.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -49,9 +49,6 @@ from app.http_error_details import (
     INVALID_PREMIUM_PLATE_INPUT_DETAIL,
 )
 from app.routers.api_key import api_key_header
-from app.routers.bmi import router as bmi_router
-from app.routers.bmi_pro import router as bmi_pro_router
-from app.routers.bmi_pro_legacy_alias import router as bmi_pro_legacy_alias_router
 from app.routers.business import router as business_router
 from app.routers.catalog import router as catalog_router
 from app.routers.foods import router as foods_router
@@ -181,6 +178,13 @@ except ImportError:  # pragma: no cover - optional dependency in runtime
 # Public compatibility surface: tests + app/__init__.py expect these attrs to exist.
 premium_week_router: Optional[APIRouter] = None
 pro_router: Optional[APIRouter] = None
+
+# BMI route registration is owned by app.main canonical bootstrap.
+# Public compatibility surface: tests + app/__init__.py expect these attrs to exist.
+FEATURE_BMI_PRO_ENABLED: bool = False
+bmi_router: Optional[APIRouter] = None
+bmi_pro_router: Optional[APIRouter] = None
+bmi_pro_legacy_alias_router: Optional[APIRouter] = None
 
 # Preserve import-time references so later monkeypatching does not mask availability checks
 _BASELINE_CALCULATE_ALL_BMR = calculate_all_bmr
@@ -4316,18 +4320,7 @@ if EXPORTS_ENABLED:
 if get_bodyfat_router is not None:
     app.include_router(get_bodyfat_router(), prefix="/api/v1")
 
-# Include BMI Pro router (with feature flag). Defaults to disabled for safety.
-_bmi_pro_flag = os.getenv("FEATURE_BMI_PRO_ENABLED")
-FEATURE_BMI_PRO_ENABLED = _is_truthy(_bmi_pro_flag) if _bmi_pro_flag is not None else False
-if FEATURE_BMI_PRO_ENABLED and bmi_pro_router:
-    # Register canonical PRO endpoint: /api/v1/pro/bmi
-    app.include_router(bmi_pro_router)
-    # Register legacy shim for backward compatibility: /api/v1/bmi/pro (deprecated)
-    if bmi_pro_legacy_alias_router:
-        app.include_router(bmi_pro_legacy_alias_router)
-
-# Include BMI router (FREE tier, no API key required)
-app.include_router(bmi_router)
+# BMI and BMI Pro route registration is owned by app.main canonical bootstrap.
 
 # Include Business router (with feature flag). Defaults to disabled for safety.
 

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -106,15 +106,12 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("registration", "include_router", "catalog_router", ""),
         LegacyFact("registration", "include_router", "shopping_list_pro_router", ""),
         LegacyFact("registration", "include_router", "shoplist_day_router", ""),
-        LegacyFact("registration", "include_router", "bmi_router", ""),
         LegacyFact("registration", "include_router", "bayes_adherence.router", ""),
         LegacyFact("registration", "include_router", "nutrition_log.router", ""),
         LegacyFact("registration", "include_router", "legacy_nutrition_alias_router", ""),
         LegacyFact("registration", "include_router", "get_bodyfat_router()", ""),
-        LegacyFact("registration", "include_router", "bmi_pro_router", ""),
         LegacyFact("registration", "include_router", "business_router", ""),
         LegacyFact("registration", "include_router", "test_router.router", ""),
-        LegacyFact("registration", "include_router", "bmi_pro_legacy_alias_router", ""),
     }
 )
 
@@ -126,14 +123,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
         LegacyFact("router_import", "app.routers", "vip", "_vip_mod"),
         LegacyFact("router_import", "app.routers.api_key", "api_key_header", ""),
         LegacyFact("router_import", "app.routers.bmi", "bmi_calculate_handler", ""),
-        LegacyFact("router_import", "app.routers.bmi", "router", "bmi_router"),
-        LegacyFact("router_import", "app.routers.bmi_pro", "router", "bmi_pro_router"),
-        LegacyFact(
-            "router_import",
-            "app.routers.bmi_pro_legacy_alias",
-            "router",
-            "bmi_pro_legacy_alias_router",
-        ),
         LegacyFact("router_import", "app.routers.bodyfat", "get_router", "get_bodyfat_router"),
         LegacyFact("router_import", "app.routers.business", "router", "business_router"),
         LegacyFact("router_import", "app.routers.catalog", "router", "catalog_router"),

--- a/tests/test_bmi_registration_router_coverage.py
+++ b/tests/test_bmi_registration_router_coverage.py
@@ -125,6 +125,34 @@ def test_register_bmi_routes_rejects_empty_free_router(
         register_bmi_routes(FastAPI())
 
 
+def test_register_bmi_routes_reports_unexpected_source_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _calculate() -> dict[str, str]:
+        return {"status": "calculate"}
+
+    async def _extra() -> dict[str, str]:
+        return {"status": "extra"}
+
+    router.post("/calculate")(_calculate)
+    router.get("/extra")(_extra)
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi route family mismatch: "
+            "missing none; unexpected GET /api/v1/bmi/extra"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
+
+
 def test_register_bmi_routes_rejects_foreign_existing_bmi_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_bmi_registration_router_coverage.py
+++ b/tests/test_bmi_registration_router_coverage.py
@@ -1,0 +1,173 @@
+"""Focused coverage for canonical BMI route registration."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
+import pytest
+
+from app.bootstrap.route_family import route_has_dependency_call
+from app.middleware.api_tiers import require_pro_tier
+from app.routers.bmi_registration import register_bmi_routes
+
+
+def _http_routes(app: FastAPI) -> list[APIRoute]:
+    return [route for route in app.routes if isinstance(route, APIRoute)]
+
+
+def _route_counts(app: FastAPI) -> dict[tuple[str, str], int]:
+    counts: dict[tuple[str, str], int] = {}
+    for route in _http_routes(app):
+        for method in sorted((route.methods or set()) - {"HEAD", "OPTIONS"}):
+            key = (method, route.path)
+            counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _route(app: FastAPI, method: str, path: str) -> APIRoute:
+    method = method.upper()
+    return next(
+        route
+        for route in _http_routes(app)
+        if route.path == path and method in (route.methods or set())
+    )
+
+
+def _unguarded_bmi_pro_router() -> APIRouter:
+    router = APIRouter(prefix="/api/v1/pro", tags=["pro"])
+
+    async def _bmi() -> dict[str, str]:
+        return {"status": "bmi"}
+
+    async def _calculate() -> dict[str, str]:
+        return {"status": "calculate"}
+
+    router.post("/bmi", deprecated=True)(_bmi)
+    router.post("/bmi/calculate")(_calculate)
+    return router
+
+
+def test_register_bmi_routes_defaults_to_free_route_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+    app = FastAPI()
+
+    registration = register_bmi_routes(app)
+
+    assert registration.feature_bmi_pro_enabled is False
+    assert registration.bmi_pro_router is None
+    assert registration.bmi_pro_legacy_alias_router is None
+    counts = _route_counts(app)
+    assert counts[("POST", "/api/v1/bmi/calculate")] == 1
+    assert ("POST", "/api/v1/pro/bmi") not in counts
+    assert ("POST", "/api/v1/pro/bmi/calculate") not in counts
+    assert ("POST", "/api/v1/bmi/pro") not in counts
+
+
+def test_register_bmi_routes_enabled_registers_pro_family_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FEATURE_BMI_PRO_ENABLED", "true")
+    app = FastAPI()
+
+    first = register_bmi_routes(app)
+    second = register_bmi_routes(app)
+
+    assert second is first
+    assert first.feature_bmi_pro_enabled is True
+    assert first.bmi_pro_router is not None
+    assert first.bmi_pro_legacy_alias_router is not None
+    counts = _route_counts(app)
+    assert counts[("POST", "/api/v1/bmi/calculate")] == 1
+    assert counts[("POST", "/api/v1/pro/bmi")] == 1
+    assert counts[("POST", "/api/v1/pro/bmi/calculate")] == 1
+    assert counts[("POST", "/api/v1/bmi/pro")] == 1
+
+
+def test_register_bmi_routes_preserves_pro_dependency_and_alias_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FEATURE_BMI_PRO_ENABLED", "yes")
+    app = FastAPI()
+
+    register_bmi_routes(app)
+
+    free_route = _route(app, "POST", "/api/v1/bmi/calculate")
+    legacy_pro_route = _route(app, "POST", "/api/v1/pro/bmi")
+    canonical_pro_route = _route(app, "POST", "/api/v1/pro/bmi/calculate")
+    alias_route = _route(app, "POST", "/api/v1/bmi/pro")
+
+    assert not route_has_dependency_call(free_route, require_pro_tier)
+    assert legacy_pro_route.deprecated is True
+    assert route_has_dependency_call(legacy_pro_route, require_pro_tier)
+    assert route_has_dependency_call(canonical_pro_route, require_pro_tier)
+    assert alias_route.deprecated is True
+    assert alias_route.openapi_extra == {
+        "x-alias-of": "/api/v1/pro/bmi",
+        "x-migration-path": "Migrate to POST /api/v1/pro/bmi (same contract)",
+    }
+    assert route_has_dependency_call(alias_route, require_pro_tier)
+
+
+def test_register_bmi_routes_rejects_empty_free_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    monkeypatch.setattr(bmi_module, "router", APIRouter())
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="BMI router from app\\.routers\\.bmi must be a non-empty APIRouter",
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_register_bmi_routes_rejects_foreign_existing_bmi_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+    app = FastAPI()
+
+    async def _shadow_bmi() -> dict[str, str]:
+        return {"status": "shadow"}
+
+    app.add_api_route("/api/v1/bmi/calculate", _shadow_bmi, methods=["POST"])
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate /api/v1/bmi/calculate route detected with a different bmi handler",
+    ):
+        register_bmi_routes(app)
+
+
+def test_register_bmi_routes_rejects_partial_existing_pro_family(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FEATURE_BMI_PRO_ENABLED", "on")
+    app = FastAPI()
+
+    async def _shadow_pro_bmi() -> dict[str, str]:
+        return {"status": "shadow"}
+
+    app.add_api_route("/api/v1/pro/bmi", _shadow_pro_bmi, methods=["POST"])
+
+    with pytest.raises(RuntimeError, match="Partial bmi pro route registration detected"):
+        register_bmi_routes(app)
+
+
+def test_register_bmi_routes_rejects_unguarded_pro_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi_pro as bmi_pro_module
+
+    monkeypatch.setenv("FEATURE_BMI_PRO_ENABLED", "true")
+    monkeypatch.setattr(bmi_pro_module, "router", _unguarded_bmi_pro_router())
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing /api/v1/pro/bmi route does not preserve bmi pro required dependency",
+    ):
+        register_bmi_routes(FastAPI())

--- a/tests/test_bmi_registration_router_coverage.py
+++ b/tests/test_bmi_registration_router_coverage.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute
 import pytest
+from starlette.responses import JSONResponse
+from starlette.routing import Route
 
 from app.bootstrap.route_family import route_has_dependency_call
 from app.middleware.api_tiers import require_pro_tier
@@ -148,6 +150,107 @@ def test_register_bmi_routes_reports_unexpected_source_route(
         match=(
             "BMI router from app\\.routers\\.bmi route family mismatch: "
             "missing none; unexpected GET /api/v1/bmi/extra"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_register_bmi_routes_rejects_non_api_route_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _plain_route(request: object) -> JSONResponse:
+        return JSONResponse({"path": str(request)})
+
+    router.routes.append(Route("/calculate", _plain_route, methods=["POST"]))
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi contains Route; " "expected APIRoute-only members"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_register_bmi_routes_rejects_multi_method_source_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _calculate() -> dict[str, str]:
+        return {"status": "calculate"}
+
+    router.add_api_route("/calculate", _calculate, methods=["GET", "POST"])
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi route /api/v1/bmi/calculate "
+            "exposes methods \\['GET', 'POST'\\]; expected exactly one "
+            "non-framework method"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_register_bmi_routes_rejects_duplicate_source_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _calculate() -> dict[str, str]:
+        return {"status": "calculate"}
+
+    async def _duplicate_calculate() -> dict[str, str]:
+        return {"status": "duplicate"}
+
+    router.post("/calculate")(_calculate)
+    router.post("/calculate")(_duplicate_calculate)
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi defines duplicate route "
+            "POST /api/v1/bmi/calculate"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_register_bmi_routes_rejects_source_route_openapi_visibility_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _calculate() -> dict[str, str]:
+        return {"status": "calculate"}
+
+    router.post("/calculate", include_in_schema=False)(_calculate)
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi route POST "
+            "/api/v1/bmi/calculate has include_in_schema=False; "
+            "expected include_in_schema=True"
         ),
     ):
         register_bmi_routes(FastAPI())

--- a/tests/test_bmi_registration_router_coverage.py
+++ b/tests/test_bmi_registration_router_coverage.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute
 import pytest
-from starlette.responses import JSONResponse
-from starlette.routing import Route
 
 from app.bootstrap.route_family import route_has_dependency_call
 from app.middleware.api_tiers import require_pro_tier
@@ -150,107 +148,6 @@ def test_register_bmi_routes_reports_unexpected_source_route(
         match=(
             "BMI router from app\\.routers\\.bmi route family mismatch: "
             "missing none; unexpected GET /api/v1/bmi/extra"
-        ),
-    ):
-        register_bmi_routes(FastAPI())
-
-
-def test_register_bmi_routes_rejects_non_api_route_member(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    import app.routers.bmi as bmi_module
-
-    router = APIRouter(prefix="/api/v1/bmi")
-
-    async def _plain_route(request: object) -> JSONResponse:
-        return JSONResponse({"path": str(request)})
-
-    router.routes.append(Route("/calculate", _plain_route, methods=["POST"]))
-    monkeypatch.setattr(bmi_module, "router", router)
-    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "BMI router from app\\.routers\\.bmi contains Route; " "expected APIRoute-only members"
-        ),
-    ):
-        register_bmi_routes(FastAPI())
-
-
-def test_register_bmi_routes_rejects_multi_method_source_route(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    import app.routers.bmi as bmi_module
-
-    router = APIRouter(prefix="/api/v1/bmi")
-
-    async def _calculate() -> dict[str, str]:
-        return {"status": "calculate"}
-
-    router.add_api_route("/calculate", _calculate, methods=["GET", "POST"])
-    monkeypatch.setattr(bmi_module, "router", router)
-    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "BMI router from app\\.routers\\.bmi route /api/v1/bmi/calculate "
-            "exposes methods \\['GET', 'POST'\\]; expected exactly one "
-            "non-framework method"
-        ),
-    ):
-        register_bmi_routes(FastAPI())
-
-
-def test_register_bmi_routes_rejects_duplicate_source_route(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    import app.routers.bmi as bmi_module
-
-    router = APIRouter(prefix="/api/v1/bmi")
-
-    async def _calculate() -> dict[str, str]:
-        return {"status": "calculate"}
-
-    async def _duplicate_calculate() -> dict[str, str]:
-        return {"status": "duplicate"}
-
-    router.post("/calculate")(_calculate)
-    router.post("/calculate")(_duplicate_calculate)
-    monkeypatch.setattr(bmi_module, "router", router)
-    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "BMI router from app\\.routers\\.bmi defines duplicate route "
-            "POST /api/v1/bmi/calculate"
-        ),
-    ):
-        register_bmi_routes(FastAPI())
-
-
-def test_register_bmi_routes_rejects_source_route_openapi_visibility_drift(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    import app.routers.bmi as bmi_module
-
-    router = APIRouter(prefix="/api/v1/bmi")
-
-    async def _calculate() -> dict[str, str]:
-        return {"status": "calculate"}
-
-    router.post("/calculate", include_in_schema=False)(_calculate)
-    monkeypatch.setattr(bmi_module, "router", router)
-    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "BMI router from app\\.routers\\.bmi route POST "
-            "/api/v1/bmi/calculate has include_in_schema=False; "
-            "expected include_in_schema=True"
         ),
     ):
         register_bmi_routes(FastAPI())

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -154,6 +154,35 @@ def test_legacy_growth_guard_rejects_reintroduced_bmi_plan_routes(
     assert errors == [expected]
 
 
+def test_legacy_growth_guard_rejects_reintroduced_bmi_router_registration() -> None:
+    source = textwrap.dedent("""
+        from app.routers.bmi import router as bmi_router
+        from app.routers.bmi_pro import router as bmi_pro_router
+        from app.routers.bmi_pro_legacy_alias import router as bmi_pro_legacy_alias_router
+
+        app.include_router(bmi_router)
+        app.include_router(bmi_pro_router)
+        app.include_router(bmi_pro_legacy_alias_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:bmi_pro_legacy_alias_router",
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:bmi_pro_router",
+        "legacy_app.py: unexpected legacy route growth: registration:include_router:bmi_router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.bmi:router -> bmi_router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.bmi_pro:router -> bmi_pro_router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.bmi_pro_legacy_alias:router -> "
+        "bmi_pro_legacy_alias_router",
+    ]
+
+
 def test_legacy_growth_guard_rejects_reintroduced_export_alias_routes() -> None:
     source = textwrap.dedent("""
         @app.get("/api/v1/premium/exports/day/{plan_id}.csv")

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -16,6 +16,7 @@ from app.bootstrap.route_family import (
     route_has_dependency_call,
     same_callable_by_module_and_qualname,
 )
+from app.routers.bmi_registration import BmiRouteRegistration
 
 
 @pytest.fixture(autouse=True)
@@ -783,6 +784,16 @@ def _prepare_bootstrap_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(app_main, "register_tracing", lambda target_app: None)
     monkeypatch.setattr(app_main, "register_vip_routes", lambda target_app: None)
     monkeypatch.setattr(app_main, "register_pro_routes", lambda target_app: (None, None))
+    monkeypatch.setattr(
+        app_main,
+        "register_bmi_routes",
+        lambda target_app: BmiRouteRegistration(
+            bmi_router=APIRouter(),
+            bmi_pro_router=None,
+            bmi_pro_legacy_alias_router=None,
+            feature_bmi_pro_enabled=False,
+        ),
+    )
     monkeypatch.setattr(app_main, "register_pro_contract_routes", lambda target_app: None)
     monkeypatch.setattr(app_main, "register_billing_routes", lambda target_app: None)
     monkeypatch.setattr(app_main, "feedback_router", _stub_router("/api/v1/feedback/rag"))
@@ -860,6 +871,47 @@ def test_paid_tier_registration_runs_vip_then_pro_and_mirrors_legacy_attrs(
     assert app_main._legacy_module.vip_router is vip
     assert app_main._legacy_module.pro_router is pro
     assert app_main._legacy_module.premium_week_router is premium_week
+
+
+def test_bmi_registration_runs_and_mirrors_legacy_attrs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    calls: list[str] = []
+    bmi = APIRouter()
+    bmi_pro = APIRouter()
+    bmi_pro_alias = APIRouter()
+
+    def _register_bmi(target_app: FastAPI) -> BmiRouteRegistration:
+        calls.append("bmi")
+        return BmiRouteRegistration(
+            bmi_router=bmi,
+            bmi_pro_router=bmi_pro,
+            bmi_pro_legacy_alias_router=bmi_pro_alias,
+            feature_bmi_pro_enabled=True,
+        )
+
+    monkeypatch.setattr(app_main, "register_bmi_routes", _register_bmi)
+    monkeypatch.setattr(app_main, "FEATURE_BMI_PRO_ENABLED", False)
+    monkeypatch.setattr(app_main, "bmi_router", None)
+    monkeypatch.setattr(app_main, "bmi_pro_router", None)
+    monkeypatch.setattr(app_main, "bmi_pro_legacy_alias_router", None)
+    monkeypatch.setattr(app_main._legacy_module, "FEATURE_BMI_PRO_ENABLED", False)
+    monkeypatch.setattr(app_main._legacy_module, "bmi_router", None)
+    monkeypatch.setattr(app_main._legacy_module, "bmi_pro_router", None)
+    monkeypatch.setattr(app_main._legacy_module, "bmi_pro_legacy_alias_router", None)
+
+    _bootstrap_temp_app(FastAPI())
+
+    assert calls == ["bmi"]
+    assert app_main.FEATURE_BMI_PRO_ENABLED is True
+    assert app_main.bmi_router is bmi
+    assert app_main.bmi_pro_router is bmi_pro
+    assert app_main.bmi_pro_legacy_alias_router is bmi_pro_alias
+    assert app_main._legacy_module.FEATURE_BMI_PRO_ENABLED is True
+    assert app_main._legacy_module.bmi_router is bmi
+    assert app_main._legacy_module.bmi_pro_router is bmi_pro
+    assert app_main._legacy_module.bmi_pro_legacy_alias_router is bmi_pro_alias
 
 
 def test_vip_compat_resolver_returns_none_when_vip_disabled(

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -6,7 +6,8 @@ from fastapi import APIRouter, Depends, FastAPI, Response, WebSocket
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 import pytest
-from starlette.routing import BaseRoute
+from starlette.responses import JSONResponse
+from starlette.routing import BaseRoute, Route
 
 import app.main as app_main
 from app.bootstrap.route_family import (
@@ -16,7 +17,7 @@ from app.bootstrap.route_family import (
     route_has_dependency_call,
     same_callable_by_module_and_qualname,
 )
-from app.routers.bmi_registration import BmiRouteRegistration
+from app.routers.bmi_registration import BmiRouteRegistration, register_bmi_routes
 
 
 @pytest.fixture(autouse=True)
@@ -912,6 +913,199 @@ def test_bmi_registration_runs_and_mirrors_legacy_attrs(
     assert app_main._legacy_module.bmi_router is bmi
     assert app_main._legacy_module.bmi_pro_router is bmi_pro
     assert app_main._legacy_module.bmi_pro_legacy_alias_router is bmi_pro_alias
+
+
+def _bmi_route_counts(app: FastAPI) -> dict[tuple[str, str], int]:
+    counts: dict[tuple[str, str], int] = {}
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        for method in sorted((route.methods or set()) - {"HEAD", "OPTIONS"}):
+            key = (method, route.path)
+            counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def test_bmi_registration_defaults_to_free_route_only_and_caches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+    app = FastAPI()
+
+    first = register_bmi_routes(app)
+    second = register_bmi_routes(app)
+
+    assert second is first
+    assert first.feature_bmi_pro_enabled is False
+    assert first.bmi_pro_router is None
+    assert first.bmi_pro_legacy_alias_router is None
+    counts = _bmi_route_counts(app)
+    assert counts[("POST", "/api/v1/bmi/calculate")] == 1
+    assert ("POST", "/api/v1/pro/bmi") not in counts
+    assert ("POST", "/api/v1/pro/bmi/calculate") not in counts
+    assert ("POST", "/api/v1/bmi/pro") not in counts
+
+
+def test_bmi_registration_enabled_registers_pro_family_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FEATURE_BMI_PRO_ENABLED", "true")
+    app = FastAPI()
+
+    registration = register_bmi_routes(app)
+
+    assert registration.feature_bmi_pro_enabled is True
+    assert registration.bmi_pro_router is not None
+    assert registration.bmi_pro_legacy_alias_router is not None
+    counts = _bmi_route_counts(app)
+    assert counts[("POST", "/api/v1/bmi/calculate")] == 1
+    assert counts[("POST", "/api/v1/pro/bmi")] == 1
+    assert counts[("POST", "/api/v1/pro/bmi/calculate")] == 1
+    assert counts[("POST", "/api/v1/bmi/pro")] == 1
+
+
+def test_bmi_registration_rejects_empty_free_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    monkeypatch.setattr(bmi_module, "router", APIRouter())
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="BMI router from app\\.routers\\.bmi must be a non-empty APIRouter",
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_bmi_registration_reports_unexpected_source_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _calculate() -> dict[str, str]:
+        return {"status": "calculate"}
+
+    async def _extra() -> dict[str, str]:
+        return {"status": "extra"}
+
+    router.post("/calculate")(_calculate)
+    router.get("/extra")(_extra)
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi route family mismatch: "
+            "missing none; unexpected GET /api/v1/bmi/extra"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_bmi_registration_rejects_non_api_route_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _plain_route(request: object) -> JSONResponse:
+        return JSONResponse({"path": str(request)})
+
+    router.routes.append(Route("/calculate", _plain_route, methods=["POST"]))
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi contains Route; " "expected APIRoute-only members"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_bmi_registration_rejects_multi_method_source_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _calculate() -> dict[str, str]:
+        return {"status": "calculate"}
+
+    router.add_api_route("/calculate", _calculate, methods=["GET", "POST"])
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi route /api/v1/bmi/calculate "
+            "exposes methods \\['GET', 'POST'\\]; expected exactly one "
+            "non-framework method"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_bmi_registration_rejects_duplicate_source_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _calculate() -> dict[str, str]:
+        return {"status": "calculate"}
+
+    async def _duplicate_calculate() -> dict[str, str]:
+        return {"status": "duplicate"}
+
+    router.post("/calculate")(_calculate)
+    router.post("/calculate")(_duplicate_calculate)
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi defines duplicate route "
+            "POST /api/v1/bmi/calculate"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
+
+
+def test_bmi_registration_rejects_source_route_openapi_visibility_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.routers.bmi as bmi_module
+
+    router = APIRouter(prefix="/api/v1/bmi")
+
+    async def _calculate() -> dict[str, str]:
+        return {"status": "calculate"}
+
+    router.post("/calculate", include_in_schema=False)(_calculate)
+    monkeypatch.setattr(bmi_module, "router", router)
+    monkeypatch.delenv("FEATURE_BMI_PRO_ENABLED", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "BMI router from app\\.routers\\.bmi route POST "
+            "/api/v1/bmi/calculate has include_in_schema=False; "
+            "expected include_in_schema=True"
+        ),
+    ):
+        register_bmi_routes(FastAPI())
 
 
 def test_vip_compat_resolver_returns_none_when_vip_disabled(


### PR DESCRIPTION
## Goal
Move BMI route registration ownership out of `legacy_app.py` and into canonical FastAPI bootstrap in `app/main.py`, without changing public BMI behavior.

## Business Reason
BMI/BMI Pro routes are part of the backend API contract and should be registered by canonical bootstrap, not legacy compatibility wiring. This reduces duplicate route ownership risk while preserving existing clients and paid-tier behavior.

## Scope
- Add `app/routers/bmi_registration.py` as the canonical BMI route-family registrar.
- Register free BMI routes always from `app/main.py`.
- Register BMI Pro canonical routes and the deprecated legacy alias only when `FEATURE_BMI_PRO_ENABLED` is truthy.
- Preserve compatibility exports for `FEATURE_BMI_PRO_ENABLED`, `bmi_router`, `bmi_pro_router`, and `bmi_pro_legacy_alias_router` without restoring legacy ownership.
- Tighten legacy growth guard coverage so BMI router imports/includes cannot be reintroduced in `legacy_app.py`.
- Add focused tests for canonical ownership, route inventory, duplicate protection, Pro dependency guard, alias metadata, and OpenAPI stability.
- Add `docs/review/PR_2016_FIXED_MAPPING.md` as the canonical review artifact.

## Out Of Scope
- No BMI math or schema changes.
- No bodyfat, FoodDB, AI, frontend/iOS, dependency, or deprecated-endpoint removal work.
- No root `AGENTS.md` process-rule edit in this runtime PR.
- No local full `make verify`; this lane uses the operator-approved machine-heavy exception and current-head GitHub CI as the full-suite signal.

## Linked Issues / Related PRs
- No linked issue is required for this narrow route-ownership refactor.
- Related separate lane: PR #2018 owns dependency/proxy tooling; this BMI PR does not modify proxy, dependency, or install behavior.
- PR #2014 belongs to the colleague lane and was not touched from this worktree.

## Split Justification
This PR is already the narrow split for BMI route ownership: canonical registration, compatibility exports, guardrails, and focused tests. Splitting the registrar from its bootstrap wiring or tests would leave duplicate route ownership and review-governance proof incomplete. Dependency/proxy, broad legacy removal, frontend/iOS, AI, and deprecated-endpoint cleanup remain separate lanes.

## Files Changed
- `app/main.py`
- `app/__init__.py`
- `app/routers/bmi_registration.py`
- `legacy_app.py`
- `scripts/ci/check_legacy_growth_guard.py`
- `tests/test_bmi_registration_router_coverage.py`
- `tests/test_legacy_growth_guard.py`
- `tests/test_main_paywall_bootstrap.py`
- `docs/architecture/backend_routing_map.md`
- `docs/review/PR_2016_FIXED_MAPPING.md`

## Key Decisions
- `legacy_app.py` now keeps compatibility placeholders only; it no longer owns BMI router imports or `include_router(...)` calls.
- `register_bmi_routes(app)` is fail-closed: unexpected, empty, duplicate, partial, or unguarded BMI route families raise before registration.
- BMI registration guard failures now include concrete route mismatch details for path/method, duplicate key, member type, and OpenAPI visibility drift.
- `register_bmi_routes(app)` documents per-app first-call feature flag caching; fresh app/process construction is the supported way to observe a changed `FEATURE_BMI_PRO_ENABLED` value.
- `app.main` mirrors compatibility attributes after canonical registration so old import surfaces remain stable.
- Canonical app entrypoint for this route ownership proof is `app.main:app`; direct legacy compatibility app construction is not the production route owner.

## Tests / Validation
Local full `make verify` was intentionally not run under the operator-approved machine-heavy exception.

Passed locally:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/ci/check_legacy_growth_guard.py`
- `git diff --check origin/main...HEAD`
- `FEATURE_BMI_PRO_ENABLED=0` route inventory proof: exactly `POST /api/v1/bmi/calculate` for the BMI route-family set.
- `FEATURE_BMI_PRO_ENABLED=1` route inventory proof: exactly `POST /api/v1/bmi/calculate`, `POST /api/v1/pro/bmi`, `POST /api/v1/pro/bmi/calculate`, `POST /api/v1/bmi/pro`; Pro routes guarded by `require_pro_tier`; legacy alias remains deprecated with migration metadata.
- `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_bmi_registration_router_coverage.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_bmi_calculate_endpoint.py tests/test_bmi_pro_api.py tests/test_bmi_pro_endpoint_errors.py tests/test_bmi_pro_missing_hip.py tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_bola_contract_pack.py tests/test_paid_route_guards.py`
- `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" make openapi-check`
- `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" PREPUSH_DEBUG=1 make validate-changed`
- `PATH="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH" pre-commit run --all-files`
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 2016 --commit-range origin/main..HEAD --experiment-runner-evidence-mode required --body "$(gh pr view 2016 --repo Katsiarynakavaleuskaya/PulsePlate --json body -q .body)"`
- Experiment Runner `artifacts/orchestration/experiments/results/exp-fb358458ae4e.json`: accepted after Sourcery remediation, all oracle return codes `0`.
- Pre-push hooks through head `33580147d`: changed-files mypy where applicable, pip-audit, backend tests, full-repo Bandit, and Docker build test where applicable.
- After dependency-stack rebase onto `220139000`: `check_preflight.py`, `check_agent_consistency.py`, `check_legacy_growth_guard.py`, FEATURE_BMI_PRO_ENABLED=0/1 route inventory proofs, focused BMI/security pytest bundle, `make openapi-check`, `make validate-changed`, `pre-commit run --all-files`, `git diff --check`, and push-time pre-push hooks all passed.
- After Codecov patch-coverage remediation: focused coverage for `app/routers/bmi_registration.py` reports `100.00%` line and branch coverage; `make validate-changed`, `pre-commit run --all-files`, `git diff --check`, and commit hooks passed.
- After CI-selected diff-coverage remediation: `tests/test_main_paywall_bootstrap.py` now carries the BMI registrar success and fail-closed branch coverage that CI `test-pr` selects; local coverage through that file reports `100.00%` for `app/routers/bmi_registration.py`. `check_preflight.py`, `check_agent_consistency.py`, `check_legacy_growth_guard.py`, `make openapi-check`, `make validate-changed`, `pre-commit run --all-files`, `git diff --check`, and commit hooks passed.
- After CodeRabbit advisory docstring remediation: production BMI registration helpers now have concise docstrings; focused pytest and selected-suite coverage proof still report `100.00%` for `app/routers/bmi_registration.py`; `git diff --check` and commit hooks passed.
- After CodeRabbit duplicate-test nitpick remediation: `tests/test_bmi_registration_router_coverage.py` no longer duplicates the router-validation regex assertions now owned by the CI-selected `tests/test_main_paywall_bootstrap.py`; focused pytest across both BMI test files and selected-suite coverage proof still report `100.00%` for `app/routers/bmi_registration.py`.

## Security Notes
- Free BMI calculation remains public/free.
- BMI Pro and legacy BMI Pro alias remain behind `require_pro_tier` when enabled.
- Duplicate FastAPI method/path registrations are guarded by canonical route-family registration tests.
- No secrets, auth token handling, billing, deploy, or migration surfaces are changed.

## Risks / Rollback
Rollback is a clean revert of the BMI registration commits, which restores previous legacy ownership. Primary risks are duplicate route registration or accidentally exposing Pro BMI without tier guard; both are covered by the new focused tests, route inventory proof, security contract tests, and legacy-growth guard.

## Deferred / Follow-ups
None. Current-PR actionables are to be fixed in this PR, not deferred by default.

## AGENTS.md Or Agent-Instruction Updates
None in this production-code PR. The local-validation policy preference stays separate from this BMI runtime refactor.

## Lane Start Provenance
Packet: artifacts/orchestration/task_packets/68028055c67e.json

Role order executed before implementation:
`agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`

Post-open packet:
`artifacts/orchestration/task_packets/b9100128481b.json`

## Premortem Risk Review
- PM-BMI-001: validation too narrow. Disposition: FIXED by focused BMI/bootstrap/security/OpenAPI tests, `make validate-changed`, and `pre-commit run --all-files`.
- PM-BMI-002: duplicate or lost BMI route guard. Disposition: FIXED by canonical route-family guard and focused route inventory tests.
- Hidden assumption: canonical `app.main:app` runtime ownership. Disposition: NOT-A-BUG because backend runtime route ownership is proven through canonical `app.main` bootstrap.

## Experiment Runner Evidence
Artifact: artifacts/orchestration/experiments/results/exp-fb358458ae4e.json

Result: accepted. Oracle commands passed:
- focused BMI/bootstrap/security pytest bundle
- `make openapi-check`
- `python3 scripts/ci/check_legacy_growth_guard.py`

The first Runner packet that included `make validate-changed` was rejected because the sandbox checkout intentionally lacks the shared repo `.venv`; `make validate-changed` was therefore validated in the real worktree and kept as a required local gate.

## Post-Open Review Evidence
- PASS: post-open packet `artifacts/orchestration/task_packets/b9100128481b.json`.
- PASS: mandatory role order executed: `qa-engineer-agent -> bug-hunter -> security-auditor`.
- PASS: `qa-engineer-agent` found no current-PR QA actionables.
- PASS: `bug-hunter` found no current-PR regressions.
- PASS: `security-auditor` refreshed on current head and found no security actionables.
- PASS: Codex Security diff scan/finding discovery artifact: `artifacts/security_lab/pr_2016_bmi_bootstrap/diff_security_scan.md`, no reportable findings.
- PASS: `pulseplate-pr-review` run; advisory `large-diff-risk` dispositioned as NOT-A-BUG in the fixed mapping.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Review/actionable mapping is tracked in `docs/review/PR_2016_FIXED_MAPPING.md`.

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#pullrequestreview-4560935403 -> 3301be7d65a171c9cc029930ff9f73cec58a3b16
Disposition: FIXED
Commit: 3301be7d65a171c9cc029930ff9f73cec58a3b16
Evidence: BMI registration diagnostics and first-call feature-flag caching were clarified in code/docstring and covered by `tests/test_bmi_registration_router_coverage.py`; focused pytest, `make openapi-check`, `make validate-changed`, `pre-commit run --all-files`, and Phase2 gates passed.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#pullrequestreview-4565385286 -> 42978e28e086aee0c007f71da44276b801ba87b6
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#discussion_r3469821502 -> 42978e28e086aee0c007f71da44276b801ba87b6
Disposition: FIXED
Commit: 42978e28e086aee0c007f71da44276b801ba87b6
Evidence: `docs/review/PR_2016_FIXED_MAPPING.md` keeps merge-readiness gate checklist items unchecked until final merge readiness while preserving completed-work evidence in prose above. `git diff --check`, `check_preflight.py`, and commit hooks passed.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#issuecomment-4793153666 -> 68c1d4d6ecee59a1d01af7d00def0197df9ff4e0
Disposition: FIXED
Commit: 68c1d4d6ecee59a1d01af7d00def0197df9ff4e0
Evidence: `tests/test_bmi_registration_router_coverage.py` now covers the BMI registration guard branches Codecov reported for `app/routers/bmi_registration.py`: non-`APIRoute` members, multi-method source routes, duplicate source routes, and `include_in_schema` drift. Focused coverage reports `100.00%` line and branch coverage for the file; `make validate-changed`, `pre-commit run --all-files`, `git diff --check`, and commit hooks passed.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#issuecomment-4787837121 -> 5e2e125a5cd733c96b1f3715d98f2a85c853d20b
Disposition: FIXED
Commit: 5e2e125a5cd733c96b1f3715d98f2a85c853d20b
Evidence: `app/routers/bmi_registration.py` now documents the production BMI registration helper functions. The PR body also includes related-PR context and split justification. Test-function docstrings remain intentionally out of scope because PulsePlate test style does not require per-test docstrings and adding broad test docstrings would reduce signal without changing the runtime BMI contract.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2016#pullrequestreview-4566649513 -> d2748ac9b109bfedaf74b7e3c6360f4eab04602c
Disposition: FIXED
Commit: d2748ac9b109bfedaf74b7e3c6360f4eab04602c
Evidence: `tests/test_bmi_registration_router_coverage.py` no longer duplicates router-validation regex assertions owned by the CI-selected `tests/test_main_paywall_bootstrap.py` suite. Focused pytest across both BMI test files and selected-suite coverage proof passed after the de-duplication.

Canonical artifact: `docs/review/PR_2016_FIXED_MAPPING.md`.

Implementation commits:
- `ba1eabf3d` - move BMI registration to canonical bootstrap.
- `761e2637a` - add PR #2016 fixed mapping artifact.
- `614c37f0c` - align PR #2016 mapping artifact with Phase2 parser contract.
- `3301be7d6` - clarify BMI registration guard failures.
- `b045a55a3` - map Sourcery feedback in the canonical artifact.
- `240f481e9` - record post-open role/security/review evidence.
- `33580147d` - refresh fixed mapping after dependency-stack rebase.
- `42978e28e` - keep merge-readiness gate checkboxes unchecked until the final merge-readiness pass.
- `0becdd6ae` - map CodeRabbit gate feedback in the canonical artifact.
- `4ebc9e45f` - include CodeRabbit review-summary URL in the canonical mapping.
- `68c1d4d6e` - cover BMI registration guard drift branches reported by Codecov.
- `9bfc5e50d` - map Codecov coverage feedback in the canonical artifact.
- `855738ce7` - move BMI registrar branch coverage into the CI-selected main bootstrap suite.
- `ff7c6d335` - map the CI-selected diff-coverage remediation evidence.
- `5e2e125a5` - document BMI registration production helpers.
- `989e56a9e` - disposition CodeRabbit advisory checks in the canonical artifact.
- `c86d46ae7` - record final merge-readiness evidence in the canonical artifact.
- `d2748ac9b` - deduplicate BMI registrar guard coverage after CodeRabbit nitpick.
- `5a7d6a927` - map the duplicate-test nitpick in the canonical artifact.

## Merge Readiness
Final merge-readiness pass completed with the documented operator-approved machine-heavy local `make verify` exception. Full-suite truth is current-head GitHub CI; local validation used the PR-scoped narrow gates recorded above.

- [x] Current-head GitHub CI passes for the pushed head.
- [x] Post-open role passes completed: `qa-engineer-agent -> bug-hunter -> security-auditor`.
- [x] Codex Security diff scan/finding discovery run.
- [x] `pulseplate-pr-review` run; advisory `large-diff-risk` dispositioned.
- [x] CodeRabbit, Sourcery, Cubic, Codecov, and human review surfaces inspected; all current-PR actionables fixed or dispositioned.
- [x] PR body mirrors `docs/review/PR_2016_FIXED_MAPPING.md`.
- [x] Strict merge-readiness checks pass with the documented machine-heavy exception.

Final readiness evidence:
- Current-head CI passed for the BMI/backend lane: `test-pr (3.13)`, `coverage-pr`, `diff-coverage`, `codecov/patch`, `lint`, `security`, `security-scan`, `OpenAPI sync`, `build`, CodeQL, PR body Phase2 gates, merge-readiness gate, docs/governance guards, and PR automation.
- Expected skips/neutral checks were limited to untouched specialized lanes such as iOS, feature/main coverage lanes, publish, Trivy, Sourcery review, and Cubic.
- `check_review_threads_disposition.py --pr-number 2016 --require-auth` passed.
- `check_merge_ready.py --pr-number 2016 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BMI route registration is now handled by the main app startup, ensuring the standard BMI calculator is always available and enabling BMI Pro routes when the feature flag is on.
* **Bug Fixes**
  * Prevents duplicate or partially registered BMI Pro route families; improves robustness of route setup.
* **Documentation**
  * Updated backend routing documentation and added a review mapping note for BMI Pro ownership and feature-flag behavior.
* **Tests**
  * Added and extended tests to validate default vs enabled behavior, OpenAPI metadata stability, dependency wiring, and legacy compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





