### PR TITLE
refactor(api): move bodyfat registration to canonical bootstrap

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -43,6 +43,7 @@ _LOCAL_EXPORTS: dict[str, tuple[str, str]] = {
     "bmi_router": ("app.main", "bmi_router"),
     "bmi_pro_router": ("app.main", "bmi_pro_router"),
     "bmi_pro_legacy_alias_router": ("app.main", "bmi_pro_legacy_alias_router"),
+    "get_bodyfat_router": ("app.routers.bodyfat", "get_router"),
 }
 
 
@@ -138,6 +139,7 @@ __all__ = [
     "bmi_router",
     "bmi_pro_router",
     "bmi_pro_legacy_alias_router",
+    "get_bodyfat_router",
     "MATPLOTLIB_AVAILABLE",
     "generate_bmi_visualization",
 ]

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ from app.routers.admin_operations import (
     ADMIN_OPERATION_ROUTE_SPECS,
     router as admin_operations_router,
 )
+from app.routers.bodyfat import BODYFAT_ROUTE_SPECS, router as bodyfat_router
 from app.routers.bmi_compat import BMI_COMPAT_ROUTE_SPECS, router as bmi_compat_router
 from app.routers.bmi_registration import BmiRouteRegistration, register_bmi_routes
 from app.routers.billing import register_billing_routes
@@ -110,6 +111,10 @@ _ADMIN_OPERATION_ROUTE_SPECS: tuple[tuple[str, str], ...] = tuple(
 _BMI_COMPAT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in BMI_COMPAT_ROUTE_SPECS
+)
+_BODYFAT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in BODYFAT_ROUTE_SPECS
 )
 _LEGACY_EXPORT_ALIAS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
@@ -245,6 +250,17 @@ def _restaurant_moderation_route_members(
             required_dependencies=(api_key_dependency,),
         )
         for path, method, include_in_schema in _RESTAURANT_MODERATION_ROUTE_SPECS
+    )
+
+
+def _bodyfat_route_members() -> tuple[RouteMemberContract, ...]:
+    return tuple(
+        RouteMemberContract(
+            path=path,
+            method=method,
+            include_in_schema=include_in_schema,
+        )
+        for path, method, include_in_schema in _BODYFAT_ROUTE_SPECS
     )
 
 
@@ -756,6 +772,17 @@ def _include_shoplist_export_router_if_needed(target_app: FastAPI) -> None:
     )
 
 
+def _include_bodyfat_router_if_needed(target_app: FastAPI) -> None:
+    """Register public bodyfat route as one canonical static family."""
+
+    ensure_route_family_registered(
+        target_app,
+        family_name="Bodyfat",
+        routers=(bodyfat_router,),
+        members=_bodyfat_route_members(),
+    )
+
+
 def _include_restaurant_moderation_router_if_needed(target_app: FastAPI) -> None:
     """Register restaurant moderation route as one protected atomic family."""
 
@@ -924,6 +951,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _include_admin_operations_router_if_needed(app)
     _register_bmi_routes(app)
     _include_bmi_compat_router_if_needed(app)
+    _include_bodyfat_router_if_needed(app)
     _include_plan_export_routers_if_needed(app)
     _include_shoplist_export_router_if_needed(app)
     _include_legacy_export_alias_router_if_needed(app)

--- a/app/routers/bodyfat.py
+++ b/app/routers/bodyfat.py
@@ -39,6 +39,19 @@ class BodyFatRequest(BaseModel):
         )
 
 
+class BodyFatLabels(BaseModel):
+    methods: str
+    median: str
+    units: str
+
+
+class BodyFatResponse(BaseModel):
+    methods: dict[str, float]
+    median: float | None
+    lang: str
+    labels: BodyFatLabels
+
+
 async def calc_bodyfat(req: BodyFatRequest) -> dict[str, object]:
     lang = normalize_lang(req.language)
     data: dict[str, object] = dict(req.model_dump(exclude_none=True))
@@ -67,10 +80,10 @@ async def calc_bodyfat(req: BodyFatRequest) -> dict[str, object]:
 
 
 router = APIRouter()
-router.post("/api/v1/bodyfat")(calc_bodyfat)
+router.post("/api/v1/bodyfat", response_model=BodyFatResponse)(calc_bodyfat)
 
 
 def get_router() -> APIRouter:
     compat_router = APIRouter()
-    compat_router.post("/bodyfat")(calc_bodyfat)
+    compat_router.post("/bodyfat", response_model=BodyFatResponse)(calc_bodyfat)
     return compat_router

--- a/app/routers/bodyfat.py
+++ b/app/routers/bodyfat.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, Field, field_validator
 from core.bodyfat import estimate_all
 from core.i18n import normalize_lang, t
 
+BODYFAT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (("/api/v1/bodyfat", "POST", True),)
+
 
 class BodyFatRequest(BaseModel):
     height_m: Optional[float] = Field(None, gt=0, description="Height in meters, must be positive")
@@ -37,34 +39,38 @@ class BodyFatRequest(BaseModel):
         )
 
 
+async def calc_bodyfat(req: BodyFatRequest) -> dict[str, object]:
+    lang = normalize_lang(req.language)
+    data: dict[str, object] = dict(req.model_dump(exclude_none=True))
+
+    # Convert meters to centimeters for core.bodyfat US Navy compatibility.
+    if req.height_m is not None:
+        data.setdefault("height_cm", req.height_m * 100.0)
+
+    if req.bmi is None and req.weight_kg is not None and req.height_m is not None:
+        data["bmi"] = req.weight_kg / (req.height_m**2)
+
+    result = estimate_all(data)
+
+    labels = {
+        "methods": t(lang, "bodyfat_methods"),
+        "median": t(lang, "bodyfat_median"),
+        "units": t(lang, "bodyfat_units_percent"),
+    }
+
+    return {
+        "methods": result["methods"],
+        "median": result["median"],
+        "lang": str(lang),
+        "labels": labels,
+    }
+
+
+router = APIRouter()
+router.post("/api/v1/bodyfat")(calc_bodyfat)
+
+
 def get_router() -> APIRouter:
-    router = APIRouter()
-
-    @router.post("/bodyfat")
-    async def calc_bodyfat(req: BodyFatRequest) -> dict[str, object]:
-        lang = normalize_lang(req.language)
-        data: dict[str, object] = dict(req.model_dump(exclude_none=True))
-
-        # Convert meters to centimeters for core.bodyfat US Navy compatibility.
-        if req.height_m is not None:
-            data.setdefault("height_cm", req.height_m * 100.0)
-
-        if req.bmi is None and req.weight_kg is not None and req.height_m is not None:
-            data["bmi"] = req.weight_kg / (req.height_m**2)
-
-        result = estimate_all(data)
-
-        labels = {
-            "methods": t(lang, "bodyfat_methods"),
-            "median": t(lang, "bodyfat_median"),
-            "units": t(lang, "bodyfat_units_percent"),
-        }
-
-        return {
-            "methods": result["methods"],
-            "median": result["median"],
-            "lang": str(lang),
-            "labels": labels,
-        }
-
-    return router
+    compat_router = APIRouter()
+    compat_router.post("/bodyfat")(calc_bodyfat)
+    return compat_router

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -181,7 +181,7 @@ Evidence:
   - `responses=RATE_LIMIT_429_RESPONSES`
   - `@limit_if_available(RATE_LIMIT_EXPORTS)`
 
-### Conditional routers: Bodyfat / BMI Pro / Business
+### Conditional routers: BMI Pro / Business
 
 Anchor (stable): `app/main.py -> app/routers/bmi_registration.py` owns BMI route registration; `legacy_app.py` remains a compatibility seam for direct-call shims and mirrored attrs.
 
@@ -189,12 +189,36 @@ Evidence:
 - `app/main.py -> ensure_canonical_app_bootstrap()`
 - `app/routers/bmi_registration.py -> register_bmi_routes()`
 
-- Bodyfat: included if router factory is available (`get_bodyfat_router`)
 - BMI Free: canonical `/api/v1/bmi/calculate` is registered by `app/main.py` via `app/routers/bmi_registration.py`
 - BMI Pro: registered by `app/main.py` via `app/routers/bmi_registration.py`, included only if `FEATURE_BMI_PRO_ENABLED` is truthy
   - canonical: `/api/v1/pro/bmi`
   - legacy alias: `/api/v1/bmi/pro`
 - Business: included only if `BUSINESS_MODULE_ENABLED` is truthy
+
+### Bodyfat route family (canonical-owned bootstrap)
+
+Anchor (stable): `app/main.py -> _include_bodyfat_router_if_needed(app)` owns
+`app/routers/bodyfat.py`.
+
+Evidence:
+- `app/routers/bodyfat.py` defines `BODYFAT_ROUTE_SPECS`, a module-level
+  canonical router for `POST /api/v1/bodyfat`, and a stable direct-inclusion
+  `get_router()` adapter for old `/bodyfat` compatibility tests/utilities.
+- `app/main.py -> _include_bodyfat_router_if_needed(app)` registers the
+  canonical bodyfat family through `ensure_route_family_registered(...)` and
+  `RouteMemberContract`.
+- `legacy_app.py` does not import or include `app.routers.bodyfat`; legacy
+  growth guard tests reject direct, aliased, module-qualified, and factory-based
+  bodyfat re-registration in `legacy_app.py`.
+
+Runtime effect:
+- In normal runtime: `POST /api/v1/bodyfat` is routable exactly once through
+  canonical bootstrap.
+- Direct compatibility: including `app.routers.bodyfat.get_router()` still
+  provides unprefixed `POST /bodyfat` for old direct-router inclusion callers.
+- OpenAPI: the source route keeps `include_in_schema=True`, but the final
+  canonical OpenAPI builder still filters `/api/v1/bodyfat` out of published
+  `/openapi.json`; generated client/OpenAPI artifacts are unchanged.
 
 ### Test router (non-production env)
 

--- a/docs/review/BODYFAT_CANONICAL_BOOTSTRAP_PREMORTEM.md
+++ b/docs/review/BODYFAT_CANONICAL_BOOTSTRAP_PREMORTEM.md
@@ -51,7 +51,7 @@ the current runtime contract is hidden-but-routable.
 Closure: FIXED. The source route keeps `include_in_schema=True` to preserve
 source metadata, the final canonical OpenAPI builder continues filtering the
 path, and tests cover both bootstrap visibility drift and final OpenAPI hiding.
-`make openapi-check DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
+`VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" make openapi-check DEV_PYTHON="$VENV_PYTHON"`
 passed with no generated artifact diff.
 
 ### 4. Validation looked green while changed files were not selected

--- a/docs/review/BODYFAT_CANONICAL_BOOTSTRAP_PREMORTEM.md
+++ b/docs/review/BODYFAT_CANONICAL_BOOTSTRAP_PREMORTEM.md
@@ -1,0 +1,107 @@
+# Bodyfat Canonical Bootstrap Premortem
+
+Mode: `pr-premortem`
+
+Skill: `pulseplate-premortem-risk-review`
+
+Task packet: `artifacts/orchestration/task_packets/b1f4071b1aa9.json`
+
+## Summary
+
+Plan: move `POST /api/v1/bodyfat` route ownership from `legacy_app.py` to
+canonical `app.main` bootstrap without changing bodyfat formulas, schemas,
+response shape, auth/tier policy, or generated OpenAPI/client artifacts.
+
+Frame: it is 6 months from now, this cleanup failed, and we are looking
+backward to understand why.
+
+## Failure Modes And Closure
+
+### 1. Legacy route ownership returned through a different import shape
+
+Failure story: removing the obvious `get_bodyfat_router()` include would not be
+enough if a later edit reintroduced `app.routers.bodyfat.router`, an alias, or a
+module-qualified include in `legacy_app.py`. That would quietly restore duplicate
+route ownership and make `legacy_app.py` keep growing as a runtime router owner.
+
+Closure: FIXED. `legacy_app.py` no longer imports or includes
+`app.routers.bodyfat`, `scripts/ci/check_legacy_growth_guard.py` no longer
+allowlists the bodyfat import/registration facts, and
+`tests/test_legacy_growth_guard.py` rejects factory, direct, aliased, and
+module-qualified bodyfat re-registration.
+
+### 2. Compatibility callers got the wrong prefix
+
+Failure story: canonicalizing the module-level router could break old direct
+inclusion callers if `get_router()` started returning `/api/v1/bodyfat` instead
+of the historical unprefixed `/bodyfat` route. That would preserve production
+runtime while breaking root shim/direct router compatibility tests and utilities.
+
+Closure: FIXED. `app/routers/bodyfat.py` now has a canonical module-level router
+for `/api/v1/bodyfat`, while `get_router()` returns a fresh compatibility router
+for `/bodyfat`. `tests/test_main_paywall_bootstrap.py` proves `/bodyfat` works
+for direct inclusion and `/api/v1/bodyfat` is not created by that adapter.
+
+### 3. OpenAPI visibility drift leaked bodyfat into generated clients
+
+Failure story: moving ownership to `app.main` could make `/api/v1/bodyfat`
+appear in the published OpenAPI schema or generated frontend types, even though
+the current runtime contract is hidden-but-routable.
+
+Closure: FIXED. The source route keeps `include_in_schema=True` to preserve
+source metadata, the final canonical OpenAPI builder continues filtering the
+path, and tests cover both bootstrap visibility drift and final OpenAPI hiding.
+`make openapi-check DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
+passed with no generated artifact diff.
+
+### 4. Validation looked green while changed files were not selected
+
+Failure story: `make validate-changed` can report success without selecting
+uncommitted branch changes, creating false confidence if focused tests are not
+run against the actual changed surface.
+
+Closure: FIXED for this lane. Focused bodyfat/bootstrap/legacy guard/API tests
+passed, `pre-commit run --all-files` passed after formatting hook fixes, and
+`make validate-changed` will be repeated after commit so the branch diff exists
+for the selector.
+
+## Most Likely Failure
+
+The most likely failure was legacy ownership returning in a different import
+shape, because the prior allowlist explicitly accepted the bodyfat factory path.
+
+## Most Dangerous Failure
+
+The most dangerous failure was duplicate runtime ownership with hidden OpenAPI
+drift: users would still get 200 responses, but route truth and generated
+contract truth would diverge.
+
+## Hidden Assumption
+
+The hidden assumption was that deleting the old include was enough. It was not;
+the guard needed to shrink so the same route could not come back under another
+import spelling.
+
+## Revised Plan
+
+- Keep the canonical `app.main` bootstrap implementation.
+- Keep `get_router()` as an unprefixed compatibility adapter.
+- Shrink the legacy growth guard allowlist and add bodyfat-specific negative
+  tests.
+- Record BMI derivation delegation as a separate backlog item instead of
+  changing bodyfat math in this PR.
+
+## Pre-Merge Checklist
+
+- Focused bodyfat API and bootstrap tests pass.
+- `scripts/ci/check_legacy_growth_guard.py` passes.
+- `make openapi-check` passes with repo venv and no generated artifact diff.
+- `make validate-changed` is run after commit so branch diff selection is real.
+- `pre-commit run --all-files` passes.
+- Full local `make verify` remains explicitly deferred per operator CPU
+  constraint, with no merge-ready claim.
+
+## Decision
+
+`proceed with changes`: the risky parts are addressed by code, guards, tests,
+documentation, and a backlog follow-up for BMI derivation delegation.

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -85,9 +85,9 @@ frontend runtime, iOS, or migration changes.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021#discussion_r3473407588 -> 87a931b921098fb2da1de486753a988ad99b9ff2
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021#discussion_r3473407591 -> 87a931b921098fb2da1de486753a988ad99b9ff2
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021#discussion_r3473407623 -> 87a931b921098fb2da1de486753a988ad99b9ff2
-
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021#pullrequestreview-4569752389 -> 87a931b921098fb2da1de486753a988ad99b9ff2
 Disposition: FIXED
-
+Commit: 87a931b921098fb2da1de486753a988ad99b9ff2
 Evidence: commit `87a931b921098fb2da1de486753a988ad99b9ff2` adds typed bodyfat response metadata, closes `builtins.__import__` alias and walrus import-function alias bypasses, fixes review artifact command/checklist hygiene, and adds JSON content-type test clarity; validation passed via focused pytest (`41 passed`), legacy guard script, openapi-check, validate-changed, agent consistency, pre-commit all-files, and diff check.
 
 ## Mapping Notes

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -7,9 +7,9 @@ Branch: `codex/move-bodyfat-registration-to-canonical-bootstrap`
 ## Summary
 
 This PR moves `POST /api/v1/bodyfat` route ownership from `legacy_app.py` to
-canonical `app.main` bootstrap without changing formulas, schemas, response
-shape, auth/tier policy, rate limiting, generated OpenAPI, or generated client
-artifacts.
+canonical `app.main` bootstrap without changing formulas, request validation,
+response payload shape, auth/tier policy, rate limiting, generated OpenAPI, or
+generated client artifacts.
 
 ## Scope
 
@@ -22,14 +22,16 @@ artifacts.
 - Remove bodyfat import/include ownership from `legacy_app.py`.
 - Shrink the legacy growth guard allowlist and add bodyfat-specific negative
   tests for factory, direct, aliased, and module-qualified re-registration.
+- Add typed bodyfat response-model metadata on hidden/direct route declarations
+  without changing the returned payload shape or generated client artifacts.
 - Update backend routing documentation and backlog a P1 follow-up for future
   BMI-engine derivation delegation.
 
 ## Out Of Scope
 
-No bodyfat math, BMI derivation semantics, schema, response-shape, auth/tier,
-rate-limit, generated OpenAPI/client, DB, frontend runtime, iOS, or migration
-changes.
+No bodyfat math, BMI derivation semantics, request-validation behavior,
+response-payload shape, auth/tier, rate-limit, generated OpenAPI/client, DB,
+frontend runtime, iOS, or migration changes.
 
 ## Implementation Commits
 
@@ -42,6 +44,9 @@ changes.
   destructuring, and walrus assignment shapes.
 - `bf5436342` - preserves the security-auditor guard fix while satisfying the
   changed-file mypy pre-push hook.
+- `87a931b92` - fixes current-head CodeRabbit actionables: typed hidden/direct
+  bodyfat response metadata, remaining dynamic-import guard bypasses, review
+  artifact command/checklist hygiene, and JSON content-type test clarity.
 
 ## Lane Start Provenance
 
@@ -75,7 +80,25 @@ changes.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021#discussion_r3473407568 -> 87a931b921098fb2da1de486753a988ad99b9ff2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021#discussion_r3473407580 -> 87a931b921098fb2da1de486753a988ad99b9ff2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021#discussion_r3473407588 -> 87a931b921098fb2da1de486753a988ad99b9ff2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021#discussion_r3473407591 -> 87a931b921098fb2da1de486753a988ad99b9ff2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021#discussion_r3473407623 -> 87a931b921098fb2da1de486753a988ad99b9ff2
+
+Disposition: FIXED
+
+Evidence: commit `87a931b921098fb2da1de486753a988ad99b9ff2` adds typed
+bodyfat response-model metadata for both hidden/direct registrations, closes
+`builtins.__import__` alias and walrus import-function alias bypasses in
+`scripts/ci/check_legacy_growth_guard.py`, adds matching guard regressions,
+fixes the review artifact `openapi-check` command/checklist state, and asserts
+JSON content type before parsing the direct bodyfat compatibility response.
+Validation passed: focused bodyfat/bootstrap/API/legacy-guard pytest suite
+(`41 passed`), `python3 scripts/ci/check_legacy_growth_guard.py`,
+`VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`,
+`make validate-changed`, `python3 scripts/orchestration/check_agent_consistency.py`,
+`pre-commit run --all-files`, and `git diff --check`.
 
 ## Mapping Notes
 
@@ -287,6 +310,16 @@ passed. The post-commit run selected `tests/test_api.py`,
   `large-diff-risk` note, dispositioned above.
 - PASS on push hook: changed-files mypy, pre-push backend pytest, full-repo
   Bandit, and Docker build test.
+- PASS after CodeRabbit fix:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_main_paywall_bootstrap.py -k bodyfat tests/test_api.py::test_v1_bodyfat tests/test_api.py::test_v1_bodyfat_missing_hip tests/test_api.py::test_bodyfat_router_export_uses_canonical_package_path tests/test_app_bodyfat_v1.py tests/test_bodyfat_labels_coverage.py tests/edges/test_bodyfat_edges.py tests/test_bodyfat_shim.py tests/test_docker_workflow_build_path_contract.py::test_docker_entrypoint_keeps_bodyfat_hidden_but_routable tests/test_app_public_surface.py::test_app_public_surface_smoke tests/test_legacy_growth_guard.py`
+  (`41 passed`).
+- PASS after CodeRabbit fix: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS after CodeRabbit fix:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`
+- PASS after CodeRabbit fix: `make validate-changed`
+- PASS after CodeRabbit fix: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS after CodeRabbit fix: `pre-commit run --all-files`
+- PASS after CodeRabbit fix: `git diff --check`
 
 Full local `make verify` was not run per operator CPU constraint. This PR does
 not claim merge readiness from local gates alone.

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -1,0 +1,200 @@
+# PR #2021 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2021
+
+Branch: `codex/move-bodyfat-registration-to-canonical-bootstrap`
+
+## Summary
+
+This PR moves `POST /api/v1/bodyfat` route ownership from `legacy_app.py` to
+canonical `app.main` bootstrap without changing formulas, schemas, response
+shape, auth/tier policy, rate limiting, generated OpenAPI, or generated client
+artifacts.
+
+## Scope
+
+- Add `BODYFAT_ROUTE_SPECS` and a module-level canonical bodyfat router in
+  `app/routers/bodyfat.py`.
+- Register the bodyfat static family from `app/main.py` through
+  `RouteMemberContract` and `ensure_route_family_registered(...)`.
+- Keep `app.routers.bodyfat.get_router()` as a fresh unprefixed `/bodyfat`
+  compatibility adapter for old direct-inclusion callers.
+- Remove bodyfat import/include ownership from `legacy_app.py`.
+- Shrink the legacy growth guard allowlist and add bodyfat-specific negative
+  tests for factory, direct, aliased, and module-qualified re-registration.
+- Update backend routing documentation and backlog a P1 follow-up for future
+  BMI-engine derivation delegation.
+
+## Out Of Scope
+
+No bodyfat math, BMI derivation semantics, schema, response-shape, auth/tier,
+rate-limit, generated OpenAPI/client, DB, frontend runtime, iOS, or migration
+changes.
+
+## Implementation Commits
+
+- `d8c2313fc157ca39109268e262af7644056e028b` - moves bodyfat route
+  registration to canonical bootstrap, removes legacy ownership, adds guards
+  and tests, and records premortem/backlog evidence.
+
+## Lane Start Provenance
+
+- Base branch: `main`
+- Branch: `codex/move-bodyfat-registration-to-canonical-bootstrap`
+- Packet: `artifacts/orchestration/task_packets/b1f4071b1aa9.json`
+- Role order executed pre-open:
+  `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`
+- Packet creation was treated as provenance/routing only; role passes were
+  executed explicitly before implementation.
+
+## Discussion Thread Pass
+
+- [x] Fixed mapping artifact created after GitHub assigned PR number `#2021`.
+- [ ] Post-open discussion-thread pass pending.
+- [ ] CodeRabbit comments/actionables inspected.
+- [ ] Sourcery comments/actionables inspected.
+- [ ] Cubic comments/actionables inspected.
+- [ ] Current-head CI complete before readiness language.
+- [ ] Strict merge-readiness checks run after the final review/check cycle.
+
+## Fixed in Commit Mapping
+
+Initial PR open: no human review threads existed at artifact creation.
+
+No review-thread FIXED mappings are recorded yet. Any post-open actionable bot
+or human findings must be fixed, mapped here with disposition proof, mirrored in
+the PR body, and only then resolved.
+
+## Premortem Findings
+
+Artifact: `docs/review/BODYFAT_CANONICAL_BOOTSTRAP_PREMORTEM.md`
+
+Disposition: FIXED
+
+Finding: legacy bodyfat ownership could return through a different import shape.
+
+Commit: `d8c2313fc157ca39109268e262af7644056e028b`
+
+Evidence: `legacy_app.py` no longer imports/includes `app.routers.bodyfat`;
+`scripts/ci/check_legacy_growth_guard.py` no longer allowlists the bodyfat
+factory import/registration facts; `tests/test_legacy_growth_guard.py` rejects
+factory, direct, aliased, and module-qualified bodyfat re-registration.
+
+Disposition: FIXED
+
+Finding: direct `get_router()` compatibility callers could get the wrong route
+prefix after canonicalization.
+
+Commit: `d8c2313fc157ca39109268e262af7644056e028b`
+
+Evidence: `app/routers/bodyfat.py` keeps the canonical router at
+`/api/v1/bodyfat` and keeps `get_router()` as an unprefixed `/bodyfat`
+compatibility adapter; `tests/test_main_paywall_bootstrap.py` covers direct
+adapter `/bodyfat` success and `/api/v1/bodyfat` absence.
+
+Disposition: FIXED
+
+Finding: moving ownership could leak `/api/v1/bodyfat` into published OpenAPI or
+generated client artifacts.
+
+Commit: `d8c2313fc157ca39109268e262af7644056e028b`
+
+Evidence: `tests/test_main_paywall_bootstrap.py` covers source/final OpenAPI
+visibility behavior, and
+`VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" make openapi-check DEV_PYTHON="$VENV_PYTHON"`
+passed with no generated artifact diff.
+
+Disposition: FIXED
+
+Finding: `make validate-changed` could false-green before commit because the
+branch diff selector had no committed diff.
+
+Commit: `d8c2313fc157ca39109268e262af7644056e028b`
+
+Evidence: the pre-commit `make validate-changed` no-selection run was treated as
+non-sufficient; focused pytest, full `tests/test_legacy_growth_guard.py`,
+`pre-commit run --all-files`, and post-commit `make validate-changed` all
+passed. The post-commit run selected `tests/test_api.py`,
+`tests/test_app_public_surface.py`, `tests/test_bodyfat.py`,
+`tests/test_legacy_growth_guard.py`, and `tests/test_main_paywall_bootstrap.py`.
+
+## Experiment Runner Evidence
+
+- Packet:
+  `artifacts/orchestration/experiments/bodyfat-canonical-bootstrap-oracle-packet.json`
+- Result:
+  `artifacts/orchestration/experiments/results/bodyfat-canonical-bootstrap-oracle-result.json`
+- Experiment id: `exp-7c4838ebc835`
+- Status: accepted
+- Runner mode: `oracle_only_governance_reviewer`
+- Oracles passed:
+  - `python3 -m pytest -q tests/test_main_paywall_bootstrap.py -k bodyfat`
+  - `python3 -m pytest -q tests/test_legacy_growth_guard.py`
+  - `python3 scripts/ci/check_legacy_growth_guard.py`
+- Result: 3/3 oracle commands passed; `mutated_paths=[]`;
+  `shared_tree_untouched=true`; source diff was applied in the isolated
+  checkout.
+- Contribution kind: `oracle_review`
+- Co-author required: yes
+- Co-author trailer is present on implementation commit
+  `d8c2313fc157ca39109268e262af7644056e028b`.
+
+## Local Validation
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_main_paywall_bootstrap.py -k bodyfat`
+- PASS:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_legacy_growth_guard.py`
+- PASS:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_api.py::test_v1_bodyfat tests/test_api.py::test_v1_bodyfat_missing_hip tests/test_api.py::test_bodyfat_router_export_uses_canonical_package_path tests/test_app_bodyfat_v1.py tests/test_bodyfat_labels_coverage.py tests/edges/test_bodyfat_edges.py tests/test_bodyfat_shim.py tests/test_docker_workflow_build_path_contract.py::test_docker_entrypoint_keeps_bodyfat_hidden_but_routable tests/test_app_public_surface.py::test_app_public_surface_smoke`
+- PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" make openapi-check DEV_PYTHON="$VENV_PYTHON"`
+- PASS: `pre-commit run --all-files`
+- PASS: `make validate-changed`
+- PASS: `git show --check --oneline HEAD`
+- PASS on push hook: changed-files mypy, pre-push backend pytest, full-repo
+  Bandit, and Docker build test.
+
+Full local `make verify` was not run per operator CPU constraint. This PR does
+not claim merge readiness from local gates alone.
+
+## Security Notes
+
+No auth, billing, secrets, LLM, quota, rate-limit, entitlement, or tier policy
+changes. The security-relevant change is a stricter legacy growth guard that now
+rejects bodyfat route registration returning to `legacy_app.py`.
+
+## Risks / Rollback
+
+Risk: duplicate route ownership, OpenAPI visibility drift, or compatibility
+prefix regression.
+
+Mitigation: static route-family guard tests, legacy growth guard tests, direct
+router compatibility tests, focused API parity tests, and OpenAPI check.
+
+Rollback: revert this PR to restore the prior `legacy_app.py` bodyfat include
+path. No migration, generated client, or persisted data rollback is required.
+
+## Deferred / Follow-Ups
+
+- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-bodyfat-bmi-engine-delegation`:
+  delegate bodyfat missing-BMI derivation to the canonical BMI engine in a
+  separate parity-reviewed PR.
+
+## Merge Readiness
+
+Not merge-ready.
+
+Required before merge:
+
+- [ ] Current-head CI passes.
+- [ ] Post-open role passes completed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [ ] Codex Security diff scan / finding discovery run if available.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] CodeRabbit/Sourcery/Cubic comments inspected and dispositioned.
+- [ ] PR body mirrors this fixed-mapping artifact after artifact commit lands.
+- [ ] Strict merge-readiness checks pass.

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -52,6 +52,9 @@ changes.
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 - [x] Fixed mapping artifact created after GitHub assigned PR number `#2021`.
+- [x] Post-open `qa-engineer-agent` pass completed: no actionable findings.
+- [x] Post-open `bug-hunter` pass completed; actionable finding fixed and
+  dispositioned below.
 - [ ] Post-open discussion-thread pass pending.
 - [ ] CodeRabbit comments/actionables inspected.
 - [ ] Sourcery comments/actionables inspected.
@@ -69,6 +72,37 @@ Initial PR open: no human review threads existed at artifact creation. Any
 post-open actionable bot or human findings must be fixed, mapped in
 `## Fixed in Commit Mapping` with disposition proof, mirrored in the PR body,
 and only then resolved.
+
+## Post-Open Role Findings
+
+Role: `qa-engineer-agent`
+
+Disposition: NOT-A-BUG
+
+Evidence: Post-open QA pass found no actionable findings. Residual risk was
+limited to intentionally deferred full local `make verify`, pending current-head
+CI at review time, and external bot rate-limit/no-actionable states.
+
+Role: `bug-hunter`
+
+Disposition: FIXED
+
+Finding: `scripts/ci/check_legacy_growth_guard.py` could miss bodyfat route
+ownership reintroduced through a dynamic import assigned to an already
+allowlisted router name, for example
+`business_router = importlib.import_module("app.routers.bodyfat").router`.
+
+Commit: `44bc4440a`
+
+Evidence: `scripts/ci/check_legacy_growth_guard.py` now records dynamic
+`app.routers.*` imports assigned to local names as `router_import:dynamic`
+facts, while preserving the existing plan-export dynamic alias baseline.
+`tests/test_legacy_growth_guard.py` adds `importlib.import_module(...)` and
+`__import__(...)` bodyfat regressions hidden as `business_router`. Focused
+validation passed:
+`python3 scripts/ci/check_legacy_growth_guard.py`,
+`VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_legacy_growth_guard.py`, and
+`make validate-changed`.
 
 ## Premortem Findings
 

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -47,6 +47,8 @@ frontend runtime, iOS, or migration changes.
 - `87a931b92` - fixes current-head CodeRabbit actionables: typed hidden/direct
   bodyfat response metadata, remaining dynamic-import guard bypasses, review
   artifact command/checklist hygiene, and JSON content-type test clarity.
+- `73ada8d42` - closes the merge-ready bug-hunter nested dynamic router
+  composition bypass.
 
 ## Lane Start Provenance
 
@@ -155,6 +157,28 @@ the same helper to satisfy changed-file mypy; behavior remains covered by
 `tests/test_legacy_growth_guard.py` (`68 passed`),
 `python3 scripts/ci/check_legacy_growth_guard.py`, and
 `pre-commit run --hook-stage pre-push mypy --files scripts/ci/check_legacy_growth_guard.py`.
+
+Role: `bug-hunter` merge-ready pass
+
+Disposition: FIXED
+
+Finding: `scripts/ci/check_legacy_growth_guard.py` still allowed an already
+allowlisted legacy router variable to compose a dynamically imported bodyfat
+router before the final `app.include_router(business_router)` call, for example
+`business_router.include_router(importlib.import_module("app.routers.bodyfat").router)`.
+
+Commit: `73ada8d421688917c0b2eebfcf630eb2b96de70e`
+
+Evidence: `scripts/ci/check_legacy_growth_guard.py` now records dynamic
+`app.routers.*` imports nested inside route/router registration call subtrees.
+`tests/test_legacy_growth_guard.py` covers both direct
+`app.include_router(importlib.import_module(...).router)` and composed
+`business_router.include_router(importlib.import_module(...).router)` bodyfat
+regressions. Validation passed: focused nested regression pytest, full
+`tests/test_legacy_growth_guard.py` (`76 passed`), focused
+bodyfat/bootstrap/API/legacy-guard suite (`43 passed`),
+`python3 scripts/ci/check_legacy_growth_guard.py`, `make validate-changed`,
+`pre-commit run --all-files`, and `git diff --check`.
 
 Role: Codex Security diff scan
 
@@ -310,6 +334,18 @@ passed. The post-commit run selected `tests/test_api.py`,
 - PASS after CodeRabbit fix: `python3 scripts/orchestration/check_agent_consistency.py`
 - PASS after CodeRabbit fix: `pre-commit run --all-files`
 - PASS after CodeRabbit fix: `git diff --check`
+- PASS after merge-ready bug-hunter fix:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_legacy_growth_guard.py::test_legacy_growth_guard_rejects_nested_dynamic_bodyfat_router_registration tests/test_legacy_growth_guard.py::test_legacy_growth_guard_rejects_nested_dynamic_bodyfat_router_composition tests/test_legacy_growth_guard.py::test_current_legacy_app_passes_growth_guard`
+- PASS after merge-ready bug-hunter fix:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_legacy_growth_guard.py`
+  (`76 passed`).
+- PASS after merge-ready bug-hunter fix:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_main_paywall_bootstrap.py -k bodyfat tests/test_api.py::test_v1_bodyfat tests/test_api.py::test_v1_bodyfat_missing_hip tests/test_api.py::test_bodyfat_router_export_uses_canonical_package_path tests/test_app_bodyfat_v1.py tests/test_bodyfat_labels_coverage.py tests/edges/test_bodyfat_edges.py tests/test_bodyfat_shim.py tests/test_docker_workflow_build_path_contract.py::test_docker_entrypoint_keeps_bodyfat_hidden_but_routable tests/test_app_public_surface.py::test_app_public_surface_smoke tests/test_legacy_growth_guard.py`
+  (`43 passed`).
+- PASS after merge-ready bug-hunter fix: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS after merge-ready bug-hunter fix: `make validate-changed`
+- PASS after merge-ready bug-hunter fix: `pre-commit run --all-files`
+- PASS after merge-ready bug-hunter fix: `git diff --check`
 
 Full local `make verify` was not run per operator CPU constraint. This PR does
 not claim merge readiness from local gates alone.

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -127,7 +127,7 @@ passed. The post-commit run selected `tests/test_api.py`,
 
 - Packet:
   `artifacts/orchestration/experiments/bodyfat-canonical-bootstrap-oracle-packet.json`
-- Result:
+- Artifact:
   `artifacts/orchestration/experiments/results/bodyfat-canonical-bootstrap-oracle-result.json`
 - Experiment id: `exp-7c4838ebc835`
 - Status: accepted

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -210,7 +210,7 @@ Commit: `d8c2313fc157ca39109268e262af7644056e028b`
 
 Evidence: `tests/test_main_paywall_bootstrap.py` covers source/final OpenAPI
 visibility behavior, and
-`VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" make openapi-check DEV_PYTHON="$VENV_PYTHON"`
+`VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`
 passed with no generated artifact diff.
 
 Disposition: FIXED
@@ -260,7 +260,7 @@ passed. The post-commit run selected `tests/test_api.py`,
   `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_api.py::test_v1_bodyfat tests/test_api.py::test_v1_bodyfat_missing_hip tests/test_api.py::test_bodyfat_router_export_uses_canonical_package_path tests/test_app_bodyfat_v1.py tests/test_bodyfat_labels_coverage.py tests/edges/test_bodyfat_edges.py tests/test_bodyfat_shim.py tests/test_docker_workflow_build_path_contract.py::test_docker_entrypoint_keeps_bodyfat_hidden_but_routable tests/test_app_public_surface.py::test_app_public_surface_smoke`
 - PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
 - PASS:
-  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" make openapi-check DEV_PYTHON="$VENV_PYTHON"`
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`
 - PASS: `pre-commit run --all-files`
 - PASS: `make validate-changed`
 - PASS: `git show --check --oneline HEAD`
@@ -321,10 +321,10 @@ Not merge-ready.
 Required before merge:
 
 - [ ] Current-head CI passes.
-- [x] Post-open role passes completed:
+- [ ] Post-open role passes completed:
   `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- [x] Codex Security diff scan / finding discovery run.
-- [x] `pulseplate-pr-review` completed.
+- [ ] Codex Security diff scan / finding discovery run.
+- [ ] `pulseplate-pr-review` completed.
 - [ ] CodeRabbit/Sourcery/Cubic comments inspected and dispositioned on final
   current head.
 - [ ] PR body mirrors this fixed-mapping artifact after artifact commit lands.

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -40,6 +40,8 @@ changes.
   legacy router names.
 - `90c185114` - closes security-auditor dynamic import bypasses for alias,
   destructuring, and walrus assignment shapes.
+- `bf5436342` - preserves the security-auditor guard fix while satisfying the
+  changed-file mypy pre-push hook.
 
 ## Lane Start Provenance
 
@@ -135,6 +137,11 @@ simple aliases, destructuring, and walrus assignment hidden behind
 focused bodyfat/bootstrap/API suite (`39 passed`), `make validate-changed`,
 `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`,
 `pre-commit run --all-files`, and `git diff --check`.
+Follow-up hook fix commit `bf5436342` only renames an internal accumulator in
+the same helper to satisfy changed-file mypy; behavior remains covered by
+`tests/test_legacy_growth_guard.py` (`68 passed`),
+`python3 scripts/ci/check_legacy_growth_guard.py`, and
+`pre-commit run --hook-stage pre-push mypy --files scripts/ci/check_legacy_growth_guard.py`.
 
 Role: Codex Security diff scan
 
@@ -268,6 +275,12 @@ passed. The post-commit run selected `tests/test_api.py`,
   `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`
 - PASS after security-auditor fix: `pre-commit run --all-files`
 - PASS after security-auditor fix: `git diff --check`
+- PASS after mypy hook fix:
+  `pre-commit run --hook-stage pre-push mypy --files scripts/ci/check_legacy_growth_guard.py`
+- PASS after mypy hook fix:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_legacy_growth_guard.py`
+- PASS after mypy hook fix: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS after mypy hook fix: `pre-commit run --all-files`
 - PASS: Codex Security scan `d9f75240-8a67-4c76-b8d6-e2062323022a`
   completed, 5/5 reviewed, 0 findings.
 - PASS: `pulseplate-pr-review` dry-run report generated; only advisory

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -49,6 +49,8 @@ changes.
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - [x] Fixed mapping artifact created after GitHub assigned PR number `#2021`.
 - [ ] Post-open discussion-thread pass pending.
 - [ ] CodeRabbit comments/actionables inspected.
@@ -59,11 +61,14 @@ changes.
 
 ## Fixed in Commit Mapping
 
-Initial PR open: no human review threads existed at artifact creation.
+- No actionable review comments
 
-No review-thread FIXED mappings are recorded yet. Any post-open actionable bot
-or human findings must be fixed, mapped here with disposition proof, mirrored in
-the PR body, and only then resolved.
+## Mapping Notes
+
+Initial PR open: no human review threads existed at artifact creation. Any
+post-open actionable bot or human findings must be fixed, mapped in
+`## Fixed in Commit Mapping` with disposition proof, mirrored in the PR body,
+and only then resolved.
 
 ## Premortem Findings
 

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -36,6 +36,10 @@ changes.
 - `d8c2313fc157ca39109268e262af7644056e028b` - moves bodyfat route
   registration to canonical bootstrap, removes legacy ownership, adds guards
   and tests, and records premortem/backlog evidence.
+- `44bc4440a` - rejects direct dynamic bodyfat imports assigned to allowlisted
+  legacy router names.
+- `90c185114` - closes security-auditor dynamic import bypasses for alias,
+  destructuring, and walrus assignment shapes.
 
 ## Lane Start Provenance
 
@@ -55,10 +59,15 @@ changes.
 - [x] Post-open `qa-engineer-agent` pass completed: no actionable findings.
 - [x] Post-open `bug-hunter` pass completed; actionable finding fixed and
   dispositioned below.
-- [ ] Post-open discussion-thread pass pending.
-- [ ] CodeRabbit comments/actionables inspected.
-- [ ] Sourcery comments/actionables inspected.
-- [ ] Cubic comments/actionables inspected.
+- [x] Post-open `security-auditor` pass completed; actionable finding fixed and
+  dispositioned below.
+- [x] Codex Security diff scan completed: 5/5 reviewed, 0 findings.
+- [x] `pulseplate-pr-review` completed; advisory large-diff note dispositioned
+  below.
+- [ ] Post-open discussion-thread pass pending final current-head bot/CI refresh.
+- [ ] CodeRabbit comments/actionables inspected on final current head.
+- [ ] Sourcery comments/actionables inspected on final current head.
+- [ ] Cubic comments/actionables inspected on final current head.
 - [ ] Current-head CI complete before readiness language.
 - [ ] Strict merge-readiness checks run after the final review/check cycle.
 
@@ -103,6 +112,60 @@ validation passed:
 `python3 scripts/ci/check_legacy_growth_guard.py`,
 `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_legacy_growth_guard.py`, and
 `make validate-changed`.
+
+Role: `security-auditor`
+
+Disposition: FIXED
+
+Finding: `scripts/ci/check_legacy_growth_guard.py` still missed dynamic bodyfat
+route re-registration when `import_module` was aliased, when the imported router
+was assigned through tuple/list destructuring, or when a walrus assignment wrote
+the router into the already allowlisted `business_router` name.
+
+Commit: `90c185114`
+
+Evidence: `scripts/ci/check_legacy_growth_guard.py` now tracks aliases to
+`importlib.import_module` and `__import__`, pairs dynamic `app.routers.*` imports
+with concrete assignment targets, and records `ast.NamedExpr` targets.
+`tests/test_legacy_growth_guard.py` covers aliased import-module calls,
+simple aliases, destructuring, and walrus assignment hidden behind
+`business_router`. Validation passed:
+`python3 scripts/ci/check_legacy_growth_guard.py`,
+`VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_legacy_growth_guard.py`,
+focused bodyfat/bootstrap/API suite (`39 passed`), `make validate-changed`,
+`VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`,
+`pre-commit run --all-files`, and `git diff --check`.
+
+Role: Codex Security diff scan
+
+Disposition: NOT-A-BUG
+
+Evidence: Codex Security scan `d9f75240-8a67-4c76-b8d6-e2062323022a`
+completed for range
+`8a637a9ad2ab618ec2e7e550132f5a615146d968..90c1851147c806761a776ee4821cc39b7b88a64c`.
+Report:
+`/private/var/folders/bw/12x002vn67v2bvjpbhbtm8480000gn/T/codex-security-scans-i7T2Pe/bodyfat-canonical-bootstrap/90c1851147c806761a776ee4821cc39b7b88a64c_20260625T090928Z_01vnvpd2/report.md`.
+Coverage: 5/5 reviewed surfaces, 0 reportable findings. Reviewed surfaces:
+`app/__init__.py`, `app/main.py`, `app/routers/bodyfat.py`, `legacy_app.py`,
+and `scripts/ci/check_legacy_growth_guard.py`.
+
+Role: `pulseplate-pr-review`
+
+Disposition: NOT-A-BUG
+
+Finding: advisory `large-diff-risk` note because the PR diff exceeds the
+review-risk threshold.
+
+Evidence: The diff is intentionally cohesive despite size: one bodyfat
+route-ownership migration, its bootstrap/legacy guard tests, review artifact,
+premortem, routing docs, and one backlog follow-up. Local narrow gates selected
+the changed backend tests and passed: focused bodyfat/bootstrap/API suite
+(`39 passed`), `tests/test_legacy_growth_guard.py` (`68 passed`),
+`python3 scripts/ci/check_legacy_growth_guard.py`, `make validate-changed`,
+`make openapi-check` via repo venv, `pre-commit run --all-files`, and
+`git diff --check`. Report artifacts:
+`/tmp/pulseplate_pr_2021_review_report.md` and
+`/tmp/pulseplate_pr_2021_review_report.json`.
 
 ## Premortem Findings
 
@@ -194,6 +257,21 @@ passed. The post-commit run selected `tests/test_api.py`,
 - PASS: `pre-commit run --all-files`
 - PASS: `make validate-changed`
 - PASS: `git show --check --oneline HEAD`
+- PASS after security-auditor fix:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_legacy_growth_guard.py`
+- PASS after security-auditor fix:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_main_paywall_bootstrap.py -k bodyfat tests/test_api.py::test_v1_bodyfat tests/test_api.py::test_v1_bodyfat_missing_hip tests/test_api.py::test_bodyfat_router_export_uses_canonical_package_path tests/test_app_bodyfat_v1.py tests/test_bodyfat_labels_coverage.py tests/edges/test_bodyfat_edges.py tests/test_bodyfat_shim.py tests/test_docker_workflow_build_path_contract.py::test_docker_entrypoint_keeps_bodyfat_hidden_but_routable tests/test_app_public_surface.py::test_app_public_surface_smoke tests/test_legacy_growth_guard.py`
+- PASS after security-auditor fix: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS after security-auditor fix: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS after security-auditor fix: `make validate-changed`
+- PASS after security-auditor fix:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`
+- PASS after security-auditor fix: `pre-commit run --all-files`
+- PASS after security-auditor fix: `git diff --check`
+- PASS: Codex Security scan `d9f75240-8a67-4c76-b8d6-e2062323022a`
+  completed, 5/5 reviewed, 0 findings.
+- PASS: `pulseplate-pr-review` dry-run report generated; only advisory
+  `large-diff-risk` note, dispositioned above.
 - PASS on push hook: changed-files mypy, pre-push backend pytest, full-repo
   Bandit, and Docker build test.
 
@@ -230,10 +308,11 @@ Not merge-ready.
 Required before merge:
 
 - [ ] Current-head CI passes.
-- [ ] Post-open role passes completed:
+- [x] Post-open role passes completed:
   `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- [ ] Codex Security diff scan / finding discovery run if available.
-- [ ] `pulseplate-pr-review` completed.
-- [ ] CodeRabbit/Sourcery/Cubic comments inspected and dispositioned.
+- [x] Codex Security diff scan / finding discovery run.
+- [x] `pulseplate-pr-review` completed.
+- [ ] CodeRabbit/Sourcery/Cubic comments inspected and dispositioned on final
+  current head.
 - [ ] PR body mirrors this fixed-mapping artifact after artifact commit lands.
 - [ ] Strict merge-readiness checks pass.

--- a/docs/review/PR_2021_FIXED_MAPPING.md
+++ b/docs/review/PR_2021_FIXED_MAPPING.md
@@ -88,17 +88,7 @@ frontend runtime, iOS, or migration changes.
 
 Disposition: FIXED
 
-Evidence: commit `87a931b921098fb2da1de486753a988ad99b9ff2` adds typed
-bodyfat response-model metadata for both hidden/direct registrations, closes
-`builtins.__import__` alias and walrus import-function alias bypasses in
-`scripts/ci/check_legacy_growth_guard.py`, adds matching guard regressions,
-fixes the review artifact `openapi-check` command/checklist state, and asserts
-JSON content type before parsing the direct bodyfat compatibility response.
-Validation passed: focused bodyfat/bootstrap/API/legacy-guard pytest suite
-(`41 passed`), `python3 scripts/ci/check_legacy_growth_guard.py`,
-`VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`,
-`make validate-changed`, `python3 scripts/orchestration/check_agent_consistency.py`,
-`pre-commit run --all-files`, and `git diff --check`.
+Evidence: commit `87a931b921098fb2da1de486753a988ad99b9ff2` adds typed bodyfat response metadata, closes `builtins.__import__` alias and walrus import-function alias bypasses, fixes review artifact command/checklist hygiene, and adds JSON content-type test clarity; validation passed via focused pytest (`41 passed`), legacy guard script, openapi-check, validate-changed, agent consistency, pre-commit all-files, and diff check.
 
 ## Mapping Notes
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -24,6 +24,28 @@ If it is not recorded here — it does not exist.
 
 <!-- EXPERIMENT_BACKLOG_ENTRIES:INSERT BELOW -->
 
+<a id="ledger-p1-bodyfat-bmi-engine-delegation"></a>
+- [ ] P1: Delegate bodyfat missing-BMI derivation to canonical BMI engine
+  - Owner: @katsiaryna_kavaleuskaya (Backend / Nutrition)
+  - Priority: P1
+  - Target PR: TBD after bodyfat route ownership cleanup
+  - Status: Open
+  - Area: backend routing / nutrition calculation semantics
+  - Reason (EN): `app/routers/bodyfat.py` currently derives BMI locally when
+    the request omits `bmi`, while canonical BMI calculation and rounding
+    semantics live in the BMI engine. This PR keeps bodyfat math unchanged while
+    moving route ownership; the derivation seam needs a separate parity-reviewed
+    PR so formula and rounding behavior do not drift accidentally.
+  - Links: `app/routers/bodyfat.py`, `core/bmi/engine.py`,
+    `tests/test_api.py::test_v1_bodyfat`,
+    `tests/edges/test_bodyfat_edges.py`
+  - DoD: Missing-BMI bodyfat requests delegate through the canonical BMI
+    calculation seam or record an explicit semantics decision; supplied-BMI
+    requests remain unchanged; deterministic parity tests cover supplied BMI,
+    derived BMI, Deurenberg output, and rounding behavior; generated
+    OpenAPI/client artifacts remain unchanged unless a separately reviewed
+    contract change requires it.
+
 <a id="ledger-p1-first-class-auth-principal-mapping"></a>
 - [ ] P1: First-class authenticated principal mapping for API-key-derived subjects
   - Owner: @katsiaryna_kavaleuskaya (Backend / Security)

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -383,13 +383,6 @@ def stop_background_updates() -> None:
     return None
 
 
-GetRouterCallable = Callable[[], APIRouter]
-get_bodyfat_router: Optional[GetRouterCallable]
-try:
-    from app.routers.bodyfat import get_router as get_bodyfat_router
-except ImportError:
-    get_bodyfat_router = None
-
 # Only load the local .env automatically for explicit local/dev environments.
 _env_was_sanitized = "PATH" not in os.environ
 _app_env = get_runtime_env_name()
@@ -4316,11 +4309,7 @@ if EXPORTS_ENABLED:
             raise HTTPException(status_code=500, detail=f"PDF export failed: {str(e)}") from e
 
 
-# Include bodyfat router if available
-if get_bodyfat_router is not None:
-    app.include_router(get_bodyfat_router(), prefix="/api/v1")
-
-# BMI and BMI Pro route registration is owned by app.main canonical bootstrap.
+# Bodyfat, BMI, and BMI Pro route registration is owned by app.main canonical bootstrap.
 
 # Include Business router (with feature flag). Defaults to disabled for safety.
 

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -137,6 +137,7 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
             "router",
             "nutrition_recommendations_router",
         ),
+        LegacyFact("router_import", "dynamic", "app.routers.plan_export", "_plan_mod"),
         LegacyFact(
             "router_import", "app.routers.pro_nutrition_contracts", "pro_nutrition_plate", ""
         ),
@@ -334,7 +335,48 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
             for alias in node.names:
                 if alias.name == "app.routers" or alias.name.startswith("app.routers."):
                     facts.add(LegacyFact("router_import", "import", alias.name, alias.asname or ""))
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            value = node.value
+            if value is None:
+                continue
+            targets = list(node.targets) if isinstance(node, ast.Assign) else [node.target]
+            target_names = [target.id for target in targets if isinstance(target, ast.Name)]
+            if not target_names:
+                continue
+            for module_name in _dynamic_app_router_import_modules(value):
+                for target_name in target_names:
+                    facts.add(LegacyFact("router_import", "dynamic", module_name, target_name))
     return facts
+
+
+def _dynamic_app_router_import_modules(node: ast.AST) -> frozenset[str]:
+    """Return dynamic app.routers module imports embedded in an AST node."""
+
+    modules: set[str] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        module_name = _dynamic_import_module_name(child)
+        if module_name is None:
+            continue
+        if module_name == "app.routers" or module_name.startswith("app.routers."):
+            modules.add(module_name)
+    return frozenset(modules)
+
+
+def _dynamic_import_module_name(call: ast.Call) -> str | None:
+    if not call.args:
+        return None
+    first_arg = call.args[0]
+    if not isinstance(first_arg, ast.Constant) or not isinstance(first_arg.value, str):
+        return None
+
+    func = call.func
+    if isinstance(func, ast.Name) and func.id in {"__import__", "import_module"}:
+        return first_arg.value
+    if isinstance(func, ast.Attribute) and func.attr == "import_module":
+        return first_arg.value
+    return None
 
 
 def collect_sensitive_call_counts(

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -325,6 +325,7 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
         return set()
 
     facts: set[LegacyFact] = set()
+    dynamic_import_names = _collect_dynamic_import_function_names(tree)
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module is not None:
             if node.module != "app.routers" and not node.module.startswith("app.routers."):
@@ -340,23 +341,128 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
             if value is None:
                 continue
             targets = list(node.targets) if isinstance(node, ast.Assign) else [node.target]
-            target_names = [target.id for target in targets if isinstance(target, ast.Name)]
-            if not target_names:
-                continue
-            for module_name in _dynamic_app_router_import_modules(value):
-                for target_name in target_names:
+            for target in targets:
+                for module_name, target_name in _dynamic_app_router_import_assignments(
+                    value,
+                    target,
+                    import_func_names=dynamic_import_names,
+                ):
                     facts.add(LegacyFact("router_import", "dynamic", module_name, target_name))
+        elif isinstance(node, ast.NamedExpr):
+            for module_name, target_name in _dynamic_app_router_import_assignments(
+                node.value,
+                node.target,
+                import_func_names=dynamic_import_names,
+            ):
+                facts.add(LegacyFact("router_import", "dynamic", module_name, target_name))
     return facts
 
 
-def _dynamic_app_router_import_modules(node: ast.AST) -> frozenset[str]:
+def _collect_dynamic_import_function_names(tree: ast.Module) -> frozenset[str]:
+    """Return names that may call Python's dynamic import helpers."""
+
+    names: set[str] = {"__import__", "import_module"}
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "importlib":
+                for alias in node.names:
+                    if alias.name == "import_module":
+                        imported_name = alias.asname or alias.name
+                        if imported_name not in names:
+                            names.add(imported_name)
+                            changed = True
+                continue
+
+            value: ast.AST | None = None
+            targets: list[ast.expr] = []
+            if isinstance(node, ast.Assign):
+                value = node.value
+                targets = list(node.targets)
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                value = node.value
+                targets = [node.target]
+            if value is None or not _is_dynamic_import_function_reference(
+                value,
+                import_func_names=frozenset(names),
+            ):
+                continue
+
+            for target in targets:
+                for target_name in _assignment_target_names(target):
+                    if target_name not in names:
+                        names.add(target_name)
+                        changed = True
+    return frozenset(names)
+
+
+def _is_dynamic_import_function_reference(
+    node: ast.AST,
+    *,
+    import_func_names: frozenset[str],
+) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id in import_func_names
+    return isinstance(node, ast.Attribute) and node.attr == "import_module"
+
+
+def _assignment_target_names(node: ast.AST) -> tuple[str, ...]:
+    if isinstance(node, ast.Name):
+        return (node.id,)
+    if isinstance(node, (ast.Tuple, ast.List)):
+        names: list[str] = []
+        for element in node.elts:
+            names.extend(_assignment_target_names(element))
+        return tuple(names)
+    return ()
+
+
+def _dynamic_app_router_import_assignments(
+    value: ast.AST,
+    target: ast.AST,
+    *,
+    import_func_names: frozenset[str],
+) -> tuple[tuple[str, str], ...]:
+    """Return dynamic app.routers imports paired with the assigned target name."""
+
+    if isinstance(target, (ast.Tuple, ast.List)) and isinstance(value, (ast.Tuple, ast.List)):
+        pairs: list[tuple[str, str]] = []
+        for value_item, target_item in zip(value.elts, target.elts, strict=False):
+            pairs.extend(
+                _dynamic_app_router_import_assignments(
+                    value_item,
+                    target_item,
+                    import_func_names=import_func_names,
+                )
+            )
+        return tuple(pairs)
+
+    target_names = _assignment_target_names(target)
+    if not target_names:
+        return ()
+
+    pairs: list[tuple[str, str]] = []
+    for module_name in _dynamic_app_router_import_modules(
+        value, import_func_names=import_func_names
+    ):
+        for target_name in target_names:
+            pairs.append((module_name, target_name))
+    return tuple(pairs)
+
+
+def _dynamic_app_router_import_modules(
+    node: ast.AST,
+    *,
+    import_func_names: frozenset[str],
+) -> frozenset[str]:
     """Return dynamic app.routers module imports embedded in an AST node."""
 
     modules: set[str] = set()
     for child in ast.walk(node):
         if not isinstance(child, ast.Call):
             continue
-        module_name = _dynamic_import_module_name(child)
+        module_name = _dynamic_import_module_name(child, import_func_names=import_func_names)
         if module_name is None:
             continue
         if module_name == "app.routers" or module_name.startswith("app.routers."):
@@ -364,7 +470,11 @@ def _dynamic_app_router_import_modules(node: ast.AST) -> frozenset[str]:
     return frozenset(modules)
 
 
-def _dynamic_import_module_name(call: ast.Call) -> str | None:
+def _dynamic_import_module_name(
+    call: ast.Call,
+    *,
+    import_func_names: frozenset[str],
+) -> str | None:
     if not call.args:
         return None
     first_arg = call.args[0]
@@ -372,7 +482,7 @@ def _dynamic_import_module_name(call: ast.Call) -> str | None:
         return None
 
     func = call.func
-    if isinstance(func, ast.Name) and func.id in {"__import__", "import_module"}:
+    if isinstance(func, ast.Name) and func.id in import_func_names:
         return first_arg.value
     if isinstance(func, ast.Attribute) and func.attr == "import_module":
         return first_arg.value

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -109,7 +109,6 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("registration", "include_router", "bayes_adherence.router", ""),
         LegacyFact("registration", "include_router", "nutrition_log.router", ""),
         LegacyFact("registration", "include_router", "legacy_nutrition_alias_router", ""),
-        LegacyFact("registration", "include_router", "get_bodyfat_router()", ""),
         LegacyFact("registration", "include_router", "business_router", ""),
         LegacyFact("registration", "include_router", "test_router.router", ""),
     }
@@ -123,7 +122,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
         LegacyFact("router_import", "app.routers", "vip", "_vip_mod"),
         LegacyFact("router_import", "app.routers.api_key", "api_key_header", ""),
         LegacyFact("router_import", "app.routers.bmi", "bmi_calculate_handler", ""),
-        LegacyFact("router_import", "app.routers.bodyfat", "get_router", "get_bodyfat_router"),
         LegacyFact("router_import", "app.routers.business", "router", "business_router"),
         LegacyFact("router_import", "app.routers.catalog", "router", "catalog_router"),
         LegacyFact("router_import", "app.routers.foods", "router", "foods_router"),

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -427,16 +427,16 @@ def _dynamic_app_router_import_assignments(
     """Return dynamic app.routers imports paired with the assigned target name."""
 
     if isinstance(target, (ast.Tuple, ast.List)) and isinstance(value, (ast.Tuple, ast.List)):
-        pairs: list[tuple[str, str]] = []
+        destructured_pairs: list[tuple[str, str]] = []
         for value_item, target_item in zip(value.elts, target.elts, strict=False):
-            pairs.extend(
+            destructured_pairs.extend(
                 _dynamic_app_router_import_assignments(
                     value_item,
                     target_item,
                     import_func_names=import_func_names,
                 )
             )
-        return tuple(pairs)
+        return tuple(destructured_pairs)
 
     target_names = _assignment_target_names(target)
     if not target_names:

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -366,13 +366,17 @@ def _collect_dynamic_import_function_names(tree: ast.Module) -> frozenset[str]:
     while changed:
         changed = False
         for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom) and node.module == "importlib":
+            if isinstance(node, ast.ImportFrom) and node.module in {"builtins", "importlib"}:
                 for alias in node.names:
-                    if alias.name == "import_module":
-                        imported_name = alias.asname or alias.name
-                        if imported_name not in names:
-                            names.add(imported_name)
-                            changed = True
+                    if (node.module, alias.name) not in {
+                        ("builtins", "__import__"),
+                        ("importlib", "import_module"),
+                    }:
+                        continue
+                    imported_name = alias.asname or alias.name
+                    if imported_name not in names:
+                        names.add(imported_name)
+                        changed = True
                 continue
 
             value: ast.AST | None = None
@@ -381,6 +385,9 @@ def _collect_dynamic_import_function_names(tree: ast.Module) -> frozenset[str]:
                 value = node.value
                 targets = list(node.targets)
             elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                value = node.value
+                targets = [node.target]
+            elif isinstance(node, ast.NamedExpr):
                 value = node.value
                 targets = [node.target]
             if value is None or not _is_dynamic_import_function_reference(

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -355,6 +355,21 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
                 import_func_names=dynamic_import_names,
             ):
                 facts.add(LegacyFact("router_import", "dynamic", module_name, target_name))
+        elif isinstance(node, ast.Call):
+            if not _is_router_registration_call(node):
+                continue
+            for module_name in _dynamic_app_router_import_modules(
+                node,
+                import_func_names=dynamic_import_names,
+            ):
+                facts.add(
+                    LegacyFact(
+                        "router_import",
+                        "dynamic",
+                        module_name,
+                        _safe_unparse(node.func),
+                    )
+                )
     return facts
 
 
@@ -412,6 +427,10 @@ def _is_dynamic_import_function_reference(
     if isinstance(node, ast.Name):
         return node.id in import_func_names
     return isinstance(node, ast.Attribute) and node.attr == "import_module"
+
+
+def _is_router_registration_call(call: ast.Call) -> bool:
+    return isinstance(call.func, ast.Attribute) and call.func.attr in APP_REGISTRATION_METHODS
 
 
 def _assignment_target_names(node: ast.AST) -> tuple[str, ...]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,13 +155,12 @@ def test_v1_bodyfat_missing_hip(client: TestClient) -> None:
     assert "us_navy" not in data["methods"]
 
 
-def test_bodyfat_import_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Deterministic seam test for bodyfat router unavailability path."""
+def test_bodyfat_router_export_uses_canonical_package_path() -> None:
+    """Bodyfat compatibility export stays outside legacy_app route ownership."""
     import app as app_mod
-    import legacy_app
+    from app.routers.bodyfat import get_router
 
-    monkeypatch.setattr(legacy_app, "get_bodyfat_router", None, raising=True)
-    assert app_mod.get_bodyfat_router is None
+    assert app_mod.get_bodyfat_router is get_router
 
 
 def test_insight_import_failure(

--- a/tests/test_app_public_surface.py
+++ b/tests/test_app_public_surface.py
@@ -28,6 +28,7 @@ def test_app_public_surface_smoke() -> None:
     assert hasattr(app, "make_weekly_menu"), "app.make_weekly_menu must be exported"
     assert hasattr(app, "build_nutrition_targets"), "app.build_nutrition_targets must be exported"
     assert hasattr(app, "get_update_scheduler"), "app.get_update_scheduler must be exported"
+    assert hasattr(app, "get_bodyfat_router"), "app.get_bodyfat_router must be exported"
 
     # Visualization flags (optional but must be present)
     assert hasattr(app, "MATPLOTLIB_AVAILABLE"), "app.MATPLOTLIB_AVAILABLE must be exported"

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -588,6 +588,73 @@ def test_legacy_growth_guard_rejects_reintroduced_aliased_shoplist_export_regist
     ]
 
 
+def test_legacy_growth_guard_rejects_reintroduced_bodyfat_factory_registration() -> None:
+    source = textwrap.dedent("""
+        from app.routers.bodyfat import get_router as get_bodyfat_router
+
+        app.include_router(get_bodyfat_router(), prefix="/api/v1")
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:get_bodyfat_router()",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.bodyfat:get_router -> get_bodyfat_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_direct_bodyfat_router_registration() -> None:
+    source = textwrap.dedent("""
+        from app.routers.bodyfat import router
+
+        app.include_router(router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: registration:include_router:router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.bodyfat:router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_aliased_bodyfat_router_registration() -> None:
+    source = textwrap.dedent("""
+        from app.routers.bodyfat import router as canonical_bodyfat_router
+
+        app.include_router(canonical_bodyfat_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:canonical_bodyfat_router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.bodyfat:router -> canonical_bodyfat_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_module_qualified_bodyfat_router_registration() -> None:
+    source = textwrap.dedent("""
+        import app.routers.bodyfat as bodyfat_routes
+
+        app.include_router(bodyfat_routes.router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:bodyfat_routes.router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:import:app.routers.bodyfat -> bodyfat_routes",
+    ]
+
+
 def test_legacy_growth_guard_rejects_reintroduced_restaurant_moderation_registration() -> None:
     source = textwrap.dedent("""
         from app.routers.restaurants import moderation_router as restaurant_moderation_router

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -655,6 +655,36 @@ def test_legacy_growth_guard_rejects_module_qualified_bodyfat_router_registratio
     ]
 
 
+def test_legacy_growth_guard_rejects_dynamic_bodyfat_router_hidden_as_allowed_name() -> None:
+    source = textwrap.dedent("""
+        import importlib
+
+        business_router = importlib.import_module("app.routers.bodyfat").router
+        app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_dunder_import_bodyfat_router_hidden_as_allowed_name() -> None:
+    source = textwrap.dedent("""
+        business_router = __import__("app.routers.bodyfat", fromlist=["router"]).router
+        app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router",
+    ]
+
+
 def test_legacy_growth_guard_rejects_reintroduced_restaurant_moderation_registration() -> None:
     source = textwrap.dedent("""
         from app.routers.restaurants import moderation_router as restaurant_moderation_router

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -798,6 +798,41 @@ def test_legacy_growth_guard_rejects_walrus_import_function_alias_bodyfat_router
     ]
 
 
+def test_legacy_growth_guard_rejects_nested_dynamic_bodyfat_router_registration() -> None:
+    source = textwrap.dedent("""
+        import importlib
+
+        app.include_router(importlib.import_module("app.routers.bodyfat").router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:importlib.import_module('app.routers.bodyfat').router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> app.include_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_nested_dynamic_bodyfat_router_composition() -> None:
+    source = textwrap.dedent("""
+        from fastapi import APIRouter
+        import importlib
+
+        business_router = APIRouter()
+        business_router.include_router(importlib.import_module("app.routers.bodyfat").router)
+        app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router.include_router",
+    ]
+
+
 def test_legacy_growth_guard_rejects_reintroduced_restaurant_moderation_registration() -> None:
     source = textwrap.dedent("""
         from app.routers.restaurants import moderation_router as restaurant_moderation_router

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -701,6 +701,22 @@ def test_legacy_growth_guard_rejects_aliased_import_module_bodyfat_router() -> N
     ]
 
 
+def test_legacy_growth_guard_rejects_aliased_builtin_import_bodyfat_router() -> None:
+    source = textwrap.dedent("""
+        from builtins import __import__ as load_router_module
+
+        business_router = load_router_module("app.routers.bodyfat", fromlist=["router"]).router
+        app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router",
+    ]
+
+
 def test_legacy_growth_guard_rejects_simple_import_module_alias_bodyfat_router() -> None:
     source = textwrap.dedent("""
         import importlib
@@ -754,6 +770,23 @@ def test_legacy_growth_guard_rejects_walrus_dynamic_bodyfat_router() -> None:
         import importlib
 
         if (business_router := importlib.import_module("app.routers.bodyfat").router):
+            app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_walrus_import_function_alias_bodyfat_router() -> None:
+    source = textwrap.dedent("""
+        import importlib
+
+        if (load_router_module := importlib.import_module):
+            business_router = load_router_module("app.routers.bodyfat").router
             app.include_router(business_router)
         """)
 

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -685,6 +685,86 @@ def test_legacy_growth_guard_rejects_dunder_import_bodyfat_router_hidden_as_allo
     ]
 
 
+def test_legacy_growth_guard_rejects_aliased_import_module_bodyfat_router() -> None:
+    source = textwrap.dedent("""
+        from importlib import import_module as load_router_module
+
+        business_router = load_router_module("app.routers.bodyfat").router
+        app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_simple_import_module_alias_bodyfat_router() -> None:
+    source = textwrap.dedent("""
+        import importlib
+
+        load_router_module = importlib.import_module
+        business_router = load_router_module("app.routers.bodyfat").router
+        app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_simple_dunder_import_alias_bodyfat_router() -> None:
+    source = textwrap.dedent("""
+        load_router_module = __import__
+        business_router = load_router_module("app.routers.bodyfat", fromlist=["router"]).router
+        app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_destructured_dynamic_bodyfat_router() -> None:
+    source = textwrap.dedent("""
+        import importlib
+
+        business_router, _ = (importlib.import_module("app.routers.bodyfat").router, None)
+        app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_walrus_dynamic_bodyfat_router() -> None:
+    source = textwrap.dedent("""
+        import importlib
+
+        if (business_router := importlib.import_module("app.routers.bodyfat").router):
+            app.include_router(business_router)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:dynamic:app.routers.bodyfat -> business_router",
+    ]
+
+
 def test_legacy_growth_guard_rejects_reintroduced_restaurant_moderation_registration() -> None:
     source = textwrap.dedent("""
         from app.routers.restaurants import moderation_router as restaurant_moderation_router

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -2322,6 +2322,7 @@ def test_bodyfat_direct_router_remains_unprefixed_compatibility() -> None:
 
     response = client.post("/bodyfat", json=payload)
     assert response.status_code == 200
+    assert response.headers.get("content-type", "").startswith("application/json")
     assert {"labels", "lang", "median", "methods"} <= response.json().keys()
     assert client.post("/api/v1/bodyfat", json=payload).status_code == 404
 

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -274,6 +274,70 @@ def _bmi_compat_stub_router(
     return router
 
 
+def _bodyfat_stub_router(
+    *,
+    omit: frozenset[str] = frozenset(),
+    method_overrides: dict[str, str] | None = None,
+    include_overrides: dict[str, bool] | None = None,
+) -> APIRouter:
+    router = APIRouter()
+    method_override_map = method_overrides or {}
+    include_override_map = include_overrides or {}
+
+    for path, method, include_in_schema in app_main._BODYFAT_ROUTE_SPECS:
+        if path in omit:
+            continue
+        route_method = method_override_map.get(path, method).lower()
+        route_include = include_override_map.get(path, include_in_schema)
+
+        async def _bodyfat_handler(path: str = path) -> dict[str, str]:
+            return {"status": path}
+
+        getattr(router, route_method)(path, include_in_schema=route_include)(_bodyfat_handler)
+
+    return router
+
+
+def _duplicate_bodyfat_stub_router() -> APIRouter:
+    router = _bodyfat_stub_router()
+    duplicate_path, duplicate_method, duplicate_include = app_main._BODYFAT_ROUTE_SPECS[0]
+
+    async def _second_bodyfat_handler() -> dict[str, str]:
+        return {"status": "duplicate"}
+
+    getattr(router, duplicate_method.lower())(
+        duplicate_path,
+        include_in_schema=duplicate_include,
+    )(_second_bodyfat_handler)
+    return router
+
+
+def _bodyfat_stub_router_with_combined_methods() -> APIRouter:
+    router = APIRouter()
+    path, method, include_in_schema = app_main._BODYFAT_ROUTE_SPECS[0]
+
+    async def _bodyfat_handler() -> dict[str, str]:
+        return {"status": path}
+
+    router.add_api_route(
+        path,
+        _bodyfat_handler,
+        methods=[method, "GET" if method == "POST" else "POST"],
+        include_in_schema=include_in_schema,
+    )
+    return router
+
+
+def _bodyfat_stub_router_with_unrelated_path() -> APIRouter:
+    router = _bodyfat_stub_router()
+
+    async def _unrelated_handler() -> dict[str, str]:
+        return {"status": "unrelated"}
+
+    router.get("/api/v1/unrelated-bodyfat-probe")(_unrelated_handler)
+    return router
+
+
 def _legacy_export_alias_stub_router(
     *,
     omit: frozenset[str] = frozenset(),
@@ -605,6 +669,25 @@ def _app_with_bmi_compat_routes_and_extra_method(*, combined_route: bool) -> Fas
         app.add_api_route(
             path, _bmi_compat_handler, methods=[method], include_in_schema=include_in_schema
         )
+
+    async def _extra_method_handler() -> dict[str, str]:
+        return {"status": "extra-method"}
+
+    opposite_method = "POST" if extra_method == "GET" else "GET"
+    extra_methods = [extra_method, opposite_method] if combined_route else [opposite_method]
+    app.add_api_route(
+        extra_path,
+        _extra_method_handler,
+        methods=extra_methods,
+        include_in_schema=extra_include,
+    )
+    return app
+
+
+def _app_with_bodyfat_routes_and_extra_method(*, combined_route: bool) -> FastAPI:
+    app = FastAPI()
+    extra_path, extra_method, extra_include = app_main._BODYFAT_ROUTE_SPECS[0]
+    app.include_router(app_main.bodyfat_router)
 
     async def _extra_method_handler() -> dict[str, str]:
         return {"status": "extra-method"}
@@ -2048,6 +2131,213 @@ def test_bmi_compat_route_registration_rejects_duplicate_canonical_router_paths(
         match="BMI compatibility router does not define the expected route family",
     ):
         _bootstrap_temp_app(FastAPI())
+
+
+def test_bodyfat_route_registration_is_idempotent() -> None:
+    app = FastAPI()
+
+    app_main._include_bodyfat_router_if_needed(app)
+    app_main._include_bodyfat_router_if_needed(app)
+
+    for path, method, include_in_schema in app_main._BODYFAT_ROUTE_SPECS:
+        matching_routes = [
+            route
+            for route in app.routes
+            if getattr(route, "path", None) == path
+            and method in (getattr(route, "methods", None) or set())
+        ]
+        assert len(matching_routes) == 1
+        matching_route = matching_routes[0]
+        assert getattr(matching_route, "include_in_schema", True) is include_in_schema
+        assert getattr(matching_route.endpoint, "__module__", "") == "app.routers.bodyfat"
+        assert not matching_route.dependant.dependencies
+        assert 429 not in (matching_route.responses or {})
+
+    assert not any(
+        getattr(route, "path", None) == "/bodyfat"
+        and "POST" in (getattr(route, "methods", None) or set())
+        for route in app.routes
+    )
+
+
+def test_bodyfat_route_registration_rejects_wrong_method() -> None:
+    app = FastAPI()
+    path, method, include_in_schema = app_main._BODYFAT_ROUTE_SPECS[0]
+
+    async def _wrong_method_bodyfat_route() -> dict[str, str]:
+        return {"status": "wrong-method"}
+
+    wrong_method = "GET" if method == "POST" else "POST"
+    getattr(app, wrong_method.lower())(path, include_in_schema=include_in_schema)(
+        _wrong_method_bodyfat_route
+    )
+
+    with pytest.raises(RuntimeError, match="Partial bodyfat route registration detected"):
+        app_main._include_bodyfat_router_if_needed(app)
+
+
+def test_bodyfat_route_registration_rejects_wrong_method_in_canonical_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path, method, _include_in_schema = app_main._BODYFAT_ROUTE_SPECS[0]
+    wrong_method = "GET" if method == "POST" else "POST"
+    monkeypatch.setattr(
+        app_main,
+        "bodyfat_router",
+        _bodyfat_stub_router(method_overrides={path: wrong_method}),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Bodyfat router does not define the expected route family",
+    ):
+        app_main._include_bodyfat_router_if_needed(FastAPI())
+
+
+def test_bodyfat_route_registration_rejects_combined_methods_in_canonical_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        app_main,
+        "bodyfat_router",
+        _bodyfat_stub_router_with_combined_methods(),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Bodyfat router does not define the expected route family",
+    ):
+        app_main._include_bodyfat_router_if_needed(FastAPI())
+
+
+def test_bodyfat_route_registration_rejects_existing_wrong_method_after_full_family() -> None:
+    with pytest.raises(RuntimeError, match="Partial bodyfat route registration detected"):
+        app_main._include_bodyfat_router_if_needed(
+            _app_with_bodyfat_routes_and_extra_method(combined_route=False)
+        )
+
+
+def test_bodyfat_route_registration_rejects_existing_combined_methods() -> None:
+    with pytest.raises(RuntimeError, match="Partial bodyfat route registration detected"):
+        app_main._include_bodyfat_router_if_needed(
+            _app_with_bodyfat_routes_and_extra_method(combined_route=True)
+        )
+
+
+def test_bodyfat_route_registration_rejects_foreign_handlers() -> None:
+    app = FastAPI()
+    path, method, include_in_schema = app_main._BODYFAT_ROUTE_SPECS[0]
+
+    async def _foreign_bodyfat_route() -> dict[str, str]:
+        return {"status": "foreign"}
+
+    getattr(app, method.lower())(path, include_in_schema=include_in_schema)(_foreign_bodyfat_route)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different bodyfat handler",
+    ):
+        app_main._include_bodyfat_router_if_needed(app)
+
+
+def test_bodyfat_route_registration_rejects_openapi_visibility_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path, _method, include_in_schema = app_main._BODYFAT_ROUTE_SPECS[0]
+    monkeypatch.setattr(
+        app_main,
+        "bodyfat_router",
+        _bodyfat_stub_router(include_overrides={path: not include_in_schema}),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Bodyfat router does not preserve OpenAPI visibility",
+    ):
+        app_main._include_bodyfat_router_if_needed(FastAPI())
+
+
+def test_bodyfat_route_registration_rejects_existing_openapi_visibility_drift() -> None:
+    app = FastAPI()
+    app.include_router(app_main.bodyfat_router)
+    path, method, include_in_schema = app_main._BODYFAT_ROUTE_SPECS[0]
+    matching_route = next(
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == path
+        and method in (getattr(route, "methods", None) or set())
+    )
+    matching_route.include_in_schema = not include_in_schema
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve bodyfat OpenAPI visibility",
+    ):
+        app_main._include_bodyfat_router_if_needed(app)
+
+
+def test_bodyfat_route_registration_rejects_unrelated_router_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        app_main,
+        "bodyfat_router",
+        _bodyfat_stub_router_with_unrelated_path(),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Bodyfat router does not define the expected route family",
+    ):
+        app_main._include_bodyfat_router_if_needed(FastAPI())
+
+
+def test_bodyfat_route_registration_rejects_duplicate_canonical_router_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_main, "bodyfat_router", _duplicate_bodyfat_stub_router())
+
+    with pytest.raises(
+        RuntimeError,
+        match="Bodyfat router does not define the expected route family",
+    ):
+        app_main._include_bodyfat_router_if_needed(FastAPI())
+
+
+def test_bodyfat_direct_router_remains_unprefixed_compatibility() -> None:
+    from app.routers.bodyfat import get_router
+
+    app = FastAPI()
+    app.include_router(get_router())
+    client = TestClient(app)
+    payload = {
+        "height_m": 1.75,
+        "weight_kg": 75,
+        "age": 30,
+        "gender": "male",
+        "neck_cm": 38,
+        "waist_cm": 80,
+        "language": "en",
+    }
+
+    response = client.post("/bodyfat", json=payload)
+    assert response.status_code == 200
+    assert {"labels", "lang", "median", "methods"} <= response.json().keys()
+    assert client.post("/api/v1/bodyfat", json=payload).status_code == 404
+
+
+def test_bodyfat_final_openapi_hides_path() -> None:
+    app_main.app.openapi_schema = None
+    route_matches = [
+        route
+        for route in app_main.app.routes
+        if getattr(route, "path", None) == "/api/v1/bodyfat"
+        and "POST" in (getattr(route, "methods", None) or set())
+    ]
+
+    assert len(route_matches) == 1
+    assert "/api/v1/bodyfat" not in app_main.app.openapi()["paths"]
+    assert "/bodyfat" not in app_main.app.openapi()["paths"]
 
 
 def test_plan_export_route_registration_is_idempotent(


### PR DESCRIPTION
## Goal

Move `POST /api/v1/bodyfat` ownership from `legacy_app.py` into canonical `app.main` bootstrap without changing HTTP behavior.

## Business Reason

This removes one more legacy route-registration seam while preserving the public bodyfat compatibility contract and keeping generated client/OpenAPI artifacts unchanged.

## Scope

- Add canonical bodyfat route specs and module-level router in `app/routers/bodyfat.py`.
- Register the bodyfat static route family from `app/main.py` through `ensure_route_family_registered(...)`.
- Keep `get_router()` as a stable unprefixed `/bodyfat` direct-inclusion adapter.
- Remove bodyfat import/include ownership from `legacy_app.py`.
- Shrink the legacy growth guard allowlist and add bodyfat re-registration guard tests, including dynamic import bypass regressions.
- Add typed bodyfat response-model metadata on hidden/direct route declarations without changing the returned payload shape or generated client artifacts.
- Update routing docs and backlog follow-up for future BMI-engine derivation delegation.
- Maintain canonical fixed-mapping and premortem evidence under `docs/review/`.

## Out Of Scope

No formula, BMI derivation semantics, request-validation behavior, response-payload shape, auth/tier, rate-limit, generated OpenAPI/client, canonical BMI engine behavior, DB, frontend runtime, iOS, or migration changes.

## Files Changed

- `app/routers/bodyfat.py`
- `app/main.py`
- `legacy_app.py`
- `app/__init__.py`
- `scripts/ci/check_legacy_growth_guard.py`
- `tests/test_main_paywall_bootstrap.py`
- `tests/test_legacy_growth_guard.py`
- `tests/test_api.py`
- `tests/test_app_public_surface.py`
- `docs/architecture/backend_routing_map.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/BODYFAT_CANONICAL_BOOTSTRAP_PREMORTEM.md`
- `docs/review/PR_2021_FIXED_MAPPING.md`

## Key Decisions

- Use the existing `RouteMemberContract` / `ensure_route_family_registered(...)` guard instead of bespoke duplicate detection.
- Preserve old direct router compatibility by keeping `get_router()` unprefixed.
- Keep the source route `include_in_schema=True`, with final published OpenAPI still filtering `/api/v1/bodyfat`.
- Treat dynamic `app.routers.*` imports in `legacy_app.py` as import-growth facts so removed route ownership cannot be hidden behind an allowed variable name.
- Defer BMI derivation delegation to a P1 backlog item to avoid changing math in this route-ownership PR.

## Tests / Validation

Passed locally:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_main_paywall_bootstrap.py -k bodyfat`
- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_legacy_growth_guard.py`
- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_api.py::test_v1_bodyfat tests/test_api.py::test_v1_bodyfat_missing_hip tests/test_api.py::test_bodyfat_router_export_uses_canonical_package_path tests/test_app_bodyfat_v1.py tests/test_bodyfat_labels_coverage.py tests/edges/test_bodyfat_edges.py tests/test_bodyfat_shim.py tests/test_docker_workflow_build_path_contract.py::test_docker_entrypoint_keeps_bodyfat_hidden_but_routable tests/test_app_public_surface.py::test_app_public_surface_smoke`
- `python3 scripts/ci/check_legacy_growth_guard.py`
- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; make openapi-check DEV_PYTHON="$VENV_PYTHON"`
- `pre-commit run --all-files`
- `make validate-changed`
- `git show --check --oneline HEAD`
- Push hooks: changed-files mypy, pre-push backend pytest, full-repo Bandit, Docker build test.

Additional post-open review-fix validation:

- bug-hunter dynamic import fix: `tests/test_legacy_growth_guard.py`, `python3 scripts/ci/check_legacy_growth_guard.py`, `make validate-changed`.
- security-auditor alias/destructuring/walrus guard fix: focused bodyfat/bootstrap/API suite, `tests/test_legacy_growth_guard.py`, `python3 scripts/ci/check_legacy_growth_guard.py`, `make validate-changed`, `make openapi-check`, `pre-commit run --all-files`, `git diff --check`, changed-file mypy.
- CodeRabbit fix commit `87a931b921098fb2da1de486753a988ad99b9ff2`: focused bodyfat/bootstrap/API/legacy-guard pytest suite (`41 passed`), `python3 scripts/ci/check_legacy_growth_guard.py`, `make openapi-check`, `make validate-changed`, `python3 scripts/orchestration/check_agent_consistency.py`, `pre-commit run --all-files`, and `git diff --check`.
- Nested dynamic-router guard fix commit `73ada8d421688917c0b2eebfcf630eb2b96de70e`: focused nested regression pytest, full `tests/test_legacy_growth_guard.py` (`76 passed`), focused bodyfat/bootstrap/API/legacy-guard suite (`43 passed`), `python3 scripts/ci/check_legacy_growth_guard.py`, `make validate-changed`, `pre-commit run --all-files`, and `git diff --check`.

Post-open review tooling:

- `qa-engineer-agent`: no actionable findings.
- `bug-hunter`: actionable dynamic-import guard finding fixed in `44bc4440a` and mapped in the artifact.
- `security-auditor`: actionable alias/destructuring/walrus dynamic-import guard finding fixed in `90c185114`; changed-file mypy cleanup in `bf5436342`; mapped in the artifact.
- Codex Security scan `d9f75240-8a67-4c76-b8d6-e2062323022a`: 5/5 reviewed, 0 findings.
- `pulseplate-pr-review`: completed; only advisory `large-diff-risk` note, dispositioned as NOT-A-BUG in the artifact.
- CodeRabbit current-head actionables from review `4569752389`: 5/5 fixed in `87a931b921098fb2da1de486753a988ad99b9ff2` and mapped in the artifact.
- Merge-ready `bug-hunter` nested dynamic-router composition finding fixed in `73ada8d421688917c0b2eebfcf630eb2b96de70e` and dispositioned in the artifact.

Full local `make verify` was not run per operator CPU constraint. No green/mergeable claim is made from local evidence alone.

## Security Notes

No auth, billing, secrets, LLM, quota, rate-limit, entitlement, or tier policy changes. The legacy guard now fails closed on static and dynamic bodyfat route re-registration in `legacy_app.py`.

## Risks / Rollback

Risk: duplicate route ownership, OpenAPI visibility drift, compatibility prefix regression, or hidden dynamic legacy route reintroduction.

Mitigation: static route-family guard tests, legacy growth guard tests including dynamic import hidden-name regressions, direct router compatibility tests, focused API parity tests, and OpenAPI check.

Rollback: revert this PR to restore the prior legacy bodyfat include path; no migrations, generated client artifacts, or persisted data are involved.

## Deferred / Follow-ups

- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-bodyfat-bmi-engine-delegation` tracks future delegation of missing-BMI derivation to the canonical BMI engine.

## AGENTS Updates

No AGENTS.md or scoped agent instruction changes.

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/b1f4071b1aa9.json`
- Branch: `codex/move-bodyfat-registration-to-canonical-bootstrap`
- Role order executed pre-open: `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`

## Premortem Evidence

- Artifact: `docs/review/BODYFAT_CANONICAL_BOOTSTRAP_PREMORTEM.md`
- Decision: `proceed with changes`
- Findings closed before PR open through code, guards, tests, docs, and backlog tracking.

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/bodyfat-canonical-bootstrap-oracle-result.json`
- Packet: `artifacts/orchestration/experiments/bodyfat-canonical-bootstrap-oracle-packet.json`
- Experiment id: `exp-7c4838ebc835`
- Status: `accepted`
- Runner mode: `oracle_only_governance_reviewer`
- Oracles executed: 3
- Shared tree untouched: `true`
- Contribution kind: `oracle_review`
- Co-author required: yes; implementation commits include `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Fixed mapping artifact created after GitHub assigned PR number `#2021`.
- [x] Post-open `qa-engineer-agent` pass completed: no actionable findings.
- [x] Post-open `bug-hunter` pass completed; actionable dynamic-import guard finding fixed and dispositioned in the artifact.
- [x] Post-open `security-auditor` pass completed; actionable alias/destructuring/walrus dynamic-import guard finding fixed and dispositioned in the artifact.
- [x] Codex Security diff scan completed: 5/5 reviewed, 0 findings.
- [x] `pulseplate-pr-review` completed; advisory large-diff note dispositioned in the artifact.
- [x] CodeRabbit review `4569752389` actionables fixed and mapped in the artifact.
- [ ] CodeRabbit comments/actionables inspected on final current head after commit `a16641520` lands.
- [ ] Sourcery comments/actionables inspected on final current head after commit `a16641520` lands.
- [ ] Cubic comments/actionables inspected on final current head after commit `a16641520` lands.
- [ ] Current-head CI complete before readiness language.
- [ ] Strict merge-readiness checks run after the final review/check cycle.

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_2021_FIXED_MAPPING.md`

Artifact: `docs/review/PR_2021_FIXED_MAPPING.md`

## Merge Readiness

Not merge-ready until the new current-head CI/bot cycle for commit `a16641520` and this PR-body mirror update completes.

Required before merge:

- [ ] Current-head CI passes.
- [ ] CodeRabbit/Sourcery/Cubic comments inspected and dispositioned on final current head.
- [ ] Strict merge-readiness checks pass.

## Next Best Step

Refresh current-head CI and bot comments for commit `a16641520`, resolve only mapped threads after disposition proof, then run strict merge-readiness checks before any readiness language.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bodyfat endpoints are now available through the app’s main startup path, with both the main API route and a compatible direct route supported.
  * Responses now return a clearer, structured bodyfat result with localized labels.

* **Bug Fixes**
  * Improved request handling so missing values are filled more reliably before calculation.
  * Reduced routing inconsistencies by preventing duplicate or conflicting bodyfat registrations.

* **Documentation**
  * Updated backend routing docs and planning notes to reflect the new bodyfat route ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->