### PR TITLE
fix(security): expire PyTorch pip-audit waiver (fail-closed after remove-by)

### DIFF
--- a/docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md
+++ b/docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md
@@ -13,7 +13,8 @@ finding is limited to the optional vector profile.
 - **Owner:** @katsiaryna_kavaleuskaya
 - **Remove-by:** 2026-07-17
 - **Backlog:** `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-pytorch-jit-cve-2025-3000-vector-profile`
-- **pip-audit waiver:** `scripts/ci_pip_audit.sh`
+- **pip-audit waiver:** `scripts/ci_pip_audit.sh` (fail-closed after the
+  remove-by date)
 - **Last checked:** 2026-06-24
 
 ## Current Repo State
@@ -39,7 +40,8 @@ finding is limited to the optional vector profile.
 
 - `requirements-rag-vector.txt:162`
 - `requirements-rag-vector-cpu.txt:119`
-- `scripts/ci_pip_audit.sh:40`
+- `scripts/ci_pip_audit.sh`: scoped `pip-audit` waiver with executable
+  remove-by enforcement.
 - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-pytorch-jit-cve-2025-3000-vector-profile`
 
 ## Exposure Assessment

--- a/scripts/ci_pip_audit.sh
+++ b/scripts/ci_pip_audit.sh
@@ -7,6 +7,7 @@ if ! command -v pip-audit >/dev/null 2>&1; then
 fi
 
 readonly PYTORCH_JIT_CVE_ID="CVE-2025-3000"
+readonly PYTORCH_JIT_WAIVER_REMOVE_BY="2026-07-17"
 overall_status=0
 
 manifests=("requirements.txt")
@@ -39,6 +40,11 @@ for manifest in "${manifests[@]}"; do
   )
   case "${manifest}" in
     requirements-rag-vector.txt | requirements-rag-vector-cpu.txt)
+      today="$(date -u +%Y-%m-%d)"
+      if [[ "${today}" > "${PYTORCH_JIT_WAIVER_REMOVE_BY}" ]]; then
+        echo "[ci_pip_audit] ERROR: ${PYTORCH_JIT_CVE_ID} waiver expired on ${PYTORCH_JIT_WAIVER_REMOVE_BY}; remove the waiver or refresh the advisory with reviewed evidence" >&2
+        exit 1
+      fi
       audit_args+=(--ignore-vuln "${PYTORCH_JIT_CVE_ID}")
       ;;
   esac

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -425,7 +425,11 @@ def test_pytorch_jit_cve_pip_audit_waiver_evidence_is_scoped_and_current() -> No
     pip_audit_text = PIP_AUDIT_HELPER.read_text(encoding="utf-8")
 
     assert 'readonly PYTORCH_JIT_CVE_ID="CVE-2025-3000"' in pip_audit_text
+    assert 'readonly PYTORCH_JIT_WAIVER_REMOVE_BY="2026-07-17"' in pip_audit_text
     assert "requirements-rag-vector.txt | requirements-rag-vector-cpu.txt" in pip_audit_text
+    assert 'date -u +%Y-%m-%d' in pip_audit_text
+    assert '"${today}" > "${PYTORCH_JIT_WAIVER_REMOVE_BY}"' in pip_audit_text
+    assert "${PYTORCH_JIT_CVE_ID} waiver expired" in pip_audit_text
     assert '--ignore-vuln "${PYTORCH_JIT_CVE_ID}"' in pip_audit_text
     assert "requirements.txt | requirements-ci-lite.txt" not in pip_audit_text
 

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -1574,6 +1574,63 @@ fi
     assert (tmp_path / "pip-audit-requirements-evals.json").exists()
 
 
+def test_pip_audit_helper_rejects_expired_pytorch_jit_waiver(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_pip_audit = fake_bin / "pip-audit"
+    fake_pip_audit.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ -n "${output}" ]]; then
+  printf '{}\n' > "${output}"
+fi
+""",
+        encoding="utf-8",
+    )
+    fake_pip_audit.chmod(0o755)
+    fake_date = fake_bin / "date"
+    fake_date.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '2026-07-18\n'
+""",
+        encoding="utf-8",
+    )
+    fake_date.chmod(0o755)
+
+    for manifest in ("requirements.txt", "requirements-rag-vector.txt"):
+        (tmp_path / manifest).write_text("example==1.0.0\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["CI"] = "1"
+    env["PATH"] = os.pathsep.join((str(fake_bin), "/usr/bin", "/bin", "/usr/sbin", "/sbin"))
+
+    result = subprocess.run(
+        ["/bin/bash", str(REPO_ROOT / "scripts" / "ci_pip_audit.sh")],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "CVE-2025-3000 waiver expired on 2026-07-17" in result.stderr
+    assert not (tmp_path / "pip-audit-requirements-rag-vector.json").exists()
+
+
 def test_pip_audit_helper_scans_all_manifests_before_returning_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- Close a CI/security-control regression where `scripts/ci_pip_audit.sh` unconditionally ignored `CVE-2025-3000` for optional RAG/vector manifests with no executable expiry, which can indefinitely mask a known PyTorch CVE.
- Ensure the waiver is governed by the documented `Remove-by` date and that CI fails closed after that date instead of silently suppressing alerts.

### Description
- Add `PYTORCH_JIT_WAIVER_REMOVE_BY="2026-07-17"` and a UTC date check to `scripts/ci_pip_audit.sh` that rejects the waiver and exits non-zero when the current date is past the remove-by date, before appending the scoped `--ignore-vuln` argument for the `requirements-rag-vector` manifests.
- Update `docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md` to document that the pip-audit waiver is now fail-closed after the remove-by date and to update the evidence anchor to reference executable enforcement.
- Strengthen regression guards in `tests/guards/test_security_devtooling_regression_guards.py` to assert the new `PYTORCH_JIT_WAIVER_REMOVE_BY` constant and presence of the runtime date check snippets in the helper script.
- Add a deterministic shell-based pytest `test_pip_audit_helper_rejects_expired_pytorch_jit_waiver` to `tests/test_python_supply_chain_controls.py` that uses fake `date`/`pip-audit` shims to exercise the expired-waiver path and assert the helper fails closed without producing the RAG/vector audit output.

### Testing
- Ran `python3 scripts/orchestration/check_preflight.py` which passed. 
- Performed a static shell syntax check with `bash -n scripts/ci_pip_audit.sh` and compiled test modules with `python -m py_compile` which succeeded for the modified test files. 
- Executed targeted shell reproductions using fake `pip-audit`/`date` in an isolated temporary directory and verified that (a) on `2026-07-18` the script exits with status `1` and does not write RAG/vector audit output, and (b) on `2026-07-17` the scoped `--ignore-vuln CVE-2025-3000` remains applied; both reproductions matched the expected behavior. 
- Attempted to run the focused `pytest` selection but it could not complete in this environment due to missing `pyenv`/project dependencies (`pyenv: version '3.13.6' is not installed`, `ModuleNotFoundError: No module named 'fastapi'`) and `pre-commit` is not installed here, so full local `pytest`/`pre-commit` runs were not executed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d7ac43e88832c99e41626ec13e921)

## Summary by Sourcery

Установить срок действия для исключения `pip-audit` по уязвимости PyTorch CVE-2025-3000 для манифестов RAG/vector, чтобы CI завершался с ошибкой («fail closed») после истечения даты удаления исключения.

Bug Fixes:
- Обеспечить отклонение исключения `pip-audit` по PyTorch CVE-2025-3000 после задокументированной даты удаления вместо бесконечного тихого подавления оповещений.

Enhancements:
- Задокументировать, что исключение `pip-audit` для PyTorch JIT теперь применяется по принципу «fail closed» после даты удаления и связать его с исполняемой логикой принудительного контроля в вспомогательном скрипте.

Tests:
- Добавить регрессионный тест, который моделирует просроченное исключение для PyTorch JIT и проверяет, что вспомогательный скрипт `pip-audit` завершается с ошибкой и не выводит результаты аудита RAG/vector.
- Усилить регрессионные проверки дев-тулов, чтобы утверждать корректность константы даты удаления исключения для PyTorch JIT и наличие логики проверки даты выполнения во вспомогательном скрипте `pip-audit`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce an expiry date on the PyTorch CVE-2025-3000 pip-audit waiver for RAG/vector manifests so CI fails closed once the waiver is past its remove-by date.

Bug Fixes:
- Ensure the PyTorch CVE-2025-3000 pip-audit waiver is rejected after its documented remove-by date instead of silently suppressing alerts indefinitely.

Enhancements:
- Document that the PyTorch JIT pip-audit waiver is now enforced in a fail-closed manner after the remove-by date and link it to executable enforcement in the helper script.

Tests:
- Add a regression test that simulates an expired PyTorch JIT waiver and verifies the pip-audit helper exits with failure and does not emit RAG/vector audit output.
- Strengthen dev tooling regression guards to assert the PyTorch JIT waiver remove-by constant and the presence of the runtime date check logic in the pip-audit helper script.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expire the PyTorch `pip-audit` waiver for CVE-2025-3000 by enforcing a remove-by date, so CI fails closed after 2026-07-17 instead of silently ignoring the vuln for RAG/vector manifests.

- **Bug Fixes**
  - Added `PYTORCH_JIT_WAIVER_REMOVE_BY="2026-07-17"` and a UTC date check in `scripts/ci_pip_audit.sh`; reject the waiver past this date before applying `--ignore-vuln` for `requirements-rag-vector*.txt`.
  - Updated `docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md` to document fail-closed behavior with executable enforcement.
  - Strengthened regression guards to assert the new constant and date-check snippets.
  - Added a deterministic pytest that shims `date`/`pip-audit` to verify the helper exits non-zero on 2026-07-18 and does not emit RAG/vector audit output.

<sup>Written for commit 23cca0710688495c129c4f3316cffad10030cd10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened vulnerability audit checks by enforcing an expiration date on a security waiver.
  * Audit runs now stop with a clear error once the waiver is past its allowed date, preventing outdated exceptions from being used.
  * Improved security advisory wording to make the waiver scope and expiry behavior clearer.
  * Added regression coverage to ensure expired waivers fail as expected and no audit output is produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->