### PR TITLE
fix(orchestration): enforce zero-network oracle sandbox

### DIFF
--- a/app/security/execution_sandbox.py
+++ b/app/security/execution_sandbox.py
@@ -31,6 +31,7 @@ SANDBOX_ROOT_ENV = "AGENT_EXECUTION_SANDBOX_ROOT"
 SANDBOX_TIMEOUT_ENV = "AGENT_EXECUTION_SANDBOX_TIMEOUT_SECONDS"
 SANDBOX_MAX_OUTPUT_ENV = "AGENT_EXECUTION_SANDBOX_MAX_OUTPUT_BYTES"
 SANDBOX_ALLOWED_BINARIES_ENV = "AGENT_EXECUTION_SANDBOX_ALLOWED_BINARIES"
+SANDBOX_DISABLE_NETWORK_ENV = "AGENT_EXECUTION_SANDBOX_DISABLE_NETWORK"
 
 DEFAULT_SANDBOX_TIMEOUT_SECONDS = 30
 DEFAULT_SANDBOX_MAX_OUTPUT_BYTES = 32_768
@@ -246,6 +247,14 @@ def resolve_allowed_binary(binary: str, *, allowed_binaries: tuple[str, ...] | N
     return resolved
 
 
+def _env_flag_enabled(name: str, *, env: Mapping[str, str] | None = None) -> bool:
+    """Return whether an environment flag is enabled."""
+
+    source = env if env is not None else os.environ
+    raw = (source.get(name) or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
 def sanitize_sandbox_env(extra_env: Mapping[str, str] | None = None) -> dict[str, str]:
     """Return sanitized environment for sandbox subprocess."""
 
@@ -264,6 +273,9 @@ def sanitize_sandbox_env(extra_env: Mapping[str, str] | None = None) -> dict[str
             raise PermissionError(f"Loader env key is not allowed in sandbox: {key}")
         if any(token in upper for token in _SENSITIVE_ENV_TOKENS):
             raise PermissionError(f"Sensitive env key is not allowed in sandbox: {key}")
+        if key == SANDBOX_DISABLE_NETWORK_ENV:
+            sanitized[key] = value
+            continue
         if upper not in _ALLOWED_EXTRA_ENV_KEYS and not any(
             upper.startswith(prefix) for prefix in _ALLOWED_EXTRA_ENV_PREFIXES
         ):
@@ -393,6 +405,17 @@ def _join_drain_thread(
     thread.join(timeout=_STREAM_JOIN_GRACE_SECONDS)
 
 
+def _network_isolation_argv(binary_path: str, argv: tuple[str, ...]) -> tuple[str, ...]:
+    """Wrap argv with OS network isolation or fail closed when unavailable."""
+
+    if os.name != "posix":
+        raise RuntimeError("Sandbox network isolation requires a POSIX host.")
+    unshare_path = shutil.which("unshare")
+    if not unshare_path:
+        raise RuntimeError("Sandbox network isolation requires the unshare binary.")
+    return (unshare_path, "--net", "--map-root-user", binary_path, *argv[1:])
+
+
 def run_local_sandbox(
     request: SandboxRequest,
     *,
@@ -411,6 +434,8 @@ def run_local_sandbox(
     max_output_bytes = require_sandbox_max_output_bytes()
     env = sanitize_sandbox_env(request.env)
     argv = (binary_path, *request.args)
+    if _env_flag_enabled(SANDBOX_DISABLE_NETWORK_ENV, env=env):
+        argv = _network_isolation_argv(binary_path, argv)
     output_budget = _SharedOutputBudget(max_bytes=max_output_bytes)
     stdout_collector = _StreamingOutputBuffer(budget=output_budget)
     stderr_collector = _StreamingOutputBuffer(budget=output_budget)

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -478,7 +478,17 @@ def _has_effective_diff(checkout_root: Path) -> bool:
     return bool(process.stdout.strip())
 
 
-def _command_to_request(command: str) -> SandboxRequest:
+def _network_sandbox_env(packet: dict[str, Any]) -> dict[str, str] | None:
+    """Return sandbox env overrides required by the packet budgets."""
+
+    if int(packet["budgets"].get("network_budget", 0)) == 0:
+        return {sandbox.SANDBOX_DISABLE_NETWORK_ENV: "true"}
+    return None
+
+
+def _command_to_request(
+    command: str, *, sandbox_env: dict[str, str] | None = None
+) -> SandboxRequest:
     """Convert a packet oracle command string into a sandbox request."""
 
     try:
@@ -494,7 +504,7 @@ def _command_to_request(command: str) -> SandboxRequest:
             f"Oracle binary {binary!r} is not allowlisted for experiment runner. "
             f"Allowed: {allowed}"
         )
-    return SandboxRequest(binary=binary, args=tuple(argv[1:]), cwd=".")
+    return SandboxRequest(binary=binary, args=tuple(argv[1:]), cwd=".", env=sandbox_env)
 
 
 def _classify_oracle_failure(result: sandbox.SandboxResult) -> str:
@@ -515,7 +525,11 @@ def _run_oracles(
 
     oracle_results: list[dict[str, Any]] = []
     failure_class: str | None = None
-    requests = [_command_to_request(oracle["command"]) for oracle in packet["immutable_oracles"]]
+    sandbox_env = _network_sandbox_env(packet)
+    requests = [
+        _command_to_request(oracle["command"], sandbox_env=sandbox_env)
+        for oracle in packet["immutable_oracles"]
+    ]
     allowed_binaries = tuple(sorted({request.binary for request in requests}))
     path_prefix = _python_oracle_path_prefix(requests)
     total_wall_clock_seconds = int(packet["budgets"]["wall_clock_seconds"])

--- a/tests/test_execution_sandbox.py
+++ b/tests/test_execution_sandbox.py
@@ -68,6 +68,40 @@ def test_parse_allowed_binaries_rejects_paths() -> None:
         sandbox.parse_allowed_binaries("/usr/bin/python3")
 
 
+def test_sanitize_sandbox_env_allows_network_disable_flag() -> None:
+    env = sandbox.sanitize_sandbox_env({sandbox.SANDBOX_DISABLE_NETWORK_ENV: "true"})
+
+    assert env[sandbox.SANDBOX_DISABLE_NETWORK_ENV] == "true"
+
+
+def test_network_isolation_argv_wraps_command_with_unshare(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sandbox.os, "name", "posix")
+    monkeypatch.setattr(sandbox.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+
+    argv = sandbox._network_isolation_argv("/usr/bin/python3", ("/usr/bin/python3", "-c", "0"))
+
+    assert argv == (
+        "/usr/bin/unshare",
+        "--net",
+        "--map-root-user",
+        "/usr/bin/python3",
+        "-c",
+        "0",
+    )
+
+
+def test_network_isolation_argv_fails_closed_without_unshare(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sandbox.os, "name", "posix")
+    monkeypatch.setattr(sandbox.shutil, "which", lambda _binary: None)
+
+    with pytest.raises(RuntimeError, match="requires the unshare binary"):
+        sandbox._network_isolation_argv("/usr/bin/python3", ("/usr/bin/python3",))
+
+
 def test_require_sandbox_timeout_seconds_rejects_non_integer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -1141,6 +1141,22 @@ def test_classify_oracle_failure_matches_only_standalone_oom_markers() -> None:
     assert experiment_runner._classify_oracle_failure(oom_result) == "oom"
 
 
+def test_zero_network_budget_marks_oracle_sandbox_network_disabled() -> None:
+    packet = _validate_packet(
+        _base_packet(
+            mutable_path="core/rag/allowed.py",
+            oracle_command='python3 -c "import sys; sys.exit(0)"',
+        )
+    )
+
+    request = experiment_runner._command_to_request(
+        packet["immutable_oracles"][0]["command"],
+        sandbox_env=experiment_runner._network_sandbox_env(packet),
+    )
+
+    assert request.env == {experiment_runner.sandbox.SANDBOX_DISABLE_NETWORK_ENV: "true"}
+
+
 def test_evaluate_candidate_allows_first_oracle_on_one_second_budget(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
### Motivation
- The creative-code patch builder set `network_budget: 0` but forwarded request-controlled `oracle_commands` into the Experiment Runner which used the local sandbox that only set cwd/env/timeouts and did not enforce network isolation, allowing interpreters (e.g., `python3 -c ...`) to open outbound connections in violation of the PR-2 contract. 
- The change aims to make the zero-network budget an enforced sandbox constraint rather than metadata only, failing closed when host isolation support is not available.

### Description
- Added a sandbox network-disable environment marker `AGENT_EXECUTION_SANDBOX_DISABLE_NETWORK` and a helper `_env_flag_enabled(...)` to `app/security/execution_sandbox.py` so the sanitizer permits the flag while still rejecting other sensitive env keys. 
- Implemented `_network_isolation_argv(...)` in `app/security/execution_sandbox.py` that wraps the requested binary with `unshare --net --map-root-user` on POSIX hosts and fails closed when `unshare` or POSIX support is unavailable, and made `run_local_sandbox(...)` use that wrapper when the disable-network flag is present. 
- Propagated Experiment Runner budgets into sandbox requests by adding `_network_sandbox_env(...)` and passing the resulting env into `_command_to_request(...)` in `scripts/orchestration/experiment_runner.py` when `network_budget == 0`, so oracle runs receive the network-disable marker. 
- Added focused regression tests to `tests/test_execution_sandbox.py` (sanitizer acceptance, `unshare` wrap, fail-closed behavior) and to `tests/test_experiment_runner.py` (packet→request env propagation) to exercise the new contract and behavior.

### Testing
- Static checks: `python3 -m py_compile` succeeded for the modified files `app/security/execution_sandbox.py`, `scripts/orchestration/experiment_runner.py`, `tests/test_execution_sandbox.py`, and `tests/test_experiment_runner.py`. 
- Repo preflight: `python3 scripts/orchestration/check_preflight.py` and `python3 scripts/orchestration/check_agent_consistency.py` completed successfully in this environment. 
- Unit test execution was not possible in this environment because `pytest`/`flake8`/`pre-commit` were not available and PyPI fetches failed for the test bootstrap, so the newly added pytest cases were added but could not be executed here; they are included for CI/local runs where test tooling is available. 
- Environment notes: lint (`make lint`) and `pre-commit run --all-files` could not be run due to missing tooling in the execution environment; these checks should be run by CI or locally before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d7ac42c68832c9bc7e2e4067e5b25)

## Summary by Sourcery

Обеспечить выполнение oracle sandboxes без доступа к сети, подключив сетевые бюджеты экспериментов к среде песочницы и добавив поддержку сетевой изоляции в локальный запуск песочницы.

New Features:
- Поддержка флага отключения сети для песочницы, который при включении инициирует изоляцию сети на уровне ОС для локального выполнения песочницы.

Bug Fixes:
- Гарантировать, что oracle-команды, запускаемые с нулевым сетевым бюджетом, действительно изолированы от сети, а не просто помечены через метаданные.

Enhancements:
- Санитизировать переменные окружения песочницы, явно разрешая новый маркер-флаг отключения сети.
- Ввести помощник для обнаружения включённых флагов окружения и использовать его для условного обёртывания команд песочницы в запускающий процесс, изолирующий сеть, на поддерживаемых хостах.
- Протянуть сетевые бюджеты пакетов эксперимента в запросы к песочнице, чтобы эксперименты с нулевым сетевым бюджетом получали корректную среду песочницы.

Tests:
- Добавить регрессионные тесты для санитизации окружения песочницы, обёртывания аргументов для сетевой изоляции и поведения «fail-closed», когда поддержка изоляции недоступна.
- Добавить тесты, проверяющие, что нулевой сетевой бюджет помечает запросы к oracle-песочнице как выполненные с отключённой сетью.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce zero-network execution for oracle sandboxes by wiring experiment budgets into the sandbox environment and adding network isolation support to the local sandbox runner.

New Features:
- Support a sandbox network-disable flag that triggers OS-level network isolation for local sandbox execution when enabled.

Bug Fixes:
- Ensure oracle commands run with a zero network budget are actually network-isolated rather than only annotated via metadata.

Enhancements:
- Sanitize sandbox environment variables while explicitly allowing the new network-disable marker flag.
- Introduce a helper to detect enabled environment flags and use it to conditionally wrap sandbox commands with a network-isolating launcher on supported hosts.
- Propagate experiment packet network budgets into sandbox requests so zero-network experiments carry the correct sandbox environment.

Tests:
- Add regression tests for sandbox environment sanitization, network-isolation argument wrapping, and fail-closed behavior when isolation support is unavailable.
- Add tests verifying that zero-network budgets mark oracle sandbox requests as network-disabled.

</details>