### PR TITLE
refactor(api): move test route registration to canonical bootstrap

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -883,7 +883,7 @@
         "filename": "tests/test_app_extended_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 35
       }
     ],
     "tests/test_app_extra_coverage.py": [
@@ -1743,5 +1743,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-26T09:42:37Z"
+  "generated_at": "2026-06-27T15:52:25Z"
 }

--- a/app/main.py
+++ b/app/main.py
@@ -6,11 +6,13 @@ Keep imports deterministic: do NOT use importlib exec_module, do NOT mutate sys.
 
 from __future__ import annotations
 
+import os
 from typing import Any, Awaitable, Callable, cast
 
 import legacy_app as _legacy_module
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.responses import HTMLResponse
+from settings import get_runtime_env_name
 
 from legacy_app import (
     _install_openapi_builder,
@@ -68,6 +70,11 @@ from app.routers.restaurants import (
 )
 from app.routers.shoplist_export import router as shoplist_export_router
 from app.routers.shoplist_export_routes import SHOPLIST_ROUTE_SPECS
+from app.routers.test import (
+    TEST_ROUTE_SPECS,
+    _ensure_non_production as ensure_test_routes_non_production,
+    router as test_router,
+)
 from app.routers.vip_registration import register_vip_routes
 from app.schemas.direct_api_root import DirectApiRootProbe
 from app.utils.feature_flags import is_vip_module_enabled
@@ -115,6 +122,10 @@ _BMI_COMPAT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
 _BODYFAT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in BODYFAT_ROUTE_SPECS
+)
+_TEST_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in TEST_ROUTE_SPECS
 )
 _LEGACY_EXPORT_ALIAS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
@@ -261,6 +272,25 @@ def _bodyfat_route_members() -> tuple[RouteMemberContract, ...]:
             include_in_schema=include_in_schema,
         )
         for path, method, include_in_schema in _BODYFAT_ROUTE_SPECS
+    )
+
+
+def _test_route_members() -> tuple[RouteMemberContract, ...]:
+    return tuple(
+        RouteMemberContract(
+            path=path,
+            method=method,
+            include_in_schema=include_in_schema,
+            required_dependencies=(ensure_test_routes_non_production,),
+        )
+        for path, method, include_in_schema in _TEST_ROUTE_SPECS
+    )
+
+
+def _test_routes_enabled_for_registration() -> bool:
+    env = get_runtime_env_name()
+    return env in {"local", "dev", "development", "test", "testing", "ci"} or (
+        env == "staging" and os.getenv("ENABLE_TEST_ROUTES") == "1"
     )
 
 
@@ -783,6 +813,20 @@ def _include_bodyfat_router_if_needed(target_app: FastAPI) -> None:
     )
 
 
+def _include_test_router_if_enabled(target_app: FastAPI) -> None:
+    """Register non-production test routes as one hidden canonical family."""
+
+    if not _test_routes_enabled_for_registration():
+        return
+
+    ensure_route_family_registered(
+        target_app,
+        family_name="Test",
+        routers=(test_router,),
+        members=_test_route_members(),
+    )
+
+
 def _include_restaurant_moderation_router_if_needed(target_app: FastAPI) -> None:
     """Register restaurant moderation route as one protected atomic family."""
 
@@ -952,6 +996,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _register_bmi_routes(app)
     _include_bmi_compat_router_if_needed(app)
     _include_bodyfat_router_if_needed(app)
+    _include_test_router_if_enabled(app)
     _include_plan_export_routers_if_needed(app)
     _include_shoplist_export_router_if_needed(app)
     _include_legacy_export_alias_router_if_needed(app)

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ Keep imports deterministic: do NOT use importlib exec_module, do NOT mutate sys.
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Awaitable, Callable, cast
 
@@ -78,6 +79,8 @@ from app.routers.test import (
 from app.routers.vip_registration import register_vip_routes
 from app.schemas.direct_api_root import DirectApiRootProbe
 from app.utils.feature_flags import is_vip_module_enabled
+
+logger = logging.getLogger(__name__)
 
 app: FastAPI = _legacy_app
 VIP_MODULE_ENABLED: bool = bool(getattr(_legacy_module, "VIP_MODULE_ENABLED", False))
@@ -819,6 +822,13 @@ def _include_test_router_if_enabled(target_app: FastAPI) -> None:
     if not _test_routes_enabled_for_registration():
         return
 
+    logger.info(
+        "Test routes enabled for registration",
+        extra={
+            "runtime_env": get_runtime_env_name(),
+            "enable_test_routes": os.getenv("ENABLE_TEST_ROUTES"),
+        },
+    )
     ensure_route_family_registered(
         target_app,
         family_name="Test",

--- a/app/routers/test.py
+++ b/app/routers/test.py
@@ -7,7 +7,7 @@ Should NOT be included in production builds.
 
 import os
 from datetime import datetime, timezone
-from typing import Dict, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel
@@ -51,6 +51,20 @@ class TestResponse(BaseModel):
     message: str
     timestamp: str
     request_id: str | None = None
+
+
+class TestEchoMetadata(BaseModel):
+    """Metadata returned by the test echo endpoint."""
+
+    timestamp: str
+    endpoint: str
+
+
+class TestEchoResponse(BaseModel):
+    """Echo response model for hidden test endpoints."""
+
+    echo: dict[str, Any]
+    metadata: TestEchoMetadata
 
 
 @router.post("/rate-limit", response_model=TestResponse, include_in_schema=False)
@@ -97,8 +111,8 @@ async def test_health(response: Response) -> TestResponse:
     )
 
 
-@router.post("/echo", include_in_schema=False)
-async def test_echo(data: Dict[str, Any], response: Response) -> Dict[str, Any]:
+@router.post("/echo", response_model=TestEchoResponse, include_in_schema=False)
+async def test_echo(data: dict[str, Any], response: Response) -> TestEchoResponse:
     """
     Echo endpoint that returns the received data.
 
@@ -108,9 +122,12 @@ async def test_echo(data: Dict[str, Any], response: Response) -> Dict[str, Any]:
         data: Any JSON data to echo back
 
     Returns:
-        Dict containing the echoed data and metadata
+        TestEchoResponse containing the echoed data and metadata
     """
     timestamp = datetime.now(timezone.utc).isoformat()
     response.headers["X-Test-Timestamp"] = timestamp
 
-    return {"echo": data, "metadata": {"timestamp": timestamp, "endpoint": "echo"}}
+    return TestEchoResponse(
+        echo=data,
+        metadata=TestEchoMetadata(timestamp=timestamp, endpoint="echo"),
+    )

--- a/app/routers/test.py
+++ b/app/routers/test.py
@@ -13,6 +13,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel
 from settings import get_runtime_env_name
 
+TEST_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/test/rate-limit", "POST", False),
+    ("/api/v1/test/health", "GET", False),
+    ("/api/v1/test/echo", "POST", False),
+)
+
 
 def _ensure_non_production() -> None:
     """
@@ -34,6 +40,7 @@ router = APIRouter(
     prefix="/api/v1/test",
     tags=["test"],
     dependencies=[Depends(_ensure_non_production)],
+    include_in_schema=False,
 )
 
 
@@ -46,7 +53,7 @@ class TestResponse(BaseModel):
     request_id: str | None = None
 
 
-@router.post("/rate-limit", response_model=TestResponse)
+@router.post("/rate-limit", response_model=TestResponse, include_in_schema=False)
 async def test_rate_limit(request: Request, response: Response) -> TestResponse:
     """
     Test endpoint for rate limiting without authentication.
@@ -71,7 +78,7 @@ async def test_rate_limit(request: Request, response: Response) -> TestResponse:
     )
 
 
-@router.get("/health", response_model=TestResponse)
+@router.get("/health", response_model=TestResponse, include_in_schema=False)
 async def test_health(response: Response) -> TestResponse:
     """
     Simple health check endpoint for testing.
@@ -90,7 +97,7 @@ async def test_health(response: Response) -> TestResponse:
     )
 
 
-@router.post("/echo")
+@router.post("/echo", include_in_schema=False)
 async def test_echo(data: Dict[str, Any], response: Response) -> Dict[str, Any]:
     """
     Echo endpoint that returns the received data.

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -232,10 +232,11 @@ Evidence:
 - `app/routers/test.py` — owns `TEST_ROUTE_SPECS`, source route handlers, hidden
   `include_in_schema=False` metadata, and request-time `_ensure_non_production()`.
 - `app/main.py` — registers the test route family only when
-  `get_runtime_env_name()` resolves to `local/dev/development/test/testing/ci`, or
-  `staging` with exact `ENABLE_TEST_ROUTES=1`.
+  `get_runtime_env_name()` resolves to `unset/local/dev/development/test/testing/ci`,
+  or `staging` with exact `ENABLE_TEST_ROUTES=1`.
 - `legacy_app.py` does not import or include `app.routers.test`; the legacy growth
-  guard rejects direct, aliased, module-qualified, and dynamic re-registration there.
+  guard rejects direct, aliased, module-qualified, dynamic, and walrus
+  re-registration there.
 
 Runtime effect:
 - `POST /api/v1/test/rate-limit`

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -220,13 +220,32 @@ Runtime effect:
   canonical OpenAPI builder still filters `/api/v1/bodyfat` out of published
   `/openapi.json`; generated client/OpenAPI artifacts are unchanged.
 
-### Test router (non-production env)
+### Test router (canonical bootstrap-owned, non-production env)
 
-Anchor (stable): `legacy_app.py -> include test router only in non-prod env`
+Anchor (stable): `app/main.py -> _include_test_router_if_enabled(app)` owns
+`app/routers/test.py`.
 
-Evidence: `legacy_app.py:890-902`
+Evidence:
+- `app/bootstrap/route_family.py:26` — shared `RouteMemberContract` for exact static
+  route-family members.
+- `app/bootstrap/route_family.py:87` — shared `ensure_route_family_registered(...)` guard.
+- `app/routers/test.py` — owns `TEST_ROUTE_SPECS`, source route handlers, hidden
+  `include_in_schema=False` metadata, and request-time `_ensure_non_production()`.
+- `app/main.py` — registers the test route family only when
+  `get_runtime_env_name()` resolves to `local/dev/development/test/testing/ci`, or
+  `staging` with exact `ENABLE_TEST_ROUTES=1`.
+- `legacy_app.py` does not import or include `app.routers.test`; the legacy growth
+  guard rejects direct, aliased, module-qualified, and dynamic re-registration there.
 
-- Included only in local/dev/test (or staging with explicit `ENABLE_TEST_ROUTES=1`)
+Runtime effect:
+- `POST /api/v1/test/rate-limit`
+- `GET /api/v1/test/health`
+- `POST /api/v1/test/echo`
+
+OpenAPI effect:
+- Source `APIRoute.include_in_schema` is `False`.
+- Final public `app.openapi()` does not expose `/api/v1/test/*`; generated
+  client/OpenAPI artifacts are unchanged.
 
 ## OpenAPI generation behavior (important)
 

--- a/docs/review/PR_2029_FIXED_MAPPING.md
+++ b/docs/review/PR_2029_FIXED_MAPPING.md
@@ -36,6 +36,9 @@ lifespan, frontend, iOS, macOS, or feature-flag redesign.
 - `929fda5791333fae2c0eff31f911408e5a38bc55` - moves test route
   registration to canonical bootstrap, removes legacy ownership, adds guards
   and focused tests, and records routing-map evidence.
+- `eebcb60b8` - fixes Sourcery security observability feedback by logging
+  enabled test route registration and adding caplog coverage for staging with
+  `ENABLE_TEST_ROUTES=1`.
 
 ## Lane Start Provenance
 
@@ -62,7 +65,36 @@ lifespan, frontend, iOS, macOS, or feature-flag redesign.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: eebcb60b8
+Evidence: `app/main.py` logs enabled test route registration; `tests/test_test_route_registration_bootstrap.py` covers staging with `ENABLE_TEST_ROUTES=1` using `caplog`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#pullrequestreview-4584883808 -> eebcb60b8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#discussion_r3485790303 -> eebcb60b8
+
+## Sourcery Review Closure
+
+Disposition: FIXED
+
+Thread: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#discussion_r3485790303
+
+Commit: `eebcb60b8`
+
+Evidence: `app/main.py` now emits `Test routes enabled for registration`
+when `_include_test_router_if_enabled(...)` actually registers the hidden test
+route family, including structured `runtime_env` and `enable_test_routes`
+fields. `tests/test_test_route_registration_bootstrap.py` covers staging with
+`ENABLE_TEST_ROUTES=1` using `caplog` and verifies both logged fields while
+preserving route registration invariants.
+
+Validation:
+
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_test_route_registration_bootstrap.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_test_router.py tests/test_legacy_runtime_env_canonicalization.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_route_family_bootstrap.py tests/test_test_route_registration_bootstrap.py`
+- PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS: `make openapi-check`
+- PASS: `git diff --exit-code -- app/static/openapi.json frontend/src/api/openapi.json frontend/src/api/schema.ts`
+- PASS: `pre-commit run --all-files`
+- PASS: `make validate-changed`
 
 ## Post-open Role Review Evidence
 

--- a/docs/review/PR_2029_FIXED_MAPPING.md
+++ b/docs/review/PR_2029_FIXED_MAPPING.md
@@ -180,6 +180,8 @@ merge-readiness remain mandatory before readiness claims.
 
 ## Local Validation Evidence
 
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
 - PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
 - PASS: `pytest -q tests/test_test_router.py tests/test_legacy_runtime_env_canonicalization.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_route_family_bootstrap.py tests/test_test_route_registration_bootstrap.py`
 - PASS: `make openapi-check`

--- a/docs/review/PR_2029_FIXED_MAPPING.md
+++ b/docs/review/PR_2029_FIXED_MAPPING.md
@@ -1,0 +1,207 @@
+# PR #2029 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029
+
+Branch: `codex/move-test-route-registration-to-canonical-bootstrap`
+
+## Summary
+
+This PR moves `/api/v1/test/*` route registration ownership from
+`legacy_app.py` to canonical `app.main` bootstrap without changing handler
+payloads, headers, auth behavior, request-time production/staging fail-closed
+guards, generated OpenAPI, or generated client artifacts.
+
+## Scope
+
+- Add `TEST_ROUTE_SPECS` in `app/routers/test.py`.
+- Hide test routes at source with `include_in_schema=False`.
+- Register the test route family from `app/main.py` through
+  `RouteMemberContract` and `ensure_route_family_registered(...)`.
+- Preserve the golden registration matrix: unset/local/dev/development/test/
+  testing/ci register; production/prod do not; staging requires exact
+  `ENABLE_TEST_ROUTES=1`; unknown env does not register.
+- Preserve request-time `_ensure_non_production()` 404 behavior.
+- Remove only the legacy `app.routers.test` import/include block.
+- Shrink the legacy growth guard allowlist and add test-router reintroduction
+  tests for direct, aliased, module-qualified, dynamic, and walrus imports.
+- Update backend routing documentation.
+
+## Out Of Scope
+
+No business router, nutrition, shopping, FoodDB, dependency updates, middleware,
+lifespan, frontend, iOS, macOS, or feature-flag redesign.
+
+## Implementation Commits
+
+- `929fda5791333fae2c0eff31f911408e5a38bc55` - moves test route
+  registration to canonical bootstrap, removes legacy ownership, adds guards
+  and focused tests, and records routing-map evidence.
+
+## Lane Start Provenance
+
+- Base branch: fresh `origin/main` containing merged PR `#2021`.
+- Branch: `codex/move-test-route-registration-to-canonical-bootstrap`
+- Packet: `artifacts/orchestration/task_packets/f4b4a3415bdb.json`
+- Role order executed pre-open:
+  `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`
+- Packet creation was treated as provenance/routing only; role passes were
+  executed explicitly before implementation.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Fixed mapping artifact created after GitHub assigned PR number `#2029`.
+- [x] Post-open `qa-engineer-agent` pass completed.
+- [x] Post-open `bug-hunter` pass completed.
+- [x] Post-open `security-auditor` pass completed.
+- [x] Codex Security diff scan / finding discovery completed.
+- [x] `pulseplate-pr-review` completed.
+- [ ] Current-head CI complete before readiness language.
+- [ ] Strict merge-readiness checks run after the final review/check cycle.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Post-open Role Review Evidence
+
+Disposition: NOT-A-BUG
+
+Finding: No actionable defects reported by the mandatory post-open role passes.
+
+Evidence:
+
+- `qa-engineer-agent`: PASS; no blocking QA findings. It verified the env
+  matrix, canonical `app.main` owner, request-time production/staging-disabled
+  404 behavior, source/final OpenAPI hiding, legacy reintroduction coverage,
+  focused pytest evidence, `make validate-changed`, and generated artifact
+  zero diff.
+- `bug-hunter`: PASS; no blocking runtime/edge-case findings. It verified
+  canonical owner wiring, env precedence, request-time fail-closed behavior,
+  source/final OpenAPI hiding, dynamic legacy reintroduction tests, and
+  `git diff --check origin/main...HEAD`.
+- `security-auditor`: PASS; no blocking security findings. It verified
+  production/prod/unknown env non-registration, exact staging flag semantics,
+  request-time env-flip 404 behavior, no auth/payload/header rewrite, no
+  OpenAPI/client exposure, no legacy reintroduction gap, and no auth/business/
+  FoodDB/middleware/lifespan/frontend/iOS/macOS scope creep.
+
+## Codex Security Evidence
+
+Disposition: NOT-A-BUG
+
+Finding: Codex Security diff scan found no reportable security findings.
+
+Evidence:
+
+- Scan ID: `bd691441-a818-410d-a585-dec1477f6770`
+- Mode: branch-diff-backed Codex Security diff scan
+- Reportable findings: `0`
+- Coverage: `6/6` workbench rows closed
+- Report:
+  `/private/var/folders/bw/12x002vn67v2bvjpbhbtm8480000gn/T/codex-security-scans-zSiTqs/move-test-route-registration-to-canonical-bootstrap/929fda5791333fae2c0eff31f911408e5a38bc55_20260627T095720Z_3nu5mkap/report.md`
+
+## pulseplate-pr-review Disposition
+
+Disposition: NOT-A-BUG
+
+Finding: The advisory dry-run report flagged a `note` for large diff risk
+because the diff has 468 changed lines, above the 300-line review-risk
+threshold.
+
+Evidence: This PR is the approved narrow test-router canonical-bootstrap
+slice. The larger line count is primarily deterministic tests and guard
+coverage for the required env matrix, request-time fail-closed behavior,
+OpenAPI hiding, and legacy reintroduction cases. The approved focused pytest
+bundle, `make validate-changed`, pre-commit, post-open role passes, and Codex
+Security diff scan all ran; no actionable code/security/test defect was
+reported. No split is required for this already-scoped route-registration PR.
+
+## Premortem Finding Closure
+
+Disposition: FIXED
+
+Finding: Registration could widen by moving to canonical bootstrap but losing
+the env gate.
+
+Evidence: `app/main.py` gates registration in
+`_test_routes_enabled_for_registration()`. `tests/test_test_route_registration_bootstrap.py`
+covers unset/local/dev/development/test/testing/ci, staging exact flag,
+production/prod, unknown env, and env-precedence cases.
+
+Disposition: FIXED
+
+Finding: Test routes could leak into public OpenAPI or generated clients.
+
+Evidence: `app/routers/test.py` sets source `include_in_schema=False`, and
+`tests/test_openapi_namespace_guards.py` plus `make openapi-check` prove
+`/api/v1/test/*` stays out of public schema with zero generated artifact diff.
+
+Disposition: FIXED
+
+Finding: Legacy reintroduction could return through direct or dynamic imports.
+
+Evidence: `scripts/ci/check_legacy_growth_guard.py` no longer allowlists
+`test_router.router` or `from app.routers import test as test_router`, and
+`tests/test_legacy_growth_guard.py` covers direct, aliased, module-qualified,
+dynamic, and walrus reintroduction.
+
+Disposition: FIXED
+
+Finding: Existing tests could keep proving the old raw `legacy_app.app` owner
+instead of canonical bootstrap behavior.
+
+Evidence: `tests/test_test_router.py` and
+`tests/test_legacy_runtime_env_canonicalization.py` reload through
+`app.main` canonical bootstrap after env changes.
+
+Disposition: NOT-A-BUG
+
+Finding: Full local `make verify` is not run.
+
+Evidence: Operator explicitly approved deferring full local `make verify` for
+this PR. Focused local gates, pre-commit, current-head CI, and strict
+merge-readiness remain mandatory before readiness claims.
+
+## Experiment Runner Evidence
+
+- Runner mode: `oracle_only_governance_reviewer`
+- Experiment ID: `exp-ca7cfd17a97b`
+- Artifact: `artifacts/orchestration/experiments/results/test-route-canonical-bootstrap-oracle-result-v2.json`
+- Status: accepted
+- Shared tree untouched: true
+- Mutated paths: []
+- Oracle commands:
+  - `python3 scripts/ci/check_legacy_growth_guard.py` -> exit 0
+  - `pytest -q tests/test_test_router.py tests/test_legacy_runtime_env_canonicalization.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_route_family_bootstrap.py tests/test_test_route_registration_bootstrap.py` -> exit 0
+- Co-author trailer required and included in implementation commit:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Local Validation Evidence
+
+- PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS: `pytest -q tests/test_test_router.py tests/test_legacy_runtime_env_canonicalization.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_route_family_bootstrap.py tests/test_test_route_registration_bootstrap.py`
+- PASS: `make openapi-check`
+- PASS: `git diff --exit-code -- app/static/openapi.json frontend/src/api/openapi.json frontend/src/api/schema.ts`
+- PASS: `make validate-changed` after commit; selected changed backend tests passed.
+- PASS: `pre-commit run --all-files`
+- PASS: `git diff --check`
+- PASS: pre-push hooks, including changed-file mypy, full-repo Bandit
+  pre-push, backend pre-push tests, and Docker build test.
+- PASS: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 2029`
+- PASS: post-open `qa-engineer-agent`, `bug-hunter`, and `security-auditor`
+  role passes.
+- PASS: Codex Security diff scan / finding discovery; `0` reportable findings.
+- PASS: `pulseplate-pr-review`; advisory large-diff note dispositioned
+  `NOT-A-BUG` above.
+
+Full local `make verify` deferred by operator approval for this PR. No readiness
+claim until current-head CI and strict merge-readiness pass.
+
+## Mapping Notes
+
+Initial PR open: no actionable review comments existed at artifact creation.
+Any post-open actionable bot, human, role-agent, Codex Security, or
+`pulseplate-pr-review` finding must be fixed or formally dispositioned here
+before readiness claims.

--- a/docs/review/PR_2029_FIXED_MAPPING.md
+++ b/docs/review/PR_2029_FIXED_MAPPING.md
@@ -39,6 +39,12 @@ lifespan, frontend, iOS, macOS, or feature-flag redesign.
 - `eebcb60b8` - fixes Sourcery security observability feedback by logging
   enabled test route registration and adding caplog coverage for staging with
   `ENABLE_TEST_ROUTES=1`.
+- `6768d6ddc` - makes runtime-env canonicalization tests compatible with the
+  CI pre-commit backend-test environment that does not load async pytest
+  plugins.
+- `430c99da1` - fixes CodeRabbit feedback by documenting the complete test-route
+  matrix and adding a typed hidden response model for `/api/v1/test/echo`
+  while preserving the JSON response shape.
 
 ## Lane Start Provenance
 
@@ -70,6 +76,12 @@ Commit: eebcb60b8
 Evidence: `app/main.py` logs enabled test route registration; `tests/test_test_route_registration_bootstrap.py` covers staging with `ENABLE_TEST_ROUTES=1` using `caplog`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#pullrequestreview-4584883808 -> eebcb60b8
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#discussion_r3485790303 -> eebcb60b8
+
+Disposition: FIXED
+Commit: 430c99da1
+Evidence: `docs/architecture/backend_routing_map.md` now documents unset-env registration and walrus reintroduction coverage; `app/routers/test.py` now uses a typed hidden `TestEchoResponse` response model for `/api/v1/test/echo` while preserving the response JSON shape.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#pullrequestreview-4584957003 -> 430c99da1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#discussion_r3485844708 -> 430c99da1
 
 ## Sourcery Review Closure
 

--- a/docs/review/PR_2029_FIXED_MAPPING.md
+++ b/docs/review/PR_2029_FIXED_MAPPING.md
@@ -45,6 +45,9 @@ lifespan, frontend, iOS, macOS, or feature-flag redesign.
 - `430c99da1` - fixes CodeRabbit feedback by documenting the complete test-route
   matrix and adding a typed hidden response model for `/api/v1/test/echo`
   while preserving the JSON response shape.
+- `0807d2093` - fixes CodeRabbit feedback by adding explicit `-> None`
+  annotations to the selected lifespan coverage test methods touched by the
+  CI selected-test compatibility fix.
 
 ## Lane Start Provenance
 
@@ -82,6 +85,11 @@ Commit: 430c99da1
 Evidence: `docs/architecture/backend_routing_map.md` now documents unset-env registration and walrus reintroduction coverage; `app/routers/test.py` now uses a typed hidden `TestEchoResponse` response model for `/api/v1/test/echo` while preserving the response JSON shape.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#pullrequestreview-4584957003 -> 430c99da1
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#discussion_r3485844708 -> 430c99da1
+
+Disposition: FIXED
+Commit: 0807d2093
+Evidence: `tests/test_app_extended_coverage.py` now has explicit `-> None` return annotations on the four modified lifespan coverage test methods while preserving test behavior.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#pullrequestreview-4585679535 -> 0807d2093
 
 ## Sourcery Review Closure
 
@@ -233,6 +241,9 @@ merge-readiness remain mandatory before readiness claims.
 - PASS: `make validate-changed` after commit; selected changed backend tests passed.
 - PASS: `pre-commit run --all-files`
 - PASS: `git diff --check`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_app_extended_coverage.py::TestLifespanEvents tests/test_app_extended_coverage.py::test_test_route_registration_disabled_in_production_for_ci_diff_coverage tests/test_app_extended_coverage.py::test_test_echo_handler_returns_typed_response_for_ci_diff_coverage` after the CodeRabbit type-annotation fix.
+- PASS: `make validate-changed` after the CodeRabbit type-annotation fix.
+- PASS: `pre-commit run --all-files` after the CodeRabbit type-annotation fix.
 - PASS: pre-push hooks, including changed-file mypy, full-repo Bandit
   pre-push, backend pre-push tests, and Docker build test.
 - PASS: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 2029`

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -957,20 +957,6 @@ except ImportError as e:  # pragma: no cover
 # Premium week router registration is now handled in
 # app.routers.pro_registration.register_pro_routes() for centralized registration.
 
-# Conditionally include test router for non-production environments
-# Reuse _app_env defined earlier (line 302) to avoid duplication
-# Exclude staging from test endpoints for security (staging may be externally accessible)
-if _app_env in {"local", "dev", "development", "test", "testing", "ci"} or (
-    _app_env == "staging" and os.getenv("ENABLE_TEST_ROUTES") == "1"
-):
-    try:
-        from app.routers import test as test_router
-
-        app.include_router(test_router.router)
-        logger.info("Test endpoints enabled for environment: %s", _app_env or "local")
-    except ImportError:
-        logger.debug("Test router not available")
-
 # Provide a stable alias for plan_export to support tests that reload it dynamically
 with suppress(Exception):
     import importlib as _importlib

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -110,7 +110,6 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("registration", "include_router", "nutrition_log.router", ""),
         LegacyFact("registration", "include_router", "legacy_nutrition_alias_router", ""),
         LegacyFact("registration", "include_router", "business_router", ""),
-        LegacyFact("registration", "include_router", "test_router.router", ""),
     }
 )
 
@@ -118,7 +117,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
     {
         LegacyFact("router_import", "app.routers", "bayes_adherence", ""),
         LegacyFact("router_import", "app.routers", "nutrition_log", ""),
-        LegacyFact("router_import", "app.routers", "test", "test_router"),
         LegacyFact("router_import", "app.routers", "vip", "_vip_mod"),
         LegacyFact("router_import", "app.routers.api_key", "api_key_header", ""),
         LegacyFact("router_import", "app.routers.bmi", "bmi_calculate_handler", ""),

--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -35,8 +35,7 @@ class TestLifespanEvents:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
 
-    @pytest.mark.asyncio
-    async def test_lifespan_startup_success(self, monkeypatch: pytest.MonkeyPatch):
+    def test_lifespan_startup_success(self, monkeypatch: pytest.MonkeyPatch):
         """Test successful lifespan startup."""
         from app import lifespan
         import legacy_app
@@ -46,16 +45,20 @@ class TestLifespanEvents:
         mock_start = Mock(return_value=AsyncMock())
         patch_background_update_callables(monkeypatch, start=mock_start)
 
+        async def run_lifespan() -> None:
+            async with lifespan(mock_app):
+                pass
+
         with (
             patch.object(legacy_app, "init_db", return_value=None),
             patch.object(legacy_app, "validate_template_dir", return_value=None),
         ):
-            async with lifespan(mock_app):
-                # Verify startup was called
-                mock_start.assert_called_once_with(update_interval_hours=24)
+            asyncio.run(run_lifespan())
 
-    @pytest.mark.asyncio
-    async def test_lifespan_startup_failure(self, monkeypatch: pytest.MonkeyPatch):
+        # Verify startup was called
+        mock_start.assert_called_once_with(update_interval_hours=24)
+
+    def test_lifespan_startup_failure(self, monkeypatch: pytest.MonkeyPatch):
         """Test lifespan startup with failure."""
         from app import lifespan
         import legacy_app
@@ -65,16 +68,20 @@ class TestLifespanEvents:
         mock_start = Mock(side_effect=Exception("Startup failed"))
         patch_background_update_callables(monkeypatch, start=mock_start)
 
+        async def run_lifespan() -> None:
+            # Should not raise exception, just log error
+            async with lifespan(mock_app):
+                pass
+
         with (
             patch.object(legacy_app, "init_db", return_value=None),
             patch.object(legacy_app, "validate_template_dir", return_value=None),
         ):
-            # Should not raise exception, just log error
-            async with lifespan(mock_app):
-                mock_start.assert_called_once_with(update_interval_hours=24)
+            asyncio.run(run_lifespan())
 
-    @pytest.mark.asyncio
-    async def test_lifespan_shutdown_success(self, monkeypatch: pytest.MonkeyPatch):
+        mock_start.assert_called_once_with(update_interval_hours=24)
+
+    def test_lifespan_shutdown_success(self, monkeypatch: pytest.MonkeyPatch):
         """Test successful lifespan shutdown."""
         from app import lifespan
         import legacy_app
@@ -89,14 +96,17 @@ class TestLifespanEvents:
             patch.object(legacy_app, "init_db", return_value=None),
             patch.object(legacy_app, "validate_template_dir", return_value=None),
         ):
-            async with lifespan(mock_app):
-                pass
 
-            # Verify shutdown was called
-            mock_stop.assert_called_once()
+            async def run_lifespan() -> None:
+                async with lifespan(mock_app):
+                    pass
 
-    @pytest.mark.asyncio
-    async def test_lifespan_shutdown_failure(self, monkeypatch: pytest.MonkeyPatch):
+            asyncio.run(run_lifespan())
+
+        # Verify shutdown was called
+        mock_stop.assert_called_once()
+
+    def test_lifespan_shutdown_failure(self, monkeypatch: pytest.MonkeyPatch):
         """Test lifespan shutdown with failure."""
         from app import lifespan
         import legacy_app
@@ -111,11 +121,15 @@ class TestLifespanEvents:
             patch.object(legacy_app, "init_db", return_value=None),
             patch.object(legacy_app, "validate_template_dir", return_value=None),
         ):
-            # Should not raise exception, just log error
-            async with lifespan(mock_app):
-                pass
 
-            mock_stop.assert_called_once()
+            async def run_lifespan() -> None:
+                # Should not raise exception, just log error
+                async with lifespan(mock_app):
+                    pass
+
+            asyncio.run(run_lifespan())
+
+        mock_stop.assert_called_once()
 
 
 class TestAPIEndpoints:

--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -4,17 +4,22 @@ Additional comprehensive tests for main.py to achieve 97% coverage.
 Tests lifespan events, API endpoints, error handling, and edge cases.
 """
 
+import asyncio
 import os
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from fastapi import FastAPI, Response
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
 # Import the canonical FastAPI app (registers metrics, etc.)
+import app.main as app_main
 from app.main import app
 from app.middleware.api_tiers import TEST_KEY_VIP
+from app.routers import test as test_router
 from tests import test_restaurant_postgres_read as restaurant_pg_tests
 from tests import test_restaurant_shadow_parity as restaurant_parity_tests
 from tests import test_restaurants_router as restaurant_router_tests
@@ -172,6 +177,32 @@ class TestAPIEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ok"
+
+
+def test_test_route_registration_disabled_in_production_for_ci_diff_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.setenv("ENABLE_TEST_ROUTES", "1")
+    target_app = FastAPI()
+
+    app_main._include_test_router_if_enabled(target_app)
+
+    assert not any(
+        isinstance(route, APIRoute) and str(route.path).startswith("/api/v1/test/")
+        for route in target_app.routes
+    )
+
+
+def test_test_echo_handler_returns_typed_response_for_ci_diff_coverage() -> None:
+    response = Response()
+
+    payload = asyncio.run(test_router.test_echo({"hello": "world"}, response))
+
+    assert payload.echo == {"hello": "world"}
+    assert payload.metadata.endpoint == "echo"
+    assert response.headers["X-Test-Timestamp"] == payload.metadata.timestamp
 
 
 class TestBMIEndpoints:

--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -35,7 +35,7 @@ class TestLifespanEvents:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
 
-    def test_lifespan_startup_success(self, monkeypatch: pytest.MonkeyPatch):
+    def test_lifespan_startup_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test successful lifespan startup."""
         from app import lifespan
         import legacy_app
@@ -58,7 +58,7 @@ class TestLifespanEvents:
         # Verify startup was called
         mock_start.assert_called_once_with(update_interval_hours=24)
 
-    def test_lifespan_startup_failure(self, monkeypatch: pytest.MonkeyPatch):
+    def test_lifespan_startup_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test lifespan startup with failure."""
         from app import lifespan
         import legacy_app
@@ -81,7 +81,7 @@ class TestLifespanEvents:
 
         mock_start.assert_called_once_with(update_interval_hours=24)
 
-    def test_lifespan_shutdown_success(self, monkeypatch: pytest.MonkeyPatch):
+    def test_lifespan_shutdown_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test successful lifespan shutdown."""
         from app import lifespan
         import legacy_app
@@ -106,7 +106,7 @@ class TestLifespanEvents:
         # Verify shutdown was called
         mock_stop.assert_called_once()
 
-    def test_lifespan_shutdown_failure(self, monkeypatch: pytest.MonkeyPatch):
+    def test_lifespan_shutdown_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test lifespan shutdown with failure."""
         from app import lifespan
         import legacy_app

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -798,6 +798,87 @@ def test_legacy_growth_guard_rejects_walrus_import_function_alias_bodyfat_router
     ]
 
 
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            textwrap.dedent("""
+                from app.routers import test as test_router
+
+                app.include_router(test_router.router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:test_router.router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers:test -> test_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from app.routers.test import router as canonical_test_router
+
+                app.include_router(canonical_test_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:canonical_test_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.test:router -> canonical_test_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import app.routers.test as test_router
+
+                app.include_router(test_router.router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:test_router.router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:import:app.routers.test -> test_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                test_router = importlib.import_module("app.routers.test")
+                app.include_router(test_router.router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:test_router.router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.test -> test_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from importlib import import_module
+
+                if (test_router := import_module("app.routers.test")):
+                    app.include_router(test_router.router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:test_router.router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.test -> test_router",
+            ],
+        ),
+    ],
+)
+def test_legacy_growth_guard_rejects_reintroduced_test_router_registration(
+    source: str,
+    expected: list[str],
+) -> None:
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == expected
+
+
 def test_legacy_growth_guard_rejects_nested_dynamic_bodyfat_router_registration() -> None:
     source = textwrap.dedent("""
         import importlib

--- a/tests/test_legacy_runtime_env_canonicalization.py
+++ b/tests/test_legacy_runtime_env_canonicalization.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 from types import ModuleType
 
@@ -86,8 +87,7 @@ def test_canonical_bootstrap_staging_test_router_respects_environment_flag(
     )
 
 
-@pytest.mark.asyncio
-async def test_debug_env_uses_environment_when_app_env_missing(
+def test_debug_env_uses_environment_when_app_env_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("ENVIRONMENT", "production")
@@ -95,20 +95,19 @@ async def test_debug_env_uses_environment_when_app_env_missing(
     app_module = _reload_legacy_app()
 
     with pytest.raises(HTTPException) as exc_info:
-        await app_module.debug_env()
+        asyncio.run(app_module.debug_env())
 
     assert exc_info.value.status_code == 404
 
 
-@pytest.mark.asyncio
-async def test_health_prefers_environment_over_app_env(
+def test_health_prefers_environment_over_app_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("APP_ENV", "local")
 
     health_module = importlib.import_module("app.routers.health")
-    response = await health_module.health()
+    response = asyncio.run(health_module.health())
     assert response["environment"] == "production"
 
 

--- a/tests/test_legacy_runtime_env_canonicalization.py
+++ b/tests/test_legacy_runtime_env_canonicalization.py
@@ -22,6 +22,16 @@ def _reload_legacy_app() -> ModuleType:
     return importlib.reload(legacy_app)
 
 
+def _reload_canonical_main() -> ModuleType:
+    """Reload canonical bootstrap after env changes."""
+
+    import app.main as app_main
+    import legacy_app
+
+    importlib.reload(legacy_app)
+    return importlib.reload(app_main)
+
+
 @pytest.fixture(autouse=True)
 def _reset_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep env-based legacy app tests deterministic.
@@ -57,19 +67,19 @@ def test_legacy_app_skips_local_dotenv_in_env_production(
     assert calls == []
 
 
-def test_legacy_app_staging_test_router_respects_environment_flag(
+def test_canonical_bootstrap_staging_test_router_respects_environment_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("ENVIRONMENT", "staging")
 
-    app_module = _reload_legacy_app()
+    app_module = _reload_canonical_main()
     assert not any(
         getattr(route, "path", "") == "/api/v1/test/health"
         for route in getattr(app_module.app, "routes", [])
     )
 
     monkeypatch.setenv("ENABLE_TEST_ROUTES", "1")
-    app_module = _reload_legacy_app()
+    app_module = _reload_canonical_main()
     assert any(
         getattr(route, "path", "") == "/api/v1/test/health"
         for route in getattr(app_module.app, "routes", [])

--- a/tests/test_openapi_namespace_guards.py
+++ b/tests/test_openapi_namespace_guards.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Iterable
 
 from app.main import app
+from app.routers.test import TEST_ROUTE_SPECS
 from app.routers.admin_operations import ADMIN_OPERATION_ROUTE_SPECS
 
 ALLOWED_PREFIXES: tuple[str, ...] = (
@@ -81,6 +82,15 @@ def test_admin_debug_runtime_routes_stay_hidden_from_openapi_schema() -> None:
     paths = set(_openapi_paths())
 
     for route_path, _method in ADMIN_OPERATION_ROUTE_SPECS:
+        assert route_path in runtime_paths
+        assert route_path not in paths
+
+
+def test_test_runtime_routes_stay_hidden_from_openapi_schema() -> None:
+    runtime_paths = _runtime_paths()
+    paths = set(_openapi_paths())
+
+    for route_path, _method, _include_in_schema in TEST_ROUTE_SPECS:
         assert route_path in runtime_paths
         assert route_path not in paths
 

--- a/tests/test_test_route_registration_bootstrap.py
+++ b/tests/test_test_route_registration_bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import Counter
 
 import pytest
@@ -134,6 +135,27 @@ def test_test_route_registration_is_idempotent_in_unset_local_env() -> None:
     app_main._include_test_router_if_enabled(target_app)
     app_main._include_test_router_if_enabled(target_app)
 
+    _assert_test_routes_registered_once(target_app)
+
+
+def test_staging_test_route_registration_logs_enabled_state(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _set_runtime_env(monkeypatch, app_env="staging", enable_test_routes="1")
+    target_app = FastAPI()
+
+    with caplog.at_level(logging.INFO, logger=app_main.logger.name):
+        app_main._include_test_router_if_enabled(target_app)
+
+    matching_records = [
+        record
+        for record in caplog.records
+        if record.message == "Test routes enabled for registration"
+    ]
+    assert len(matching_records) == 1
+    assert matching_records[0].runtime_env == "staging"
+    assert matching_records[0].enable_test_routes == "1"
     _assert_test_routes_registered_once(target_app)
 
 

--- a/tests/test_test_route_registration_bootstrap.py
+++ b/tests/test_test_route_registration_bootstrap.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+import app.main as app_main
+from app.bootstrap.route_family import route_has_dependency_call
+
+_EXPECTED_TEST_ROUTE_KEYS = {
+    (path, method) for path, method, _include_in_schema in app_main._TEST_ROUTE_SPECS
+}
+_EXPECTED_TEST_ROUTE_PATHS = {path for path, _method in _EXPECTED_TEST_ROUTE_KEYS}
+
+
+@pytest.fixture(autouse=True)
+def _clear_test_route_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("APP_ENV", "ENVIRONMENT", "ENV", "ENABLE_TEST_ROUTES"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _set_runtime_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    app_env: str | None = None,
+    environment: str | None = None,
+    enable_test_routes: str | None = None,
+) -> None:
+    if app_env is not None:
+        monkeypatch.setenv("APP_ENV", app_env)
+    if environment is not None:
+        monkeypatch.setenv("ENVIRONMENT", environment)
+    if enable_test_routes is not None:
+        monkeypatch.setenv("ENABLE_TEST_ROUTES", enable_test_routes)
+
+
+def _test_routes(target_app: FastAPI) -> list[APIRoute]:
+    return [
+        route
+        for route in target_app.routes
+        if isinstance(route, APIRoute) and str(route.path) in _EXPECTED_TEST_ROUTE_PATHS
+    ]
+
+
+def _registered_test_route_counts(target_app: FastAPI) -> Counter[tuple[str, str]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for route in _test_routes(target_app):
+        for method in getattr(route, "methods", None) or set():
+            key = (str(route.path), str(method).upper())
+            if key in _EXPECTED_TEST_ROUTE_KEYS:
+                counts[key] += 1
+    return counts
+
+
+def _assert_test_routes_registered_once(target_app: FastAPI) -> None:
+    counts = _registered_test_route_counts(target_app)
+    assert set(counts) == _EXPECTED_TEST_ROUTE_KEYS
+    assert all(count == 1 for count in counts.values())
+
+    for route in _test_routes(target_app):
+        assert route.include_in_schema is False
+        assert route_has_dependency_call(route, app_main.ensure_test_routes_non_production)
+
+
+def _stub_test_router_without_dependencies() -> APIRouter:
+    router = APIRouter()
+
+    for path, method, include_in_schema in app_main._TEST_ROUTE_SPECS:
+
+        async def _handler(route_path: str = path) -> dict[str, str]:
+            return {"path": route_path}
+
+        router.add_api_route(
+            path,
+            _handler,
+            methods=[method],
+            include_in_schema=include_in_schema,
+        )
+
+    return router
+
+
+@pytest.mark.parametrize(
+    ("app_env", "environment", "enable_test_routes", "expected_enabled"),
+    [
+        (None, None, None, True),
+        ("local", None, None, True),
+        ("dev", None, None, True),
+        ("development", None, None, True),
+        ("test", None, None, True),
+        ("testing", None, None, True),
+        ("ci", None, None, True),
+        ("staging", None, "1", True),
+        ("staging", None, None, False),
+        ("staging", None, "true", False),
+        ("production", None, "1", False),
+        ("prod", None, "1", False),
+        ("unexpected", None, "1", False),
+        ("local", "production", "1", False),
+        ("production", "test", "1", False),
+    ],
+)
+def test_test_route_registration_env_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    app_env: str | None,
+    environment: str | None,
+    enable_test_routes: str | None,
+    expected_enabled: bool,
+) -> None:
+    _set_runtime_env(
+        monkeypatch,
+        app_env=app_env,
+        environment=environment,
+        enable_test_routes=enable_test_routes,
+    )
+    target_app = FastAPI()
+
+    assert app_main._test_routes_enabled_for_registration() is expected_enabled
+
+    app_main._include_test_router_if_enabled(target_app)
+
+    if expected_enabled:
+        _assert_test_routes_registered_once(target_app)
+    else:
+        assert _test_routes(target_app) == []
+
+
+def test_test_route_registration_is_idempotent_in_unset_local_env() -> None:
+    target_app = FastAPI()
+
+    app_main._include_test_router_if_enabled(target_app)
+    app_main._include_test_router_if_enabled(target_app)
+
+    _assert_test_routes_registered_once(target_app)
+
+
+def test_registered_local_test_routes_fail_closed_after_production_env_flip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_app = FastAPI()
+    app_main._include_test_router_if_enabled(target_app)
+
+    monkeypatch.setenv("APP_ENV", "production")
+    client = TestClient(target_app)
+
+    response = client.get("/api/v1/test/health")
+
+    assert response.status_code == 404
+
+
+def test_registered_local_test_routes_fail_closed_after_staging_flag_removed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_app = FastAPI()
+    app_main._include_test_router_if_enabled(target_app)
+
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.delenv("ENABLE_TEST_ROUTES", raising=False)
+    client = TestClient(target_app)
+
+    response = client.post("/api/v1/test/rate-limit")
+
+    assert response.status_code == 404
+
+
+def test_test_router_source_specs_match_hidden_routes() -> None:
+    route_specs: set[tuple[str, str, bool]] = set()
+    for route in app_main.test_router.routes:
+        assert isinstance(route, APIRoute)
+        for method in route.methods or set():
+            key = (str(route.path), str(method).upper())
+            if key in _EXPECTED_TEST_ROUTE_KEYS:
+                route_specs.add((str(route.path), str(method).upper(), route.include_in_schema))
+
+    assert route_specs == set(app_main._TEST_ROUTE_SPECS)
+
+
+def test_test_route_registration_rejects_partial_existing_family() -> None:
+    target_app = FastAPI()
+    path, method, include_in_schema = app_main._TEST_ROUTE_SPECS[0]
+
+    async def _partial_test_route() -> dict[str, str]:
+        return {"status": "partial"}
+
+    target_app.add_api_route(
+        path,
+        _partial_test_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(RuntimeError, match="Partial test route registration detected"):
+        app_main._include_test_router_if_enabled(target_app)
+
+
+def test_test_route_registration_rejects_foreign_handlers() -> None:
+    target_app = FastAPI()
+
+    for path, method, include_in_schema in app_main._TEST_ROUTE_SPECS:
+
+        async def _foreign_test_route(route_path: str = path) -> dict[str, str]:
+            return {"path": route_path}
+
+        target_app.add_api_route(
+            path,
+            _foreign_test_route,
+            methods=[method],
+            include_in_schema=include_in_schema,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different test handler",
+    ):
+        app_main._include_test_router_if_enabled(target_app)
+
+
+def test_test_route_registration_rejects_source_visibility_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_route = next(iter(app_main.test_router.routes))
+    assert isinstance(source_route, APIRoute)
+    monkeypatch.setattr(source_route, "include_in_schema", True)
+
+    with pytest.raises(RuntimeError, match="Test router does not preserve OpenAPI visibility"):
+        app_main._include_test_router_if_enabled(FastAPI())
+
+
+def test_test_route_registration_rejects_missing_request_time_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_main, "test_router", _stub_test_router_without_dependencies())
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve test required dependency",
+    ):
+        app_main._include_test_router_if_enabled(FastAPI())
+
+
+def test_enabled_test_routes_stay_hidden_from_openapi() -> None:
+    target_app = FastAPI()
+    app_main._include_test_router_if_enabled(target_app)
+
+    paths = set(target_app.openapi().get("paths", {}))
+
+    assert paths.isdisjoint(_EXPECTED_TEST_ROUTE_PATHS)

--- a/tests/test_test_router.py
+++ b/tests/test_test_router.py
@@ -12,20 +12,22 @@ import settings as app_settings
 def _import_fresh_app() -> FastAPI:
     """Import FastAPI app after ensuring env-based wiring is re-evaluated.
 
-    RU: Перезагружаем legacy_app, чтобы он перечитал env и заново настроил wiring.
-    EN: Reload legacy_app so it re-reads env and rebuilds router wiring.
+    RU: Перезагружаем legacy_app и canonical bootstrap после изменения env.
+    EN: Reload legacy_app and canonical bootstrap after env changes.
     """
     # IMPORTANT:
-    # `legacy_app` decides whether to include the test router at import time, based on env.
+    # `app.main` decides whether to include the test router during canonical bootstrap.
     # In CI, it may already be imported under a different APP_ENV/ENABLE_TEST_ROUTES state.
     # Reloading re-reads env and re-wires routers without mutating sys.modules.
     import importlib
 
+    import app.main as app_main
     import legacy_app
 
     importlib.reload(legacy_app)
+    app_main = importlib.reload(app_main)
 
-    app = legacy_app.app  # canonical app instance after env-driven wiring
+    app = app_main.app  # canonical app instance after env-driven wiring
 
     # Fail fast with a clear message if staging claims test routes should exist but doesn't.
     runtime_env = app_settings.get_runtime_env_name()


### PR DESCRIPTION
## Goal
Move `/api/v1/test/*` route registration ownership out of `legacy_app.py` and into canonical `app/main.py` bootstrap while preserving non-production-only behavior and public OpenAPI hiding.

## Business Reason
This removes one more router registration from the legacy compatibility seam after bodyfat, shrinking legacy ownership without widening product/runtime scope.

## Scope
- Add `TEST_ROUTE_SPECS` in `app/routers/test.py`.
- Hide test routes at source with `include_in_schema=False`.
- Register the test route family from `app/main.py` with `ensure_route_family_registered(...)`.
- Preserve the golden env matrix: unset/local/dev/development/test/testing/ci register; production/prod do not; staging requires exact `ENABLE_TEST_ROUTES=1`; unknown env does not register.
- Preserve request-time `_ensure_non_production()` fail-closed 404 behavior.
- Remove only the legacy `app.routers.test` import/include block.
- Shrink the legacy growth guard allowlist and add direct/alias/module/dynamic/walrus reintroduction tests.
- Update backend routing map and PR fixed mapping.

## Out of Scope
Business router, nutrition, shopping, FoodDB, dependency updates, middleware, lifespan, frontend, iOS, macOS, and feature-flag redesign.

## Files Changed
- `app/main.py`
- `app/routers/test.py`
- `legacy_app.py`
- `scripts/ci/check_legacy_growth_guard.py`
- `tests/test_test_router.py`
- `tests/test_legacy_runtime_env_canonicalization.py`
- `tests/test_legacy_growth_guard.py`
- `tests/test_openapi_namespace_guards.py`
- `tests/test_test_route_registration_bootstrap.py`
- `docs/architecture/backend_routing_map.md`
- `docs/review/PR_2029_FIXED_MAPPING.md`

## Key Decisions
- Registration remains env-gated in `app/main.py`; the PR does not switch to always-register plus request guard.
- `_ensure_non_production()` remains the request-time defense and is required in the route-family contract.
- Source route metadata is hidden, so final OpenAPI and generated clients stay unchanged.
- Legacy reintroduction guard now rejects direct, aliased, module-qualified, dynamic, and walrus test-router registration attempts.

## Tests / Validation
- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
- PASS: `pytest -q tests/test_test_router.py tests/test_legacy_runtime_env_canonicalization.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_route_family_bootstrap.py tests/test_test_route_registration_bootstrap.py`
- PASS: `make openapi-check`
- PASS: `git diff --exit-code -- app/static/openapi.json frontend/src/api/openapi.json frontend/src/api/schema.ts`
- PASS: `make validate-changed` after implementation and after Sourcery fix commits; selected changed backend tests passed.
- PASS: `pre-commit run --all-files`
- PASS: `git diff --check`
- PASS: pre-push hooks on the implementation push, including changed-file mypy, full-repo Bandit pre-push, backend pre-push tests, and Docker build test.
- PASS: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 2029`
- PASS: post-open `qa-engineer-agent`, `bug-hunter`, and `security-auditor` role passes.
- PASS: Codex Security diff scan / finding discovery; scan `bd691441-a818-410d-a585-dec1477f6770`, 0 reportable findings.
- PASS: `pulseplate-pr-review`; advisory large-diff note dispositioned `NOT-A-BUG` in the fixed mapping artifact.
- PASS: Sourcery security logging comment fixed in `eebcb60b8` and mapped in `docs/review/PR_2029_FIXED_MAPPING.md`.

Full local `make verify` deferred by operator approval for this PR. Focused local gates, pre-commit, current-head CI, and strict merge-readiness remain mandatory. No readiness claim until current-head CI and `check_merge_ready.py --require-auth` pass.

## Security Notes
Test routes remain unavailable in production/prod and unknown envs at registration time. Registered dev/staging test routes still return 404 at request time when the runtime env flips to production or staging without `ENABLE_TEST_ROUTES=1`. Codex Security diff scan completed with 0 reportable findings.

## Risks / Rollback
Risk: accidental OpenAPI exposure or production registration. Mitigation: source hidden metadata, OpenAPI namespace guard, env-matrix tests, request-time env-flip tests, and legacy growth guard. Rollback: revert the implementation commit to restore previous legacy registration behavior.

## Deferred / Follow-ups
None for this PR scope.

## AGENTS.md / Agent Instruction Updates
No process or instruction changes.

## Lane Start Provenance
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Packet: `artifacts/orchestration/task_packets/f4b4a3415bdb.json`
- Branch: `codex/move-test-route-registration-to-canonical-bootstrap`
- Base: fresh `origin/main` containing merged PR `#2021`
- Pre-open role order executed explicitly: `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/test-route-canonical-bootstrap-oracle-result-v2.json`
- Experiment ID: `exp-ca7cfd17a97b`
- Status: accepted
- Co-author trailer required and included in commit `929fda5791333fae2c0eff31f911408e5a38bc55`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#pullrequestreview-4584883808 -> eebcb60b8
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2029#discussion_r3485790303 -> eebcb60b8
- Canonical artifact: `docs/review/PR_2029_FIXED_MAPPING.md`
- Implementation commit: `929fda5791333fae2c0eff31f911408e5a38bc55`
- Sourcery fix commit: `eebcb60b8`
- Mapping artifact commits: `2898f954d`, `eae36f5c7`, `80b3d9b5f`

## Merge Readiness
- [x] Full local `make verify` deferred by operator approval and documented.
- [x] Focused local gates passed.
- [x] Post-open role passes completed.
- [x] Codex Security diff scan completed with 0 reportable findings.
- [x] `pulseplate-pr-review` completed and advisory note dispositioned.
- [ ] Current-head CI passed after the latest pushed head.
- [ ] Strict merge-readiness passed with `--require-auth`.
- [ ] No unresolved actionable review threads or bot comments after final current-head check.

## Next Best Step
Push the fixed-mapping commit, wait for current-head CI on the latest SHA, then run strict merge-readiness with auth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test endpoints are now registered through the canonical startup/bootstrapping flow, enabled in approved non-production environments, with staging support via `ENABLE_TEST_ROUTES=1`.
* **Bug Fixes**
  * Test endpoints remain available at runtime but are excluded from the generated OpenAPI schema.
  * The test `echo` endpoint now returns a typed response with `metadata` and an `X-Test-Timestamp` header.
* **Tests**
  * Expanded coverage for environment gating, idempotent registration, fail-closed behavior, OpenAPI hiding, and prevention of legacy reintroduction; improved async test handling.
* **Documentation**
  * Updated routing documentation and review mapping to reflect the new test-route ownership and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->