### PR TITLE
Fix promotion tool remote validation to reject spoofed remotes

### DIFF
--- a/scripts/orchestration/creative_code_pr_promotion.py
+++ b/scripts/orchestration/creative_code_pr_promotion.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess  # nosec B404: fixed git/gh subprocess wrappers only (remove-by: 2026-07-31, ref: PR-3)
 import sys
 import tempfile
+from urllib.parse import urlparse
 from typing import Any, Protocol, cast
 
 from core.evidence.fingerprints import fingerprint_payload
@@ -88,6 +89,27 @@ SUCCESS_PLAN_OUTPUT = "PASS: creative-code PR promotion plan complete"
 SUCCESS_VALIDATE_OUTPUT = "PASS: creative-code PR promotion validation complete"
 SUCCESS_APPROVE_OUTPUT = "PASS: creative-code PR promotion approval complete"
 SUCCESS_PROMOTE_OUTPUT = "PASS: creative-code PR promotion complete"
+
+
+def _origin_remote_targets_pulseplate(remote_url: str) -> bool:
+    """Return whether an origin URL resolves exactly to the PulsePlate GitHub repo."""
+    expected_owner, expected_repo = TARGET_REPOSITORY.split("/", 1)
+
+    if remote_url.startswith("git@github.com:"):
+        path = remote_url.removeprefix("git@github.com:")
+    else:
+        parsed = urlparse(remote_url)
+        if parsed.scheme not in {"https", "ssh"}:
+            return False
+        if parsed.hostname != "github.com":
+            return False
+        if parsed.scheme == "ssh" and parsed.username not in {None, "git"}:
+            return False
+        path = parsed.path.lstrip("/")
+
+    if path.endswith(".git"):
+        path = path[:-4]
+    return path == f"{expected_owner}/{expected_repo}"
 
 SAFE_PROMOTION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}$")
 SAFE_SLUG_RE = re.compile(r"[^a-z0-9]+")
@@ -1001,8 +1023,8 @@ def _prepare_checkout(
         git.run(["checkout", "--detach", base_commit_sha], cwd=checkout)
         if promotion_remote:
             remote_url = git.remote_url()
-            if "Katsiarynakavaleuskaya/PulsePlate" not in remote_url:
-                raise CreativeCodePRPromotionError("origin remote must target PulsePlate.")
+            if not _origin_remote_targets_pulseplate(remote_url):
+                raise CreativeCodePRPromotionError("origin remote must target GitHub PulsePlate.")
             git.run(["remote", "set-url", "origin", remote_url], cwd=checkout)
         else:
             git.run(["remote", "set-url", "--push", "origin", "DISABLED"], cwd=checkout)

--- a/tests/test_creative_code_pr_promotion.py
+++ b/tests/test_creative_code_pr_promotion.py
@@ -199,12 +199,14 @@ class FakeGit:
         remote_exists_sequence: list[bool] | None = None,
         identity: tuple[str, str] | None = ("Katsiarynakavaleuskaya", "human@example.test"),
         verify_identity_failure: bool = False,
+        remote_url: str = "git@github.com:Katsiarynakavaleuskaya/PulsePlate.git",
     ) -> None:
         self.base_sha = base_sha
         self.remote_exists = remote_exists
         self.remote_exists_sequence = list(remote_exists_sequence or [])
         self.identity = identity
         self.verify_identity_failure = verify_identity_failure
+        self._remote_url = remote_url
         self.committed = False
         self.calls: list[list[str]] = []
 
@@ -225,7 +227,7 @@ class FakeGit:
         return False
 
     def remote_url(self) -> str:
-        return "git@github.com:Katsiarynakavaleuskaya/PulsePlate.git"
+        return self._remote_url
 
     def human_identity(self) -> tuple[str, str]:
         self.calls.append(["human_identity"])
@@ -279,6 +281,43 @@ class FakeGit:
         elif "commit" in args:
             self.committed = True
         return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+
+def test_origin_remote_validation_rejects_spoofed_host() -> None:
+    assert not creative_code_pr_promotion._origin_remote_targets_pulseplate(
+        "ssh://git@evil.example/Katsiarynakavaleuskaya/PulsePlate.git"
+    )
+
+
+def test_origin_remote_validation_accepts_github_forms() -> None:
+    assert creative_code_pr_promotion._origin_remote_targets_pulseplate(
+        "git@github.com:Katsiarynakavaleuskaya/PulsePlate.git"
+    )
+    assert creative_code_pr_promotion._origin_remote_targets_pulseplate(
+        "https://github.com/Katsiarynakavaleuskaya/PulsePlate.git"
+    )
+    assert creative_code_pr_promotion._origin_remote_targets_pulseplate(
+        "ssh://git@github.com/Katsiarynakavaleuskaya/PulsePlate.git"
+    )
+
+
+def test_prepare_checkout_rejects_spoofed_promotion_remote(tmp_path: Path) -> None:
+    promotion_dir = tmp_path / "promotion"
+    promotion_dir.mkdir()
+    git = FakeGit(
+        remote_url="ssh://git@evil.example/Katsiarynakavaleuskaya/PulsePlate.git"
+    )
+
+    with pytest.raises(CreativeCodePRPromotionError, match="origin remote"):
+        creative_code_pr_promotion._prepare_checkout(
+            promotion_dir=promotion_dir,
+            dirname="promotion_checkout",
+            base_commit_sha="a" * 40,
+            git=git,
+            promotion_remote=True,
+        )
+
+    assert ["remote", "set-url", "origin", git.remote_url()] not in git.calls
 
 
 class FakeGates:


### PR DESCRIPTION
### Motivation
- The promotion tool accepted any origin URL that contained the substring `Katsiarynakavaleuskaya/PulsePlate`, which allowed attacker-controlled remotes (e.g. `ssh://git@evil.example/...`) to be treated as the PulsePlate GitHub repo and receive promoted pushes.
- The change hardens the promotion flow to ensure the checkout `origin` is only restored to canonical GitHub PulsePlate remotes before any push.

### Description
- Added a helper `_origin_remote_targets_pulseplate(remote_url: str) -> bool` that parses scp-style SSH, SSH URL, and HTTPS URL forms and verifies the remote resolves exactly to `github.com/Katsiarynakavaleuskaya/PulsePlate`.
- Replaced the previous substring check in `_prepare_checkout(..., promotion_remote=True)` with the new exact-match helper so the checkout will refuse spoofed remotes before `remote set-url origin` is executed.
- Extended `tests/test_creative_code_pr_promotion.py` to allow injecting `remote_url` on `FakeGit` and added three regression tests: `test_origin_remote_validation_rejects_spoofed_host`, `test_origin_remote_validation_accepts_github_forms`, and `test_prepare_checkout_rejects_spoofed_promotion_remote`.

### Testing
- `python -m py_compile scripts/orchestration/creative_code_pr_promotion.py tests/test_creative_code_pr_promotion.py` — passed (syntax/type-level check).
- `PYENV_VERSION=3.13.13 python -m pytest -q tests/test_creative_code_pr_promotion.py` — blocked locally due to missing test runtime dependency `fastapi` (ModuleNotFoundError), so full pytest run could not be completed here.
- `pre-commit run --all-files` — not executed locally because `pre-commit` is not installed in this environment.
- `make validate-changed` — not completed locally because no repo/shared `.venv` Python was available for hook execution, preventing the local preflight bundle from running.

Notes: this PR does not claim merge readiness because local dependency/tooling limitations prevented running the full required gate bundle; the change is minimal and focused on failing closed for non-GitHub remotes before any push occurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40291a47e0832cb7f6cbb045b123f1)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the promotion tool to validate the `origin` remote and block spoofed remotes. Only the exact GitHub PulsePlate repo is accepted before any push.

- **Bug Fixes**
  - Added `_origin_remote_targets_pulseplate` to parse SSH/HTTPS URLs and require `github.com/Katsiarynakavaleuskaya/PulsePlate`.
  - Replaced substring check in `_prepare_checkout(..., promotion_remote=True)` with exact-match validation to fail closed before `remote set-url`.
  - Updated tests: allow `FakeGit` remote injection and added regression tests for spoofed host rejection and valid GitHub forms.

<sup>Written for commit 631ce2af1cb2a5f299fc57175842379996628616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

