### PR TITLE
fix(orchestration): restore create-only promotion push lease

### DIFF
--- a/docs/orchestration/contracts/CREATIVE_CODE_PR_PROMOTION_CONTRACT.md
+++ b/docs/orchestration/contracts/CREATIVE_CODE_PR_PROMOTION_CONTRACT.md
@@ -175,8 +175,10 @@ Rules:
 - maximum length 80;
 - existing branch blocks;
 - final branch absence recheck immediately before push;
+- push uses an atomic create-only remote-ref lease (`--force-with-lease=refs/heads/<branch>:`)
+  so a branch that appears after the final absence check is rejected before mutation;
 - push result must report a new branch;
-- no force push;
+- no force update to an existing branch;
 - no update to an existing branch;
 - no auto-rebase.
 

--- a/scripts/orchestration/creative_code_pr_promotion.py
+++ b/scripts/orchestration/creative_code_pr_promotion.py
@@ -399,6 +399,7 @@ class GitTransport:
             [
                 "push",
                 "--porcelain",
+                f"--force-with-lease=refs/heads/{branch}:",
                 "origin",
                 f"HEAD:refs/heads/{branch}",
             ],

--- a/tests/test_creative_code_pr_promotion.py
+++ b/tests/test_creative_code_pr_promotion.py
@@ -759,13 +759,46 @@ def test_github_transport_forbids_draft_ready_review_merge_and_auth_token() -> N
             creative_code_pr_promotion._reject_forbidden_gh_args(args)
 
 
-def test_git_transport_contains_no_force_push_flag() -> None:
+def test_git_transport_uses_create_only_lease_without_force_push() -> None:
     source = (REPO_ROOT / "scripts/orchestration/creative_code_pr_promotion.py").read_text(
         encoding="utf-8"
     )
 
-    assert "--force" not in source
-    assert "--force-with-lease" not in source
+    assert '"--force",' not in source
+    assert "--force-with-lease=refs/heads/{branch}:" in source
+
+
+def test_git_transport_push_new_branch_uses_atomic_create_only_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(
+        self: creative_code_pr_promotion.GitTransport,
+        args: list[str],
+        *,
+        cwd: Path,
+        input_text: str | None = None,
+        check: bool = True,
+        timeout_seconds: int = 600,
+    ) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="[new branch]", stderr="")
+
+    monkeypatch.setattr(creative_code_pr_promotion.GitTransport, "run", fake_run)
+
+    creative_code_pr_promotion.GitTransport().push_new_branch(
+        cwd=REPO_ROOT,
+        branch="experiment/create-only",
+    )
+
+    assert captured["args"] == [
+        "push",
+        "--porcelain",
+        "--force-with-lease=refs/heads/experiment/create-only:",
+        "origin",
+        "HEAD:refs/heads/experiment/create-only",
+    ]
 
 
 def test_no_pipeline_promote_or_notify_imports() -> None:


### PR DESCRIPTION
### Motivation

- Prevent a TOCTOU race where a concurrently-created `experiment/*` branch could be fast-forwarded by the promotion push and mutate an existing remote ref, violating the promotion contract that the promotion must never update an existing branch.

### Description

- Restore atomic create-only push semantics by adding `--force-with-lease=refs/heads/{branch}:` to `GitTransport.push_new_branch` in `scripts/orchestration/creative_code_pr_promotion.py` so the push is rejected if the remote ref exists at push time.
- Add focused regression tests in `tests/test_creative_code_pr_promotion.py` that assert the create-only lease is used and still forbid a bare `--force` flag.
- Update the promotion contract in `docs/orchestration/contracts/CREATIVE_CODE_PR_PROMOTION_CONTRACT.md` to document the required create-only lease and the invariant that no existing branch may be updated.
- Preserve the existing behavioral checks that the push must report a new branch and reject non-atomic updates.

### Testing

- Ran the orchestration preflight `python3 scripts/orchestration/check_preflight.py`, which passed the repo-level sanity checks reported by the runbook.
- Performed syntax checks with `python3 -m py_compile scripts/orchestration/creative_code_pr_promotion.py tests/test_creative_code_pr_promotion.py`, which succeeded.
- Ran `git diff --check` to validate no whitespace/merge conflicts, which succeeded.
- Could not run the full test suite: `pytest` is not available in the execution environment so `python3 -m pytest -q tests/test_creative_code_pr_promotion.py` could not be executed (missing `pytest`).
- Could not run `pre-commit run --all-files` in this environment because `pre-commit` is not installed.

Commit: `4d2f56a`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4027c17c0c832c8cbe32b550dae83e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores create-only promotion push semantics to make branch creation atomic and prevent TOCTOU races that could update an existing `experiment/*` branch. Promotions now fail if the remote ref appears before push, preserving the “no update to existing branch” contract.

- **Bug Fixes**
  - Add `--force-with-lease=refs/heads/{branch}:` to `GitTransport.push_new_branch` so pushes are create-only.
  - Add regression tests to assert the lease is used and reject any bare `--force`.
  - Update the promotion contract docs to require the create-only lease and clarify that existing branches must never be updated.

<sup>Written for commit f7418d17b788e73b0fee997b085c6512cdaf0795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

