### PR TITLE
test(vip): align regions route lookup with effective routes

### DIFF
--- a/docs/review/PR_2039_FIXED_MAPPING.md
+++ b/docs/review/PR_2039_FIXED_MAPPING.md
@@ -17,7 +17,7 @@
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- [x] Sourcery review comment disposition recorded.
+- [x] Sourcery and CodeRabbit review comment dispositions recorded.
 - [x] Local focused tests, `make validate-changed`, and `pre-commit run --all-files` passed.
 - [x] Pre-push hooks passed, including `pip-audit`, backend tests, and full-repo Bandit.
 - [ ] Current-head CI complete before readiness language.
@@ -40,6 +40,13 @@ Disposition: NOT-A-BUG
 Evidence: `app/effective_routes.py:15`, `app/effective_routes.py:67`, `app/effective_routes.py:73`, `app/effective_routes.py:77`, `tests/test_vip_coverage_boost_fixed.py:109`, `tests/test_vip_coverage_boost_fixed.py:115`, `AGENTS.md:65`
 Reason: `route_endpoint_for_path_method(...)` is the canonical effective-route lookup helper; it intentionally receives the app route table and expands included-router contexts internally via `iter_effective_route_candidates(...)`. Missing routes still return `None` and preserve the test assertion message; duplicate routes intentionally fail closed because duplicate FastAPI method/path registrations are forbidden by repo policy.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2039#pullrequestreview-4587776067
+
+Disposition: FIXED
+Commit: 6aebe9a23
+Evidence: `docs/review/PR_2039_FIXED_MAPPING.md:61`, `docs/review/PR_2039_FIXED_MAPPING.md:62`, `docs/review/PR_2039_FIXED_MAPPING.md:63`
+Reason: Validation evidence now uses repo-relative `./.venv/bin/python` commands instead of absolute local machine paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2039#discussion_r3488160515 -> 6aebe9a23
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2039#pullrequestreview-4587781951 -> 6aebe9a23
 
 ## Validation Evidence
 

--- a/docs/review/PR_2039_FIXED_MAPPING.md
+++ b/docs/review/PR_2039_FIXED_MAPPING.md
@@ -1,0 +1,77 @@
+# PR 2039 Fixed in Commit Mapping
+
+## PR
+
+- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2039
+- Title: `test(vip): align regions route lookup with effective routes`
+- Branch: `codex/fix-main-vip-effective-route-test`
+- Base: `main`
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/eda0af18b627.json`
+- Goal: Fix post-merge main CI VIP regions route test by using effective route helpers.
+- Role dispatch: `agent-coordinator -> qa-engineer-agent -> bug-hunter`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] No actionable review comments at artifact creation.
+- [x] Local focused tests, `make validate-changed`, and `pre-commit run --all-files` passed.
+- [x] Pre-push hooks passed, including `pip-audit`, backend tests, and full-repo Bandit.
+- [ ] Current-head CI complete before readiness language.
+- [ ] Strict merge-readiness checks run after the final review/check cycle.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/pr2039-vip-effective-route-oracle-packet.json`
+- Artifact: `artifacts/orchestration/experiments/results/pr2039-vip-effective-route-oracle-result.json`
+- Runner mode: `oracle_only_governance_reviewer`
+- Result: accepted; shared tree untouched; 2/2 oracle pytest commands returned 0.
+- Contribution kind: `oracle_review`
+- Commit trailer required: yes, because the accepted oracle result shaped the commit decision.
+- Commit trailer used on commit `2ad8ed133bf2275e66d2fb9e40de6823b45cbfda`:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Validation Evidence
+
+- Main CI run `28326897612`, `test-main (3.12, 90)`, `tests/test_vip_coverage_boost_fixed.py::TestVIPCoverageBoostFixed::test_vip_regions_missing_function` raw `app.routes` lookup failure is fixed by commit `2ad8ed133bf2275e66d2fb9e40de6823b45cbfda`.
+- Main CI run `28326897612`, `test-main (3.11, 60)`, the same VIP regions route lookup failure is fixed by commit `2ad8ed133bf2275e66d2fb9e40de6823b45cbfda`.
+- `python3 scripts/orchestration/check_preflight.py --path tests/test_vip_coverage_boost_fixed.py`: PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py`: PASS.
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Fix post-merge main CI VIP regions route test by using effective route helpers" --task-class ci_fix --path tests/test_vip_coverage_boost_fixed.py --requested-agent qa-engineer-agent --requested-agent bug-hunter --pr-phase pre_open`: packet `eda0af18b627`.
+- `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/eda0af18b627.json --pretty`: dispatch order confirmed.
+- Role passes: `agent-coordinator`, `qa-engineer-agent`, `bug-hunter`: no blocking findings.
+- Premortem: `artifacts/orchestration/premortem/pr2039-vip-effective-route-hotfix-premortem.md`; findings fixed or process-dispositioned.
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest tests/test_vip_coverage_boost_fixed.py::TestVIPCoverageBoostFixed::test_vip_regions_missing_function -q`: 1 passed.
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest tests/test_vip_coverage_boost_fixed.py -q`: 8 passed.
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m ruff check tests/test_vip_coverage_boost_fixed.py`: PASS.
+- `git diff --check`: PASS.
+- `make validate-changed`: selected `tests/test_vip_coverage_boost_fixed.py`; 8 passed.
+- `pre-commit run --all-files`: PASS.
+- Pre-push hooks: `pip-audit`, backend tests, and full-repo Bandit PASS.
+
+## Merge Readiness
+
+- [ ] Current-head CI is passing for PR #2039.
+- [ ] Review threads and bot actionables are dispositioned.
+- [ ] `check_merge_ready.py --require-auth` passes for PR #2039.
+
+## Machine-Heavy Exception
+
+Full local `make verify` was not run for this narrow main-CI hotfix per the operator-approved machine-heavy exception. Local evidence is the focused regression suite, `make validate-changed`, `pre-commit run --all-files`, pre-push hooks, and current-head GitHub CI parity before merge.
+
+## Security Notes
+
+No production code, auth, secrets, dependency, workflow, or runtime security behavior changed. No new Codex Security scan was launched for this test-only route-helper migration to avoid redundant scan loops.
+
+## Deferred / Follow-ups
+
+- The raw-route lookup guard gap is real. Do not add a broad guard in this red-main hotfix; first run a false-positive scan over existing route-introspection tests and then add a narrow guard that targets endpoint discovery loops over raw `app.routes`.
+- Starlette/httpx2 deprecation warning remains outside this main-CI hotfix.
+- Private Python index/proxy work remains in the dedicated infrastructure lane.

--- a/docs/review/PR_2039_FIXED_MAPPING.md
+++ b/docs/review/PR_2039_FIXED_MAPPING.md
@@ -17,7 +17,7 @@
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- [x] No actionable review comments at artifact creation.
+- [x] Sourcery review comment disposition recorded.
 - [x] Local focused tests, `make validate-changed`, and `pre-commit run --all-files` passed.
 - [x] Pre-push hooks passed, including `pip-audit`, backend tests, and full-repo Bandit.
 - [ ] Current-head CI complete before readiness language.
@@ -36,7 +36,10 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: NOT-A-BUG
+Evidence: `app/effective_routes.py:15`, `app/effective_routes.py:67`, `app/effective_routes.py:73`, `app/effective_routes.py:77`, `tests/test_vip_coverage_boost_fixed.py:109`, `tests/test_vip_coverage_boost_fixed.py:115`, `AGENTS.md:65`
+Reason: `route_endpoint_for_path_method(...)` is the canonical effective-route lookup helper; it intentionally receives the app route table and expands included-router contexts internally via `iter_effective_route_candidates(...)`. Missing routes still return `None` and preserve the test assertion message; duplicate routes intentionally fail closed because duplicate FastAPI method/path registrations are forbidden by repo policy.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2039#pullrequestreview-4587776067
 
 ## Validation Evidence
 

--- a/docs/review/PR_2039_FIXED_MAPPING.md
+++ b/docs/review/PR_2039_FIXED_MAPPING.md
@@ -51,9 +51,9 @@ Reason: `route_endpoint_for_path_method(...)` is the canonical effective-route l
 - `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/eda0af18b627.json --pretty`: dispatch order confirmed.
 - Role passes: `agent-coordinator`, `qa-engineer-agent`, `bug-hunter`: no blocking findings.
 - Premortem: `artifacts/orchestration/premortem/pr2039-vip-effective-route-hotfix-premortem.md`; findings fixed or process-dispositioned.
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest tests/test_vip_coverage_boost_fixed.py::TestVIPCoverageBoostFixed::test_vip_regions_missing_function -q`: 1 passed.
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest tests/test_vip_coverage_boost_fixed.py -q`: 8 passed.
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m ruff check tests/test_vip_coverage_boost_fixed.py`: PASS.
+- `./.venv/bin/python -m pytest tests/test_vip_coverage_boost_fixed.py::TestVIPCoverageBoostFixed::test_vip_regions_missing_function -q`: 1 passed.
+- `./.venv/bin/python -m pytest tests/test_vip_coverage_boost_fixed.py -q`: 8 passed.
+- `./.venv/bin/python -m ruff check tests/test_vip_coverage_boost_fixed.py`: PASS.
 - `git diff --check`: PASS.
 - `make validate-changed`: selected `tests/test_vip_coverage_boost_fixed.py`; 8 passed.
 - `pre-commit run --all-files`: PASS.

--- a/tests/test_vip_coverage_boost_fixed.py
+++ b/tests/test_vip_coverage_boost_fixed.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
+from app.effective_routes import route_endpoint_for_path_method
 from app.middleware import api_tiers
 
 
@@ -105,15 +106,11 @@ class TestVIPCoverageBoostFixed:
         flakiness if the suite ends up with multiple loaded module instances.
         """
         app = _get_app()
-        endpoint = None
-        for route in getattr(app, "routes", []):
-            if getattr(route, "path", None) != "/api/v1/vip/regions":
-                continue
-            methods = getattr(route, "methods", None) or set()
-            if "GET" not in methods:
-                continue
-            endpoint = getattr(route, "endpoint", None)
-            break
+        endpoint = route_endpoint_for_path_method(
+            getattr(app, "routes", []),
+            "/api/v1/vip/regions",
+            "GET",
+        )
 
         assert endpoint is not None, "VIP regions route endpoint not found"
         monkeypatch.setitem(getattr(endpoint, "__globals__", {}), "get_available_regions", None)


### PR DESCRIPTION
## Goal
Fix post-merge main CI failure in `tests/test_vip_coverage_boost_fixed.py::TestVIPCoverageBoostFixed::test_vip_regions_missing_function`.

## Business Reason
Restore `main` CI by aligning a stale VIP test lookup with the effective FastAPI route table introduced by the included-router compatibility layer.

## Scope
- Replace the raw `app.routes` endpoint scan for `GET /api/v1/vip/regions` with `route_endpoint_for_path_method(...)`.
- Keep patching the actual registered endpoint globals so the existing provider-unavailable error contract remains tested.

## Out Of Scope
- Production route registration or runtime behavior changes.
- OpenAPI/schema/dependency changes.
- A broad raw-route lookup guard in this hotfix; the gap is real, but should be added after a false-positive scan so it does not block red-main recovery.

## Why This Was Not Caught Earlier
This was not a schema/OpenAPI issue. The route exists in the effective route table, but this older coverage test searched raw `app.routes` via `route.path`, `route.methods`, and `route.endpoint`. `#2038` fixed the raw-route tests visible in the previous current-head failure set; this file was not selected by that PR's focused diff/local gates and surfaced only in the next post-merge `test-main` shard.

## Guard Gap
Yes: we are missing a narrow guard for tests that discover route endpoints by scanning raw `app.routes` instead of using `app.effective_routes`. I am not adding the guard in this red-main hotfix because an initial scan shows legitimate raw route uses too, so the guard needs a careful allowlist/pattern design.

## Tests
Local and CI validation evidence for this hotfix is listed under Validation below. The PR keeps the dedicated Validation section because the repo merge-readiness artifact mirrors exact command evidence there.

## Validation
- `python3 scripts/orchestration/check_preflight.py --path tests/test_vip_coverage_boost_fixed.py` - PASS
- `python3 scripts/orchestration/check_agent_consistency.py` - PASS
- `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/eda0af18b627.json --pretty` - PASS, role order confirmed
- `python -m pytest -q tests/test_vip_coverage_boost_fixed.py::TestVIPCoverageBoostFixed::test_vip_regions_missing_function` - PASS
- `python -m pytest -q tests/test_vip_coverage_boost_fixed.py` - PASS (`8 passed`)
- `python -m ruff check tests/test_vip_coverage_boost_fixed.py` - PASS
- `make validate-changed` after commit - PASS, selected `tests/test_vip_coverage_boost_fixed.py`
- `pre-commit run --all-files` - PASS
- Pre-push hook - PASS (`pip-audit`, backend pre-push tests, full-repo bandit)

Full local `make verify` was not run under the operator-approved machine-heavy exception for red-main/narrow CI hotfixes; current-head PR CI and strict merge-readiness remain required before merge.

## Role / Review Evidence
- Coordinator pass: completed, scope locked to `tests/test_vip_coverage_boost_fixed.py`.
- QA pass: completed, no blocking findings.
- Bug-hunter pass: completed, no blocking findings; confirmed pre-commit caveat that `make validate-changed` had to be rerun after commit.
- Premortem: local artifact `artifacts/orchestration/premortem/pr2039-vip-effective-route-hotfix-premortem.md`, all findings fixed/process-dispositioned.
- Experiment Runner oracle-only evidence: accepted, shared tree untouched, 2/2 oracle pytest commands passed.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Disposition: NOT-A-BUG
Evidence: `app/effective_routes.py:15`, `app/effective_routes.py:67`, `tests/test_vip_coverage_boost_fixed.py:109`, `tests/test_vip_coverage_boost_fixed.py:115`, `AGENTS.md:65`
Reason: `route_endpoint_for_path_method(...)` is the effective-route helper; it accepts `app.routes` and expands included-router contexts internally. Missing routes still return `None` for the existing assertion message, while duplicate routes intentionally fail closed under repo policy.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2039#pullrequestreview-4587776067

Disposition: FIXED
Commit: 6aebe9a23
Evidence: `docs/review/PR_2039_FIXED_MAPPING.md:61`, `docs/review/PR_2039_FIXED_MAPPING.md:62`, `docs/review/PR_2039_FIXED_MAPPING.md:63`
Reason: Validation evidence now uses repo-relative `./.venv/bin/python` commands instead of absolute local machine paths.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2039#discussion_r3488160515 -> 6aebe9a23
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2039#pullrequestreview-4587781951 -> 6aebe9a23

## Merge Readiness
- [ ] Current-head PR CI passed
- [ ] Bot/review actionables dispositioned
- [ ] Strict merge-readiness wrapper passed with auth
- [ ] Post-merge local `main` synced and temporary worktree/cache/artifacts cleaned up

## Security Notes
No auth, secrets, dependency, suppression, workflow, or runtime security surface changed.

## Risks / Rollback
Risk is limited to one test. Rollback is reverting commit `2ad8ed133bf2275e66d2fb9e40de6823b45cbfda` if the test helper behavior exposes unexpected route duplication.

## Summary by Sourcery

Согласовать поиск тестового маршрута VIP-регионов с фактическим вспомогательным методом разрешения маршрутов FastAPI, чтобы исправить падающий основной CI-тест.

Исправления ошибок:
- Исправить тест отсутствующей функции VIP-регионов, используя общий вспомогательный метод `route_endpoint_for_path_method` вместо ручного обхода сырых `app.routes`.

Тесты:
- Обновить тест повышения покрытия VIP, чтобы находить конечную точку `GET /api/v1/vip/regions` через стандартный вспомогательный метод поиска маршрута, сохранив существующий контракт поведения при недоступности провайдера.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align VIP regions test route lookup with the effective FastAPI route resolution helper to fix a failing main CI test.

Bug Fixes:
- Fix VIP regions missing-function test by using the shared route_endpoint_for_path_method helper instead of manually scanning raw app.routes.

Tests:
- Update VIP coverage boost test to locate the /api/v1/vip/regions GET endpoint via the standard route lookup helper while preserving the existing provider-unavailable behavior contract.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI by switching the VIP regions test to the effective route lookup so it reliably finds GET `/api/v1/vip/regions`. Added review notes in `docs/review` (mapped CodeRabbit disposition and redacted local paths); no production code changed.

- **Bug Fixes**
  - Use `route_endpoint_for_path_method` from `app.effective_routes` instead of scanning `app.routes` before patching endpoint globals.

<sup>Written for commit acc94dc81bc6f57fc0f837a1bdf8378ac91ec7c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

