### PR TITLE
fix(routes): align runtime route introspection with effective routes

### DIFF
--- a/app/middleware/metrics.py
+++ b/app/middleware/metrics.py
@@ -37,7 +37,8 @@ logger = logging.getLogger(__name__)
 EXCLUDED_ROUTE_TEMPLATES: set[str] = {"/metrics", "/health", "/ready", "/health/db"}
 
 # Bounded route cache config.
-# Cache key is endpoint_id (id(endpoint)) to avoid holding strong refs to callables.
+# Cache key is (id(request.app), id(endpoint)) to avoid holding strong refs while
+# keeping same-handler route templates isolated across FastAPI app instances.
 ROUTE_CACHE_MAX_SIZE: int = 1024
 # If set (seconds), cached entries expire after TTL. None = no expiry.
 ROUTE_CACHE_TTL_S: float | None = None
@@ -304,8 +305,9 @@ def _excluded_by_path(request: Request) -> bool:
     return path in EXCLUDED_ROUTE_TEMPLATES
 
 
+_RouteCacheKey = tuple[int, int]
 _RouteCacheEntry = tuple[str, float]
-_ROUTE_CACHE: "OrderedDict[int, _RouteCacheEntry]" = OrderedDict()
+_ROUTE_CACHE: "OrderedDict[_RouteCacheKey, _RouteCacheEntry]" = OrderedDict()
 _ROUTE_CACHE_LOCK = Lock()
 _ROUTE_CACHE_EVICTIONS: int = 0
 _ROUTE_CACHE_EXPIRED: int = 0
@@ -316,34 +318,38 @@ def _now_monotonic() -> float:
     return monotonic()
 
 
-def _route_cache_get(endpoint_id: int) -> str | None:
+def _route_cache_key(request: Request, endpoint: object) -> _RouteCacheKey:
+    return (id(request.app), id(endpoint))
+
+
+def _route_cache_get(cache_key: _RouteCacheKey) -> str | None:
     ttl_s = ROUTE_CACHE_TTL_S
     now = _now_monotonic()
     with _ROUTE_CACHE_LOCK:
-        entry = _ROUTE_CACHE.get(endpoint_id)
+        entry = _ROUTE_CACHE.get(cache_key)
         if entry is None:
             return None
         value, inserted_at = entry
         if ttl_s is not None and (now - inserted_at) > ttl_s:
             global _ROUTE_CACHE_EXPIRED
-            _ROUTE_CACHE.pop(endpoint_id, None)
+            _ROUTE_CACHE.pop(cache_key, None)
             _ROUTE_CACHE_EXPIRED += 1
             return None
 
         # Mark as most-recently-used.
-        _ROUTE_CACHE.move_to_end(endpoint_id, last=True)
+        _ROUTE_CACHE.move_to_end(cache_key, last=True)
         return value
 
 
-def _route_cache_set(endpoint_id: int, value: str) -> None:
+def _route_cache_set(cache_key: _RouteCacheKey, value: str) -> None:
     max_size = ROUTE_CACHE_MAX_SIZE
     if max_size <= 0:
         return
 
     now = _now_monotonic()
     with _ROUTE_CACHE_LOCK:
-        _ROUTE_CACHE[endpoint_id] = (value, now)
-        _ROUTE_CACHE.move_to_end(endpoint_id, last=True)
+        _ROUTE_CACHE[cache_key] = (value, now)
+        _ROUTE_CACHE.move_to_end(cache_key, last=True)
         if len(_ROUTE_CACHE) > max_size:
             global _ROUTE_CACHE_EVICTIONS
             _ROUTE_CACHE.popitem(last=False)
@@ -382,17 +388,16 @@ def _route_template(request: Request) -> str:
     if endpoint is None:
         return "unknown"
 
-    # Check cache first (key is endpoint object id for stability)
-    endpoint_id = id(endpoint)
-    cached = _route_cache_get(endpoint_id)
-    if cached is not None:
-        return cached
-
     # Find the APIRoute that matches this endpoint
     router = getattr(request.app, "router", None)
     routes = getattr(router, "routes", None)
     if routes is None:
         return "unknown"
+
+    cache_key = _route_cache_key(request, endpoint)
+    cached = _route_cache_get(cache_key)
+    if cached is not None:
+        return cached
 
     # Collect all candidate routes for this endpoint
     candidates: list[str] = []
@@ -414,7 +419,7 @@ def _route_template(request: Request) -> str:
         result = max(candidates, key=len)
 
     # Cache result for future requests
-    _route_cache_set(endpoint_id, result)
+    _route_cache_set(cache_key, result)
     return result
 
 

--- a/docs/review/PR_2040_FIXED_MAPPING.md
+++ b/docs/review/PR_2040_FIXED_MAPPING.md
@@ -40,6 +40,8 @@
 - `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/dfc28f8b69f1.json --mode runtime --implementation-owner qa-engineer-agent --pretty`: PASS.
 - Role passes: `agent-coordinator`, `qa-engineer-agent`, `bug-hunter`: no remaining blocking findings after the typed-test hygiene fix.
 - `./.venv/bin/python -m pytest tests/test_app_basic_combined.py tests/test_app_vip_comprehensive_97.py tests/test_vip_production_simple.py tests/test_creative_research_pilot_api.py tests/test_legacy_export_aliases.py tests/test_test_router.py tests/test_legacy_runtime_env_canonicalization.py tests/test_test_route_registration_bootstrap.py tests/test_vip_api.py tests/test_route_patch_helper.py tests/test_metrics.py -q`: PASS, 167 passed.
+- `./.venv/bin/python -m pytest tests/test_test_route_registration_bootstrap.py tests/test_creative_code_pr_promotion.py -q`: PASS, 46 passed.
+- `./.venv/bin/python -m flake8 .`: PASS after fixing CI-lint F401/F402 findings.
 - `./.venv/bin/python -m mypy app/middleware/metrics.py --no-incremental --cache-dir=/dev/null`: PASS.
 - `./.venv/bin/python -m mypy tests/test_vip_api.py tests/test_vip_production_simple.py --no-incremental --cache-dir=/dev/null`: PASS.
 - `make validate-changed`: PASS after commit; selected the changed test/helper files and passed.

--- a/docs/review/PR_2040_FIXED_MAPPING.md
+++ b/docs/review/PR_2040_FIXED_MAPPING.md
@@ -20,6 +20,7 @@
 - [x] CodeRabbit no-actionables at PR open.
 - [x] QA pass completed; typed-test finding fixed.
 - [x] Bug-hunter pass completed; no actionable bug findings.
+- [x] Current-head `lint` backend-tests finding fixed: changed-file creative research runtime tests now use sync wrappers instead of `pytest-asyncio`-dependent `async def`.
 - [x] Local focused tests, `make validate-changed`, and `pre-commit run --all-files` passed.
 - [x] Pre-push hooks passed, including mypy, pip-audit, backend tests, full-repo Bandit, and docker build test.
 - [ ] Current-head CI complete before readiness language.
@@ -40,12 +41,14 @@
 - `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/dfc28f8b69f1.json --mode runtime --implementation-owner qa-engineer-agent --pretty`: PASS.
 - Role passes: `agent-coordinator`, `qa-engineer-agent`, `bug-hunter`: no remaining blocking findings after the typed-test hygiene fix.
 - `./.venv/bin/python -m pytest tests/test_app_basic_combined.py tests/test_app_vip_comprehensive_97.py tests/test_vip_production_simple.py tests/test_creative_research_pilot_api.py tests/test_legacy_export_aliases.py tests/test_test_router.py tests/test_legacy_runtime_env_canonicalization.py tests/test_test_route_registration_bootstrap.py tests/test_vip_api.py tests/test_route_patch_helper.py tests/test_metrics.py -q`: PASS, 167 passed.
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest tests/test_creative_research_pilot_api.py -q`: PASS, 23 passed.
+- `VENV_PYTHON="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh`: PASS, 188 selected tests.
 - `./.venv/bin/python -m pytest tests/test_test_route_registration_bootstrap.py tests/test_creative_code_pr_promotion.py -q`: PASS, 46 passed.
 - `./.venv/bin/python -m flake8 .`: PASS after fixing CI-lint F401/F402 findings.
 - `./.venv/bin/python -m mypy app/middleware/metrics.py --no-incremental --cache-dir=/dev/null`: PASS.
 - `./.venv/bin/python -m mypy tests/test_vip_api.py tests/test_vip_production_simple.py --no-incremental --cache-dir=/dev/null`: PASS.
-- `make validate-changed`: PASS after commit; selected the changed test/helper files and passed.
-- `pre-commit run --all-files`: PASS.
+- `make validate-changed`: PASS after current-head lint backend-tests fix; selected the changed test/helper files and passed.
+- `pre-commit run --all-files`: PASS after current-head lint backend-tests fix.
 - Pre-push hooks: mypy, pip-audit, backend tests, full-repo Bandit, and docker build test PASS.
 
 ## Merge Readiness

--- a/docs/review/PR_2040_FIXED_MAPPING.md
+++ b/docs/review/PR_2040_FIXED_MAPPING.md
@@ -1,0 +1,69 @@
+# PR 2040 Fixed in Commit Mapping
+
+## PR
+
+- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2040
+- Title: `fix(routes): align runtime route introspection with effective routes`
+- Branch: `codex/fix-main-vip-effective-route-introspection`
+- Base: `main`
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/dfc28f8b69f1.json`
+- Goal: Fix post-merge main VIP/router route introspection failures.
+- Role dispatch: `agent-coordinator -> qa-engineer-agent -> bug-hunter`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] CodeRabbit no-actionables at PR open.
+- [x] QA pass completed; typed-test finding fixed.
+- [x] Bug-hunter pass completed; no actionable bug findings.
+- [x] Local focused tests, `make validate-changed`, and `pre-commit run --all-files` passed.
+- [x] Pre-push hooks passed, including mypy, pip-audit, backend tests, full-repo Bandit, and docker build test.
+- [ ] Current-head CI complete before readiness language.
+- [ ] Strict merge-readiness checks run after the final review/check cycle.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Experiment Runner Evidence
+
+- Not applicable: no Experiment Runner artifact was created for this urgent red-main hotfix; the change was governed through preflight, task bootstrap, role dispatch, QA, bug-hunter review, focused tests, `make validate-changed`, and pre-commit/pre-push gates.
+
+## Validation Evidence
+
+- Main CI run `28328791782`, `test-main (3.11, 60)`, `test-main (3.12, 90)`, and `test-main (3.13, 90)` failed on raw route-table introspection after PR #2039 merged; fixed by commit `f61c40410f8e02fd1e144f5813d8b1559b454f0a`.
+- `python3 scripts/orchestration/check_preflight.py`: PASS.
+- `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/dfc28f8b69f1.json --mode runtime --implementation-owner qa-engineer-agent --pretty`: PASS.
+- Role passes: `agent-coordinator`, `qa-engineer-agent`, `bug-hunter`: no remaining blocking findings after the typed-test hygiene fix.
+- `./.venv/bin/python -m pytest tests/test_app_basic_combined.py tests/test_app_vip_comprehensive_97.py tests/test_vip_production_simple.py tests/test_creative_research_pilot_api.py tests/test_legacy_export_aliases.py tests/test_test_router.py tests/test_legacy_runtime_env_canonicalization.py tests/test_test_route_registration_bootstrap.py tests/test_vip_api.py tests/test_route_patch_helper.py tests/test_metrics.py -q`: PASS, 167 passed.
+- `./.venv/bin/python -m mypy app/middleware/metrics.py --no-incremental --cache-dir=/dev/null`: PASS.
+- `./.venv/bin/python -m mypy tests/test_vip_api.py tests/test_vip_production_simple.py --no-incremental --cache-dir=/dev/null`: PASS.
+- `make validate-changed`: PASS after commit; selected the changed test/helper files and passed.
+- `pre-commit run --all-files`: PASS.
+- Pre-push hooks: mypy, pip-audit, backend tests, full-repo Bandit, and docker build test PASS.
+
+## Merge Readiness
+
+- [ ] Current-head CI is passing for PR #2040.
+- [x] CodeRabbit completed with no-actionables at PR open.
+- [ ] Sourcery/Cubic no-actionables confirmed on the final PR head.
+- [ ] Review threads and bot actionables are dispositioned.
+- [ ] `check_merge_ready.py --require-auth` passes for PR #2040.
+
+## Machine-Heavy Exception
+
+Full local `make verify` was not run for this narrow main-CI hotfix per the operator-approved machine-heavy exception. Local evidence is the focused regression suite, `make validate-changed`, `pre-commit run --all-files`, pre-push hooks, and current-head GitHub CI parity before merge.
+
+## Security Notes
+
+No auth, secrets, dependency, workflow, or release behavior changed. No Codex Security scan was rerun for this hotfix to avoid redundant scan loops.
+
+## Deferred / Follow-ups
+
+- The raw-route lookup guard gap is real. Do not add a broad guard in this red-main hotfix; first run a false-positive scan over existing route-introspection tests and then add a narrow guard that targets endpoint discovery loops over raw runtime `app.routes`.
+- Starlette/httpx2 deprecation warning remains outside this main-CI hotfix.
+- Private Python index/proxy work remains in the dedicated infrastructure lane.

--- a/scripts/orchestration/creative_code_pr_promotion.py
+++ b/scripts/orchestration/creative_code_pr_promotion.py
@@ -44,12 +44,9 @@ from scripts.orchestration.creative_code_patch_workspace import (
     read_json,
     resolve_run_dir as resolve_patch_run_dir,
     resolve_run_file as resolve_patch_run_file,
-    run_git,
-    shared_tree_status,
     write_json_atomic,
 )
 from scripts.orchestration.creative_code_pr_promotion_contract import (
-    APPROVAL_DECISION,
     RUNNER_COAUTHOR,
     TARGET_BASE_BRANCH,
     TARGET_REPOSITORY,

--- a/scripts/orchestration/creative_code_pr_promotion_contract.py
+++ b/scripts/orchestration/creative_code_pr_promotion_contract.py
@@ -18,11 +18,6 @@ from pathlib import Path
 from typing import Any, cast
 
 from core.evidence.fingerprints import build_asset_id, build_idempotency_key, fingerprint_payload
-from scripts.orchestration.creative_code_patch_contract import (
-    HARD_MAX_CHANGED_FILES,
-    HARD_MAX_DIFF_LINES,
-    HARD_MAX_PATCH_BYTES,
-)
 
 SCHEMA_VERSION = "1.0"
 POLICY_VERSION = "creative-code-pr-promotion-pr3"

--- a/tests/_route_patch.py
+++ b/tests/_route_patch.py
@@ -19,6 +19,13 @@ from typing import Any, Callable, Iterable, cast
 
 import pytest
 
+from app.effective_routes import (
+    iter_effective_route_candidates,
+    route_endpoint,
+    route_methods,
+    route_path,
+)
+
 
 @dataclass(frozen=True)
 class RouteMatch:
@@ -43,19 +50,14 @@ def find_route_endpoint(*, app: Any, path: str, method: str) -> Callable[..., An
     wanted_method = _norm_method(method)
 
     matches: list[RouteMatch] = []
-    for r in getattr(app, "routes", []) or []:
-        r_path = getattr(r, "path", None)
-        r_methods = getattr(r, "methods", None)
-        r_endpoint = getattr(r, "endpoint", None)
-
+    for r in iter_effective_route_candidates(getattr(app, "routes", []) or []):
+        r_path = route_path(r)
         if r_path != path:
             continue
-        if not r_methods:
-            continue
-
-        methods = tuple(sorted({_norm_method(m) for m in cast(Iterable[str], r_methods)}))
+        methods = tuple(sorted({_norm_method(m) for m in route_methods(r)}))
         if wanted_method not in methods:
             continue
+        r_endpoint = route_endpoint(r)
         if not callable(r_endpoint):
             continue
 

--- a/tests/test_app_basic_combined.py
+++ b/tests/test_app_basic_combined.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 
 import app
 import pytest
+from app.effective_routes import iter_effective_route_candidates, route_path
 from app.bootstrap.direct_api_root import LEGACY_BMI_WEB_ROUTE
 from tests.helpers.module_resolve import resolve_module
 
@@ -39,14 +40,12 @@ class TestAppImport:
             "/ws",
         }
         package_paths = {
-            getattr(route, "path", None) or getattr(route, "path_format", "")
-            for route in app.app.routes
+            route_path(route) for route in iter_effective_route_candidates(app.app.routes)
         }
         from app.main import app as main_app
 
         main_paths = {
-            getattr(route, "path", None) or getattr(route, "path_format", "")
-            for route in main_app.routes
+            route_path(route) for route in iter_effective_route_candidates(main_app.routes)
         }
 
         assert additive_paths.issubset(package_paths)
@@ -76,8 +75,7 @@ class TestAppImport:
 
         package_app = app.app
         route_paths = {
-            getattr(route, "path", None) or getattr(route, "path_format", "")
-            for route in package_app.routes
+            route_path(route) for route in iter_effective_route_candidates(package_app.routes)
         }
 
         assert package_app is replacement_app
@@ -101,10 +99,7 @@ class TestAppVIPIntegration:
         assert fastapi_app is not None
 
         # The app should be created and standard routes present
-        paths = {
-            getattr(route, "path", None) or getattr(route, "path_format", "")
-            for route in fastapi_app.routes
-        }
+        paths = {route_path(route) for route in iter_effective_route_candidates(fastapi_app.routes)}
         # Check for health endpoint (both unversioned and versioned)
         assert "/health" in paths or "/api/v1/health" in paths
 

--- a/tests/test_app_vip_comprehensive_97.py
+++ b/tests/test_app_vip_comprehensive_97.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.effective_routes import iter_effective_route_candidates, route_path
+
 
 class TestAppVIPComprehensive97:
     """Comprehensive tests for app.py VIP functionality to improve coverage to 97%."""
@@ -225,7 +227,9 @@ class TestAppVIPComprehensive97:
         assert hasattr(app, "app")
         # Check for presence of basic routes (safely)
         if app.app is not None and hasattr(app.app, "routes"):
-            route_paths = [route.path for route in app.app.routes]
+            route_paths = [
+                route_path(route) for route in iter_effective_route_candidates(app.app.routes)
+            ]
             assert "/" in route_paths
             assert "/health" in route_paths
             assert "/api/v1/health" in route_paths

--- a/tests/test_creative_research_pilot_api.py
+++ b/tests/test_creative_research_pilot_api.py
@@ -367,8 +367,7 @@ def test_creative_research_invalid_provider_payload_returns_503(
     assert _json_body(response) == {"detail": "creative_research_provider_invalid_response"}
 
 
-@pytest.mark.asyncio
-async def test_runtime_missing_transparency_registry_fails_closed(
+def test_runtime_missing_transparency_registry_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Missing transparency metadata must stop the runtime before quota consumption."""
@@ -384,14 +383,13 @@ async def test_runtime_missing_transparency_registry_fails_closed(
     from app.services.creative_research_runtime import run_creative_research_pilot_task
 
     with pytest.raises(HTTPException) as exc_info:
-        await run_creative_research_pilot_task(_task_payload())
+        asyncio.run(run_creative_research_pilot_task(_task_payload()))
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "transparency_registry_unavailable"
 
 
-@pytest.mark.asyncio
-async def test_runtime_incomplete_transparency_registry_fails_closed(
+def test_runtime_incomplete_transparency_registry_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Incomplete transparency metadata must fail closed before provider use."""
@@ -404,14 +402,13 @@ async def test_runtime_incomplete_transparency_registry_fails_closed(
     from app.services.creative_research_runtime import run_creative_research_pilot_task
 
     with pytest.raises(HTTPException) as exc_info:
-        await run_creative_research_pilot_task(_task_payload())
+        asyncio.run(run_creative_research_pilot_task(_task_payload()))
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "transparency_registry_incomplete"
 
 
-@pytest.mark.asyncio
-async def test_runtime_non_auto_safe_mode_fails_closed(
+def test_runtime_non_auto_safe_mode_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The service must reject unsupported execution modes before provider use."""
@@ -438,14 +435,13 @@ async def test_runtime_non_auto_safe_mode_fails_closed(
     from app.services.creative_research_runtime import run_creative_research_pilot_task
 
     with pytest.raises(HTTPException) as exc_info:
-        await run_creative_research_pilot_task(task)
+        asyncio.run(run_creative_research_pilot_task(task))
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "agent_execution_review_required"
 
 
-@pytest.mark.asyncio
-async def test_runtime_non_vip_api_key_fails_closed(
+def test_runtime_non_vip_api_key_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The service must reject non-VIP keys before quota or provider work."""
@@ -462,14 +458,13 @@ async def test_runtime_non_vip_api_key_fails_closed(
     from app.services.creative_research_runtime import run_creative_research_pilot_task
 
     with pytest.raises(HTTPException) as exc_info:
-        await run_creative_research_pilot_task(_task_payload())
+        asyncio.run(run_creative_research_pilot_task(_task_payload()))
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "creative_research_vip_required"
 
 
-@pytest.mark.asyncio
-async def test_runtime_llm_gate_failure_returns_503(
+def test_runtime_llm_gate_failure_returns_503(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Privileged-action audit failures must fail closed before quota/provider work."""
@@ -485,14 +480,13 @@ async def test_runtime_llm_gate_failure_returns_503(
     from app.services.creative_research_runtime import run_creative_research_pilot_task
 
     with pytest.raises(HTTPException) as exc_info:
-        await run_creative_research_pilot_task(_task_payload())
+        asyncio.run(run_creative_research_pilot_task(_task_payload()))
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "llm_generation_unavailable"
 
 
-@pytest.mark.asyncio
-async def test_runtime_provider_none_returns_503(
+def test_runtime_provider_none_returns_503(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A missing provider instance must fail closed with stable detail."""
@@ -510,14 +504,13 @@ async def test_runtime_provider_none_returns_503(
     from app.services.creative_research_runtime import run_creative_research_pilot_task
 
     with pytest.raises(HTTPException) as exc_info:
-        await run_creative_research_pilot_task(_task_payload())
+        asyncio.run(run_creative_research_pilot_task(_task_payload()))
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "LLM provider not available"
 
 
-@pytest.mark.asyncio
-async def test_runtime_provider_exception_returns_503(
+def test_runtime_provider_exception_returns_503(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Unexpected provider failures must map to the stable unavailable detail."""
@@ -542,14 +535,13 @@ async def test_runtime_provider_exception_returns_503(
     from app.services.creative_research_runtime import run_creative_research_pilot_task
 
     with pytest.raises(HTTPException) as exc_info:
-        await run_creative_research_pilot_task(_task_payload())
+        asyncio.run(run_creative_research_pilot_task(_task_payload()))
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "creative_research_generation_unavailable"
 
 
-@pytest.mark.asyncio
-async def test_runtime_empty_provider_payload_returns_503(
+def test_runtime_empty_provider_payload_returns_503(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Non-string or empty provider payloads must fail closed."""
@@ -574,7 +566,7 @@ async def test_runtime_empty_provider_payload_returns_503(
     from app.services.creative_research_runtime import run_creative_research_pilot_task
 
     with pytest.raises(HTTPException) as exc_info:
-        await run_creative_research_pilot_task(_task_payload())
+        asyncio.run(run_creative_research_pilot_task(_task_payload()))
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "creative_research_provider_invalid_response"

--- a/tests/test_creative_research_pilot_api.py
+++ b/tests/test_creative_research_pilot_api.py
@@ -10,6 +10,11 @@ from httpx import Response
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 import pytest
 
+from app.effective_routes import (
+    iter_effective_route_candidates,
+    route_include_in_schema,
+    route_path,
+)
 from app.middleware.api_tiers import SubscriptionTier, TEST_KEY_VIP
 from app.schemas.creative_research import (
     CreativeResearchPilotInput,
@@ -138,8 +143,8 @@ def test_creative_research_route_is_hidden_from_openapi() -> None:
     from app.main import app
 
     runtime_routes = {
-        str(getattr(route, "path", "")): getattr(route, "include_in_schema", True)
-        for route in app.routes
+        route_path(route): route_include_in_schema(route)
+        for route in iter_effective_route_candidates(app.routes)
     }
 
     assert ROUTE_PATH in runtime_routes

--- a/tests/test_legacy_export_aliases.py
+++ b/tests/test_legacy_export_aliases.py
@@ -12,6 +12,13 @@ from fastapi.testclient import TestClient
 import pytest
 
 import app as app_pkg
+from app.effective_routes import (
+    iter_effective_route_candidates,
+    route_include_in_schema,
+    route_methods,
+    route_path,
+    route_responses,
+)
 import app.main as app_main
 import legacy_app
 
@@ -21,9 +28,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 def _matching_routes(path: str, method: str) -> list[object]:
     return [
         route
-        for route in app_main.app.routes
-        if getattr(route, "path", None) == path
-        and method in (getattr(route, "methods", None) or set())
+        for route in iter_effective_route_candidates(app_main.app.routes)
+        if route_path(route) == path and method in route_methods(route)
     ]
 
 
@@ -49,9 +55,9 @@ def test_legacy_export_alias_routes_are_hidden_shim_owned_and_protected() -> Non
         route = matching_routes[0]
         endpoint = getattr(route, "endpoint", None)
         assert getattr(endpoint, "__module__", "") == "app.routers.legacy_export_aliases"
-        assert getattr(route, "include_in_schema", True) is include_in_schema
+        assert route_include_in_schema(route) is include_in_schema
         assert path not in openapi_paths
-        assert 429 in getattr(route, "responses", {})
+        assert 429 in route_responses(route)
         assert "request" in inspect.signature(endpoint).parameters
         assert any(
             _is_legacy_api_key_dependency(dependency) for dependency in route.dependencies
@@ -174,15 +180,15 @@ def test_legacy_export_alias_route_resolves_rebound_helper(
 def test_legacy_export_aliases_absent_when_export_gate_is_disabled() -> None:
     code = """
 import json
+from app.effective_routes import iter_effective_route_candidates, route_methods, route_path
 import app.main as app_main
 
 counts = {}
 for path, method, _include in app_main._LEGACY_EXPORT_ALIAS_ROUTE_SPECS:
     counts[f"{method} {path}"] = sum(
         1
-        for route in app_main.app.routes
-        if getattr(route, "path", None) == path
-        and method in (getattr(route, "methods", None) or set())
+        for route in iter_effective_route_candidates(app_main.app.routes)
+        if route_path(route) == path and method in route_methods(route)
     )
 print(json.dumps({"enabled": app_main._legacy_module.EXPORTS_ENABLED, "counts": counts}))
 """

--- a/tests/test_legacy_runtime_env_canonicalization.py
+++ b/tests/test_legacy_runtime_env_canonicalization.py
@@ -8,6 +8,8 @@ import dotenv
 import pytest
 from fastapi import HTTPException
 
+from app.effective_routes import iter_effective_route_candidates, route_path
+
 
 def _reload_legacy_app() -> ModuleType:
     """Reload legacy_app after env changes.
@@ -75,15 +77,15 @@ def test_canonical_bootstrap_staging_test_router_respects_environment_flag(
 
     app_module = _reload_canonical_main()
     assert not any(
-        getattr(route, "path", "") == "/api/v1/test/health"
-        for route in getattr(app_module.app, "routes", [])
+        route_path(route) == "/api/v1/test/health"
+        for route in iter_effective_route_candidates(getattr(app_module.app, "routes", []))
     )
 
     monkeypatch.setenv("ENABLE_TEST_ROUTES", "1")
     app_module = _reload_canonical_main()
     assert any(
-        getattr(route, "path", "") == "/api/v1/test/health"
-        for route in getattr(app_module.app, "routes", [])
+        route_path(route) == "/api/v1/test/health"
+        for route in iter_effective_route_candidates(getattr(app_module.app, "routes", []))
     )
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 
 import app
 from app.bootstrap.metrics import register_metrics
+from app.effective_routes import iter_effective_route_candidates, route_methods, route_path
 
 # Use conftest.py client fixture (don't define local one to avoid bypassing test setup)
 
@@ -45,9 +46,8 @@ def _get_metrics_get_routes(app_instance: FastAPI) -> list[object]:
 
     return [
         route
-        for route in app_instance.routes
-        if getattr(route, "path", None) == "/metrics"
-        and "GET" in (getattr(route, "methods", None) or set())
+        for route in iter_effective_route_candidates(app_instance.routes)
+        if route_path(route) == "/metrics" and "GET" in route_methods(route)
     ]
 
 
@@ -490,6 +490,50 @@ def test_metrics_route_template_normalizes_trailing_slash_before_cache() -> None
     assert _route_template(request) == "/api/v1/slash"
 
 
+def test_metrics_route_template_cache_is_app_scoped() -> None:
+    from starlette.requests import Request
+
+    import app.middleware.metrics as metrics_mod
+
+    with metrics_mod._ROUTE_CACHE_LOCK:
+        metrics_mod._ROUTE_CACHE.clear()
+
+    async def _shared_route() -> dict[str, str]:
+        return {"status": "ok"}
+
+    first_app = FastAPI()
+    second_app = FastAPI()
+    first_app.add_api_route("/api/v1/cache/first", _shared_route, methods=["GET"])
+    second_app.add_api_route("/api/v1/cache/second", _shared_route, methods=["GET"])
+
+    def _request(app_instance: FastAPI, path: str) -> Request:
+        return Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": path,
+                "raw_path": path.encode(),
+                "query_string": b"",
+                "headers": [],
+                "client": ("testclient", 123),
+                "server": ("testserver", 80),
+                "scheme": "http",
+                "http_version": "1.1",
+                "app": app_instance,
+                "endpoint": _shared_route,
+            }
+        )
+
+    assert (
+        metrics_mod._route_template(_request(first_app, "/api/v1/cache/first"))
+        == "/api/v1/cache/first"
+    )
+    assert (
+        metrics_mod._route_template(_request(second_app, "/api/v1/cache/second"))
+        == "/api/v1/cache/second"
+    )
+
+
 def test_metrics_middleware_noop_when_metrics_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -648,7 +692,7 @@ def test_route_cache_disabled_when_max_size_zero(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(metrics_mod, "ROUTE_CACHE_MAX_SIZE", 0)
 
     # Call _route_cache_set (should return early at line 193)
-    metrics_mod._route_cache_set(123, "/api/v1/test")
+    metrics_mod._route_cache_set((1, 123), "/api/v1/test")
 
     # Cache should remain empty
     stats = metrics_mod._route_cache_stats()
@@ -676,17 +720,17 @@ def test_route_cache_ttl_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(metrics_mod, "_now_monotonic", lambda: t["v"])
 
     # Add entry at t=1000.0
-    endpoint_id = 999
-    metrics_mod._route_cache_set(endpoint_id, "/api/v1/test")
+    cache_key = (1, 999)
+    metrics_mod._route_cache_set(cache_key, "/api/v1/test")
 
     # Should be cached (delta=0.0 < 0.01)
-    assert metrics_mod._route_cache_get(endpoint_id) == "/api/v1/test"
+    assert metrics_mod._route_cache_get(cache_key) == "/api/v1/test"
 
     # Advance time beyond TTL (delta=0.02 > 0.01)
     t["v"] = 1000.02
 
     # Should be expired (returns None, increments _ROUTE_CACHE_EXPIRED)
-    assert metrics_mod._route_cache_get(endpoint_id) is None
+    assert metrics_mod._route_cache_get(cache_key) is None
     stats = metrics_mod._route_cache_stats()
     assert stats["expired"] >= 1
 
@@ -708,9 +752,9 @@ def test_route_cache_eviction_on_overflow(monkeypatch: pytest.MonkeyPatch) -> No
         metrics_mod._ROUTE_CACHE.clear()
 
     # Add 3 entries (should evict first)
-    metrics_mod._route_cache_set(1, "/route1")
-    metrics_mod._route_cache_set(2, "/route2")
-    metrics_mod._route_cache_set(3, "/route3")  # Should trigger eviction
+    metrics_mod._route_cache_set((1, 1), "/route1")
+    metrics_mod._route_cache_set((1, 2), "/route2")
+    metrics_mod._route_cache_set((1, 3), "/route3")  # Should trigger eviction
 
     # Check stats
     stats = metrics_mod._route_cache_stats()

--- a/tests/test_test_route_registration_bootstrap.py
+++ b/tests/test_test_route_registration_bootstrap.py
@@ -10,6 +10,12 @@ from fastapi.testclient import TestClient
 
 import app.main as app_main
 from app.bootstrap.route_family import route_has_dependency_call
+from app.effective_routes import (
+    iter_effective_route_candidates,
+    route_include_in_schema,
+    route_methods,
+    route_path,
+)
 
 _EXPECTED_TEST_ROUTE_KEYS = {
     (path, method) for path, method, _include_in_schema in app_main._TEST_ROUTE_SPECS
@@ -38,19 +44,19 @@ def _set_runtime_env(
         monkeypatch.setenv("ENABLE_TEST_ROUTES", enable_test_routes)
 
 
-def _test_routes(target_app: FastAPI) -> list[APIRoute]:
+def _test_routes(target_app: FastAPI) -> list[object]:
     return [
         route
-        for route in target_app.routes
-        if isinstance(route, APIRoute) and str(route.path) in _EXPECTED_TEST_ROUTE_PATHS
+        for route in iter_effective_route_candidates(target_app.routes)
+        if route_path(route) in _EXPECTED_TEST_ROUTE_PATHS
     ]
 
 
 def _registered_test_route_counts(target_app: FastAPI) -> Counter[tuple[str, str]]:
     counts: Counter[tuple[str, str]] = Counter()
     for route in _test_routes(target_app):
-        for method in getattr(route, "methods", None) or set():
-            key = (str(route.path), str(method).upper())
+        for method in route_methods(route):
+            key = (route_path(route), method)
             if key in _EXPECTED_TEST_ROUTE_KEYS:
                 counts[key] += 1
     return counts
@@ -62,7 +68,7 @@ def _assert_test_routes_registered_once(target_app: FastAPI) -> None:
     assert all(count == 1 for count in counts.values())
 
     for route in _test_routes(target_app):
-        assert route.include_in_schema is False
+        assert route_include_in_schema(route) is False
         assert route_has_dependency_call(route, app_main.ensure_test_routes_non_production)
 
 

--- a/tests/test_test_route_registration_bootstrap.py
+++ b/tests/test_test_route_registration_bootstrap.py
@@ -75,13 +75,13 @@ def _assert_test_routes_registered_once(target_app: FastAPI) -> None:
 def _stub_test_router_without_dependencies() -> APIRouter:
     router = APIRouter()
 
-    for path, method, include_in_schema in app_main._TEST_ROUTE_SPECS:
+    for spec_path, method, include_in_schema in app_main._TEST_ROUTE_SPECS:
 
-        async def _handler(route_path: str = path) -> dict[str, str]:
-            return {"path": route_path}
+        async def _handler(current_route_path: str = spec_path) -> dict[str, str]:
+            return {"path": current_route_path}
 
         router.add_api_route(
-            path,
+            spec_path,
             _handler,
             methods=[method],
             include_in_schema=include_in_schema,
@@ -227,13 +227,13 @@ def test_test_route_registration_rejects_partial_existing_family() -> None:
 def test_test_route_registration_rejects_foreign_handlers() -> None:
     target_app = FastAPI()
 
-    for path, method, include_in_schema in app_main._TEST_ROUTE_SPECS:
+    for spec_path, method, include_in_schema in app_main._TEST_ROUTE_SPECS:
 
-        async def _foreign_test_route(route_path: str = path) -> dict[str, str]:
-            return {"path": route_path}
+        async def _foreign_test_route(current_route_path: str = spec_path) -> dict[str, str]:
+            return {"path": current_route_path}
 
         target_app.add_api_route(
-            path,
+            spec_path,
             _foreign_test_route,
             methods=[method],
             include_in_schema=include_in_schema,

--- a/tests/test_test_router.py
+++ b/tests/test_test_router.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from app.effective_routes import iter_effective_route_candidates, route_path
 import settings as app_settings
 
 
@@ -33,8 +34,8 @@ def _import_fresh_app() -> FastAPI:
     runtime_env = app_settings.get_runtime_env_name()
     if runtime_env == "staging" and os.getenv("ENABLE_TEST_ROUTES") == "1":
         has_test_routes = any(
-            getattr(route, "path", "").startswith("/api/v1/test/")
-            for route in getattr(app, "routes", [])
+            route_path(route).startswith("/api/v1/test/")
+            for route in iter_effective_route_candidates(getattr(app, "routes", []))
         )
         assert has_test_routes, (
             "Test router routes are missing after legacy_app reload. "

--- a/tests/test_vip_api.py
+++ b/tests/test_vip_api.py
@@ -9,6 +9,8 @@ EN: Tests for VIP API endpoints
 import pytest
 from fastapi.testclient import TestClient
 
+from tests._route_patch import find_route_endpoint, patch_endpoint_global
+
 
 def test_vip_health(client: TestClient, vip_headers: dict[str, str]) -> None:
     """Test VIP health endpoint returns 200"""
@@ -23,8 +25,6 @@ def test_vip_health(client: TestClient, vip_headers: dict[str, str]) -> None:
 def test_deprecated_weekly_plan_handles_dict_plan(
     monkeypatch: pytest.MonkeyPatch, client: TestClient, vip_headers: dict[str, str]
 ) -> None:
-    from fastapi.routing import APIRoute
-
     def fake_make_weekly_menu(*, profile: object) -> dict[str, object]:
         return {
             "week_start": "2026-01-01",
@@ -35,24 +35,20 @@ def test_deprecated_weekly_plan_handles_dict_plan(
             "adherence_score": 0,
         }
 
-    deprecated_route = next(
-        (
-            r
-            for r in client.app.routes
-            if isinstance(r, APIRoute)
-            and r.path == "/api/v1/vip/weekly-plan"
-            and "POST" in (r.methods or set())
-        ),
-        None,
+    deprecated_endpoint = find_route_endpoint(
+        app=client.app,
+        path="/api/v1/vip/weekly-plan",
+        method="POST",
     )
-    assert deprecated_route is not None, "POST /api/v1/vip/weekly-plan route not found"
     # NOTE: String-based module patching (e.g. "app.routers.vip.make_weekly_menu") can be flaky
     # under dual-module / reload / shim-import behavior. Patch the registered route handler globals
     # for determinism (see docs/ENGINEERING_LESSONS.md).
-    monkeypatch.setitem(
-        deprecated_route.endpoint.__globals__, "make_weekly_menu", fake_make_weekly_menu
+    patch_endpoint_global(
+        monkeypatch=monkeypatch,
+        endpoint=deprecated_endpoint,
+        name="make_weekly_menu",
+        value=fake_make_weekly_menu,
     )
-    assert deprecated_route.endpoint.__globals__["make_weekly_menu"] is fake_make_weekly_menu
 
     payload = {
         "sex": "female",

--- a/tests/test_vip_production_simple.py
+++ b/tests/test_vip_production_simple.py
@@ -7,6 +7,8 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
+from tests._route_patch import find_route_endpoint, patch_endpoint_global
+
 VALID_WEEKLY_PLAN_REQUEST = {
     "sex": "male",
     "age": 30,
@@ -84,27 +86,24 @@ class TestVIPProductionMode:
         monkeypatch.setenv("API_KEY", "secret-key")
         monkeypatch.setenv("VIP_API_KEYS", "secret-key")  # pragma: allowlist secret
 
-        from fastapi.routing import APIRoute
-
         import app
 
         def raise_exc(*args, **kwargs):
             # sourcery skip: raise-specific-error
             raise Exception("Menu generation failed")
 
-        deprecated_route = next(
-            (
-                route
-                for route in app.app.routes
-                if isinstance(route, APIRoute)
-                and route.path == "/api/v1/vip/weekly-plan"
-                and "POST" in (route.methods or set())
-            ),
-            None,
+        deprecated_endpoint = find_route_endpoint(
+            app=app.app,
+            path="/api/v1/vip/weekly-plan",
+            method="POST",
         )
-        assert deprecated_route is not None, "POST /api/v1/vip/weekly-plan route not found"
         # Patch the registered route globals for deterministic behavior under reload/shim imports.
-        monkeypatch.setitem(deprecated_route.endpoint.__globals__, "make_weekly_menu", raise_exc)
+        patch_endpoint_global(
+            monkeypatch=monkeypatch,
+            endpoint=deprecated_endpoint,
+            name="make_weekly_menu",
+            value=raise_exc,
+        )
 
         client = TestClient(cast(ASGIApp, app.app))
 


### PR DESCRIPTION
## Goal
Fix post-merge `main` failures caused by tests and test helpers reading raw FastAPI/Starlette `app.routes` after included-router effective route handling.

## Business Reason
Restore `main` CI signal without widening the dependency/runtime PR scope.

## Scope
- Use `app.effective_routes` helpers in runtime app route-table assertions.
- Make `tests/_route_patch.py` effective-route aware so endpoint patch tests find routes hidden behind included-router markers.
- Scope metrics route-template cache by `(app, endpoint)` instead of endpoint id only, preventing cross-app stale route-template reuse in long test processes.
- Add a regression test for app-scoped metrics route-template cache behavior.
- Remove stale unused creative-code PR promotion imports surfaced by the current-head lint gate.
- Convert selected creative research runtime tests from `pytest-asyncio`-dependent `async def` to sync `asyncio.run(...)` wrappers so CI pre-commit backend-tests can run them without async plugins.

## Why This Was Not Found Immediately
The earlier fix covered the single visible failing test. Branch-diff validation does not select untouched neighboring tests before they are changed, and schema/OpenAPI checks passed because the routes were actually registered. The failure mode was test/runtime introspection of raw route internals, not missing route registration.

There is a guard gap: no current guard forbids raw runtime `app.routes` scans when `iter_effective_route_candidates(...)` is required. A broad ban would need careful false-positive handling because router-source scans and intentional negative checks are still valid.

## Out Of Scope
- No dependency bumps.
- No Starlette/FastAPI/Pydantic changes.
- No Codex Security rerun for this hotfix.
- No broad route-introspection lint guard in this PR.

## Tests
- `python3 scripts/orchestration/check_preflight.py`
- `pre-commit run --all-files`
- `make validate-changed`
- `python -m pytest tests/test_app_basic_combined.py tests/test_app_vip_comprehensive_97.py tests/test_vip_production_simple.py tests/test_creative_research_pilot_api.py tests/test_legacy_export_aliases.py tests/test_test_router.py tests/test_legacy_runtime_env_canonicalization.py tests/test_test_route_registration_bootstrap.py tests/test_vip_api.py tests/test_route_patch_helper.py tests/test_metrics.py -q`
- `python -m pytest tests/test_creative_research_pilot_api.py -q`
- `VENV_PYTHON="/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh`
- `python -m pytest tests/test_test_route_registration_bootstrap.py tests/test_creative_code_pr_promotion.py -q`
- `python -m flake8 .`
- `python -m mypy app/middleware/metrics.py --no-incremental --cache-dir=/dev/null`
- `python -m mypy tests/test_vip_api.py tests/test_vip_production_simple.py --no-incremental --cache-dir=/dev/null`

## Validation
Same evidence as `## Tests`; current-head CI is still the merge truth before readiness language.

## Review Notes
- QA final pass found a valid typed-test hygiene issue around endpoint `.__globals__`; fixed by using `tests._route_patch.find_route_endpoint` and `patch_endpoint_global`.
- Final bug-hunter pass returned no actionable bug findings after PR open.
- Current-head `lint` found one CI-only backend-tests issue: changed-file creative research runtime tests relied on `pytest-asyncio`; fixed by using sync `asyncio.run(...)` wrappers.
- No Codex Security scan was rerun for this hotfix.

## Experiment Runner Evidence
Not applicable: no Experiment Runner artifact was created for this urgent red-main hotfix; the change was governed through preflight, task bootstrap, role dispatch, QA, bug-hunter review, focused tests, `make validate-changed`, and pre-commit/pre-push gates.

## Risks / Rollback
Risk is limited to route-table introspection tests and the metrics route-template cache key. Rollback is reverting this commit if CI exposes an unexpected regression.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2040_FIXED_MAPPING.md`
