### PR TITLE
feat(orchestration): add creative-code telemetry and rejection taxonomy

### DIFF
--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -520,7 +520,7 @@ Accepted sequence for this initiative:
 1. PR1: governance foundation
 2. PR2: deterministic bootstrap tooling
 3. PR3: runner MVP
-4. PR4: promotion automation + telemetry
+4. PR4: private-loop telemetry and rejection taxonomy
 5. PR5: CV docs/eval lane
 6. PR6: first applied `LLM/RAG reliability` optimization PR
 

--- a/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
+++ b/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
@@ -126,7 +126,9 @@ PR-0 is a contract-only start point.
   Experiment Runner candidate-mode evaluation, and sanitized result metadata.
 - PR-3: allow human-approved non-draft PR creation from one accepted PR-2 patch
   under a separate plan -> validation -> approval -> receipt contract.
-- PR-4: add candidate evaluation telemetry and rejection taxonomy.
+- PR-4: add local candidate evaluation telemetry and rejection taxonomy over
+  sanitized PR-1/PR-2/PR-3 artifacts; no public GitHub App backend, Slack beta,
+  live review ingestion, or new authority.
 - PR-5: add review-disposition integration without review-thread resolution authority.
 - PR-6: run the first governed applied creative-code candidate through normal PR governance.
 
@@ -140,6 +142,20 @@ Minimum future telemetry fields are defined now for the later train and must not
 - `failure_class`
 - `human_decision`
 - `cost_metadata_available`
+
+PR-4 telemetry artifacts are defined by:
+
+- `docs/orchestration/contracts/CREATIVE_CODE_TELEMETRY_CONTRACT.md`
+- `docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json`
+- `docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json`
+- `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.schema.json`
+- `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json`
+- `scripts/orchestration/creative_code_telemetry_contract.py`
+- `scripts/orchestration/creative_code_telemetry.py`
+
+PR-4 rollups are advisory local measurements only. They are not routing truth,
+review-thread disposition evidence, fixed-mapping evidence, merge-readiness
+evidence, product runtime truth, or release evidence.
 
 ---
 

--- a/docs/orchestration/ORCHESTRATION_TELEMETRY_SPEC.md
+++ b/docs/orchestration/ORCHESTRATION_TELEMETRY_SPEC.md
@@ -53,6 +53,32 @@ Required promotion fields:
 - `disposition`
 - `durable_artifact_path`
 
+### 1.3 Creative-Code Telemetry Artifacts
+
+Canonical inputs for the governed creative-code private-pilot funnel remain
+local and gitignored under:
+
+- `artifacts/orchestration/creative_code/spec_runs/`
+- `artifacts/orchestration/creative_code/patch_runs/`
+- `artifacts/orchestration/creative_code/promotions/`
+
+PR-4 adds a creative-code-specific telemetry sidecar:
+
+- Contract: `docs/orchestration/contracts/CREATIVE_CODE_TELEMETRY_CONTRACT.md`
+- Event schema:
+  `docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json`
+- Rollup schema:
+  `docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json`
+- Taxonomy schema:
+  `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.schema.json`
+- Reference taxonomy:
+  `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json`
+
+This sidecar reads only sanitized PR-1/PR-2/PR-3 creative-code artifacts and
+must not read raw patches, raw prompts, raw provider payloads, oracle
+stdout/stderr, Slack payloads, GitHub API payloads, review thread bodies, PR
+bodies, secrets, token values, or local absolute paths.
+
 ---
 
 ## 2) Aggregation Output
@@ -79,6 +105,29 @@ Rollup contains:
 - `experiments.promoted_count`
 - `experiments.deferred_count`
 - `experiments.rows.<experiment_id>`
+
+### 2.2 Creative-Code Telemetry Rollup Artifact (advisory)
+
+Canonical output (local, gitignored):
+
+- `artifacts/orchestration/creative_code/telemetry/creative_code_telemetry_rollup.json`
+- `artifacts/orchestration/creative_code/telemetry/creative_code_telemetry_events.jsonl`
+- `artifacts/orchestration/creative_code/telemetry/creative_code_telemetry_summary.md`
+- `artifacts/orchestration/creative_code/telemetry/creative_code_rejection_taxonomy.v1.json`
+
+Creative-code rollups contain:
+
+- `event_count`
+- `funnel.*` counts for specification bundles, patch results, promotion plan /
+  validation / approval, and opened PR receipts
+- integer basis-point rates (`10000 = 100%`)
+- counts by stage, status, failure class, and rejection taxonomy class
+- source artifact fingerprints
+- local-only caveats
+
+The creative-code sidecar is intentionally separate from
+`telemetry_rollup.py` agent reliability scoring. It is funnel measurement, not
+automatic routing truth.
 
 ---
 
@@ -131,6 +180,12 @@ python scripts/orchestration/telemetry_rollup.py
 python scripts/orchestration/telemetry_rollup.py \
   --experiment-results-dir artifacts/orchestration/experiments/results \
   --experiment-promotions-dir artifacts/orchestration/experiments/promotions
+
+python -m scripts.orchestration.creative_code_telemetry \
+  --spec-runs-dir artifacts/orchestration/creative_code/spec_runs \
+  --patch-runs-dir artifacts/orchestration/creative_code/patch_runs \
+  --promotions-dir artifacts/orchestration/creative_code/promotions \
+  --output-dir artifacts/orchestration/creative_code/telemetry
 ```
 
 ### 5.2 Frequency
@@ -146,6 +201,10 @@ python scripts/orchestration/telemetry_rollup.py \
 - No auto-edits of `AGENT_ROUTING_GRAPH.md` / `AGENT_CAPABILITY_MATRIX.md`.
 - No storage of raw LLM outputs in telemetry rollups.
 - No remote analytics pipeline in P2.
+- No GitHub/Slack live ingestion, review-thread resolution, fixed-mapping
+  automation, merge-readiness claims, branch/PR mutation, provider calls,
+  product runtime imports, semantic-cache activation, or public platform
+  backend from creative-code telemetry.
 
 ---
 

--- a/docs/orchestration/contracts/CREATIVE_CODE_TELEMETRY_CONTRACT.md
+++ b/docs/orchestration/contracts/CREATIVE_CODE_TELEMETRY_CONTRACT.md
@@ -1,0 +1,121 @@
+# CreativeCodeTelemetry Contract
+
+Status: PR-4 local telemetry and rejection taxonomy. No product runtime impact.
+
+PR-4 measures the governed creative-code private-pilot funnel from sanitized
+local PR-1, PR-2, and PR-3 artifacts:
+
+```text
+CreativeCodeSpecificationBundle
+-> CreativeCodePatchResult
+-> CreativeCodePRPromotion plan / validation / approval / receipt
+-> CreativeCodeTelemetryEvent
+-> CreativeCodeTelemetryRollup
+```
+
+It does not authorize repository writes, branch or PR creation, review-thread
+resolution, fixed-mapping edits, merge-readiness claims, merge, release,
+provider calls, product runtime AI, OpenAPI/client changes, frontend/iOS
+changes, Slack delivery, GitHub App changes, semantic-cache activation, or
+public multi-tenant use.
+
+## Artifacts
+
+Strict schemas:
+
+- `creative_code_telemetry_event.v1.schema.json`
+- `creative_code_telemetry_rollup.v1.schema.json`
+- `creative_code_rejection_taxonomy.v1.schema.json`
+
+Reference taxonomy:
+
+- `creative_code_rejection_taxonomy.v1.json`
+
+Validators and collector:
+
+```bash
+python -m scripts.orchestration.creative_code_telemetry_contract
+python -m scripts.orchestration.creative_code_telemetry
+```
+
+Local outputs stay under:
+
+```text
+artifacts/orchestration/creative_code/telemetry/
+```
+
+That directory is local-only and gitignored. It must never be committed.
+
+## Inputs
+
+Allowed inputs are already-sanitized local artifacts under
+`artifacts/orchestration/creative_code/**`:
+
+- PR-1 specification bundles;
+- PR-2 `result.json` patch-builder results;
+- PR-3 promotion plan, validation, approval, and receipt artifacts.
+
+The collector validates those inputs with the existing PR-1/PR-2/PR-3 contract
+validators before it emits any event. Malformed artifacts are counted only as
+safe read-error events with fingerprint-only identifiers; raw exception text,
+paths, prompts, patches, provider payloads, and command output are not copied.
+
+## Telemetry Event
+
+`CreativeCodeTelemetryEvent` stores:
+
+- stable event identity and idempotency key;
+- source artifact type, id, and fingerprint;
+- lane stage and status;
+- candidate lineage IDs when available;
+- closed rejection taxonomy codes;
+- bounded counts and sizes;
+- cost metadata placeholders only when sanitized counts exist;
+- explicit non-authority flags.
+
+It must not store raw patch text, raw prompts, raw model responses, reasoning,
+provider payloads, oracle stdout/stderr, local absolute paths, secrets, token
+values, Slack payloads, GitHub API payloads, review thread bodies, PR bodies, or
+merge-readiness claims.
+
+## Rejection Taxonomy
+
+The taxonomy is closed. Events may reference only stable codes from
+`creative_code_rejection_taxonomy.v1.json`.
+
+Unknown is allowed as a counted class so drift is visible, but free-form
+rejection explanations are not allowed in telemetry events. Detailed source
+messages stay in the source local artifacts only if those artifacts are already
+sanitized by their own contracts.
+
+## Rollup
+
+`CreativeCodeTelemetryRollup` aggregates:
+
+- funnel counts;
+- integer basis-point rates;
+- counts by stage, status, failure class, and rejection class;
+- source artifact fingerprints;
+- local-only caveats.
+
+Rates use basis points for deterministic integer math:
+
+```text
+10000 = 100%
+5000 = 50%
+```
+
+The rollup is advisory only. It is not routing truth, fixed-mapping evidence,
+bot-review disposition evidence, merge-readiness evidence, product runtime
+truth, or release evidence.
+
+## Boundary
+
+PR-4 is a measurement layer for the private loop. Public GitHub App backend,
+public Slack beta, live review-disposition ingestion, review-thread resolution,
+and the first governed applied candidate remain later PRs.
+
+Rollback removes the PR-4 telemetry contracts, collector, tests, docs, and
+ledger references. Because PR-4 adds no runtime behavior, provider integration,
+workflow mutation, DB migration, OpenAPI/client change, Slack setting, or GitHub
+App setting, rollback requires no runtime or release coordination.

--- a/docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json
+++ b/docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json
@@ -1,0 +1,162 @@
+{
+  "artifact_type": "creative_code_rejection_taxonomy",
+  "classes": [
+    {
+      "code": "approval_missing",
+      "likely_owner": "human-operator",
+      "retryability": "operator_review",
+      "severity": "medium",
+      "stage": "promotion_approval"
+    },
+    {
+      "code": "base_drift",
+      "likely_owner": "dev-operator",
+      "retryability": "retryable",
+      "severity": "medium",
+      "stage": "promotion_plan"
+    },
+    {
+      "code": "branch_exists",
+      "likely_owner": "dev-operator",
+      "retryability": "operator_review",
+      "severity": "medium",
+      "stage": "promotion_plan"
+    },
+    {
+      "code": "duplicate_variant",
+      "likely_owner": "architecture-specialist",
+      "retryability": "retryable",
+      "severity": "medium",
+      "stage": "specification"
+    },
+    {
+      "code": "github_transport_failed",
+      "likely_owner": "dev-operator",
+      "retryability": "retryable",
+      "severity": "medium",
+      "stage": "pr_open"
+    },
+    {
+      "code": "guard_failure",
+      "likely_owner": "qa-engineer-agent",
+      "retryability": "operator_review",
+      "severity": "high",
+      "stage": "patch_evaluation"
+    },
+    {
+      "code": "infra_flake",
+      "likely_owner": "dev-operator",
+      "retryability": "retryable",
+      "severity": "medium",
+      "stage": "patch_evaluation"
+    },
+    {
+      "code": "invalid_input",
+      "likely_owner": "agent-coordinator",
+      "retryability": "operator_review",
+      "severity": "medium",
+      "stage": "specification"
+    },
+    {
+      "code": "leak_detected",
+      "likely_owner": "security-auditor",
+      "retryability": "not_retryable",
+      "severity": "high",
+      "stage": "artifact_read_error"
+    },
+    {
+      "code": "lineage_mismatch",
+      "likely_owner": "architecture-specialist",
+      "retryability": "not_retryable",
+      "severity": "high",
+      "stage": "promotion_validation"
+    },
+    {
+      "code": "malformed_artifact",
+      "likely_owner": "dev-operator",
+      "retryability": "operator_review",
+      "severity": "medium",
+      "stage": "artifact_read_error"
+    },
+    {
+      "code": "metric_regression",
+      "likely_owner": "qa-engineer-agent",
+      "retryability": "operator_review",
+      "severity": "high",
+      "stage": "patch_evaluation"
+    },
+    {
+      "code": "oom",
+      "likely_owner": "dev-operator",
+      "retryability": "retryable",
+      "severity": "high",
+      "stage": "patch_evaluation"
+    },
+    {
+      "code": "patch_drift",
+      "likely_owner": "security-auditor",
+      "retryability": "not_retryable",
+      "severity": "high",
+      "stage": "promotion_validation"
+    },
+    {
+      "code": "policy_violation",
+      "likely_owner": "security-auditor",
+      "retryability": "not_retryable",
+      "severity": "high",
+      "stage": "patch_evaluation"
+    },
+    {
+      "code": "pr_readback_failed",
+      "likely_owner": "dev-operator",
+      "retryability": "retryable",
+      "severity": "medium",
+      "stage": "pr_open"
+    },
+    {
+      "code": "review_blocker",
+      "likely_owner": "qa-engineer-agent",
+      "retryability": "operator_review",
+      "severity": "high",
+      "stage": "specification"
+    },
+    {
+      "code": "specification_rejected",
+      "likely_owner": "agent-coordinator",
+      "retryability": "operator_review",
+      "severity": "medium",
+      "stage": "specification"
+    },
+    {
+      "code": "timeout",
+      "likely_owner": "dev-operator",
+      "retryability": "retryable",
+      "severity": "medium",
+      "stage": "patch_evaluation"
+    },
+    {
+      "code": "unchanged_result",
+      "likely_owner": "dev-operator",
+      "retryability": "retryable",
+      "severity": "medium",
+      "stage": "patch_evaluation"
+    },
+    {
+      "code": "unknown",
+      "likely_owner": "agent-coordinator",
+      "retryability": "operator_review",
+      "severity": "medium",
+      "stage": "artifact_read_error"
+    },
+    {
+      "code": "unsafe_authority",
+      "likely_owner": "security-auditor",
+      "retryability": "not_retryable",
+      "severity": "high",
+      "stage": "specification"
+    }
+  ],
+  "policy_version": "creative-code-telemetry-pr4",
+  "sanitized": true,
+  "schema_version": "1.0"
+}

--- a/docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.schema.json
+++ b/docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_code_rejection_taxonomy.v1.schema.json",
+  "title": "CreativeCodeRejectionTaxonomy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "classes",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_code_rejection_taxonomy" },
+    "policy_version": { "const": "creative-code-telemetry-pr4" },
+    "classes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/taxonomy_class" }
+    },
+    "sanitized": { "const": true }
+  },
+  "$defs": {
+    "taxonomy_class": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "stage",
+        "severity",
+        "retryability",
+        "likely_owner"
+      ],
+      "properties": {
+        "code": {
+          "enum": [
+            "approval_missing",
+            "base_drift",
+            "branch_exists",
+            "duplicate_variant",
+            "github_transport_failed",
+            "guard_failure",
+            "infra_flake",
+            "invalid_input",
+            "leak_detected",
+            "lineage_mismatch",
+            "malformed_artifact",
+            "metric_regression",
+            "oom",
+            "patch_drift",
+            "policy_violation",
+            "pr_readback_failed",
+            "review_blocker",
+            "specification_rejected",
+            "timeout",
+            "unchanged_result",
+            "unknown",
+            "unsafe_authority"
+          ]
+        },
+        "stage": {
+          "enum": [
+            "specification",
+            "patch_evaluation",
+            "promotion_plan",
+            "promotion_validation",
+            "promotion_approval",
+            "pr_open",
+            "artifact_read_error"
+          ]
+        },
+        "severity": { "enum": ["info", "low", "medium", "high"] },
+        "retryability": {
+          "enum": ["retryable", "not_retryable", "operator_review"]
+        },
+        "likely_owner": {
+          "enum": [
+            "agent-coordinator",
+            "architecture-specialist",
+            "security-auditor",
+            "qa-engineer-agent",
+            "bug-hunter",
+            "dev-operator",
+            "human-operator"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.schema.json
+++ b/docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.schema.json
@@ -16,9 +16,162 @@
     "artifact_type": { "const": "creative_code_rejection_taxonomy" },
     "policy_version": { "const": "creative-code-telemetry-pr4" },
     "classes": {
-      "type": "array",
-      "minItems": 1,
-      "items": { "$ref": "#/$defs/taxonomy_class" }
+      "const": [
+        {
+          "code": "approval_missing",
+          "likely_owner": "human-operator",
+          "retryability": "operator_review",
+          "severity": "medium",
+          "stage": "promotion_approval"
+        },
+        {
+          "code": "base_drift",
+          "likely_owner": "dev-operator",
+          "retryability": "retryable",
+          "severity": "medium",
+          "stage": "promotion_plan"
+        },
+        {
+          "code": "branch_exists",
+          "likely_owner": "dev-operator",
+          "retryability": "operator_review",
+          "severity": "medium",
+          "stage": "promotion_plan"
+        },
+        {
+          "code": "duplicate_variant",
+          "likely_owner": "architecture-specialist",
+          "retryability": "retryable",
+          "severity": "medium",
+          "stage": "specification"
+        },
+        {
+          "code": "github_transport_failed",
+          "likely_owner": "dev-operator",
+          "retryability": "retryable",
+          "severity": "medium",
+          "stage": "pr_open"
+        },
+        {
+          "code": "guard_failure",
+          "likely_owner": "qa-engineer-agent",
+          "retryability": "operator_review",
+          "severity": "high",
+          "stage": "patch_evaluation"
+        },
+        {
+          "code": "infra_flake",
+          "likely_owner": "dev-operator",
+          "retryability": "retryable",
+          "severity": "medium",
+          "stage": "patch_evaluation"
+        },
+        {
+          "code": "invalid_input",
+          "likely_owner": "agent-coordinator",
+          "retryability": "operator_review",
+          "severity": "medium",
+          "stage": "specification"
+        },
+        {
+          "code": "leak_detected",
+          "likely_owner": "security-auditor",
+          "retryability": "not_retryable",
+          "severity": "high",
+          "stage": "artifact_read_error"
+        },
+        {
+          "code": "lineage_mismatch",
+          "likely_owner": "architecture-specialist",
+          "retryability": "not_retryable",
+          "severity": "high",
+          "stage": "promotion_validation"
+        },
+        {
+          "code": "malformed_artifact",
+          "likely_owner": "dev-operator",
+          "retryability": "operator_review",
+          "severity": "medium",
+          "stage": "artifact_read_error"
+        },
+        {
+          "code": "metric_regression",
+          "likely_owner": "qa-engineer-agent",
+          "retryability": "operator_review",
+          "severity": "high",
+          "stage": "patch_evaluation"
+        },
+        {
+          "code": "oom",
+          "likely_owner": "dev-operator",
+          "retryability": "retryable",
+          "severity": "high",
+          "stage": "patch_evaluation"
+        },
+        {
+          "code": "patch_drift",
+          "likely_owner": "security-auditor",
+          "retryability": "not_retryable",
+          "severity": "high",
+          "stage": "promotion_validation"
+        },
+        {
+          "code": "policy_violation",
+          "likely_owner": "security-auditor",
+          "retryability": "not_retryable",
+          "severity": "high",
+          "stage": "patch_evaluation"
+        },
+        {
+          "code": "pr_readback_failed",
+          "likely_owner": "dev-operator",
+          "retryability": "retryable",
+          "severity": "medium",
+          "stage": "pr_open"
+        },
+        {
+          "code": "review_blocker",
+          "likely_owner": "qa-engineer-agent",
+          "retryability": "operator_review",
+          "severity": "high",
+          "stage": "specification"
+        },
+        {
+          "code": "specification_rejected",
+          "likely_owner": "agent-coordinator",
+          "retryability": "operator_review",
+          "severity": "medium",
+          "stage": "specification"
+        },
+        {
+          "code": "timeout",
+          "likely_owner": "dev-operator",
+          "retryability": "retryable",
+          "severity": "medium",
+          "stage": "patch_evaluation"
+        },
+        {
+          "code": "unchanged_result",
+          "likely_owner": "dev-operator",
+          "retryability": "retryable",
+          "severity": "medium",
+          "stage": "patch_evaluation"
+        },
+        {
+          "code": "unknown",
+          "likely_owner": "agent-coordinator",
+          "retryability": "operator_review",
+          "severity": "medium",
+          "stage": "artifact_read_error"
+        },
+        {
+          "code": "unsafe_authority",
+          "likely_owner": "security-auditor",
+          "retryability": "not_retryable",
+          "severity": "high",
+          "stage": "specification"
+        }
+      ]
     },
     "sanitized": { "const": true }
   },

--- a/docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json
+++ b/docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_code_telemetry_event.v1.schema.json",
+  "title": "CreativeCodeTelemetryEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "event_id",
+    "idempotency_key",
+    "lane_stage",
+    "source_artifact_type",
+    "source_artifact_id",
+    "source_fingerprint",
+    "candidate_ids",
+    "status",
+    "rejection_class",
+    "failure_class",
+    "taxonomy_codes",
+    "metrics",
+    "cost_metadata",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_code_telemetry_event" },
+    "policy_version": { "const": "creative-code-telemetry-pr4" },
+    "event_id": { "$ref": "#/$defs/safe_id" },
+    "idempotency_key": { "$ref": "#/$defs/safe_id" },
+    "lane_stage": {
+      "enum": [
+        "specification",
+        "patch_evaluation",
+        "promotion_plan",
+        "promotion_validation",
+        "promotion_approval",
+        "pr_open",
+        "artifact_read_error"
+      ]
+    },
+    "source_artifact_type": {
+      "enum": [
+        "creative_code_specification",
+        "creative_code_patch_result",
+        "creative_code_pr_promotion_plan",
+        "creative_code_pr_promotion_validation",
+        "creative_code_pr_promotion_approval",
+        "creative_code_pr_promotion_receipt",
+        "creative_code_artifact_read_error"
+      ]
+    },
+    "source_artifact_id": { "$ref": "#/$defs/safe_id" },
+    "source_fingerprint": { "$ref": "#/$defs/sha256" },
+    "candidate_ids": { "$ref": "#/$defs/candidate_ids" },
+    "status": {
+      "enum": ["accepted", "rejected", "blocked", "promoted", "opened", "not_applicable"]
+    },
+    "rejection_class": { "$ref": "#/$defs/taxonomy_or_null" },
+    "failure_class": { "$ref": "#/$defs/taxonomy_or_null" },
+    "taxonomy_codes": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/taxonomy_code" }
+    },
+    "metrics": { "$ref": "#/$defs/metrics" },
+    "cost_metadata": { "$ref": "#/$defs/cost_metadata" },
+    "authority": { "$ref": "#/$defs/authority" },
+    "sanitized": { "const": true }
+  },
+  "$defs": {
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "not": {
+        "pattern": "(diff --git|raw[_ -]?(prompt|response|context|patch)|candidate\\.patch|candidate_patch|chain[_ -]?of[_ -]?thought|/[U]sers/|/private/var/|/tmp/|sk-[A-Za-z0-9_-]{12,}|gh[psoru]_|github_pat_|xox[abprs]-)"
+      }
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "taxonomy_code": {
+      "enum": [
+        "approval_missing",
+        "base_drift",
+        "branch_exists",
+        "duplicate_variant",
+        "github_transport_failed",
+        "guard_failure",
+        "infra_flake",
+        "invalid_input",
+        "leak_detected",
+        "lineage_mismatch",
+        "malformed_artifact",
+        "metric_regression",
+        "oom",
+        "patch_drift",
+        "policy_violation",
+        "pr_readback_failed",
+        "review_blocker",
+        "specification_rejected",
+        "timeout",
+        "unchanged_result",
+        "unknown",
+        "unsafe_authority"
+      ]
+    },
+    "taxonomy_or_null": {
+      "anyOf": [{ "$ref": "#/$defs/taxonomy_code" }, { "type": "null" }]
+    },
+    "candidate_ids": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_packet_id",
+        "source_bundle_id",
+        "selected_variant_id",
+        "request_id",
+        "result_id",
+        "promotion_id"
+      ],
+      "properties": {
+        "source_packet_id": { "$ref": "#/$defs/safe_id_or_null" },
+        "source_bundle_id": { "$ref": "#/$defs/safe_id_or_null" },
+        "selected_variant_id": { "$ref": "#/$defs/safe_id_or_null" },
+        "request_id": { "$ref": "#/$defs/safe_id_or_null" },
+        "result_id": { "$ref": "#/$defs/safe_id_or_null" },
+        "promotion_id": { "$ref": "#/$defs/safe_id_or_null" }
+      }
+    },
+    "safe_id_or_null": {
+      "anyOf": [{ "$ref": "#/$defs/safe_id" }, { "type": "null" }]
+    },
+    "nullable_count": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 1000000
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "variant_count",
+        "selected_variant_count",
+        "changed_files",
+        "diff_lines",
+        "patch_bytes",
+        "oracle_commands_configured",
+        "oracle_commands_executed",
+        "generation_attempts",
+        "promotion_plan_count",
+        "promotion_validation_passed",
+        "promotion_approval_count",
+        "pull_requests_opened"
+      ],
+      "properties": {
+        "variant_count": { "$ref": "#/$defs/nullable_count" },
+        "selected_variant_count": { "$ref": "#/$defs/nullable_count" },
+        "changed_files": { "$ref": "#/$defs/nullable_count" },
+        "diff_lines": { "$ref": "#/$defs/nullable_count" },
+        "patch_bytes": { "$ref": "#/$defs/nullable_count" },
+        "oracle_commands_configured": { "$ref": "#/$defs/nullable_count" },
+        "oracle_commands_executed": { "$ref": "#/$defs/nullable_count" },
+        "generation_attempts": { "$ref": "#/$defs/nullable_count" },
+        "promotion_plan_count": { "$ref": "#/$defs/nullable_count" },
+        "promotion_validation_passed": { "$ref": "#/$defs/nullable_count" },
+        "promotion_approval_count": { "$ref": "#/$defs/nullable_count" },
+        "pull_requests_opened": { "$ref": "#/$defs/nullable_count" }
+      }
+    },
+    "cost_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "available",
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+        "estimated"
+      ],
+      "properties": {
+        "available": { "type": "boolean" },
+        "input_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "cached_input_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "output_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "reasoning_output_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "estimated": { "type": "boolean" }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "read_only_telemetry",
+        "writes_repo",
+        "opens_pr",
+        "resolves_threads",
+        "claims_merge_readiness",
+        "merges",
+        "calls_network",
+        "calls_runtime",
+        "modifies_github_app",
+        "modifies_slack"
+      ],
+      "properties": {
+        "read_only_telemetry": { "const": true },
+        "writes_repo": { "const": false },
+        "opens_pr": { "const": false },
+        "resolves_threads": { "const": false },
+        "claims_merge_readiness": { "const": false },
+        "merges": { "const": false },
+        "calls_network": { "const": false },
+        "calls_runtime": { "const": false },
+        "modifies_github_app": { "const": false },
+        "modifies_slack": { "const": false }
+      }
+    }
+  }
+}

--- a/docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json
+++ b/docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json
@@ -77,7 +77,7 @@
       "maxLength": 128,
       "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
       "not": {
-        "pattern": "(diff --git|raw[_ -]?(prompt|response|context|patch)|candidate\\.patch|candidate_patch|chain[_ -]?of[_ -]?thought|/[U]sers/|/private/var/|/tmp/|sk-[A-Za-z0-9_-]{12,}|gh[psoru]_|github_pat_|xox[abprs]-)"
+        "pattern": "(diff --git|raw[_ -]?(prompt|response|context|patch)|candidate\\.patch|candidate_patch|chain[_ -]?of[_ -]?thought|provider[_ -]?payload|oracle[_ -]?(stdout|stderr)|/[U]sers/|/private/var/|/var/folders/|/tmp/|\\.venv/|\\.git/|worktrees([:/._-]|$)|authorization:\\s*bearer|private[_ -]?key|api[_ -]?key|GH_TOKEN|GITHUB_TOKEN|sk-[A-Za-z0-9_-]{12,}|gh[psoru]_|github_pat_|xox[abprs]-)"
       }
     },
     "sha256": {

--- a/docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json
+++ b/docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json
@@ -36,10 +36,10 @@
     "event_count": { "type": "integer", "minimum": 0, "maximum": 1000000 },
     "funnel": { "$ref": "#/$defs/funnel" },
     "rates": { "$ref": "#/$defs/rates" },
-    "rejections_by_class": { "$ref": "#/$defs/count_map" },
-    "failures_by_class": { "$ref": "#/$defs/count_map" },
-    "events_by_stage": { "$ref": "#/$defs/count_map" },
-    "events_by_status": { "$ref": "#/$defs/count_map" },
+    "rejections_by_class": { "$ref": "#/$defs/taxonomy_count_map" },
+    "failures_by_class": { "$ref": "#/$defs/taxonomy_count_map" },
+    "events_by_stage": { "$ref": "#/$defs/stage_count_map" },
+    "events_by_status": { "$ref": "#/$defs/status_count_map" },
     "source_artifacts": {
       "type": "array",
       "items": { "$ref": "#/$defs/source_artifact" }
@@ -60,16 +60,69 @@
     "sanitized": { "const": true }
   },
   "$defs": {
-    "count_map": {
+    "count_value": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000000
+    },
+    "taxonomy_count_map": {
       "type": "object",
-      "additionalProperties": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 1000000
-      },
       "propertyNames": {
-        "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$"
-      }
+        "enum": [
+          "approval_missing",
+          "base_drift",
+          "branch_exists",
+          "duplicate_variant",
+          "github_transport_failed",
+          "guard_failure",
+          "infra_flake",
+          "invalid_input",
+          "leak_detected",
+          "lineage_mismatch",
+          "malformed_artifact",
+          "metric_regression",
+          "oom",
+          "patch_drift",
+          "policy_violation",
+          "pr_readback_failed",
+          "review_blocker",
+          "specification_rejected",
+          "timeout",
+          "unchanged_result",
+          "unknown",
+          "unsafe_authority"
+        ]
+      },
+      "additionalProperties": { "$ref": "#/$defs/count_value" }
+    },
+    "stage_count_map": {
+      "type": "object",
+      "propertyNames": {
+        "enum": [
+          "artifact_read_error",
+          "patch_evaluation",
+          "pr_open",
+          "promotion_approval",
+          "promotion_plan",
+          "promotion_validation",
+          "specification"
+        ]
+      },
+      "additionalProperties": { "$ref": "#/$defs/count_value" }
+    },
+    "status_count_map": {
+      "type": "object",
+      "propertyNames": {
+        "enum": [
+          "accepted",
+          "blocked",
+          "not_applicable",
+          "opened",
+          "promoted",
+          "rejected"
+        ]
+      },
+      "additionalProperties": { "$ref": "#/$defs/count_value" }
     },
     "funnel": {
       "type": "object",

--- a/docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json
+++ b/docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_code_telemetry_rollup.v1.schema.json",
+  "title": "CreativeCodeTelemetryRollup",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "input_roots",
+    "event_count",
+    "funnel",
+    "rates",
+    "rejections_by_class",
+    "failures_by_class",
+    "events_by_stage",
+    "events_by_status",
+    "source_artifacts",
+    "cost",
+    "caveats",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_code_telemetry_rollup" },
+    "policy_version": { "const": "creative-code-telemetry-pr4" },
+    "input_roots": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$"
+      }
+    },
+    "event_count": { "type": "integer", "minimum": 0, "maximum": 1000000 },
+    "funnel": { "$ref": "#/$defs/funnel" },
+    "rates": { "$ref": "#/$defs/rates" },
+    "rejections_by_class": { "$ref": "#/$defs/count_map" },
+    "failures_by_class": { "$ref": "#/$defs/count_map" },
+    "events_by_stage": { "$ref": "#/$defs/count_map" },
+    "events_by_status": { "$ref": "#/$defs/count_map" },
+    "source_artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/source_artifact" }
+    },
+    "cost": { "$ref": "#/$defs/cost" },
+    "caveats": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "local_only",
+          "not_merge_readiness_evidence",
+          "not_product_runtime_truth"
+        ]
+      }
+    },
+    "sanitized": { "const": true }
+  },
+  "$defs": {
+    "count_map": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 1000000
+      },
+      "propertyNames": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$"
+      }
+    },
+    "funnel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "specification_bundles",
+        "variants_total",
+        "variants_selected",
+        "patch_results",
+        "patch_results_accepted",
+        "patch_results_rejected",
+        "promotion_plans",
+        "promotion_validations_passed",
+        "promotion_approvals",
+        "pull_requests_opened"
+      ],
+      "properties": {
+        "specification_bundles": { "type": "integer", "minimum": 0 },
+        "variants_total": { "type": "integer", "minimum": 0 },
+        "variants_selected": { "type": "integer", "minimum": 0 },
+        "patch_results": { "type": "integer", "minimum": 0 },
+        "patch_results_accepted": { "type": "integer", "minimum": 0 },
+        "patch_results_rejected": { "type": "integer", "minimum": 0 },
+        "promotion_plans": { "type": "integer", "minimum": 0 },
+        "promotion_validations_passed": { "type": "integer", "minimum": 0 },
+        "promotion_approvals": { "type": "integer", "minimum": 0 },
+        "pull_requests_opened": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "rate_bps": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 10000
+    },
+    "rates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "oracle_pass_rate_bps",
+        "human_approval_rate_bps",
+        "promotion_rate_bps",
+        "first_pass_acceptance_rate_bps"
+      ],
+      "properties": {
+        "oracle_pass_rate_bps": { "$ref": "#/$defs/rate_bps" },
+        "human_approval_rate_bps": { "$ref": "#/$defs/rate_bps" },
+        "promotion_rate_bps": { "$ref": "#/$defs/rate_bps" },
+        "first_pass_acceptance_rate_bps": { "$ref": "#/$defs/rate_bps" }
+      }
+    },
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "source_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_artifact_type",
+        "source_artifact_id",
+        "source_fingerprint"
+      ],
+      "properties": {
+        "source_artifact_type": { "$ref": "#/$defs/safe_id" },
+        "source_artifact_id": { "$ref": "#/$defs/safe_id" },
+        "source_fingerprint": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cost_metadata_available_count",
+        "token_usage_available_count",
+        "estimated_cost_usd"
+      ],
+      "properties": {
+        "cost_metadata_available_count": { "type": "integer", "minimum": 0 },
+        "token_usage_available_count": { "type": "integer", "minimum": 0 },
+        "estimated_cost_usd": { "type": "null" }
+      }
+    }
+  }
+}

--- a/docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json
+++ b/docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json
@@ -177,7 +177,10 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 128,
-      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "not": {
+        "pattern": "(diff --git|raw[_ -]?(prompt|response|context|patch)|candidate\\.patch|candidate_patch|chain[_ -]?of[_ -]?thought|provider[_ -]?payload|oracle[_ -]?(stdout|stderr)|/[U]sers/|/private/var/|/var/folders/|/tmp/|\\.venv/|\\.git/|worktrees([:/._-]|$)|authorization:\\s*bearer|private[_ -]?key|api[_ -]?key|GH_TOKEN|GITHUB_TOKEN|sk-[A-Za-z0-9_-]{12,}|gh[psoru]_|github_pat_|xox[abprs]-)"
+      }
     },
     "sha256": {
       "type": "string",

--- a/docs/review/PR_2044_FIXED_MAPPING.md
+++ b/docs/review/PR_2044_FIXED_MAPPING.md
@@ -1,0 +1,137 @@
+# PR #2044 Fixed in Commit Mapping SoT
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044
+
+Branch: `codex/creative-code-telemetry-rejection-taxonomy-pr4`
+
+## Summary
+
+This PR adds PR-4 local creative-code telemetry and rejection taxonomy over
+sanitized PR-1/PR-2/PR-3 control-plane artifacts. It measures the private-pilot
+funnel before any public GitHub App backend, Slack beta, live review ingestion,
+or broader automation authority is considered.
+
+## Scope
+
+- Add strict telemetry event, rollup, and rejection-taxonomy contracts.
+- Add a local collector for sanitized creative-code specification, patch, and
+  promotion artifacts.
+- Emit advisory local-only sidecars under the gitignored creative-code
+  telemetry artifact root.
+- Update orchestration docs, scripts scoped instructions, and the creative-code
+  backlog PR train.
+- Add deterministic tests for schema closure, duplicate-key rejection, leak
+  guards, path containment, malformed-artifact handling, deterministic rollups,
+  and repo-relative CLI paths.
+
+## Out Of Scope
+
+No product runtime behavior, OpenAPI/backend route/client changes, public
+GitHub App backend, Slack beta, live GitHub/review-thread ingestion,
+review-thread resolution, fixed-mapping automation, merge-readiness claim,
+branch mutation, provider call, or semantic-cache activation is authorized by
+this PR.
+
+## Implementation Commits
+
+- `a7bb7a5b8` - add PR-4 local creative-code telemetry contracts, collector,
+  rejection taxonomy, docs, scoped instructions, backlog updates, tests, and
+  pre-open governance evidence.
+
+## Lane Start Provenance
+
+- Base branch: `main`
+- Branch: `codex/creative-code-telemetry-rejection-taxonomy-pr4`
+- Initial packet: `artifacts/orchestration/task_packets/d1fee07492a7.json`
+- Refreshed packet after fast-forward: `artifacts/orchestration/task_packets/24a9d90008fd.json`
+- Pre-implementation role order executed:
+  `agent-coordinator -> security-auditor -> qa-engineer-agent -> cursor-specialist-agent -> architecture-specialist`
+- Packet creation was treated as provenance/routing only; role passes were
+  executed explicitly before implementation.
+
+## Discussion Thread Pass
+
+- [x] Fixed in commit mapping artifact created after GitHub assigned PR number
+  `#2044`.
+- [x] Initial PR open: no GitHub review threads existed and none were resolved.
+- [ ] Post-open `qa-engineer-agent` pass completed.
+- [ ] Post-open `bug-hunter` pass completed.
+- [ ] Post-open `security-auditor` pass completed.
+- [ ] Codex Security diff scan / finding discovery completed or explicitly
+  dispositioned.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] Current-head CI complete before readiness language.
+- [ ] Strict merge-readiness checks run after the final review/check cycle.
+
+## Fixed in Commit Mapping
+
+- No actionable GitHub review comments exist at artifact creation.
+
+## Pre-Open Premortem Closure
+
+Disposition: FIXED
+
+Commit: `a7bb7a5b8`
+
+Evidence: Repo-relative telemetry CLI paths could have nested under the output
+root instead of resolving from repo root. The path resolver in
+`scripts/orchestration/creative_code_telemetry.py` keeps repo-relative paths
+under the creative-code artifact root, with coverage in
+`tests/test_creative_code_telemetry.py::test_cli_accepts_repo_relative_artifact_paths`.
+
+Disposition: FIXED
+
+Commit: `a7bb7a5b8`
+
+Evidence: The first schema pattern introduced a literal local `/Users/...`
+guard string into changed docs. The schema now uses an escaped pattern that
+still rejects real local path values without adding the forbidden docs literal,
+with coverage in
+`tests/test_creative_code_telemetry.py::test_reference_taxonomy_and_schemas_are_closed`
+and
+`tests/guards/test_security_devtooling_regression_guards.py::test_changed_docs_do_not_add_local_users_absolute_paths`.
+
+Disposition: NOT-A-BUG
+
+Evidence: The telemetry sidecar remains advisory and local-only. The authority
+contract requires `read_only_telemetry=true` and all mutation/network/runtime
+authority flags false in
+`scripts/orchestration/creative_code_telemetry_contract.py`, with fail-closed
+coverage in
+`tests/test_creative_code_telemetry.py::test_event_rejects_raw_patch_leaks_and_mutating_authority`.
+
+## Experiment Runner Evidence
+
+Artifact: `artifacts/orchestration/experiments/results/creative-code-telemetry-pr4-oracle-result.json`
+
+Disposition: FIXED
+
+Commit: `a7bb7a5b8`
+
+Evidence: Oracle-only governance reviewer result was accepted with two oracle
+commands executed, no failure class, and shared tree untouched. The material
+oracle review is recorded by the canonical co-author trailer on commit
+`a7bb7a5b8`.
+
+## Local Validation Evidence
+
+- `python -m pytest -q tests/test_creative_code_telemetry.py` - pass.
+- `python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py::test_changed_docs_do_not_add_local_users_absolute_paths tests/test_creative_code_telemetry.py` - pass.
+- `python -m pytest -q tests/test_creative_code_specification.py tests/test_creative_code_patch_builder.py tests/test_creative_code_pr_promotion.py tests/test_creative_code_telemetry.py` - pass.
+- `python -m scripts.orchestration.creative_code_telemetry_contract --validate-taxonomy docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json` - pass.
+- `python -m scripts.orchestration.creative_code_telemetry --spec-runs-dir artifacts/orchestration/creative_code/spec_runs --patch-runs-dir artifacts/orchestration/creative_code/patch_runs --promotions-dir artifacts/orchestration/creative_code/promotions --output-dir artifacts/orchestration/creative_code/telemetry` - pass; generated gitignored sidecars were cleaned.
+- `make validate-changed` - pass.
+- `pre-commit run --all-files` - pass.
+- Pre-push hooks during `git push` - pass: changed-file mypy, pip-audit,
+  backend tests pre-push, bandit full, and docker build test.
+
+Full `make verify` is not used as readiness evidence. It was started
+accidentally, then operator-cancelled per the narrow-lane machine-budget rule;
+the PR-owned guard finding surfaced before cancellation was fixed and rerun
+with the exact guard above.
+
+## Merge Readiness
+
+Not claimed. Post-open role passes, external bot disposition, current-head CI,
+Codex Security / security scan disposition, and strict merge-readiness checks
+remain pending.

--- a/docs/review/PR_2044_FIXED_MAPPING.md
+++ b/docs/review/PR_2044_FIXED_MAPPING.md
@@ -60,7 +60,7 @@ this PR.
 - [x] Initial PR open: no GitHub review threads existed and none were resolved.
 - [x] Post-open `qa-engineer-agent` pass completed.
 - [x] Post-open `bug-hunter` pass completed.
-- [ ] Post-open `security-auditor` pass completed.
+- [x] Post-open `security-auditor` pass completed.
 - [ ] Codex Security diff scan / finding discovery completed or explicitly
   dispositioned.
 - [ ] `pulseplate-pr-review` completed.
@@ -138,6 +138,20 @@ derives read-error identity from a containment-checked creative-code-root
 relative locator fingerprint without emitting the raw locator, with coverage in
 `tests/test_creative_code_telemetry.py::test_malformed_artifacts_with_same_basename_keep_distinct_identities`.
 
+Role: `security-auditor`
+
+Disposition: FIXED
+
+Commit: `36f63bdc9`
+
+Evidence: The security-auditor pass found the Python leak guard and JSON schemas
+admitted tokenized oracle-output labels such as `oracle_stdout` and
+`oracle-stderr`, plus other tokenized unsafe labels. Commit `36f63bdc9` aligns
+the Python denylist and event/rollup schema safe-id denylist, with coverage in
+`tests/test_creative_code_telemetry.py::test_reference_taxonomy_and_schemas_are_closed`
+and
+`tests/test_creative_code_telemetry.py::test_event_rejects_raw_patch_leaks_and_mutating_authority`.
+
 ## Pre-Open Premortem Closure
 
 Disposition: FIXED
@@ -186,8 +200,7 @@ oracle review is recorded by the canonical co-author trailer on commit
 
 ## Local Validation Evidence
 
-- `python -m pytest -q tests/test_creative_code_telemetry.py` - pass.
-- `python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py::test_changed_docs_do_not_add_local_users_absolute_paths tests/test_creative_code_telemetry.py` - pass.
+- `.venv/bin/python -m pytest -q tests/test_creative_code_telemetry.py tests/guards/test_security_devtooling_regression_guards.py::test_changed_docs_do_not_add_local_users_absolute_paths` - pass.
 - `python -m pytest -q tests/test_creative_code_specification.py tests/test_creative_code_patch_builder.py tests/test_creative_code_pr_promotion.py tests/test_creative_code_telemetry.py` - pass.
 - `python -m scripts.orchestration.creative_code_telemetry_contract --validate-taxonomy docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json` - pass.
 - `python -m scripts.orchestration.creative_code_telemetry --spec-runs-dir artifacts/orchestration/creative_code/spec_runs --patch-runs-dir artifacts/orchestration/creative_code/patch_runs --promotions-dir artifacts/orchestration/creative_code/promotions --output-dir artifacts/orchestration/creative_code/telemetry` - pass; generated gitignored sidecars were cleaned.

--- a/docs/review/PR_2044_FIXED_MAPPING.md
+++ b/docs/review/PR_2044_FIXED_MAPPING.md
@@ -63,7 +63,7 @@ this PR.
 - [x] Post-open `security-auditor` pass completed.
 - [ ] Codex Security diff scan / finding discovery completed or explicitly
   dispositioned.
-- [ ] `pulseplate-pr-review` completed.
+- [x] `pulseplate-pr-review` completed.
 - [ ] Current-head CI complete before readiness language.
 - [ ] Strict merge-readiness checks run after the final review/check cycle.
 
@@ -151,6 +151,21 @@ the Python denylist and event/rollup schema safe-id denylist, with coverage in
 `tests/test_creative_code_telemetry.py::test_reference_taxonomy_and_schemas_are_closed`
 and
 `tests/test_creative_code_telemetry.py::test_event_rejects_raw_patch_leaks_and_mutating_authority`.
+
+Role: `pulseplate-pr-review`
+
+Disposition: NOT-A-BUG
+
+Evidence: The pushed-head dry-run report
+`/tmp/pulseplate_pr2044_review_report.json` produced one advisory
+large-diff review-planning note and no deterministic architecture, security, QA,
+or governance findings. The diff is a single local orchestration slice
+containing telemetry contracts, schemas, collector, docs, mapping, and focused
+tests; splitting the schemas from the builder/tests would weaken the reviewed
+contract/test pairing. Narrow gates passed, including focused telemetry/guard
+tests, `make validate-changed`, `pre-commit run --all-files`, and pre-push
+hooks. No merge-readiness claim is made while Codex Security and current-head CI
+remain pending.
 
 ## Pre-Open Premortem Closure
 

--- a/docs/review/PR_2044_FIXED_MAPPING.md
+++ b/docs/review/PR_2044_FIXED_MAPPING.md
@@ -69,7 +69,17 @@ this PR.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: role findings and tests documented below.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044#discussion_r3491179374 -> 4b1ee2921
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044#discussion_r3491179379 -> 013642ce8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044#discussion_r3491179384 -> 013642ce8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044#discussion_r3491179389 -> beae974bd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044#discussion_r3491179397 -> 013642ce8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044#discussion_r3491179405 -> beae974bd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044#discussion_r3491179411 -> 013642ce8
 
 ## Post-Open Role Findings
 
@@ -151,6 +161,25 @@ the Python denylist and event/rollup schema safe-id denylist, with coverage in
 `tests/test_creative_code_telemetry.py::test_reference_taxonomy_and_schemas_are_closed`
 and
 `tests/test_creative_code_telemetry.py::test_event_rejects_raw_patch_leaks_and_mutating_authority`.
+
+Role: `chatgpt-codex-connector`
+
+Disposition: FIXED
+
+Commit: `beae974bd`
+
+Evidence: Review threads
+`https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044#discussion_r3491179389`
+and
+`https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2044#discussion_r3491179405`
+found that PR-3 partial-failure receipts were collapsed into
+`github_transport_failed` and that telemetry startup imported the heavier
+promotion runtime for filename constants. Commit `beae974bd` classifies
+readback-verification partial failures as `pr_readback_failed`, keeps promotion
+artifact filename constants local to the telemetry module, and covers both with
+`tests/test_creative_code_telemetry.py::test_promotion_receipt_readback_failure_uses_specific_taxonomy`
+and
+`tests/test_creative_code_telemetry.py::test_telemetry_import_does_not_load_promotion_runtime_module`.
 
 Role: `pulseplate-pr-review`
 

--- a/docs/review/PR_2044_FIXED_MAPPING.md
+++ b/docs/review/PR_2044_FIXED_MAPPING.md
@@ -58,7 +58,7 @@ this PR.
 - [x] Fixed in commit mapping artifact created after GitHub assigned PR number
   `#2044`.
 - [x] Initial PR open: no GitHub review threads existed and none were resolved.
-- [ ] Post-open `qa-engineer-agent` pass completed.
+- [x] Post-open `qa-engineer-agent` pass completed.
 - [ ] Post-open `bug-hunter` pass completed.
 - [ ] Post-open `security-auditor` pass completed.
 - [ ] Codex Security diff scan / finding discovery completed or explicitly
@@ -70,6 +70,60 @@ this PR.
 ## Fixed in Commit Mapping
 
 - No actionable review comments
+
+## Post-Open Role Findings
+
+Role: `qa-engineer-agent`
+
+Disposition: FIXED
+
+Commit: `013642ce8`
+
+Evidence: The QA pass found that collector file discovery could follow
+symlinked JSON descendants inside otherwise valid artifact roots. Commit
+`013642ce8` rejects symlink components for JSON artifacts in
+`scripts/orchestration/creative_code_telemetry.py` and covers the case in
+`tests/test_creative_code_telemetry.py::test_artifact_json_symlinks_are_rejected`.
+
+Disposition: FIXED
+
+Commit: `013642ce8`
+
+Evidence: The QA pass found malformed PR-1 specification artifacts were
+silently dropped by default. Commit `013642ce8` emits the same safe
+`artifact_read_error` event for malformed specification artifacts as for
+malformed PR-2/PR-3 artifacts, with coverage in
+`tests/test_creative_code_telemetry.py::test_malformed_spec_artifact_becomes_safe_error_event_by_default`.
+
+Disposition: FIXED
+
+Commit: `013642ce8`
+
+Evidence: The QA pass found schema-only false-green risk in the rejection
+taxonomy and rollup count-map schemas. Commit `013642ce8` locks the taxonomy
+schema to the exact reference class list and restricts rollup count maps to
+taxonomy, stage, and status keys, with assertions in
+`tests/test_creative_code_telemetry.py::test_reference_taxonomy_and_schemas_are_closed`.
+
+Disposition: FIXED
+
+Commit: `340f9f80c`
+
+Evidence: The QA pass found the PR #2044 fixed-mapping artifact was missing
+from the tracked branch at the reviewed head and did not match the Phase 2
+parser shape in the local draft. Commit `414bad0b2` added the canonical
+artifact, and commit `340f9f80c` aligned the artifact with exact
+discussion-thread and fixed-mapping parser requirements. Validation:
+`scripts/orchestration/review_mapping_artifact.py::validate_mapping_artifact_text`
+returns no errors for `docs/review/PR_2044_FIXED_MAPPING.md`.
+
+Disposition: NOT-A-BUG
+
+Evidence: The QA pass reported current-head Private Python proxy health as a
+pending external gate. That is not caused by the local creative-code telemetry
+diff and remains a current-head CI monitoring item, not a PR-owned code defect.
+This artifact still does not claim merge readiness while current-head CI is
+pending or red.
 
 ## Pre-Open Premortem Closure
 

--- a/docs/review/PR_2044_FIXED_MAPPING.md
+++ b/docs/review/PR_2044_FIXED_MAPPING.md
@@ -44,6 +44,8 @@ this PR.
 - Branch: `codex/creative-code-telemetry-rejection-taxonomy-pr4`
 - Initial packet: `artifacts/orchestration/task_packets/d1fee07492a7.json`
 - Refreshed packet after fast-forward: `artifacts/orchestration/task_packets/24a9d90008fd.json`
+- Packet: `artifacts/orchestration/task_packets/d1fee07492a7.json`
+- Packet: `artifacts/orchestration/task_packets/24a9d90008fd.json`
 - Pre-implementation role order executed:
   `agent-coordinator -> security-auditor -> qa-engineer-agent -> cursor-specialist-agent -> architecture-specialist`
 - Packet creation was treated as provenance/routing only; role passes were
@@ -51,6 +53,8 @@ this PR.
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - [x] Fixed in commit mapping artifact created after GitHub assigned PR number
   `#2044`.
 - [x] Initial PR open: no GitHub review threads existed and none were resolved.
@@ -65,7 +69,7 @@ this PR.
 
 ## Fixed in Commit Mapping
 
-- No actionable GitHub review comments exist at artifact creation.
+- No actionable review comments
 
 ## Pre-Open Premortem Closure
 

--- a/docs/review/PR_2044_FIXED_MAPPING.md
+++ b/docs/review/PR_2044_FIXED_MAPPING.md
@@ -59,7 +59,7 @@ this PR.
   `#2044`.
 - [x] Initial PR open: no GitHub review threads existed and none were resolved.
 - [x] Post-open `qa-engineer-agent` pass completed.
-- [ ] Post-open `bug-hunter` pass completed.
+- [x] Post-open `bug-hunter` pass completed.
 - [ ] Post-open `security-auditor` pass completed.
 - [ ] Codex Security diff scan / finding discovery completed or explicitly
   dispositioned.
@@ -124,6 +124,19 @@ pending external gate. That is not caused by the local creative-code telemetry
 diff and remains a current-head CI monitoring item, not a PR-owned code defect.
 This artifact still does not claim merge readiness while current-head CI is
 pending or red.
+
+Role: `bug-hunter`
+
+Disposition: FIXED
+
+Commit: `4b1ee2921`
+
+Evidence: The bug-hunter pass found that malformed local artifacts with the
+same basename under different run directories could collide because
+`artifact_read_error` identity used only the basename. Commit `4b1ee2921`
+derives read-error identity from a containment-checked creative-code-root
+relative locator fingerprint without emitting the raw locator, with coverage in
+`tests/test_creative_code_telemetry.py::test_malformed_artifacts_with_same_basename_keep_distinct_identities`.
 
 ## Pre-Open Premortem Closure
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -10937,8 +10937,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Governed creative-code execution lane (PR-0 through PR-6)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (research-to-implementation leverage with closed authority)
-  - Target PR: PR-0 `feat/experiment-runner-creative-code-authority-pr0` -> PR-1 `codex/creative-code-specification-pr1` -> PR-2 `#2022` -> PR-3 `codex/creative-code-human-approved-pr-promotion-pr3` -> PR-4 -> PR-5 -> PR-6
-  - Status: PR-0 merged baseline; PR-1 merged as a repo-only specification-bundle control-plane layer; PR-2 merged in PR `#2022` as a local sandboxed candidate-patch builder; PR-3 active as human-approved non-draft PR promotion tooling; PR-4 through PR-6 remain gated future work
+  - Target PR: PR-0 `feat/experiment-runner-creative-code-authority-pr0` -> PR-1 `codex/creative-code-specification-pr1` -> PR-2 `#2022` -> PR-3 `#2030` -> PR-4 `codex/creative-code-telemetry-rejection-taxonomy-pr4` -> PR-5 -> PR-6
+  - Status: PR-0 merged baseline; PR-1 merged as a repo-only specification-bundle control-plane layer; PR-2 merged in PR `#2022` as a local sandboxed candidate-patch builder; PR-3 merged in PR `#2030` as human-approved non-draft PR promotion tooling; PR-4 active for local candidate evaluation telemetry and rejection taxonomy; PR-5 and PR-6 remain gated future work
   - Dependencies:
     - [P1: Creative research eval lane under governed experimentation epic](#ledger-p1-creative-research-eval-lane)
     - [P1: Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
@@ -10959,6 +10959,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/contracts/creative_code_pr_promotion_validation.v1.schema.json`
     - `docs/orchestration/contracts/creative_code_pr_promotion_approval.v1.schema.json`
     - `docs/orchestration/contracts/creative_code_pr_promotion_receipt.v1.schema.json`
+    - `docs/orchestration/contracts/CREATIVE_CODE_TELEMETRY_CONTRACT.md`
+    - `docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json`
+    - `docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json`
+    - `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.schema.json`
+    - `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json`
     - `scripts/orchestration/creative_code_contract.py`
     - `scripts/orchestration/creative_code_specification.py`
     - `scripts/orchestration/creative_code_spec_pipeline.py`
@@ -10969,15 +10974,18 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `scripts/orchestration/creative_code_patch_builder.py`
     - `scripts/orchestration/creative_code_pr_promotion_contract.py`
     - `scripts/orchestration/creative_code_pr_promotion.py`
+    - `scripts/orchestration/creative_code_telemetry_contract.py`
+    - `scripts/orchestration/creative_code_telemetry.py`
     - `tests/test_creative_code_contract.py`
     - `tests/test_creative_code_patch_builder.py`
     - `tests/test_creative_code_pr_promotion.py`
+    - `tests/test_creative_code_telemetry.py`
   - PR train:
     - PR-0: closed authority contract, schema, reference packet, validator, and tests; no model calls, patches, workflows, Slack/GitHub settings, or `experiment_runner.py` changes.
     - PR-1: emit deterministic implementation specification bundles from promoted creative research, with skeptic reviews, synthesis, telemetry summary, safe local artifact I/O, and fingerprint-only rejection indexes; no candidate patches, provider calls, repo writes, runtime truth, review-thread disposition authority, or merge-readiness evidence.
     - PR-2: generate isolated candidate patches only in sandboxed evaluation workspaces with exact PR-1 bundle fingerprint binding, exact `origin/main` base SHA, human admission, fixed Codex CLI argv/env, strict patch policy validation, direct Experiment Runner candidate-mode evaluation, and sanitized result metadata.
     - PR-3: allow human-approved non-draft PR creation from one accepted PR-2 patch through separate plan, isolated validation, TTY approval, promotion checkout, new `experiment/*` branch, GitHub readback, and local sanitized receipt; no real promoted candidate PR is opened during PR-3 tooling implementation.
-    - PR-4: add candidate evaluation telemetry and rejection taxonomy.
+    - PR-4: add local candidate evaluation telemetry and rejection taxonomy over sanitized PR-1/PR-2/PR-3 artifacts; no public GitHub App backend, Slack beta, live review ingestion, review-thread resolution, fixed-mapping automation, or new mutation authority.
     - PR-5: add review-disposition integration without review-thread resolution authority.
     - PR-6: run the first governed applied creative-code candidate through normal PR governance.
   - Minimum future telemetry fields (defined now, emitted no earlier than PR-1):

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -52,6 +52,16 @@
   submit reviews, resolve review threads, edit fixed mappings, claim merge
   readiness, merge, release, call Slack/GitHub App authority paths, or call
   `experiment_pipeline.py`, `experiment_promote.py`, or notification wrappers.
+- PR-4 creative-code telemetry artifacts stay local under
+  `artifacts/orchestration/creative_code/telemetry/`. The telemetry CLI
+  `creative_code_telemetry.py` may only read already-sanitized local PR-1/PR-2
+  / PR-3 creative-code artifacts and emit advisory event/rollup/taxonomy
+  sidecars. It must not read raw patches, prompts, provider payloads, oracle
+  stdout/stderr, Slack/GitHub payloads, review-thread bodies, PR bodies,
+  secrets, token values, or local absolute paths, and it must not create
+  branches, open PRs, resolve review threads, edit fixed mappings, claim merge
+  readiness, merge, release, call providers, call product runtime, or call
+  Slack/GitHub authority paths.
 - `experiment_notify.py` follows the notification contract in
   `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`: local artifact output
   is the default, SMTP email and Slack delivery are explicit opt-in only, and no

--- a/scripts/orchestration/creative_code_telemetry.py
+++ b/scripts/orchestration/creative_code_telemetry.py
@@ -167,7 +167,12 @@ def _safe_root_label(path: Path) -> str:
 def _iter_json_files(root: Path) -> list[Path]:
     if not root.exists():
         return []
-    return sorted(path for path in root.rglob("*.json") if path.is_file())
+    json_files: list[Path] = []
+    for path in sorted(root.rglob("*.json")):
+        _reject_symlink_components(path, label="artifact JSON")
+        if path.is_file():
+            json_files.append(path)
+    return json_files
 
 
 def _source_fingerprint(payload: dict[str, Any]) -> str:
@@ -399,7 +404,7 @@ def _load_spec_event(path: Path) -> dict[str, Any] | None:
         payload = read_creative_code_specification_bundle(path)
         return event_from_specification_bundle(payload)
     except CreativeCodeSpecificationError:
-        return None
+        return safe_read_error_event(path)
     except CreativeCodeTelemetryContractError:
         raise
 

--- a/scripts/orchestration/creative_code_telemetry.py
+++ b/scripts/orchestration/creative_code_telemetry.py
@@ -1,0 +1,600 @@
+"""Collect local creative-code telemetry for PR-4.
+
+The collector reads only sanitized PR-1/PR-2/PR-3 artifacts and writes local
+advisory telemetry under gitignored creative-code artifact roots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, cast
+
+from core.evidence.fingerprints import fingerprint_payload
+from scripts.orchestration.creative_code_patch_contract import (
+    CreativeCodePatchContractError,
+    read_creative_code_patch_result,
+    validate_creative_code_patch_result,
+)
+from scripts.orchestration.creative_code_pr_promotion import (
+    APPROVAL_FILE,
+    PLAN_FILE,
+    RECEIPT_FILE,
+    VALIDATION_FILE,
+)
+from scripts.orchestration.creative_code_pr_promotion_contract import (
+    CreativeCodePRPromotionContractError,
+    read_json_object as read_promotion_json_object,
+    validate_creative_code_pr_promotion_approval,
+    validate_creative_code_pr_promotion_plan,
+    validate_creative_code_pr_promotion_receipt,
+    validate_creative_code_pr_promotion_validation,
+)
+from scripts.orchestration.creative_code_specification import (
+    CreativeCodeSpecificationError,
+    read_creative_code_specification_bundle,
+    validate_creative_code_specification_bundle,
+)
+from scripts.orchestration.creative_code_telemetry_contract import (
+    CreativeCodeTelemetryContractError,
+    build_creative_code_rejection_taxonomy,
+    build_creative_code_telemetry_event,
+    build_creative_code_telemetry_rollup,
+    default_metrics,
+    reject_unsafe_telemetry_value,
+    validate_creative_code_rejection_taxonomy,
+    validate_creative_code_telemetry_event,
+    validate_creative_code_telemetry_rollup,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CREATIVE_CODE_ROOT = REPO_ROOT / "artifacts" / "orchestration" / "creative_code"
+SPEC_RUNS_DIR = CREATIVE_CODE_ROOT / "spec_runs"
+PATCH_RUNS_DIR = CREATIVE_CODE_ROOT / "patch_runs"
+PROMOTIONS_DIR = CREATIVE_CODE_ROOT / "promotions"
+TELEMETRY_ROOT = CREATIVE_CODE_ROOT / "telemetry"
+
+EVENTS_FILE = "creative_code_telemetry_events.jsonl"
+ROLLUP_FILE = "creative_code_telemetry_rollup.json"
+SUMMARY_FILE = "creative_code_telemetry_summary.md"
+TAXONOMY_FILE = "creative_code_rejection_taxonomy.v1.json"
+SUCCESS_OUTPUT = "PASS: creative-code telemetry collected"
+
+
+class CreativeCodeTelemetryError(ValueError):
+    """Raised when local telemetry collection cannot stay contained."""
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _existing_components(path: Path) -> list[Path]:
+    components: list[Path] = []
+    current_path = Path(path.anchor) if path.anchor else Path(".")
+    parts = path.parts[1:] if path.anchor else path.parts
+    for part in parts:
+        current_path = current_path / part
+        if current_path.exists() or current_path.is_symlink():
+            components.append(current_path)
+    return components
+
+
+def _reject_symlink_components(path: Path, *, label: str) -> None:
+    for component in _existing_components(path):
+        if component.is_symlink():
+            raise CreativeCodeTelemetryError(f"{label} must not traverse symlinks.")
+
+
+def _ensure_dir_root(root: Path) -> Path:
+    _reject_symlink_components(root, label="artifact root")
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise CreativeCodeTelemetryError("artifact root could not be created.") from exc
+    _reject_symlink_components(root, label="artifact root")
+    resolved = root.resolve(strict=True)
+    if not resolved.is_dir():
+        raise CreativeCodeTelemetryError("artifact root must be a directory.")
+    return resolved
+
+
+def _resolve_requested_path(raw_path: Path, *, allowed_root: Path, resolved_root: Path) -> Path:
+    if raw_path.is_absolute():
+        return raw_path
+    repo_relative = REPO_ROOT / raw_path
+    if _is_relative_to(repo_relative.resolve(strict=False), resolved_root):
+        return repo_relative
+    return allowed_root / raw_path
+
+
+def _resolve_dir(raw_path: Path, *, allowed_root: Path, create: bool, label: str) -> Path:
+    root = _ensure_dir_root(allowed_root)
+    path = _resolve_requested_path(raw_path, allowed_root=allowed_root, resolved_root=root)
+    if path.is_absolute() and not _is_relative_to(path, root):
+        raise CreativeCodeTelemetryError(f"{label} must stay under creative-code artifacts.")
+    _reject_symlink_components(path, label=label)
+    candidate = path.resolve(strict=False)
+    if not _is_relative_to(candidate, root):
+        raise CreativeCodeTelemetryError(f"{label} must stay under creative-code artifacts.")
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        raise CreativeCodeTelemetryError(f"{label} must exist.") from exc
+    if not _is_relative_to(resolved, root):
+        raise CreativeCodeTelemetryError(f"{label} must stay under creative-code artifacts.")
+    if not resolved.is_dir():
+        raise CreativeCodeTelemetryError(f"{label} must be a directory.")
+    return resolved
+
+
+def _resolve_optional_dir(raw_path: Path, *, allowed_root: Path, label: str) -> Path:
+    root = _ensure_dir_root(allowed_root)
+    path = _resolve_requested_path(raw_path, allowed_root=allowed_root, resolved_root=root)
+    if path.is_absolute() and not _is_relative_to(path, root):
+        raise CreativeCodeTelemetryError(f"{label} must stay under creative-code artifacts.")
+    _reject_symlink_components(path, label=label)
+    candidate = path.resolve(strict=False)
+    if not _is_relative_to(candidate, root):
+        raise CreativeCodeTelemetryError(f"{label} must stay under creative-code artifacts.")
+    if path.exists():
+        return _resolve_dir(path, allowed_root=allowed_root, create=False, label=label)
+    return candidate
+
+
+def _resolve_output_dir(raw_path: Path) -> Path:
+    return _resolve_dir(
+        raw_path, allowed_root=TELEMETRY_ROOT, create=True, label="output directory"
+    )
+
+
+def _safe_root_label(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix().replace("/", ".")
+    except ValueError:
+        return path.name
+
+
+def _iter_json_files(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return sorted(path for path in root.rglob("*.json") if path.is_file())
+
+
+def _source_fingerprint(payload: dict[str, Any]) -> str:
+    fingerprint = fingerprint_payload(payload)
+    if not isinstance(fingerprint, str):
+        raise CreativeCodeTelemetryError("source fingerprint must be a string.")
+    return fingerprint
+
+
+def _taxonomy_from_failure(failure_class: str | None) -> list[str]:
+    if failure_class is None:
+        return []
+    if failure_class == "duplicate_spec_fingerprint":
+        return ["duplicate_variant"]
+    if failure_class == "review_blocker":
+        return ["review_blocker"]
+    if failure_class == "unsafe_authority":
+        return ["unsafe_authority"]
+    if failure_class in {
+        "timeout",
+        "oom",
+        "metric_regression",
+        "guard_failure",
+        "policy_violation",
+        "unchanged_result",
+        "infra_flake",
+    }:
+        return [failure_class]
+    if failure_class == "invalid_input":
+        return ["invalid_input"]
+    return ["unknown"]
+
+
+def _candidate_ids(
+    *,
+    source_packet_id: str | None = None,
+    source_bundle_id: str | None = None,
+    selected_variant_id: str | None = None,
+    request_id: str | None = None,
+    result_id: str | None = None,
+    promotion_id: str | None = None,
+) -> dict[str, str | None]:
+    return {
+        "promotion_id": promotion_id,
+        "request_id": request_id,
+        "result_id": result_id,
+        "selected_variant_id": selected_variant_id,
+        "source_bundle_id": source_bundle_id,
+        "source_packet_id": source_packet_id,
+    }
+
+
+def event_from_specification_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
+    normalized = validate_creative_code_specification_bundle(bundle)
+    selected_variant_id = normalized["synthesis"]["selected_variant_id"]
+    failure_class = normalized["failure_class"]
+    status = "accepted" if selected_variant_id and failure_class is None else "rejected"
+    taxonomy_codes = _taxonomy_from_failure(failure_class)
+    rejection_class = taxonomy_codes[0] if taxonomy_codes else None
+    return cast(
+        dict[str, Any],
+        build_creative_code_telemetry_event(
+            lane_stage="specification",
+            source_artifact_type="creative_code_specification",
+            source_artifact_id=normalized["bundle_id"],
+            source_fingerprint=_source_fingerprint(normalized),
+            candidate_ids=_candidate_ids(
+                source_packet_id=normalized["source_packet_id"],
+                source_bundle_id=normalized["bundle_id"],
+                selected_variant_id=selected_variant_id,
+            ),
+            status=status,
+            rejection_class=rejection_class,
+            failure_class=rejection_class,
+            taxonomy_codes=taxonomy_codes,
+            metrics=default_metrics(
+                selected_variant_count=1 if selected_variant_id else 0,
+                variant_count=len(normalized["variants"]),
+            ),
+        ),
+    )
+
+
+def event_from_patch_result(result: dict[str, Any]) -> dict[str, Any]:
+    normalized = validate_creative_code_patch_result(result)
+    taxonomy_codes = _taxonomy_from_failure(normalized["failure_class"])
+    rejection_class = taxonomy_codes[0] if taxonomy_codes else None
+    patch_summary = normalized["patch_summary"]
+    runner_summary = normalized["runner_summary"]
+    return cast(
+        dict[str, Any],
+        build_creative_code_telemetry_event(
+            lane_stage="patch_evaluation",
+            source_artifact_type="creative_code_patch_result",
+            source_artifact_id=normalized["result_id"],
+            source_fingerprint=_source_fingerprint(normalized),
+            candidate_ids=_candidate_ids(
+                source_bundle_id=normalized["source_bundle_id"],
+                selected_variant_id=normalized["selected_variant_id"],
+                request_id=normalized["request_id"],
+                result_id=normalized["result_id"],
+            ),
+            status=normalized["status"],
+            rejection_class=rejection_class,
+            failure_class=rejection_class,
+            taxonomy_codes=taxonomy_codes,
+            metrics=default_metrics(
+                changed_files=len(normalized["changed_paths"]),
+                diff_lines=patch_summary["diff_lines"],
+                generation_attempts=runner_summary["attempts"],
+                oracle_commands_configured=runner_summary["oracle_commands_configured"],
+                oracle_commands_executed=runner_summary["oracle_commands_executed"],
+                patch_bytes=patch_summary["patch_bytes"],
+            ),
+        ),
+    )
+
+
+def event_from_promotion_plan(plan: dict[str, Any]) -> dict[str, Any]:
+    normalized = validate_creative_code_pr_promotion_plan(plan)
+    return cast(
+        dict[str, Any],
+        build_creative_code_telemetry_event(
+            lane_stage="promotion_plan",
+            source_artifact_type="creative_code_pr_promotion_plan",
+            source_artifact_id=normalized["promotion_id"],
+            source_fingerprint=_source_fingerprint(normalized),
+            candidate_ids=_candidate_ids(
+                source_bundle_id=normalized["source_bundle_id"],
+                selected_variant_id=normalized["selected_variant_id"],
+                request_id=normalized["source_request_id"],
+                result_id=normalized["source_result_id"],
+                promotion_id=normalized["promotion_id"],
+            ),
+            status="accepted",
+            metrics=default_metrics(
+                changed_files=len(normalized["changed_paths"]),
+                promotion_plan_count=1,
+            ),
+        ),
+    )
+
+
+def event_from_promotion_validation(validation: dict[str, Any]) -> dict[str, Any]:
+    normalized = validate_creative_code_pr_promotion_validation(validation)
+    fresh_oracle = normalized["fresh_oracle"]
+    return cast(
+        dict[str, Any],
+        build_creative_code_telemetry_event(
+            lane_stage="promotion_validation",
+            source_artifact_type="creative_code_pr_promotion_validation",
+            source_artifact_id=normalized["promotion_id"],
+            source_fingerprint=_source_fingerprint(normalized),
+            candidate_ids=_candidate_ids(promotion_id=normalized["promotion_id"]),
+            status="accepted",
+            metrics=default_metrics(
+                oracle_commands_configured=fresh_oracle["oracle_commands_configured"],
+                oracle_commands_executed=fresh_oracle["oracle_commands_executed"],
+                promotion_validation_passed=1,
+            ),
+        ),
+    )
+
+
+def event_from_promotion_approval(approval: dict[str, Any]) -> dict[str, Any]:
+    normalized = validate_creative_code_pr_promotion_approval(approval)
+    return cast(
+        dict[str, Any],
+        build_creative_code_telemetry_event(
+            lane_stage="promotion_approval",
+            source_artifact_type="creative_code_pr_promotion_approval",
+            source_artifact_id=normalized["approval_id"],
+            source_fingerprint=_source_fingerprint(normalized),
+            candidate_ids=_candidate_ids(promotion_id=normalized["promotion_id"]),
+            status="accepted",
+            metrics=default_metrics(promotion_approval_count=1),
+        ),
+    )
+
+
+def event_from_promotion_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    normalized = validate_creative_code_pr_promotion_receipt(receipt)
+    status = "opened" if normalized["pull_request_state"] == "open" else "blocked"
+    taxonomy_codes = [] if status == "opened" else ["github_transport_failed"]
+    return cast(
+        dict[str, Any],
+        build_creative_code_telemetry_event(
+            lane_stage="pr_open",
+            source_artifact_type="creative_code_pr_promotion_receipt",
+            source_artifact_id=normalized["receipt_id"],
+            source_fingerprint=_source_fingerprint(normalized),
+            candidate_ids=_candidate_ids(
+                result_id=normalized["source_result_id"],
+                promotion_id=normalized["promotion_id"],
+            ),
+            status=status,
+            rejection_class=taxonomy_codes[0] if taxonomy_codes else None,
+            failure_class=taxonomy_codes[0] if taxonomy_codes else None,
+            taxonomy_codes=taxonomy_codes,
+            metrics=default_metrics(pull_requests_opened=1 if status == "opened" else 0),
+        ),
+    )
+
+
+def safe_read_error_event(path: Path) -> dict[str, Any]:
+    path_fingerprint = fingerprint_payload(
+        {"artifact_name_fingerprint": fingerprint_payload({"artifact_name": path.name})}
+    )
+    source_id = path_fingerprint.removeprefix("sha256:")[:24]
+    return cast(
+        dict[str, Any],
+        build_creative_code_telemetry_event(
+            lane_stage="artifact_read_error",
+            source_artifact_type="creative_code_artifact_read_error",
+            source_artifact_id=f"read-error:{source_id}",
+            source_fingerprint=path_fingerprint,
+            candidate_ids=_candidate_ids(),
+            status="blocked",
+            rejection_class="malformed_artifact",
+            failure_class="malformed_artifact",
+            taxonomy_codes=["malformed_artifact"],
+            metrics=default_metrics(),
+        ),
+    )
+
+
+def _load_spec_event(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = read_creative_code_specification_bundle(path)
+        return event_from_specification_bundle(payload)
+    except CreativeCodeSpecificationError:
+        return None
+    except CreativeCodeTelemetryContractError:
+        raise
+
+
+def _load_patch_event(path: Path) -> dict[str, Any] | None:
+    if path.name != "result.json":
+        return None
+    try:
+        return event_from_patch_result(read_creative_code_patch_result(str(path)))
+    except CreativeCodePatchContractError:
+        return safe_read_error_event(path)
+
+
+def _load_promotion_event(path: Path) -> dict[str, Any] | None:
+    loaders = {
+        PLAN_FILE: (read_promotion_json_object, event_from_promotion_plan),
+        VALIDATION_FILE: (read_promotion_json_object, event_from_promotion_validation),
+        APPROVAL_FILE: (read_promotion_json_object, event_from_promotion_approval),
+        RECEIPT_FILE: (read_promotion_json_object, event_from_promotion_receipt),
+    }
+    loader = loaders.get(path.name)
+    if loader is None:
+        return None
+    reader, builder = loader
+    try:
+        return builder(reader(path))
+    except CreativeCodePRPromotionContractError:
+        return safe_read_error_event(path)
+
+
+def collect_events(
+    *,
+    spec_runs_dir: Path = SPEC_RUNS_DIR,
+    patch_runs_dir: Path = PATCH_RUNS_DIR,
+    promotions_dir: Path = PROMOTIONS_DIR,
+    strict: bool = False,
+) -> list[dict[str, Any]]:
+    roots = _resolve_optional_dir(
+        spec_runs_dir,
+        allowed_root=CREATIVE_CODE_ROOT,
+        label="spec runs directory",
+    )
+    patch_root = _resolve_optional_dir(
+        patch_runs_dir,
+        allowed_root=CREATIVE_CODE_ROOT,
+        label="patch runs directory",
+    )
+    promotion_root = _resolve_optional_dir(
+        promotions_dir,
+        allowed_root=CREATIVE_CODE_ROOT,
+        label="promotions directory",
+    )
+    events: list[dict[str, Any]] = []
+
+    for path in _iter_json_files(roots):
+        event = _load_spec_event(path)
+        if event is not None:
+            events.append(event)
+        elif strict:
+            events.append(safe_read_error_event(path))
+
+    for path in _iter_json_files(patch_root):
+        event = _load_patch_event(path)
+        if event is not None:
+            events.append(event)
+
+    for path in _iter_json_files(promotion_root):
+        event = _load_promotion_event(path)
+        if event is not None:
+            events.append(event)
+
+    normalized = [validate_creative_code_telemetry_event(event) for event in events]
+    return sorted(normalized, key=lambda row: row["event_id"])
+
+
+def _write_text_atomic(path: Path, content: str) -> None:
+    reject_unsafe_telemetry_value(content, label=path.name)
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_name = temp_file.name
+            temp_file.write(content)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_name, path)
+        temp_name = None
+    finally:
+        if temp_name is not None:
+            try:
+                Path(temp_name).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _write_json_atomic(path: Path, payload: Any) -> None:
+    _write_text_atomic(
+        path,
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def write_events_jsonl(path: Path, events: list[dict[str, Any]]) -> None:
+    lines = [
+        json.dumps(event, ensure_ascii=False, sort_keys=True)
+        for event in sorted(events, key=lambda row: row["event_id"])
+    ]
+    _write_text_atomic(path, "\n".join(lines) + ("\n" if lines else ""))
+
+
+def render_summary(rollup: dict[str, Any]) -> str:
+    validated = validate_creative_code_telemetry_rollup(rollup)
+    funnel = validated["funnel"]
+    lines = [
+        "# Creative-Code Telemetry Summary",
+        "",
+        "Local-only advisory telemetry. Not merge-readiness evidence.",
+        "",
+        f"- Events: {validated['event_count']}",
+        f"- Specification bundles: {funnel['specification_bundles']}",
+        f"- Patch results accepted: {funnel['patch_results_accepted']}",
+        f"- Patch results rejected: {funnel['patch_results_rejected']}",
+        f"- Pull requests opened: {funnel['pull_requests_opened']}",
+        "",
+        "Caveats:",
+    ]
+    lines.extend(f"- {caveat}" for caveat in validated["caveats"])
+    return "\n".join(lines) + "\n"
+
+
+def collect_and_write(
+    *,
+    spec_runs_dir: Path = SPEC_RUNS_DIR,
+    patch_runs_dir: Path = PATCH_RUNS_DIR,
+    promotions_dir: Path = PROMOTIONS_DIR,
+    output_dir: Path = TELEMETRY_ROOT,
+    strict: bool = False,
+) -> dict[str, Any]:
+    events = collect_events(
+        spec_runs_dir=spec_runs_dir,
+        patch_runs_dir=patch_runs_dir,
+        promotions_dir=promotions_dir,
+        strict=strict,
+    )
+    rollup = build_creative_code_telemetry_rollup(
+        events,
+        input_roots=[
+            _safe_root_label(spec_runs_dir),
+            _safe_root_label(patch_runs_dir),
+            _safe_root_label(promotions_dir),
+        ],
+    )
+    taxonomy = build_creative_code_rejection_taxonomy()
+    output = _resolve_output_dir(output_dir)
+    write_events_jsonl(output / EVENTS_FILE, events)
+    _write_json_atomic(output / ROLLUP_FILE, rollup)
+    _write_json_atomic(output / TAXONOMY_FILE, validate_creative_code_rejection_taxonomy(taxonomy))
+    _write_text_atomic(output / SUMMARY_FILE, render_summary(rollup))
+    return cast(dict[str, Any], rollup)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect local PR-4 creative-code telemetry sidecars."
+    )
+    parser.add_argument("--spec-runs-dir", default=str(SPEC_RUNS_DIR))
+    parser.add_argument("--patch-runs-dir", default=str(PATCH_RUNS_DIR))
+    parser.add_argument("--promotions-dir", default=str(PROMOTIONS_DIR))
+    parser.add_argument("--output-dir", default=str(TELEMETRY_ROOT))
+    parser.add_argument("--strict", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        collect_and_write(
+            spec_runs_dir=Path(args.spec_runs_dir),
+            patch_runs_dir=Path(args.patch_runs_dir),
+            promotions_dir=Path(args.promotions_dir),
+            output_dir=Path(args.output_dir),
+            strict=args.strict,
+        )
+    except (CreativeCodeTelemetryError, CreativeCodeTelemetryContractError) as exc:
+        print(f"FAIL: {exc}")
+        return 1
+    print(SUCCESS_OUTPUT)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/creative_code_telemetry.py
+++ b/scripts/orchestration/creative_code_telemetry.py
@@ -182,6 +182,19 @@ def _source_fingerprint(payload: dict[str, Any]) -> str:
     return fingerprint
 
 
+def _artifact_locator_fingerprint(path: Path) -> str:
+    _reject_symlink_components(path, label="artifact read error source")
+    root = CREATIVE_CODE_ROOT.resolve(strict=False)
+    resolved = path.resolve(strict=False)
+    if not _is_relative_to(resolved, root):
+        raise CreativeCodeTelemetryError(
+            "artifact read error source must stay under creative-code artifacts."
+        )
+    locator = resolved.relative_to(root).as_posix()
+    locator_fingerprint = _source_fingerprint({"artifact_locator": locator})
+    return _source_fingerprint({"artifact_locator_fingerprint": locator_fingerprint})
+
+
 def _taxonomy_from_failure(failure_class: str | None) -> list[str]:
     if failure_class is None:
         return []
@@ -378,9 +391,7 @@ def event_from_promotion_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
 
 
 def safe_read_error_event(path: Path) -> dict[str, Any]:
-    path_fingerprint = fingerprint_payload(
-        {"artifact_name_fingerprint": fingerprint_payload({"artifact_name": path.name})}
-    )
+    path_fingerprint = _artifact_locator_fingerprint(path)
     source_id = path_fingerprint.removeprefix("sha256:")[:24]
     return cast(
         dict[str, Any],

--- a/scripts/orchestration/creative_code_telemetry.py
+++ b/scripts/orchestration/creative_code_telemetry.py
@@ -19,12 +19,6 @@ from scripts.orchestration.creative_code_patch_contract import (
     read_creative_code_patch_result,
     validate_creative_code_patch_result,
 )
-from scripts.orchestration.creative_code_pr_promotion import (
-    APPROVAL_FILE,
-    PLAN_FILE,
-    RECEIPT_FILE,
-    VALIDATION_FILE,
-)
 from scripts.orchestration.creative_code_pr_promotion_contract import (
     CreativeCodePRPromotionContractError,
     read_json_object as read_promotion_json_object,
@@ -62,6 +56,11 @@ ROLLUP_FILE = "creative_code_telemetry_rollup.json"
 SUMMARY_FILE = "creative_code_telemetry_summary.md"
 TAXONOMY_FILE = "creative_code_rejection_taxonomy.v1.json"
 SUCCESS_OUTPUT = "PASS: creative-code telemetry collected"
+
+PLAN_FILE = "promotion_plan.json"
+VALIDATION_FILE = "preopen_validation.json"
+APPROVAL_FILE = "promotion_approval.json"
+RECEIPT_FILE = "promotion_receipt.json"
 
 
 class CreativeCodeTelemetryError(ValueError):
@@ -366,10 +365,22 @@ def event_from_promotion_approval(approval: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _promotion_receipt_failure_code(receipt: dict[str, Any]) -> str | None:
+    if receipt["pull_request_state"] == "open":
+        return None
+    partial_failure = str(receipt["partial_failure"] or "").lower()
+    if receipt["pull_request_url"] and (
+        "readback" in partial_failure or "verification" in partial_failure
+    ):
+        return "pr_readback_failed"
+    return "github_transport_failed"
+
+
 def event_from_promotion_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     normalized = validate_creative_code_pr_promotion_receipt(receipt)
-    status = "opened" if normalized["pull_request_state"] == "open" else "blocked"
-    taxonomy_codes = [] if status == "opened" else ["github_transport_failed"]
+    failure_code = _promotion_receipt_failure_code(normalized)
+    status = "opened" if failure_code is None else "blocked"
+    taxonomy_codes = [] if failure_code is None else [failure_code]
     return cast(
         dict[str, Any],
         build_creative_code_telemetry_event(

--- a/scripts/orchestration/creative_code_telemetry_contract.py
+++ b/scripts/orchestration/creative_code_telemetry_contract.py
@@ -36,8 +36,8 @@ SECRET_RE = re.compile(
 LEAK_TEXT_RE = re.compile(
     r"(diff --git|^\+\+\+ |^--- |@@ |candidate\.patch|raw[_ -]?"
     r"(prompt|response|context|patch)|candidate_patch|chain[_ -]?of[_ -]?thought|"
-    r"provider[_ -]?payload|oracle stdout|oracle stderr|/Users/|/private/var/|"
-    r"/var/folders/|/tmp/|\.venv/|\.git/|worktrees/|github_pat_|gh[psoru]_|"
+    r"provider[_ -]?payload|oracle[_ -]?(stdout|stderr)|/Users/|/private/var/|"
+    r"/var/folders/|/tmp/|\.venv/|\.git/|worktrees([:/._-]|$)|github_pat_|gh[psoru]_|"
     r"xox[abprs]-|sk-[A-Za-z0-9_-]{12,})",
     re.IGNORECASE | re.MULTILINE,
 )

--- a/scripts/orchestration/creative_code_telemetry_contract.py
+++ b/scripts/orchestration/creative_code_telemetry_contract.py
@@ -1,0 +1,1138 @@
+"""Strict local telemetry contracts for governed creative-code PR-4.
+
+PR-4 measures sanitized PR-1/PR-2/PR-3 creative-code artifacts. It does not
+grant repository-write, PR, review-thread, merge, release, runtime, Slack, or
+GitHub App authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+import re
+import sys
+from typing import Any, cast
+
+from core.evidence.fingerprints import build_asset_id, build_idempotency_key, fingerprint_payload
+
+SCHEMA_VERSION = "1.0"
+POLICY_VERSION = "creative-code-telemetry-pr4"
+EVENT_TYPE = "creative_code_telemetry_event"
+ROLLUP_TYPE = "creative_code_telemetry_rollup"
+TAXONOMY_TYPE = "creative_code_rejection_taxonomy"
+SUCCESS_OUTPUT = "PASS: creative-code telemetry contract valid"
+
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
+SHA256_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+SECRET_RE = re.compile(
+    r"(sk-[A-Za-z0-9_-]{12,}|gh[psoru]_[A-Za-z0-9_]{12,}|github_pat_|"
+    r"xox[abprs]-|authorization:\s*bearer|private[_ -]?key|api[_ -]?key|"
+    r"GH_TOKEN|GITHUB_TOKEN)",
+    re.IGNORECASE,
+)
+LEAK_TEXT_RE = re.compile(
+    r"(diff --git|^\+\+\+ |^--- |@@ |candidate\.patch|raw[_ -]?"
+    r"(prompt|response|context|patch)|candidate_patch|chain[_ -]?of[_ -]?thought|"
+    r"provider[_ -]?payload|oracle stdout|oracle stderr|/Users/|/private/var/|"
+    r"/var/folders/|/tmp/|\.venv/|\.git/|worktrees/|github_pat_|gh[psoru]_|"
+    r"xox[abprs]-|sk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+LANE_STAGES = frozenset(
+    {
+        "specification",
+        "patch_evaluation",
+        "promotion_plan",
+        "promotion_validation",
+        "promotion_approval",
+        "pr_open",
+        "artifact_read_error",
+    }
+)
+SOURCE_ARTIFACT_TYPES = frozenset(
+    {
+        "creative_code_specification",
+        "creative_code_patch_result",
+        "creative_code_pr_promotion_plan",
+        "creative_code_pr_promotion_validation",
+        "creative_code_pr_promotion_approval",
+        "creative_code_pr_promotion_receipt",
+        "creative_code_artifact_read_error",
+    }
+)
+EVENT_STATUSES = frozenset(
+    {"accepted", "rejected", "blocked", "promoted", "opened", "not_applicable"}
+)
+SEVERITIES = frozenset({"info", "low", "medium", "high"})
+OWNERS = frozenset(
+    {
+        "agent-coordinator",
+        "architecture-specialist",
+        "security-auditor",
+        "qa-engineer-agent",
+        "bug-hunter",
+        "dev-operator",
+        "human-operator",
+    }
+)
+RETRYABILITY = frozenset({"retryable", "not_retryable", "operator_review"})
+
+TAXONOMY_CLASSES: dict[str, dict[str, str]] = {
+    "specification_rejected": {
+        "stage": "specification",
+        "severity": "medium",
+        "retryability": "operator_review",
+        "likely_owner": "agent-coordinator",
+    },
+    "duplicate_variant": {
+        "stage": "specification",
+        "severity": "medium",
+        "retryability": "retryable",
+        "likely_owner": "architecture-specialist",
+    },
+    "review_blocker": {
+        "stage": "specification",
+        "severity": "high",
+        "retryability": "operator_review",
+        "likely_owner": "qa-engineer-agent",
+    },
+    "unsafe_authority": {
+        "stage": "specification",
+        "severity": "high",
+        "retryability": "not_retryable",
+        "likely_owner": "security-auditor",
+    },
+    "invalid_input": {
+        "stage": "specification",
+        "severity": "medium",
+        "retryability": "operator_review",
+        "likely_owner": "agent-coordinator",
+    },
+    "timeout": {
+        "stage": "patch_evaluation",
+        "severity": "medium",
+        "retryability": "retryable",
+        "likely_owner": "dev-operator",
+    },
+    "oom": {
+        "stage": "patch_evaluation",
+        "severity": "high",
+        "retryability": "retryable",
+        "likely_owner": "dev-operator",
+    },
+    "metric_regression": {
+        "stage": "patch_evaluation",
+        "severity": "high",
+        "retryability": "operator_review",
+        "likely_owner": "qa-engineer-agent",
+    },
+    "guard_failure": {
+        "stage": "patch_evaluation",
+        "severity": "high",
+        "retryability": "operator_review",
+        "likely_owner": "qa-engineer-agent",
+    },
+    "policy_violation": {
+        "stage": "patch_evaluation",
+        "severity": "high",
+        "retryability": "not_retryable",
+        "likely_owner": "security-auditor",
+    },
+    "unchanged_result": {
+        "stage": "patch_evaluation",
+        "severity": "medium",
+        "retryability": "retryable",
+        "likely_owner": "dev-operator",
+    },
+    "infra_flake": {
+        "stage": "patch_evaluation",
+        "severity": "medium",
+        "retryability": "retryable",
+        "likely_owner": "dev-operator",
+    },
+    "base_drift": {
+        "stage": "promotion_plan",
+        "severity": "medium",
+        "retryability": "retryable",
+        "likely_owner": "dev-operator",
+    },
+    "patch_drift": {
+        "stage": "promotion_validation",
+        "severity": "high",
+        "retryability": "not_retryable",
+        "likely_owner": "security-auditor",
+    },
+    "lineage_mismatch": {
+        "stage": "promotion_validation",
+        "severity": "high",
+        "retryability": "not_retryable",
+        "likely_owner": "architecture-specialist",
+    },
+    "approval_missing": {
+        "stage": "promotion_approval",
+        "severity": "medium",
+        "retryability": "operator_review",
+        "likely_owner": "human-operator",
+    },
+    "branch_exists": {
+        "stage": "promotion_plan",
+        "severity": "medium",
+        "retryability": "operator_review",
+        "likely_owner": "dev-operator",
+    },
+    "github_transport_failed": {
+        "stage": "pr_open",
+        "severity": "medium",
+        "retryability": "retryable",
+        "likely_owner": "dev-operator",
+    },
+    "pr_readback_failed": {
+        "stage": "pr_open",
+        "severity": "medium",
+        "retryability": "retryable",
+        "likely_owner": "dev-operator",
+    },
+    "leak_detected": {
+        "stage": "artifact_read_error",
+        "severity": "high",
+        "retryability": "not_retryable",
+        "likely_owner": "security-auditor",
+    },
+    "malformed_artifact": {
+        "stage": "artifact_read_error",
+        "severity": "medium",
+        "retryability": "operator_review",
+        "likely_owner": "dev-operator",
+    },
+    "unknown": {
+        "stage": "artifact_read_error",
+        "severity": "medium",
+        "retryability": "operator_review",
+        "likely_owner": "agent-coordinator",
+    },
+}
+
+EVENT_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "event_id",
+        "idempotency_key",
+        "lane_stage",
+        "source_artifact_type",
+        "source_artifact_id",
+        "source_fingerprint",
+        "candidate_ids",
+        "status",
+        "rejection_class",
+        "failure_class",
+        "taxonomy_codes",
+        "metrics",
+        "cost_metadata",
+        "authority",
+        "sanitized",
+    }
+)
+CANDIDATE_ID_KEYS = frozenset(
+    {
+        "source_packet_id",
+        "source_bundle_id",
+        "selected_variant_id",
+        "request_id",
+        "result_id",
+        "promotion_id",
+    }
+)
+METRIC_KEYS = frozenset(
+    {
+        "variant_count",
+        "selected_variant_count",
+        "changed_files",
+        "diff_lines",
+        "patch_bytes",
+        "oracle_commands_configured",
+        "oracle_commands_executed",
+        "generation_attempts",
+        "promotion_plan_count",
+        "promotion_validation_passed",
+        "promotion_approval_count",
+        "pull_requests_opened",
+    }
+)
+COST_KEYS = frozenset(
+    {
+        "available",
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+        "estimated",
+    }
+)
+AUTHORITY_KEYS = frozenset(
+    {
+        "read_only_telemetry",
+        "writes_repo",
+        "opens_pr",
+        "resolves_threads",
+        "claims_merge_readiness",
+        "merges",
+        "calls_network",
+        "calls_runtime",
+        "modifies_github_app",
+        "modifies_slack",
+    }
+)
+ROLLUP_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "input_roots",
+        "event_count",
+        "funnel",
+        "rates",
+        "rejections_by_class",
+        "failures_by_class",
+        "events_by_stage",
+        "events_by_status",
+        "source_artifacts",
+        "cost",
+        "caveats",
+        "sanitized",
+    }
+)
+FUNNEL_KEYS = frozenset(
+    {
+        "specification_bundles",
+        "variants_total",
+        "variants_selected",
+        "patch_results",
+        "patch_results_accepted",
+        "patch_results_rejected",
+        "promotion_plans",
+        "promotion_validations_passed",
+        "promotion_approvals",
+        "pull_requests_opened",
+    }
+)
+RATES_KEYS = frozenset(
+    {
+        "oracle_pass_rate_bps",
+        "human_approval_rate_bps",
+        "promotion_rate_bps",
+        "first_pass_acceptance_rate_bps",
+    }
+)
+ROLLUP_COST_KEYS = frozenset(
+    {
+        "cost_metadata_available_count",
+        "token_usage_available_count",
+        "estimated_cost_usd",
+    }
+)
+TAXONOMY_KEYS = frozenset(
+    {"schema_version", "artifact_type", "policy_version", "classes", "sanitized"}
+)
+TAXONOMY_CLASS_KEYS = frozenset({"code", "stage", "severity", "retryability", "likely_owner"})
+
+
+class CreativeCodeTelemetryContractError(ValueError):
+    """Raised when creative-code telemetry violates PR-4 boundaries."""
+
+
+def _reject_duplicate_json_object_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: set[str] = set()
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise CreativeCodeTelemetryContractError(
+                f"creative-code telemetry JSON has duplicate key: {key}"
+            )
+        seen.add(key)
+        payload[key] = value
+    return payload
+
+
+def read_json_object(path: str | Path) -> dict[str, Any]:
+    """Read a JSON object while rejecting duplicate keys."""
+
+    try:
+        payload = json.loads(
+            Path(path).read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_object_keys,
+        )
+    except CreativeCodeTelemetryContractError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CreativeCodeTelemetryContractError(
+            "Unable to read creative-code telemetry JSON."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise CreativeCodeTelemetryContractError(
+            "Creative-code telemetry artifact must be a JSON object."
+        )
+    return payload
+
+
+def reject_unsafe_telemetry_value(value: Any, *, label: str) -> None:
+    """Reject telemetry strings that could leak raw artifacts or secrets."""
+
+    if isinstance(value, str):
+        if SECRET_RE.search(value) or LEAK_TEXT_RE.search(value):
+            raise CreativeCodeTelemetryContractError(f"{label} contains unsafe telemetry text.")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_unsafe_telemetry_value(item, label=f"{label}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            reject_unsafe_telemetry_value(item, label=f"{label}.{key}")
+
+
+def _require_exact_keys(
+    payload: Mapping[str, Any], expected: frozenset[str], *, label: str
+) -> None:
+    actual = set(payload)
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing:
+        raise CreativeCodeTelemetryContractError(
+            f"{label} is missing required fields: {', '.join(missing)}"
+        )
+    if extra:
+        raise CreativeCodeTelemetryContractError(
+            f"{label} has unsupported fields: {', '.join(extra)}"
+        )
+
+
+def _require_const(payload: Mapping[str, Any], key: str, expected: Any, *, label: str) -> Any:
+    value = payload.get(key)
+    if value != expected:
+        raise CreativeCodeTelemetryContractError(f"{label}.{key} must equal {expected!r}.")
+    return value
+
+
+def _require_id(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise CreativeCodeTelemetryContractError(f"{label}.{key} must be a string.")
+    normalized = value.strip()
+    if not normalized or not ID_RE.fullmatch(normalized):
+        raise CreativeCodeTelemetryContractError(f"{label}.{key} must be a safe identifier.")
+    return normalized
+
+
+def _require_token(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise CreativeCodeTelemetryContractError(f"{label}.{key} must be a string.")
+    normalized = value.strip()
+    if not normalized or not SAFE_TOKEN_RE.fullmatch(normalized):
+        raise CreativeCodeTelemetryContractError(f"{label}.{key} must be a safe token.")
+    return normalized
+
+
+def _require_fingerprint(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise CreativeCodeTelemetryContractError(f"{label}.{key} must be a sha256 digest.")
+    return value
+
+
+def _require_bool(payload: Mapping[str, Any], key: str, *, expected: bool, label: str) -> bool:
+    value = payload.get(key)
+    if value is not expected:
+        raise CreativeCodeTelemetryContractError(f"{label}.{key} must be {expected}.")
+    return expected
+
+
+def _require_any_bool(payload: Mapping[str, Any], key: str, *, label: str) -> bool:
+    value = payload.get(key)
+    if not isinstance(value, bool):
+        raise CreativeCodeTelemetryContractError(f"{label}.{key} must be a boolean.")
+    return value
+
+
+def _require_int(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    min_value: int,
+    max_value: int,
+    label: str,
+) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CreativeCodeTelemetryContractError(f"{label}.{key} must be an integer.")
+    if not min_value <= value <= max_value:
+        raise CreativeCodeTelemetryContractError(
+            f"{label}.{key} must be between {min_value} and {max_value}."
+        )
+    return value
+
+
+def _optional_token(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise CreativeCodeTelemetryContractError(f"{label} must be null or string.")
+    normalized = value.strip()
+    if not normalized or not SAFE_TOKEN_RE.fullmatch(normalized):
+        raise CreativeCodeTelemetryContractError(f"{label} must be a safe token.")
+    return normalized
+
+
+def _normalize_candidate_ids(raw_ids: Any) -> dict[str, str | None]:
+    if not isinstance(raw_ids, dict):
+        raise CreativeCodeTelemetryContractError("candidate_ids must be a JSON object.")
+    _require_exact_keys(raw_ids, CANDIDATE_ID_KEYS, label="candidate_ids")
+    return {
+        key: _optional_token(raw_ids[key], label=f"candidate_ids.{key}")
+        for key in sorted(CANDIDATE_ID_KEYS)
+    }
+
+
+def _normalize_metrics(raw_metrics: Any) -> dict[str, int | None]:
+    if not isinstance(raw_metrics, dict):
+        raise CreativeCodeTelemetryContractError("metrics must be a JSON object.")
+    _require_exact_keys(raw_metrics, METRIC_KEYS, label="metrics")
+    normalized: dict[str, int | None] = {}
+    for key in sorted(METRIC_KEYS):
+        value = raw_metrics[key]
+        if value is None:
+            normalized[key] = None
+            continue
+        normalized[key] = _require_int(
+            raw_metrics, key, min_value=0, max_value=1_000_000, label="metrics"
+        )
+    return normalized
+
+
+def default_metrics(**overrides: int | None) -> dict[str, int | None]:
+    metrics: dict[str, int | None] = {key: None for key in sorted(METRIC_KEYS)}
+    for key, value in overrides.items():
+        if key not in metrics:
+            raise CreativeCodeTelemetryContractError(f"unknown metric key: {key}")
+        metrics[key] = value
+    return metrics
+
+
+def default_cost_metadata() -> dict[str, int | bool | None]:
+    return {
+        "available": False,
+        "cached_input_tokens": None,
+        "estimated": False,
+        "input_tokens": None,
+        "output_tokens": None,
+        "reasoning_output_tokens": None,
+    }
+
+
+def _normalize_cost_metadata(raw_cost: Any) -> dict[str, int | bool | None]:
+    if not isinstance(raw_cost, dict):
+        raise CreativeCodeTelemetryContractError("cost_metadata must be a JSON object.")
+    _require_exact_keys(raw_cost, COST_KEYS, label="cost_metadata")
+    available = _require_any_bool(raw_cost, "available", label="cost_metadata")
+    estimated = _require_any_bool(raw_cost, "estimated", label="cost_metadata")
+    normalized: dict[str, int | bool | None] = {"available": available, "estimated": estimated}
+    token_keys = ("input_tokens", "cached_input_tokens", "output_tokens", "reasoning_output_tokens")
+    for key in token_keys:
+        value = raw_cost[key]
+        if value is None:
+            normalized[key] = None
+            continue
+        normalized[key] = _require_int(
+            raw_cost, key, min_value=0, max_value=1_000_000_000, label="cost_metadata"
+        )
+    if not available and any(normalized[key] is not None for key in token_keys):
+        raise CreativeCodeTelemetryContractError(
+            "cost_metadata token counts require available=true."
+        )
+    if estimated and not available:
+        raise CreativeCodeTelemetryContractError("cost_metadata.estimated requires available=true.")
+    return {key: normalized[key] for key in sorted(normalized)}
+
+
+def default_authority() -> dict[str, bool]:
+    return {
+        "calls_network": False,
+        "calls_runtime": False,
+        "claims_merge_readiness": False,
+        "merges": False,
+        "modifies_github_app": False,
+        "modifies_slack": False,
+        "opens_pr": False,
+        "read_only_telemetry": True,
+        "resolves_threads": False,
+        "writes_repo": False,
+    }
+
+
+def _normalize_authority(raw_authority: Any) -> dict[str, bool]:
+    if not isinstance(raw_authority, dict):
+        raise CreativeCodeTelemetryContractError("authority must be a JSON object.")
+    _require_exact_keys(raw_authority, AUTHORITY_KEYS, label="authority")
+    normalized: dict[str, bool] = {}
+    for key in sorted(AUTHORITY_KEYS):
+        expected = key == "read_only_telemetry"
+        normalized[key] = _require_bool(raw_authority, key, expected=expected, label="authority")
+    return normalized
+
+
+def _normalize_taxonomy_codes(raw_codes: Any) -> list[str]:
+    if not isinstance(raw_codes, list):
+        raise CreativeCodeTelemetryContractError("taxonomy_codes must be an array.")
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw_codes):
+        if not isinstance(item, str):
+            raise CreativeCodeTelemetryContractError(f"taxonomy_codes[{index}] must be a string.")
+        code = item.strip()
+        if code not in TAXONOMY_CLASSES:
+            raise CreativeCodeTelemetryContractError(f"taxonomy_codes[{index}] is unsupported.")
+        if code in seen:
+            raise CreativeCodeTelemetryContractError("taxonomy_codes must not contain duplicates.")
+        seen.add(code)
+        normalized.append(code)
+    return sorted(normalized)
+
+
+def _event_identity_payload(event: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: event[key] for key in sorted(EVENT_KEYS - {"event_id", "idempotency_key"})}
+
+
+def _event_identity(event: Mapping[str, Any]) -> tuple[str, str]:
+    fingerprint = fingerprint_payload(cast(Any, _event_identity_payload(event)))
+    upstream_ids = (
+        str(event["source_artifact_id"]),
+        str(event["source_fingerprint"]),
+        str(event["lane_stage"]),
+    )
+    event_id = build_asset_id(
+        asset_type=EVENT_TYPE,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=upstream_ids,
+    )
+    idempotency_key = build_idempotency_key(
+        asset_type=EVENT_TYPE,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=upstream_ids,
+    )
+    return event_id, idempotency_key
+
+
+def build_creative_code_telemetry_event(
+    *,
+    lane_stage: str,
+    source_artifact_type: str,
+    source_artifact_id: str,
+    source_fingerprint: str,
+    candidate_ids: Mapping[str, str | None],
+    status: str,
+    metrics: Mapping[str, int | None],
+    taxonomy_codes: Sequence[str] = (),
+    rejection_class: str | None = None,
+    failure_class: str | None = None,
+    cost_metadata: Mapping[str, int | bool | None] | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": EVENT_TYPE,
+        "policy_version": POLICY_VERSION,
+        "event_id": "pending",
+        "idempotency_key": "pending",
+        "lane_stage": lane_stage,
+        "source_artifact_type": source_artifact_type,
+        "source_artifact_id": source_artifact_id,
+        "source_fingerprint": source_fingerprint,
+        "candidate_ids": {key: candidate_ids.get(key) for key in sorted(CANDIDATE_ID_KEYS)},
+        "status": status,
+        "rejection_class": rejection_class,
+        "failure_class": failure_class,
+        "taxonomy_codes": list(taxonomy_codes),
+        "metrics": {key: metrics.get(key) for key in sorted(METRIC_KEYS)},
+        "cost_metadata": dict(cost_metadata or default_cost_metadata()),
+        "authority": default_authority(),
+        "sanitized": True,
+    }
+    event_id, idempotency_key = _event_identity(event)
+    event["event_id"] = event_id
+    event["idempotency_key"] = idempotency_key
+    return validate_creative_code_telemetry_event(event)
+
+
+def validate_creative_code_telemetry_event(payload: Mapping[str, Any]) -> dict[str, Any]:
+    label = "CreativeCodeTelemetryEvent"
+    _require_exact_keys(payload, EVENT_KEYS, label=label)
+    lane_stage = _require_token(payload, "lane_stage", label=label)
+    if lane_stage not in LANE_STAGES:
+        raise CreativeCodeTelemetryContractError(
+            "CreativeCodeTelemetryEvent.lane_stage is unsupported."
+        )
+    source_artifact_type = _require_token(payload, "source_artifact_type", label=label)
+    if source_artifact_type not in SOURCE_ARTIFACT_TYPES:
+        raise CreativeCodeTelemetryContractError(
+            "CreativeCodeTelemetryEvent.source_artifact_type is unsupported."
+        )
+    status = _require_token(payload, "status", label=label)
+    if status not in EVENT_STATUSES:
+        raise CreativeCodeTelemetryContractError(
+            "CreativeCodeTelemetryEvent.status is unsupported."
+        )
+    rejection_class = _optional_token(payload["rejection_class"], label=f"{label}.rejection_class")
+    failure_class = _optional_token(payload["failure_class"], label=f"{label}.failure_class")
+    taxonomy_codes = _normalize_taxonomy_codes(payload["taxonomy_codes"])
+    if rejection_class is not None and rejection_class not in TAXONOMY_CLASSES:
+        raise CreativeCodeTelemetryContractError(
+            "CreativeCodeTelemetryEvent.rejection_class is unsupported."
+        )
+    if failure_class is not None and failure_class not in TAXONOMY_CLASSES:
+        raise CreativeCodeTelemetryContractError(
+            "CreativeCodeTelemetryEvent.failure_class is unsupported."
+        )
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(payload, "artifact_type", EVENT_TYPE, label=label),
+        "policy_version": _require_const(payload, "policy_version", POLICY_VERSION, label=label),
+        "event_id": _require_id(payload, "event_id", label=label),
+        "idempotency_key": _require_id(payload, "idempotency_key", label=label),
+        "lane_stage": lane_stage,
+        "source_artifact_type": source_artifact_type,
+        "source_artifact_id": _require_id(payload, "source_artifact_id", label=label),
+        "source_fingerprint": _require_fingerprint(payload, "source_fingerprint", label=label),
+        "candidate_ids": _normalize_candidate_ids(payload["candidate_ids"]),
+        "status": status,
+        "rejection_class": rejection_class,
+        "failure_class": failure_class,
+        "taxonomy_codes": taxonomy_codes,
+        "metrics": _normalize_metrics(payload["metrics"]),
+        "cost_metadata": _normalize_cost_metadata(payload["cost_metadata"]),
+        "authority": _normalize_authority(payload["authority"]),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    event_id, idempotency_key = _event_identity(normalized)
+    if normalized["event_id"] != event_id:
+        raise CreativeCodeTelemetryContractError("event_id does not match event content.")
+    if normalized["idempotency_key"] != idempotency_key:
+        raise CreativeCodeTelemetryContractError("idempotency_key does not match event content.")
+    reject_unsafe_telemetry_value(normalized, label=label)
+    return normalized
+
+
+def compute_bps(numerator: int, denominator: int) -> int | None:
+    if denominator <= 0:
+        return None
+    return (numerator * 10_000) // denominator
+
+
+def build_creative_code_rejection_taxonomy() -> dict[str, Any]:
+    return validate_creative_code_rejection_taxonomy(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "artifact_type": TAXONOMY_TYPE,
+            "policy_version": POLICY_VERSION,
+            "classes": [
+                {"code": code, **TAXONOMY_CLASSES[code]} for code in sorted(TAXONOMY_CLASSES)
+            ],
+            "sanitized": True,
+        }
+    )
+
+
+def validate_creative_code_rejection_taxonomy(payload: Mapping[str, Any]) -> dict[str, Any]:
+    label = "CreativeCodeRejectionTaxonomy"
+    _require_exact_keys(payload, TAXONOMY_KEYS, label=label)
+    classes = payload["classes"]
+    if not isinstance(classes, list) or not classes:
+        raise CreativeCodeTelemetryContractError(
+            "CreativeCodeRejectionTaxonomy.classes must be non-empty."
+        )
+    seen: set[str] = set()
+    normalized_classes: list[dict[str, str]] = []
+    for index, item in enumerate(classes):
+        if not isinstance(item, dict):
+            raise CreativeCodeTelemetryContractError(f"classes[{index}] must be a JSON object.")
+        _require_exact_keys(item, TAXONOMY_CLASS_KEYS, label=f"classes[{index}]")
+        code = _require_token(item, "code", label=f"classes[{index}]")
+        if code not in TAXONOMY_CLASSES:
+            raise CreativeCodeTelemetryContractError(f"classes[{index}].code is unsupported.")
+        if code in seen:
+            raise CreativeCodeTelemetryContractError("taxonomy classes must not repeat codes.")
+        seen.add(code)
+        expected = TAXONOMY_CLASSES[code]
+        normalized = {
+            "code": code,
+            "stage": _require_const(item, "stage", expected["stage"], label=f"classes[{index}]"),
+            "severity": _require_const(
+                item, "severity", expected["severity"], label=f"classes[{index}]"
+            ),
+            "retryability": _require_const(
+                item,
+                "retryability",
+                expected["retryability"],
+                label=f"classes[{index}]",
+            ),
+            "likely_owner": _require_const(
+                item,
+                "likely_owner",
+                expected["likely_owner"],
+                label=f"classes[{index}]",
+            ),
+        }
+        if normalized["stage"] not in LANE_STAGES:
+            raise CreativeCodeTelemetryContractError(f"classes[{index}].stage is unsupported.")
+        if normalized["severity"] not in SEVERITIES:
+            raise CreativeCodeTelemetryContractError(f"classes[{index}].severity is unsupported.")
+        if normalized["retryability"] not in RETRYABILITY:
+            raise CreativeCodeTelemetryContractError(
+                f"classes[{index}].retryability is unsupported."
+            )
+        if normalized["likely_owner"] not in OWNERS:
+            raise CreativeCodeTelemetryContractError(
+                f"classes[{index}].likely_owner is unsupported."
+            )
+        normalized_classes.append(normalized)
+    if seen != set(TAXONOMY_CLASSES):
+        raise CreativeCodeTelemetryContractError("taxonomy classes must match the closed code set.")
+    normalized_taxonomy = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(payload, "artifact_type", TAXONOMY_TYPE, label=label),
+        "policy_version": _require_const(payload, "policy_version", POLICY_VERSION, label=label),
+        "classes": sorted(normalized_classes, key=lambda row: row["code"]),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    reject_unsafe_telemetry_value(normalized_taxonomy, label=label)
+    return normalized_taxonomy
+
+
+def _count_map(
+    raw: Any, *, label: str, allowed_keys: frozenset[str] | None = None
+) -> dict[str, int]:
+    if not isinstance(raw, dict):
+        raise CreativeCodeTelemetryContractError(f"{label} must be a JSON object.")
+    normalized: dict[str, int] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not SAFE_TOKEN_RE.fullmatch(key):
+            raise CreativeCodeTelemetryContractError(f"{label} keys must be safe tokens.")
+        if allowed_keys is not None and key not in allowed_keys:
+            raise CreativeCodeTelemetryContractError(f"{label}.{key} is unsupported.")
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise CreativeCodeTelemetryContractError(
+                f"{label}.{key} must be a non-negative integer."
+            )
+        normalized[key] = value
+    return dict(sorted(normalized.items()))
+
+
+def _normalize_funnel(raw_funnel: Any) -> dict[str, int]:
+    if not isinstance(raw_funnel, dict):
+        raise CreativeCodeTelemetryContractError("funnel must be a JSON object.")
+    _require_exact_keys(raw_funnel, FUNNEL_KEYS, label="funnel")
+    return {
+        key: _require_int(raw_funnel, key, min_value=0, max_value=1_000_000, label="funnel")
+        for key in sorted(FUNNEL_KEYS)
+    }
+
+
+def _normalize_rates(raw_rates: Any) -> dict[str, int | None]:
+    if not isinstance(raw_rates, dict):
+        raise CreativeCodeTelemetryContractError("rates must be a JSON object.")
+    _require_exact_keys(raw_rates, RATES_KEYS, label="rates")
+    normalized: dict[str, int | None] = {}
+    for key in sorted(RATES_KEYS):
+        value = raw_rates[key]
+        if value is None:
+            normalized[key] = None
+            continue
+        normalized[key] = _require_int(raw_rates, key, min_value=0, max_value=10_000, label="rates")
+    return normalized
+
+
+def _normalize_rollup_cost(raw_cost: Any) -> dict[str, int | None]:
+    if not isinstance(raw_cost, dict):
+        raise CreativeCodeTelemetryContractError("cost must be a JSON object.")
+    _require_exact_keys(raw_cost, ROLLUP_COST_KEYS, label="cost")
+    estimated = raw_cost["estimated_cost_usd"]
+    if estimated is not None:
+        raise CreativeCodeTelemetryContractError("cost.estimated_cost_usd must stay null in PR-4.")
+    return {
+        "cost_metadata_available_count": _require_int(
+            raw_cost,
+            "cost_metadata_available_count",
+            min_value=0,
+            max_value=1_000_000,
+            label="cost",
+        ),
+        "estimated_cost_usd": None,
+        "token_usage_available_count": _require_int(
+            raw_cost,
+            "token_usage_available_count",
+            min_value=0,
+            max_value=1_000_000,
+            label="cost",
+        ),
+    }
+
+
+def _normalize_safe_string_list(raw: Any, *, label: str, allow_empty: bool) -> list[str]:
+    if not isinstance(raw, list):
+        raise CreativeCodeTelemetryContractError(f"{label} must be an array.")
+    if not raw and not allow_empty:
+        raise CreativeCodeTelemetryContractError(f"{label} must be non-empty.")
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw):
+        if not isinstance(item, str):
+            raise CreativeCodeTelemetryContractError(f"{label}[{index}] must be a string.")
+        value = item.strip()
+        if not value or not SAFE_TOKEN_RE.fullmatch(value):
+            raise CreativeCodeTelemetryContractError(f"{label}[{index}] must be a safe token.")
+        if value in seen:
+            raise CreativeCodeTelemetryContractError(f"{label} must not contain duplicates.")
+        seen.add(value)
+        normalized.append(value)
+    return sorted(normalized)
+
+
+def _source_artifact_rows(raw_rows: Any) -> list[dict[str, str]]:
+    if not isinstance(raw_rows, list):
+        raise CreativeCodeTelemetryContractError("source_artifacts must be an array.")
+    normalized: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for index, row in enumerate(raw_rows):
+        if not isinstance(row, dict):
+            raise CreativeCodeTelemetryContractError(
+                f"source_artifacts[{index}] must be an object."
+            )
+        _require_exact_keys(
+            row,
+            frozenset({"source_artifact_type", "source_artifact_id", "source_fingerprint"}),
+            label=f"source_artifacts[{index}]",
+        )
+        artifact_type = _require_token(
+            row, "source_artifact_type", label=f"source_artifacts[{index}]"
+        )
+        if artifact_type not in SOURCE_ARTIFACT_TYPES:
+            raise CreativeCodeTelemetryContractError(
+                f"source_artifacts[{index}].source_artifact_type is unsupported."
+            )
+        artifact_id = _require_id(row, "source_artifact_id", label=f"source_artifacts[{index}]")
+        fingerprint = _require_fingerprint(
+            row, "source_fingerprint", label=f"source_artifacts[{index}]"
+        )
+        key = (artifact_type, artifact_id)
+        if key in seen:
+            raise CreativeCodeTelemetryContractError(
+                "source_artifacts must not contain duplicates."
+            )
+        seen.add(key)
+        normalized.append(
+            {
+                "source_artifact_id": artifact_id,
+                "source_artifact_type": artifact_type,
+                "source_fingerprint": fingerprint,
+            }
+        )
+    return sorted(
+        normalized, key=lambda row: (row["source_artifact_type"], row["source_artifact_id"])
+    )
+
+
+def build_creative_code_telemetry_rollup(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    input_roots: Sequence[str],
+) -> dict[str, Any]:
+    normalized_events = [validate_creative_code_telemetry_event(event) for event in events]
+    normalized_events.sort(key=lambda row: row["event_id"])
+    funnel = {key: 0 for key in sorted(FUNNEL_KEYS)}
+    rejections_by_class: dict[str, int] = {}
+    failures_by_class: dict[str, int] = {}
+    events_by_stage: dict[str, int] = {}
+    events_by_status: dict[str, int] = {}
+    source_rows: dict[tuple[str, str], dict[str, str]] = {}
+    cost_metadata_available_count = 0
+    token_usage_available_count = 0
+
+    for event in normalized_events:
+        stage = event["lane_stage"]
+        status = event["status"]
+        events_by_stage[stage] = events_by_stage.get(stage, 0) + 1
+        events_by_status[status] = events_by_status.get(status, 0) + 1
+        source_rows[(event["source_artifact_type"], event["source_artifact_id"])] = {
+            "source_artifact_id": event["source_artifact_id"],
+            "source_artifact_type": event["source_artifact_type"],
+            "source_fingerprint": event["source_fingerprint"],
+        }
+        rejection_class = event["rejection_class"]
+        failure_class = event["failure_class"]
+        if rejection_class:
+            rejections_by_class[rejection_class] = rejections_by_class.get(rejection_class, 0) + 1
+        if failure_class:
+            failures_by_class[failure_class] = failures_by_class.get(failure_class, 0) + 1
+        for code in event["taxonomy_codes"]:
+            rejections_by_class.setdefault(code, 0)
+        metrics = event["metrics"]
+        if stage == "specification":
+            funnel["specification_bundles"] += 1
+            funnel["variants_total"] += metrics["variant_count"] or 0
+            funnel["variants_selected"] += metrics["selected_variant_count"] or 0
+        elif stage == "patch_evaluation":
+            funnel["patch_results"] += 1
+            if status == "accepted":
+                funnel["patch_results_accepted"] += 1
+            if status == "rejected":
+                funnel["patch_results_rejected"] += 1
+        elif stage == "promotion_plan":
+            funnel["promotion_plans"] += 1
+        elif stage == "promotion_validation" and status == "accepted":
+            funnel["promotion_validations_passed"] += 1
+        elif stage == "promotion_approval" and status == "accepted":
+            funnel["promotion_approvals"] += 1
+        elif stage == "pr_open" and status == "opened":
+            funnel["pull_requests_opened"] += 1
+        cost = event["cost_metadata"]
+        if cost["available"]:
+            cost_metadata_available_count += 1
+            if any(
+                cost[key] is not None
+                for key in (
+                    "input_tokens",
+                    "cached_input_tokens",
+                    "output_tokens",
+                    "reasoning_output_tokens",
+                )
+            ):
+                token_usage_available_count += 1
+
+    rollup = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": ROLLUP_TYPE,
+        "policy_version": POLICY_VERSION,
+        "input_roots": list(input_roots),
+        "event_count": len(normalized_events),
+        "funnel": funnel,
+        "rates": {
+            "first_pass_acceptance_rate_bps": compute_bps(
+                funnel["patch_results_accepted"], funnel["patch_results"]
+            ),
+            "human_approval_rate_bps": compute_bps(
+                funnel["promotion_approvals"], funnel["promotion_plans"]
+            ),
+            "oracle_pass_rate_bps": compute_bps(
+                funnel["patch_results_accepted"], funnel["patch_results"]
+            ),
+            "promotion_rate_bps": compute_bps(
+                funnel["pull_requests_opened"], funnel["patch_results_accepted"]
+            ),
+        },
+        "rejections_by_class": dict(sorted(rejections_by_class.items())),
+        "failures_by_class": dict(sorted(failures_by_class.items())),
+        "events_by_stage": dict(sorted(events_by_stage.items())),
+        "events_by_status": dict(sorted(events_by_status.items())),
+        "source_artifacts": sorted(
+            source_rows.values(),
+            key=lambda row: (row["source_artifact_type"], row["source_artifact_id"]),
+        ),
+        "cost": {
+            "cost_metadata_available_count": cost_metadata_available_count,
+            "estimated_cost_usd": None,
+            "token_usage_available_count": token_usage_available_count,
+        },
+        "caveats": [
+            "local_only",
+            "not_merge_readiness_evidence",
+            "not_product_runtime_truth",
+        ],
+        "sanitized": True,
+    }
+    return validate_creative_code_telemetry_rollup(rollup)
+
+
+def validate_creative_code_telemetry_rollup(payload: Mapping[str, Any]) -> dict[str, Any]:
+    label = "CreativeCodeTelemetryRollup"
+    _require_exact_keys(payload, ROLLUP_KEYS, label=label)
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(payload, "artifact_type", ROLLUP_TYPE, label=label),
+        "policy_version": _require_const(payload, "policy_version", POLICY_VERSION, label=label),
+        "input_roots": _normalize_safe_string_list(
+            payload["input_roots"], label="input_roots", allow_empty=True
+        ),
+        "event_count": _require_int(
+            payload, "event_count", min_value=0, max_value=1_000_000, label=label
+        ),
+        "funnel": _normalize_funnel(payload["funnel"]),
+        "rates": _normalize_rates(payload["rates"]),
+        "rejections_by_class": _count_map(
+            payload["rejections_by_class"],
+            label="rejections_by_class",
+            allowed_keys=frozenset(TAXONOMY_CLASSES),
+        ),
+        "failures_by_class": _count_map(
+            payload["failures_by_class"],
+            label="failures_by_class",
+            allowed_keys=frozenset(TAXONOMY_CLASSES),
+        ),
+        "events_by_stage": _count_map(
+            payload["events_by_stage"], label="events_by_stage", allowed_keys=LANE_STAGES
+        ),
+        "events_by_status": _count_map(
+            payload["events_by_status"], label="events_by_status", allowed_keys=EVENT_STATUSES
+        ),
+        "source_artifacts": _source_artifact_rows(payload["source_artifacts"]),
+        "cost": _normalize_rollup_cost(payload["cost"]),
+        "caveats": _normalize_safe_string_list(
+            payload["caveats"], label="caveats", allow_empty=False
+        ),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    if normalized["event_count"] != sum(normalized["events_by_stage"].values()):
+        raise CreativeCodeTelemetryContractError("event_count must match events_by_stage total.")
+    reject_unsafe_telemetry_value(normalized, label=label)
+    return normalized
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate PR-4 creative-code telemetry contracts.")
+    parser.add_argument("--validate-event", help="Path to telemetry event JSON.")
+    parser.add_argument("--validate-rollup", help="Path to telemetry rollup JSON.")
+    parser.add_argument("--validate-taxonomy", help="Path to rejection taxonomy JSON.")
+    args = parser.parse_args(argv)
+
+    validators = [
+        (args.validate_event, validate_creative_code_telemetry_event),
+        (args.validate_rollup, validate_creative_code_telemetry_rollup),
+        (args.validate_taxonomy, validate_creative_code_rejection_taxonomy),
+    ]
+    try:
+        ran = False
+        for path, validator in validators:
+            if not path:
+                continue
+            validator(read_json_object(path))
+            ran = True
+        if not ran:
+            build_creative_code_rejection_taxonomy()
+    except CreativeCodeTelemetryContractError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(SUCCESS_OUTPUT)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_creative_code_telemetry.py
+++ b/tests/test_creative_code_telemetry.py
@@ -4,6 +4,7 @@ from collections import Counter
 import json
 from pathlib import Path
 import re
+import sys
 from typing import Any
 
 import pytest
@@ -13,12 +14,6 @@ from scripts.orchestration import creative_code_telemetry
 from scripts.orchestration.creative_code_patch_contract import (
     build_creative_code_patch_build_request,
     build_creative_code_patch_result,
-)
-from scripts.orchestration.creative_code_pr_promotion import (
-    APPROVAL_FILE,
-    PLAN_FILE,
-    RECEIPT_FILE,
-    VALIDATION_FILE,
 )
 from scripts.orchestration.creative_code_pr_promotion_contract import (
     build_creative_code_pr_promotion_approval,
@@ -41,6 +36,10 @@ from scripts.orchestration.creative_code_telemetry_contract import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+PLAN_FILE = creative_code_telemetry.PLAN_FILE
+VALIDATION_FILE = creative_code_telemetry.VALIDATION_FILE
+APPROVAL_FILE = creative_code_telemetry.APPROVAL_FILE
+RECEIPT_FILE = creative_code_telemetry.RECEIPT_FILE
 REFERENCE_BUNDLE = REPO_ROOT / "docs/orchestration/contracts/creative_code_specification.v1.json"
 EVENT_SCHEMA = (
     REPO_ROOT / "docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json"
@@ -142,7 +141,11 @@ index 8f11111..8f22222 100644
     )
 
 
-def _promotion_artifacts(result: dict[str, Any]) -> dict[str, dict[str, Any]]:
+def _promotion_artifacts(
+    result: dict[str, Any],
+    *,
+    partial_failure: str | None = None,
+) -> dict[str, dict[str, Any]]:
     promotion_id = "pr4-telemetry-test"
     target_branch = "experiment/pr4-telemetry-test"
     patch_fingerprint = result["patch_summary"]["patch_fingerprint"]
@@ -191,6 +194,7 @@ def _promotion_artifacts(result: dict[str, Any]) -> dict[str, dict[str, Any]]:
         pull_request_number=2040,
         pull_request_url="https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2040",
         approved_by_login="Katsiarynakavaleuskaya",
+        partial_failure=partial_failure,
     )
     return {
         PLAN_FILE: plan,
@@ -393,6 +397,10 @@ def test_collect_and_write_outputs_local_only_sanitized_sidecars(
     assert "not merge-readiness evidence" in emitted.lower()
 
 
+def test_telemetry_import_does_not_load_promotion_runtime_module() -> None:
+    assert "scripts.orchestration.creative_code_pr_promotion" not in sys.modules
+
+
 def test_cli_accepts_repo_relative_artifact_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -427,6 +435,21 @@ def test_cli_accepts_repo_relative_artifact_paths(
     assert captured.err == ""
     assert (telemetry_root / creative_code_telemetry.ROLLUP_FILE).is_file()
     assert not (root / "telemetry" / "artifacts").exists()
+
+
+def test_promotion_receipt_readback_failure_uses_specific_taxonomy() -> None:
+    receipt = _promotion_artifacts(
+        _reference_patch_result(),
+        partial_failure="created PR failed non-draft readback verification",
+    )[RECEIPT_FILE]
+
+    event = creative_code_telemetry.event_from_promotion_receipt(receipt)
+
+    assert event["status"] == "blocked"
+    assert event["rejection_class"] == "pr_readback_failed"
+    assert event["failure_class"] == "pr_readback_failed"
+    assert event["taxonomy_codes"] == ["pr_readback_failed"]
+    assert event["metrics"]["pull_requests_opened"] == 0
 
 
 def test_malformed_patch_artifact_becomes_safe_error_event(

--- a/tests/test_creative_code_telemetry.py
+++ b/tests/test_creative_code_telemetry.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+from collections import Counter
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+import pytest
+
+from core.evidence.fingerprints import fingerprint_payload
+from scripts.orchestration import creative_code_telemetry
+from scripts.orchestration.creative_code_patch_contract import (
+    build_creative_code_patch_build_request,
+    build_creative_code_patch_result,
+)
+from scripts.orchestration.creative_code_pr_promotion import (
+    APPROVAL_FILE,
+    PLAN_FILE,
+    RECEIPT_FILE,
+    VALIDATION_FILE,
+)
+from scripts.orchestration.creative_code_pr_promotion_contract import (
+    build_creative_code_pr_promotion_approval,
+    build_creative_code_pr_promotion_plan,
+    build_creative_code_pr_promotion_receipt,
+    build_creative_code_pr_promotion_validation,
+    promotion_plan_fingerprint,
+)
+from scripts.orchestration.creative_code_specification import (
+    read_creative_code_specification_bundle,
+)
+from scripts.orchestration.creative_code_telemetry_contract import (
+    CreativeCodeTelemetryContractError,
+    build_creative_code_rejection_taxonomy,
+    build_creative_code_telemetry_event,
+    build_creative_code_telemetry_rollup,
+    default_metrics,
+    read_json_object,
+    validate_creative_code_rejection_taxonomy,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REFERENCE_BUNDLE = REPO_ROOT / "docs/orchestration/contracts/creative_code_specification.v1.json"
+EVENT_SCHEMA = (
+    REPO_ROOT / "docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json"
+)
+ROLLUP_SCHEMA = (
+    REPO_ROOT / "docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json"
+)
+TAXONOMY_SCHEMA = (
+    REPO_ROOT / "docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.schema.json"
+)
+REFERENCE_TAXONOMY = (
+    REPO_ROOT / "docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json"
+)
+
+
+def _reference_bundle() -> dict[str, Any]:
+    return read_creative_code_specification_bundle(REFERENCE_BUNDLE)
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _configure_artifact_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, Path, Path]:
+    repo = tmp_path / "repo"
+    root = repo / "artifacts" / "orchestration" / "creative_code"
+    spec_runs = root / "spec_runs"
+    patch_runs = root / "patch_runs"
+    promotions = root / "promotions"
+    telemetry = root / "telemetry"
+    monkeypatch.setattr(creative_code_telemetry, "REPO_ROOT", repo)
+    monkeypatch.setattr(creative_code_telemetry, "CREATIVE_CODE_ROOT", root)
+    monkeypatch.setattr(creative_code_telemetry, "SPEC_RUNS_DIR", spec_runs)
+    monkeypatch.setattr(creative_code_telemetry, "PATCH_RUNS_DIR", patch_runs)
+    monkeypatch.setattr(creative_code_telemetry, "PROMOTIONS_DIR", promotions)
+    monkeypatch.setattr(creative_code_telemetry, "TELEMETRY_ROOT", telemetry)
+    return root, spec_runs, patch_runs, promotions, telemetry
+
+
+def _reference_request(base_sha: str) -> dict[str, Any]:
+    return build_creative_code_patch_build_request(
+        source_bundle=_reference_bundle(),
+        base_commit_sha=base_sha,
+        approval_ref="PR-4-test-approval",
+        allowed_existing_paths=["core/rag/orchestration.py"],
+        allowed_new_paths=[],
+        oracle_commands=["pytest -q tests/test_creative_code_patch_builder.py"],
+        metrics=["candidate patch remains measurable without raw patch capture"],
+        budgets={
+            "generation_attempts": 1,
+            "generation_timeout_seconds": 60,
+            "evaluation_timeout_seconds": 60,
+            "max_changed_files": 3,
+            "max_diff_lines": 200,
+            "max_patch_bytes": 20000,
+        },
+    )
+
+
+def _reference_patch_result(*, accepted: bool = True) -> dict[str, Any]:
+    request = _reference_request("a" * 40)
+    patch_text = """diff --git a/core/rag/orchestration.py b/core/rag/orchestration.py
+index 8f11111..8f22222 100644
+--- a/core/rag/orchestration.py
++++ b/core/rag/orchestration.py
+@@ -1,2 +1,2 @@
+ def value() -> int:
+-    return 1
++    return 2
+"""
+    runner_result = {
+        "experiment_id": "exp-pr4-telemetry",
+        "status": "accepted" if accepted else "rejected",
+        "failure_class": None if accepted else "guard_failure",
+        "mutated_paths": ["core/rag/orchestration.py"],
+        "budget_observations": {
+            "oracle_commands_configured": 1,
+            "attempts": 1,
+            "retries_consumed": 0,
+        },
+        "oracle_results": [{"status": "passed"}] if accepted else [],
+        "shared_tree_untouched": True,
+    }
+    return build_creative_code_patch_result(
+        request=request,
+        changed_paths=["core/rag/orchestration.py"],
+        patch_fingerprint=fingerprint_payload({"candidate_patch": patch_text}),
+        patch_bytes=len(patch_text.encode("utf-8")),
+        diff_lines=len(patch_text.splitlines()),
+        runner_result=runner_result,
+        checkout_destroyed=True,
+        origin_removed=True,
+        shared_tree_untouched=True,
+        failure_class=None if accepted else "guard_failure",
+    )
+
+
+def _promotion_artifacts(result: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    promotion_id = "pr4-telemetry-test"
+    target_branch = "experiment/pr4-telemetry-test"
+    patch_fingerprint = result["patch_summary"]["patch_fingerprint"]
+    plan = build_creative_code_pr_promotion_plan(
+        promotion_id=promotion_id,
+        source_result_id=result["result_id"],
+        source_request_id=result["request_id"],
+        source_bundle_id=result["source_bundle_id"],
+        source_bundle_fingerprint=result["source_bundle_fingerprint"],
+        selected_variant_id=result["selected_variant_id"],
+        selected_variant_fingerprint=result["selected_variant_fingerprint"],
+        patch_fingerprint=patch_fingerprint,
+        base_commit_sha=result["base_commit_sha"],
+        changed_paths=result["changed_paths"],
+        target_head_branch=target_branch,
+        pull_request_title="feat(orchestration): add creative-code telemetry test",
+        pull_request_body_fingerprint=fingerprint_payload({"body": "safe promotion body"}),
+    )
+    plan_fingerprint = promotion_plan_fingerprint(plan)
+    validation = build_creative_code_pr_promotion_validation(
+        promotion_id=promotion_id,
+        plan_fingerprint=plan_fingerprint,
+        patch_fingerprint=patch_fingerprint,
+        base_commit_sha=result["base_commit_sha"],
+        oracle_commands_configured=1,
+        oracle_commands_executed=1,
+    )
+    approval = build_creative_code_pr_promotion_approval(
+        promotion_id=promotion_id,
+        plan_fingerprint=plan_fingerprint,
+        validation_fingerprint=validation["validation_fingerprint"],
+        approved_by_login="Katsiarynakavaleuskaya",
+        confirmed_patch_fingerprint=patch_fingerprint,
+        confirmed_base_commit_sha=result["base_commit_sha"],
+        confirmed_target_branch=target_branch,
+    )
+    receipt = build_creative_code_pr_promotion_receipt(
+        promotion_id=promotion_id,
+        plan_fingerprint=plan_fingerprint,
+        validation_fingerprint=validation["validation_fingerprint"],
+        approval_id=approval["approval_id"],
+        source_result_id=result["result_id"],
+        patch_fingerprint=patch_fingerprint,
+        head_branch=target_branch,
+        commit_sha="b" * 40,
+        pull_request_number=2040,
+        pull_request_url="https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2040",
+        approved_by_login="Katsiarynakavaleuskaya",
+    )
+    return {
+        PLAN_FILE: plan,
+        VALIDATION_FILE: validation,
+        APPROVAL_FILE: approval,
+        RECEIPT_FILE: receipt,
+    }
+
+
+def test_reference_taxonomy_and_schemas_are_closed() -> None:
+    event_schema = json.loads(EVENT_SCHEMA.read_text(encoding="utf-8"))
+    rollup_schema = json.loads(ROLLUP_SCHEMA.read_text(encoding="utf-8"))
+    taxonomy_schema = json.loads(TAXONOMY_SCHEMA.read_text(encoding="utf-8"))
+    reference_taxonomy = read_json_object(REFERENCE_TAXONOMY)
+
+    assert validate_creative_code_rejection_taxonomy(reference_taxonomy) == (
+        build_creative_code_rejection_taxonomy()
+    )
+    assert event_schema["additionalProperties"] is False
+    assert rollup_schema["additionalProperties"] is False
+    assert taxonomy_schema["additionalProperties"] is False
+    assert event_schema["$defs"]["authority"]["additionalProperties"] is False
+    assert event_schema["$defs"]["metrics"]["additionalProperties"] is False
+    assert rollup_schema["$defs"]["funnel"]["additionalProperties"] is False
+    assert taxonomy_schema["$defs"]["taxonomy_class"]["additionalProperties"] is False
+    assert "github_transport_failed" in event_schema["$defs"]["taxonomy_code"]["enum"]
+    unsafe_text_pattern = re.compile(
+        event_schema["$defs"]["safe_id"]["not"]["pattern"],
+        re.IGNORECASE,
+    )
+    assert unsafe_text_pattern.search("/Users/example/repo")
+
+
+def test_duplicate_json_keys_fail_closed(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version":"1.0","schema_version":"2.0"}', encoding="utf-8")
+
+    with pytest.raises(CreativeCodeTelemetryContractError, match="duplicate key"):
+        read_json_object(duplicate)
+
+
+def test_event_rejects_raw_patch_leaks_and_mutating_authority() -> None:
+    source_fingerprint = "sha256:" + ("a" * 64)
+
+    with pytest.raises(CreativeCodeTelemetryContractError, match="unsafe telemetry text"):
+        build_creative_code_telemetry_event(
+            lane_stage="specification",
+            source_artifact_type="creative_code_specification",
+            source_artifact_id="candidate.patch",
+            source_fingerprint=source_fingerprint,
+            candidate_ids={
+                "source_packet_id": None,
+                "source_bundle_id": None,
+                "selected_variant_id": None,
+                "request_id": None,
+                "result_id": None,
+                "promotion_id": None,
+            },
+            status="blocked",
+            rejection_class="leak_detected",
+            failure_class="leak_detected",
+            taxonomy_codes=["leak_detected"],
+            metrics=default_metrics(),
+        )
+
+    event = build_creative_code_telemetry_event(
+        lane_stage="specification",
+        source_artifact_type="creative_code_specification",
+        source_artifact_id="source-bundle",
+        source_fingerprint=source_fingerprint,
+        candidate_ids={
+            "source_packet_id": None,
+            "source_bundle_id": None,
+            "selected_variant_id": None,
+            "request_id": None,
+            "result_id": None,
+            "promotion_id": None,
+        },
+        status="accepted",
+        metrics=default_metrics(),
+    )
+    event["authority"]["opens_pr"] = True
+
+    with pytest.raises(CreativeCodeTelemetryContractError, match="authority.opens_pr"):
+        build_creative_code_telemetry_rollup([event], input_roots=["spec_runs"])
+
+
+def test_collect_events_and_rollup_counts_are_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, spec_runs, patch_runs, promotions, _ = _configure_artifact_roots(monkeypatch, tmp_path)
+    patch_result = _reference_patch_result()
+    _write_json(spec_runs / "run-a" / "bundle.json", _reference_bundle())
+    _write_json(patch_runs / "run-a" / "result.json", patch_result)
+    for filename, payload in _promotion_artifacts(patch_result).items():
+        _write_json(promotions / "promotion-a" / filename, payload)
+
+    first = creative_code_telemetry.collect_events(
+        spec_runs_dir=spec_runs,
+        patch_runs_dir=patch_runs,
+        promotions_dir=promotions,
+    )
+    second = creative_code_telemetry.collect_events(
+        spec_runs_dir=spec_runs,
+        patch_runs_dir=patch_runs,
+        promotions_dir=promotions,
+    )
+    rollup = build_creative_code_telemetry_rollup(
+        first,
+        input_roots=["spec_runs", "patch_runs", "promotions"],
+    )
+
+    assert first == second
+    assert rollup["event_count"] == 6
+    assert rollup["funnel"]["specification_bundles"] == 1
+    assert rollup["funnel"]["patch_results_accepted"] == 1
+    assert rollup["funnel"]["promotion_plans"] == 1
+    assert rollup["funnel"]["promotion_validations_passed"] == 1
+    assert rollup["funnel"]["promotion_approvals"] == 1
+    assert rollup["funnel"]["pull_requests_opened"] == 1
+    assert rollup["rates"]["promotion_rate_bps"] == 10000
+    assert Counter(event["lane_stage"] for event in first) == {
+        "specification": 1,
+        "patch_evaluation": 1,
+        "promotion_plan": 1,
+        "promotion_validation": 1,
+        "promotion_approval": 1,
+        "pr_open": 1,
+    }
+
+
+def test_collect_and_write_outputs_local_only_sanitized_sidecars(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, spec_runs, patch_runs, promotions, telemetry_root = _configure_artifact_roots(
+        monkeypatch,
+        tmp_path,
+    )
+    patch_result = _reference_patch_result()
+    _write_json(spec_runs / "run-a" / "bundle.json", _reference_bundle())
+    _write_json(patch_runs / "run-a" / "result.json", patch_result)
+    for filename, payload in _promotion_artifacts(patch_result).items():
+        _write_json(promotions / "promotion-a" / filename, payload)
+
+    rollup = creative_code_telemetry.collect_and_write(
+        spec_runs_dir=spec_runs,
+        patch_runs_dir=patch_runs,
+        promotions_dir=promotions,
+        output_dir=telemetry_root,
+    )
+    emitted = "\n".join(
+        (telemetry_root / filename).read_text(encoding="utf-8")
+        for filename in (
+            creative_code_telemetry.EVENTS_FILE,
+            creative_code_telemetry.ROLLUP_FILE,
+            creative_code_telemetry.SUMMARY_FILE,
+            creative_code_telemetry.TAXONOMY_FILE,
+        )
+    )
+
+    assert rollup["event_count"] == 6
+    assert "diff --git" not in emitted
+    assert "candidate.patch" not in emitted
+    assert "raw_prompt" not in emitted
+    assert "provider_payload" not in emitted
+    assert "/Users/" not in emitted
+    assert str(tmp_path) not in emitted
+    assert "ghp_" not in emitted
+    assert "not merge-readiness evidence" in emitted.lower()
+
+
+def test_cli_accepts_repo_relative_artifact_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root, spec_runs, patch_runs, promotions, telemetry_root = _configure_artifact_roots(
+        monkeypatch,
+        tmp_path,
+    )
+    patch_result = _reference_patch_result()
+    _write_json(spec_runs / "run-a" / "bundle.json", _reference_bundle())
+    _write_json(patch_runs / "run-a" / "result.json", patch_result)
+    for filename, payload in _promotion_artifacts(patch_result).items():
+        _write_json(promotions / "promotion-a" / filename, payload)
+
+    exit_code = creative_code_telemetry.main(
+        [
+            "--spec-runs-dir",
+            "artifacts/orchestration/creative_code/spec_runs",
+            "--patch-runs-dir",
+            "artifacts/orchestration/creative_code/patch_runs",
+            "--promotions-dir",
+            "artifacts/orchestration/creative_code/promotions",
+            "--output-dir",
+            "artifacts/orchestration/creative_code/telemetry",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == creative_code_telemetry.SUCCESS_OUTPUT
+    assert captured.err == ""
+    assert (telemetry_root / creative_code_telemetry.ROLLUP_FILE).is_file()
+    assert not (root / "telemetry" / "artifacts").exists()
+
+
+def test_malformed_patch_artifact_becomes_safe_error_event(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, spec_runs, patch_runs, promotions, _ = _configure_artifact_roots(monkeypatch, tmp_path)
+    (spec_runs / "empty").mkdir(parents=True)
+    (promotions / "empty").mkdir(parents=True)
+    bad_result = patch_runs / "bad-run" / "result.json"
+    bad_result.parent.mkdir(parents=True)
+    bad_result.write_text('{"result_type":"x","result_type":"y"}', encoding="utf-8")
+
+    events = creative_code_telemetry.collect_events(
+        spec_runs_dir=spec_runs,
+        patch_runs_dir=patch_runs,
+        promotions_dir=promotions,
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event["lane_stage"] == "artifact_read_error"
+    assert event["source_artifact_type"] == "creative_code_artifact_read_error"
+    assert event["source_artifact_id"].startswith("read-error:")
+    assert event["failure_class"] == "malformed_artifact"
+    assert event["taxonomy_codes"] == ["malformed_artifact"]
+    assert str(bad_result) not in json.dumps(event, sort_keys=True)
+
+
+def test_artifact_roots_must_stay_inside_creative_code_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, _, patch_runs, promotions, _ = _configure_artifact_roots(monkeypatch, tmp_path)
+
+    with pytest.raises(creative_code_telemetry.CreativeCodeTelemetryError, match="must stay"):
+        creative_code_telemetry.collect_events(
+            spec_runs_dir=tmp_path / "outside",
+            patch_runs_dir=patch_runs,
+            promotions_dir=promotions,
+        )

--- a/tests/test_creative_code_telemetry.py
+++ b/tests/test_creative_code_telemetry.py
@@ -217,6 +217,14 @@ def test_reference_taxonomy_and_schemas_are_closed() -> None:
     assert rollup_schema["$defs"]["funnel"]["additionalProperties"] is False
     assert taxonomy_schema["$defs"]["taxonomy_class"]["additionalProperties"] is False
     assert "github_transport_failed" in event_schema["$defs"]["taxonomy_code"]["enum"]
+    assert taxonomy_schema["properties"]["classes"]["const"] == reference_taxonomy["classes"]
+    taxonomy_codes = {row["code"] for row in reference_taxonomy["classes"]}
+    assert (
+        set(rollup_schema["$defs"]["taxonomy_count_map"]["propertyNames"]["enum"]) == taxonomy_codes
+    )
+    assert rollup_schema["properties"]["rejections_by_class"]["$ref"].endswith("taxonomy_count_map")
+    assert rollup_schema["properties"]["events_by_stage"]["$ref"].endswith("stage_count_map")
+    assert rollup_schema["properties"]["events_by_status"]["$ref"].endswith("status_count_map")
     unsafe_text_pattern = re.compile(
         event_schema["$defs"]["safe_id"]["not"]["pattern"],
         re.IGNORECASE,
@@ -425,6 +433,56 @@ def test_malformed_patch_artifact_becomes_safe_error_event(
     assert event["failure_class"] == "malformed_artifact"
     assert event["taxonomy_codes"] == ["malformed_artifact"]
     assert str(bad_result) not in json.dumps(event, sort_keys=True)
+
+
+def test_malformed_spec_artifact_becomes_safe_error_event_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, spec_runs, patch_runs, promotions, _ = _configure_artifact_roots(monkeypatch, tmp_path)
+    (patch_runs / "empty").mkdir(parents=True)
+    (promotions / "empty").mkdir(parents=True)
+    bad_bundle = spec_runs / "bad-run" / "bundle.json"
+    bad_bundle.parent.mkdir(parents=True)
+    bad_bundle.write_text('{"bundle_type":"x","bundle_type":"y"}', encoding="utf-8")
+
+    events = creative_code_telemetry.collect_events(
+        spec_runs_dir=spec_runs,
+        patch_runs_dir=patch_runs,
+        promotions_dir=promotions,
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event["lane_stage"] == "artifact_read_error"
+    assert event["source_artifact_type"] == "creative_code_artifact_read_error"
+    assert event["failure_class"] == "malformed_artifact"
+    assert event["taxonomy_codes"] == ["malformed_artifact"]
+    assert str(bad_bundle) not in json.dumps(event, sort_keys=True)
+
+
+def test_artifact_json_symlinks_are_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, spec_runs, patch_runs, promotions, _ = _configure_artifact_roots(monkeypatch, tmp_path)
+    (patch_runs / "empty").mkdir(parents=True)
+    (promotions / "empty").mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text(json.dumps(_reference_bundle()), encoding="utf-8")
+    link = spec_runs / "linked-run" / "bundle.json"
+    link.parent.mkdir(parents=True)
+    try:
+        link.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(creative_code_telemetry.CreativeCodeTelemetryError, match="symlinks"):
+        creative_code_telemetry.collect_events(
+            spec_runs_dir=spec_runs,
+            patch_runs_dir=patch_runs,
+            promotions_dir=promotions,
+        )
 
 
 def test_artifact_roots_must_stay_inside_creative_code_root(

--- a/tests/test_creative_code_telemetry.py
+++ b/tests/test_creative_code_telemetry.py
@@ -435,6 +435,36 @@ def test_malformed_patch_artifact_becomes_safe_error_event(
     assert str(bad_result) not in json.dumps(event, sort_keys=True)
 
 
+def test_malformed_artifacts_with_same_basename_keep_distinct_identities(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, spec_runs, patch_runs, promotions, _ = _configure_artifact_roots(monkeypatch, tmp_path)
+    (spec_runs / "empty").mkdir(parents=True)
+    (promotions / "empty").mkdir(parents=True)
+    for run_id in ("run-a", "run-b"):
+        bad_result = patch_runs / run_id / "result.json"
+        bad_result.parent.mkdir(parents=True)
+        bad_result.write_text('{"result_type":"x","result_type":"y"}', encoding="utf-8")
+
+    events = creative_code_telemetry.collect_events(
+        spec_runs_dir=spec_runs,
+        patch_runs_dir=patch_runs,
+        promotions_dir=promotions,
+    )
+    rollup = build_creative_code_telemetry_rollup(events, input_roots=["patch_runs"])
+
+    assert len(events) == 2
+    assert len({event["event_id"] for event in events}) == 2
+    assert len({event["source_artifact_id"] for event in events}) == 2
+    assert len({event["source_fingerprint"] for event in events}) == 2
+    assert rollup["event_count"] == 2
+    assert len(rollup["source_artifacts"]) == 2
+    emitted = json.dumps({"events": events, "rollup": rollup}, sort_keys=True)
+    assert str(tmp_path) not in emitted
+    assert "/Users/" not in emitted
+
+
 def test_malformed_spec_artifact_becomes_safe_error_event_by_default(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_creative_code_telemetry.py
+++ b/tests/test_creative_code_telemetry.py
@@ -229,7 +229,20 @@ def test_reference_taxonomy_and_schemas_are_closed() -> None:
         event_schema["$defs"]["safe_id"]["not"]["pattern"],
         re.IGNORECASE,
     )
+    rollup_unsafe_text_pattern = re.compile(
+        rollup_schema["$defs"]["safe_id"]["not"]["pattern"],
+        re.IGNORECASE,
+    )
     assert unsafe_text_pattern.search("/Users/example/repo")
+    for unsafe_token in (
+        "oracle_stdout",
+        "oracle-stderr",
+        "provider_payload",
+        "GITHUB_TOKEN",
+        "worktrees:creative-code",
+    ):
+        assert unsafe_text_pattern.search(unsafe_token)
+        assert rollup_unsafe_text_pattern.search(unsafe_token)
 
 
 def test_duplicate_json_keys_fail_closed(tmp_path: Path) -> None:
@@ -243,26 +256,34 @@ def test_duplicate_json_keys_fail_closed(tmp_path: Path) -> None:
 def test_event_rejects_raw_patch_leaks_and_mutating_authority() -> None:
     source_fingerprint = "sha256:" + ("a" * 64)
 
-    with pytest.raises(CreativeCodeTelemetryContractError, match="unsafe telemetry text"):
-        build_creative_code_telemetry_event(
-            lane_stage="specification",
-            source_artifact_type="creative_code_specification",
-            source_artifact_id="candidate.patch",
-            source_fingerprint=source_fingerprint,
-            candidate_ids={
-                "source_packet_id": None,
-                "source_bundle_id": None,
-                "selected_variant_id": None,
-                "request_id": None,
-                "result_id": None,
-                "promotion_id": None,
-            },
-            status="blocked",
-            rejection_class="leak_detected",
-            failure_class="leak_detected",
-            taxonomy_codes=["leak_detected"],
-            metrics=default_metrics(),
-        )
+    for unsafe_source_artifact_id in (
+        "candidate.patch",
+        "oracle_stdout",
+        "oracle-stderr",
+        "provider_payload",
+        "GITHUB_TOKEN",
+        "worktrees:creative-code",
+    ):
+        with pytest.raises(CreativeCodeTelemetryContractError, match="unsafe telemetry text"):
+            build_creative_code_telemetry_event(
+                lane_stage="specification",
+                source_artifact_type="creative_code_specification",
+                source_artifact_id=unsafe_source_artifact_id,
+                source_fingerprint=source_fingerprint,
+                candidate_ids={
+                    "source_packet_id": None,
+                    "source_bundle_id": None,
+                    "selected_variant_id": None,
+                    "request_id": None,
+                    "result_id": None,
+                    "promotion_id": None,
+                },
+                status="blocked",
+                rejection_class="leak_detected",
+                failure_class="leak_detected",
+                taxonomy_codes=["leak_detected"],
+                metrics=default_metrics(),
+            )
 
     event = build_creative_code_telemetry_event(
         lane_stage="specification",


### PR DESCRIPTION
## Goal
Add PR-4 local creative-code telemetry and rejection taxonomy for the governed private pilot.

## Business reason
Measure the PR-1/PR-2/PR-3 creative-code funnel before any public GitHub App backend, Slack beta, live review ingestion, or broader automation authority is considered.

## Scope
- Add closed telemetry event, rollup, and rejection-taxonomy contracts.
- Add a local collector for sanitized `artifacts/orchestration/creative_code/{spec_runs,patch_runs,promotions}` inputs.
- Emit advisory local-only sidecars under `artifacts/orchestration/creative_code/telemetry/`.
- Update orchestration docs, `scripts/AGENTS.md`, and the backlog PR train.
- Add focused tests for schema closure, duplicate-key rejection, leak guards, path containment, symlink rejection, malformed-artifact handling, deterministic rollups, repo-relative CLI paths, receipt failure taxonomy, and telemetry import boundaries.

## Out of scope
- No product runtime behavior.
- No OpenAPI/backend route/client changes.
- No public GitHub App backend.
- No Slack beta.
- No live GitHub/review-thread ingestion.
- No review-thread resolution automation, fixed-mapping automation, merge-readiness claim, branch mutation, provider call, or semantic-cache activation.

## Files changed / likely touched
- `scripts/orchestration/creative_code_telemetry_contract.py`
- `scripts/orchestration/creative_code_telemetry.py`
- `tests/test_creative_code_telemetry.py`
- `docs/orchestration/contracts/creative_code_telemetry_*.schema.json`
- `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.*`
- `docs/orchestration/contracts/CREATIVE_CODE_TELEMETRY_CONTRACT.md`
- `docs/orchestration/ORCHESTRATION_TELEMETRY_SPEC.md`
- `docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md`
- `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_2044_FIXED_MAPPING.md`
- `scripts/AGENTS.md`

## Key decisions
- Telemetry is advisory and local-only.
- Event authority is fail-closed: read-only telemetry must be true; mutating authority flags must remain false.
- Rejection taxonomy is closed and schema-backed.
- Collector reads only already-sanitized PR-1/PR-2/PR-3 artifacts.
- Regex schemas avoid adding literal local `/Users/...` path strings to docs while still rejecting actual local path values.

## Tests / validation
- `.venv/bin/python -m pytest -q tests/test_creative_code_telemetry.py tests/guards/test_security_devtooling_regression_guards.py::test_changed_docs_do_not_add_local_users_absolute_paths` - pass.
- `.venv/bin/python -m pytest -q tests/test_creative_code_telemetry.py` - pass after final review-thread fixes: 13 tests.
- `.venv/bin/python -m scripts.orchestration.creative_code_telemetry_contract --validate-taxonomy docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json` - pass.
- `python -m json.tool docs/orchestration/contracts/creative_code_telemetry_event.v1.schema.json >/dev/null && python -m json.tool docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json >/dev/null` - pass.
- `make validate-changed` - pass.
- `pre-commit run --all-files` - pass.
- Pre-push hooks during `git push` - pass: changed-file mypy, pip-audit, backend pre-push tests, full bandit, docker build test where applicable.
- `.venv/bin/python scripts/orchestration/check_review_threads_disposition.py --pr-number 2044` - pass after resolving 7 threads.
- `pulseplate-pr-review` dry run on pushed head - completed; one advisory large-diff note dispositioned as NOT-A-BUG in `docs/review/PR_2044_FIXED_MAPPING.md`.

Full `make verify` is not used as readiness evidence for this operator-approved machine-heavy lane. It was started accidentally, then operator-cancelled per the narrow-lane machine-budget rule; the PR-owned docs guard finding surfaced before cancellation was fixed and rerun with the exact guard above.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/creative-code-telemetry-pr4-oracle-result.json`

Status: accepted
Runner mode: oracle-only governance reviewer
Oracle commands executed: 2
Co-author trailer: present in commit `a7bb7a5b8`

## Premortem / Risk Review
Pre-open premortem findings were closed before PR open:
- FIXED: repo-relative telemetry CLI paths could nest under the output root. Evidence: `tests/test_creative_code_telemetry.py::test_cli_accepts_repo_relative_artifact_paths` and `scripts/orchestration/creative_code_telemetry.py` path resolver.
- FIXED: new docs schema pattern introduced a literal local `/Users/...` path string. Evidence: exact docs guard plus escaped schema pattern.
- NOT-A-BUG: telemetry remains advisory, not routing or merge truth. Evidence: contract docs and fail-closed `authority` schema.

Post-open role/review findings are recorded in `docs/review/PR_2044_FIXED_MAPPING.md`:
- QA findings fixed in `013642ce8` / mapped in `5e2f484d2`.
- Bug-hunter read-error identity collision fixed in `4b1ee2921` / mapped in `8fc18b25b`.
- Security-auditor tokenized leak-label finding fixed in `36f63bdc9` / mapped in `da88bff1e`.
- `pulseplate-pr-review` advisory large-diff note dispositioned as NOT-A-BUG in `98fe58432`.
- Seven GitHub review threads from `chatgpt-codex-connector` are mapped in `docs/review/PR_2044_FIXED_MAPPING.md`; remaining receipt/import fixes are in `beae974bd` and mapped in `f8f1bc69e`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- All 7 resolved review threads have disposition proof and commit-after-comment evidence.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2044_FIXED_MAPPING.md`

## Merge Readiness
Not claimed. Codex Security diff scan/finding discovery did not start in the app workspace before timeout, current-head CI is still running on the latest push, and strict merge-readiness must be rerun after CI settles.

## Security notes
- No secrets, raw prompts, raw patches, provider payloads, oracle stdout/stderr, Slack/GitHub payloads, review-thread bodies, PR bodies, or local absolute paths are accepted into telemetry.
- Output remains under gitignored local artifact roots.
- No network or runtime calls are added by the collector.

## Risks / rollback
Rollback removes the PR-4 telemetry contracts, collector, docs, tests, and backlog references. Because this is local orchestration tooling only, rollback does not affect product runtime, public API, OpenAPI clients, billing, auth, Slack, or GitHub App behavior.

## Deferred / follow-ups
- PR-5 remains gated for review-disposition integration without review-thread resolution authority.
- PR-6 remains gated for the first governed applied creative-code candidate through normal PR governance.

## AGENTS.md or agent-instruction updates
Updated `scripts/AGENTS.md` to lock the PR-4 telemetry boundary: local-only, sanitized inputs only, no runtime/GitHub/Slack/review/merge authority.

## Next best step
Start the Codex Security diff scan workspace if required, then inspect latest current-head CI and rerun strict merge-readiness after all checks settle.
