### PR TITLE
fix(test): restore main creative telemetry import check

### DIFF
--- a/docs/review/PR_2049_FIXED_MAPPING.md
+++ b/docs/review/PR_2049_FIXED_MAPPING.md
@@ -1,0 +1,139 @@
+# PR #2049 Fixed in Commit Mapping SoT
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2049
+
+Branch: `codex/fix-main-creative-telemetry-py313`
+
+## Summary
+
+This PR fixes the Python 3.13 main-CI creative-code telemetry import-isolation
+test by moving the runtime-boundary assertion into a fresh interpreter. The
+production contract is unchanged: importing `scripts.orchestration.creative_code_telemetry`
+must not import `scripts.orchestration.creative_code_pr_promotion`.
+
+## Scope
+
+- Update `tests/test_creative_code_telemetry.py`.
+- Replace the parent-process `sys.modules` assertion with a subprocess probe
+  using `sys.executable`.
+- Keep the child probe limited to importing
+  `scripts.orchestration.creative_code_telemetry` and checking the child
+  interpreter's `sys.modules`.
+
+## Out Of Scope
+
+No production orchestration code, PR promotion runtime behavior, import-boundary
+weakening, `sys.modules` mutation, local full `make verify`, or unrelated
+creative-code PR-5 work is in scope.
+
+## Implementation Commits
+
+- `788282272` - isolate the creative-code telemetry import-boundary test in a
+  fresh interpreter and keep subprocess diagnostics bounded.
+
+## Lane Start Provenance
+
+- Base branch: `main`
+- Branch: `codex/fix-main-creative-telemetry-py313`
+- Base commit: `71af9d208b26435352fc821b79a2d78cebb319f5`
+- Packet: `artifacts/orchestration/task_packets/192b00bc8106.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Pre-open role order executed:
+  `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> architecture-specialist`
+- Packet creation was treated as provenance/routing only; role passes were
+  executed explicitly before implementation.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Post-open `qa-engineer-agent` pass completed.
+- [x] Post-open `bug-hunter` pass completed.
+- [x] Post-open `security-auditor` pass completed.
+- [ ] Codex Security diff scan / finding discovery completed.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] Current-head CI complete before readiness language.
+- [ ] Strict merge-readiness checks run after the final review/check cycle.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Initial Review-State Notes
+
+No actionable code review threads existed when this artifact was created. The
+issue-level Codex, CodeRabbit, and Sourcery messages reported usage or review
+limits rather than code defects. They remain external review-cap blockers for
+merge readiness, not test-fix defects.
+
+## Post-Open Role Review Evidence
+
+Disposition: NOT-A-BUG
+
+Finding: The mandatory post-open role passes did not report any required code
+or security fix for the scoped test change.
+
+Evidence:
+
+- `qa-engineer-agent`: PASS for QA adequacy. It confirmed the fresh-interpreter
+  probe covers the collection-order contamination from
+  `tests/test_creative_code_pr_promotion.py`.
+- `bug-hunter`: PASS at code level. It identified no required test fix; the
+  only code-level caveat was non-blocking timeout diagnostic polish.
+- `security-auditor`: PASS. It confirmed the subprocess posture uses
+  `sys.executable`, argv-list execution, no shell, no `# nosec`, bounded output,
+  and no production guard weakening.
+
+## Premortem Finding Closure
+
+Disposition: FIXED
+
+Finding: The hotfix could false-green by cleaning or depending on the parent
+pytest interpreter state instead of proving the telemetry import contract.
+
+Evidence: `tests/test_creative_code_telemetry.py` now runs the import-boundary
+probe in a fresh interpreter and does not mutate `sys.modules`.
+
+Disposition: FIXED
+
+Finding: The subprocess probe could violate repo subprocess policy.
+
+Evidence: The test uses `[sys.executable, "-c", probe]`, no shell, no `# nosec`,
+and the focused guard run
+`tests/guards/test_subprocess_uses_absolute_binaries.py tests/guards/test_nosec_policy_guard.py`
+passed.
+
+Disposition: FIXED
+
+Finding: Branch-scoped validation could false-pass before the file was committed.
+
+Evidence: `make validate-changed` was rerun after commit `788282272`; it
+selected `tests/test_creative_code_telemetry.py` and ran 13 tests successfully.
+
+## Experiment Runner Evidence
+
+- Runner mode: `oracle_only_governance_reviewer`
+- Experiment ID: `exp-8142bcb7a773`
+- Artifact: `artifacts/orchestration/experiments/results/creative-telemetry-py313-oracle.json`
+- Status: accepted
+- Shared tree untouched: true
+- Mutated paths: []
+- Source diff paths: `tests/test_creative_code_telemetry.py`
+- Oracle commands:
+  - `python -m pytest -q tests/test_creative_code_pr_promotion.py tests/test_creative_code_telemetry.py::test_telemetry_import_does_not_load_promotion_runtime_module -p no:cacheprovider` -> exit 0
+  - `python -m pytest -q tests/guards/test_subprocess_uses_absolute_binaries.py tests/guards/test_nosec_policy_guard.py` -> exit 0
+- Co-author trailer required and included in implementation commit:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Local Validation Evidence
+
+- PASS: `env PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_creative_code_pr_promotion.py tests/test_creative_code_telemetry.py::test_telemetry_import_does_not_load_promotion_runtime_module -p no:cacheprovider`
+- PASS: `env PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_creative_code_telemetry.py tests/test_creative_code_pr_promotion.py -p no:cacheprovider`
+- PASS: `env PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_subprocess_uses_absolute_binaries.py tests/guards/test_nosec_policy_guard.py`
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS during push hooks: `pip-audit`, backend pre-push pytest, and full-repo
+  Bandit.
+- Not run: local full `make verify`, per repo budget rule and operator request.

--- a/tests/test_creative_code_telemetry.py
+++ b/tests/test_creative_code_telemetry.py
@@ -4,6 +4,7 @@ from collections import Counter
 import json
 from pathlib import Path
 import re
+import subprocess
 import sys
 from typing import Any
 
@@ -398,7 +399,41 @@ def test_collect_and_write_outputs_local_only_sanitized_sidecars(
 
 
 def test_telemetry_import_does_not_load_promotion_runtime_module() -> None:
-    assert "scripts.orchestration.creative_code_pr_promotion" not in sys.modules
+    probe = """
+import json
+import sys
+
+from scripts.orchestration import creative_code_telemetry
+
+runtime_module = "scripts.orchestration.creative_code_pr_promotion"
+print(json.dumps({"promotion_runtime_loaded": runtime_module in sys.modules}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    stdout_tail = result.stdout[-1000:]
+    stderr_tail = result.stderr[-2000:]
+    assert result.returncode == 0, (
+        "fresh telemetry import probe failed "
+        f"returncode={result.returncode}\nstdout:\n{stdout_tail}\nstderr:\n{stderr_tail}"
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            "fresh telemetry import probe emitted malformed JSON "
+            f"stdout:\n{stdout_tail}\nstderr:\n{stderr_tail}"
+        ) from exc
+    assert payload == {"promotion_runtime_loaded": False}, (
+        "creative_code_telemetry import loaded promotion runtime module "
+        f"in a fresh interpreter payload={payload!r}\n"
+        f"stdout:\n{stdout_tail}\nstderr:\n{stderr_tail}"
+    )
 
 
 def test_cli_accepts_repo_relative_artifact_paths(


### PR DESCRIPTION
## Goal
Fix the `test-main (3.13, 90)` main-CI failure from run `28383199594` / job `84091109836` without changing production orchestration code.

## Business reason
Restore the Python 3.13 main test signal while preserving the creative-code telemetry/promotion import boundary.

## Scope
- `tests/test_creative_code_telemetry.py`
- Replace the parent-process `sys.modules` assertion with a fresh-interpreter subprocess probe using `sys.executable`.
- The child process imports only `scripts.orchestration.creative_code_telemetry` and reports whether `scripts.orchestration.creative_code_pr_promotion` was loaded.
- Add canonical review mapping artifact `docs/review/PR_2049_FIXED_MAPPING.md` after GitHub assigned PR number `#2049`.

## Out of scope
- Production orchestration code changes.
- Weakening the telemetry/promotion boundary.
- Mutating `sys.modules` to force a green test.
- Local full `make verify`.

## Key decisions
- The real contract is preserved: importing telemetry must not import the promotion runtime.
- The test now avoids pytest collection-order contamination from `tests/test_creative_code_pr_promotion.py`.
- Duplicate check: PR #2048 was inspected and does not modify this telemetry test or the promotion runtime boundary, so this hotfix is not a duplicate.

## Tests
- PASS: `env PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_creative_code_pr_promotion.py tests/test_creative_code_telemetry.py::test_telemetry_import_does_not_load_promotion_runtime_module -p no:cacheprovider`
- PASS: `env PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_creative_code_telemetry.py tests/test_creative_code_pr_promotion.py -p no:cacheprovider`
- PASS: `env PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_subprocess_uses_absolute_binaries.py tests/guards/test_nosec_policy_guard.py`
- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `make validate-changed` after commit; selected `tests/test_creative_code_telemetry.py` and ran 13 tests.
- PASS: `pre-commit run --all-files`
- PASS during push hooks: `pip-audit`, backend pre-push pytest, and full-repo Bandit.
- Not run: local full `make verify`, per repo budget rule and operator request.

## Security notes
- The subprocess uses `[sys.executable, "-c", probe]`, no shell, no `# nosec`, no environment dump, and bounded stdout/stderr diagnostics.
- No secrets, tokens, local artifact payloads, or raw external data are emitted by the test.
- Codex Security diff scan `0001f7c8-1b4b-44c6-b3aa-31782717e005` completed against head `6b434a83f58965cf19b522da8f2ca9df65d1d142`; finding count: 0.

## Risks / rollback
- Main risk is a false-green import boundary test; mitigated by running the probe in a fresh Python interpreter and by focused ordered repro coverage.
- Rollback is a single-file test revert.
- Current-head GitHub CI run `28391250989` passed on head `6b434a83f58965cf19b522da8f2ca9df65d1d142`.

## Deferred / follow-ups
None.

## AGENTS.md or agent-instruction updates
None.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/192b00bc8106.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Branch: `codex/fix-main-creative-telemetry-py313`
- Base: `origin/main` at `71af9d208b26435352fc821b79a2d78cebb319f5`
- Pre-open role passes completed: `agent-coordinator`, `qa-engineer-agent`, `bug-hunter`, `security-auditor`, `cursor-specialist-agent`, `architecture-specialist`.
- Pre-open premortem: proceed with changes; risks were false-green parent interpreter state, subprocess policy regression, and missing branch-scoped validation. Mitigations are the fresh interpreter probe, subprocess/nosec guards, and post-commit `make validate-changed`.

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/creative-telemetry-py313-oracle.json`
- Runner mode: `oracle_only_governance_reviewer`
- Status: `accepted`
- Source diff paths: `tests/test_creative_code_telemetry.py`
- Mutated paths: `[]`
- Shared tree untouched: `true`
- Oracle commands executed: 2
- Attribution: commit `788282272` includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>` because the oracle review shaped validation and commit decision.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open `qa-engineer-agent` pass completed.
- [x] Post-open `bug-hunter` pass completed.
- [x] Post-open `security-auditor` pass completed.
- [x] Codex Security diff scan / finding discovery completed.
- [x] `pulseplate-pr-review` completed.
- [x] Current-head CI complete before readiness language.
- [x] Strict merge-readiness checks run after the final review/check cycle.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2049_FIXED_MAPPING.md`

## Merge Readiness
- Local narrow bundle: passed as listed above.
- Current-head CI: PASS on run `28391250989` for head `6b434a83f58965cf19b522da8f2ca9df65d1d142`, including `lint`, `security`, `test-pr (3.13)`, `coverage-pr`, `diff-coverage`, PR body gates, merge-readiness gate, and private proxy health.
- Bot/review comments: Codex connector, CodeRabbit, and Sourcery rate/usage-limit comments contained no actionable code findings; CodeRabbit and Sourcery status checks are PASS; Cubic is neutral/skipped.
- Strict merge-readiness guard: PASS locally with `GITHUB_TOKEN=$(gh auth token) python3 scripts/ci/check_pr_merge_readiness.py --pr-number 2049 --repo Katsiarynakavaleuskaya/PulsePlate`; result: `0 unresolved threads, all actionable bot comments mapped in canonical artifact`.
