### PR TITLE
chore(deps): enforce dependency ownership without expanding legacy authority

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -37,6 +37,14 @@ vector runtime stack. It also owns `httpx2` as the Starlette TestClient
 backend for backend test lanes; runtime, Docker runtime, and CI-lite profiles
 must not install `httpx2`.
 
+The dependency ownership audit in
+`scripts/ci/check_python_dependency_surfaces.py` is the canonical authority for
+the first audited subset: `pyarrow`, `pandas`, `httpx2`, `reportlab`,
+`matplotlib`, `numpy`, and `aiosqlite`. `pyarrow` is data/eval-only unless a
+future PR documents canonical runtime owner evidence; runtime, Docker runtime,
+CI-lite, and `requirements-lock.txt` must not install it. Legacy-only usage is
+`legacy_compat_transitional` evidence, not production dependency ownership.
+
 Local/manual profiles (`requirements-data.txt`, `requirements-evals.txt`, and
 `requirements-rag-vector-cpu.txt`) are not shared GitHub Actions
 `requirements-profile` values.

--- a/constraints.txt
+++ b/constraints.txt
@@ -53,8 +53,6 @@ mako>=1.3.12  # GHSA-v92g-xgxw-vvmm / GHSA-2h4p-vjrc-8xpq security floor
 psycopg>=3.2.3
 email-validator>=2.3.0
 cryptography>=48.0.1
-# PyArrow floor mirrors requirements.in / requirements-ci-lite.in.
-pyarrow>=20.0.0
 # Guidance for agentops compatibility (agentops requires packaging<25).
 # Not enforced here to avoid conflicts with the current lock files.
 # If you need agentops locally, use an isolated venv or a separate constraints-agentops.txt.

--- a/docs/DEPENDENCY_MANAGEMENT.md
+++ b/docs/DEPENDENCY_MANAGEMENT.md
@@ -5,7 +5,8 @@ This project uses `pip-tools` to manage dependencies with deterministic builds.
 Canonical dependency-surface ownership lives in
 `docs/contracts/PYTHON_DEPENDENCY_SURFACES.md`. The executable contract check is
 `scripts/ci/check_python_dependency_surfaces.py`; `verify_requirements.py`
-remains as a compatibility wrapper for that validator.
+remains as a legacy compatibility wrapper for that validator and is not a
+separate ownership authority.
 
 ## Files
 
@@ -74,8 +75,17 @@ CI lanes.
 `requirements-data.in` owns offline data-build dependencies for snapshot
 builders such as `scripts/build_food_db.py` and `scripts/build_recipe_db.py`.
 The compiled `requirements-data.txt` profile includes `pandas` plus explicit
-Parquet writer support through `pyarrow`, without changing the existing
-runtime, Docker, or CI-lite dependency ownership for `pyarrow`.
+Parquet writer support through `pyarrow`. Runtime, Docker runtime, CI-lite, and
+`requirements-lock.txt` must not install or legitimize `pyarrow` unless a future
+PR documents canonical app/core/provider runtime owner evidence in
+`docs/contracts/PYTHON_DEPENDENCY_SURFACES.md`.
+
+The dependency ownership audit currently enforces only the first audited subset:
+`pyarrow`, `pandas`, `httpx2`, `reportlab`, `matplotlib`, `numpy`, and
+`aiosqlite`. Legacy usage is evidence of transitional compatibility pressure,
+not runtime ownership. `legacy_app.py`, root `bmi_visualization.py`, and legacy
+BMI compatibility shims can produce `legacy_compat_transitional` evidence only;
+they cannot by themselves make a dependency canonical runtime authority.
 
 `requirements-evals.in` owns the tracked offline eval dependency surface for
 the local RAGAS companion runner. RAGAS native execution is disabled while

--- a/docs/contracts/PYTHON_DEPENDENCY_SURFACES.md
+++ b/docs/contracts/PYTHON_DEPENDENCY_SURFACES.md
@@ -61,6 +61,52 @@ for dependency graph visibility.
 test, and dev-full-lock surfaces only; it must stay out of runtime, Docker
 runtime, and CI-lite surfaces.
 
+## Dependency Ownership Audit
+
+`scripts/ci/check_python_dependency_surfaces.py` runs the first-pass dependency
+ownership audit by default. The first enforced subset is intentionally narrow:
+`pyarrow`, `pandas`, `httpx2`, `reportlab`, `matplotlib`, `numpy`, and
+`aiosqlite`.
+
+Findings use stable severity tiers:
+
+| Severity | Meaning | Default behavior |
+|---|---|---|
+| `error` | Confirmed policy violation | Fails the validator |
+| `warning` | Suspicious but not safe to remove in this PR | Report only |
+| `info` | Documented owner or transitional debt | Report only |
+
+Stable reason codes include `ownership_ok`,
+`runtime_direct_no_canonical_owner`,
+`legacy_only_runtime_authority_forbidden`,
+`data_eval_dependency_in_runtime`, `test_dev_dependency_in_runtime`,
+`canonical_runtime_owner_documented`, `legacy_compat_transitional`, and
+`transitive_only_direct_runtime_candidate`.
+
+Legacy usage is evidence of transitional compatibility pressure, not runtime
+ownership. A production dependency must have canonical runtime ownership outside
+`legacy_app.py` or be explicitly documented as a temporary
+`legacy_compat_transitional` dependency with an extraction/removal path. Root
+`bmi_visualization.py`, legacy BMI compatibility shims, and
+`app/services/bmi_compat.py` cannot by themselves promote a package to
+canonical runtime ownership.
+
+| Package | First-pass rule |
+|---|---|
+| `pyarrow` | Error if present in runtime or CI-lite surfaces without canonical runtime owner evidence. Keep data/eval ownership separate. |
+| `pandas` | Error if present in runtime, Docker runtime, or CI-lite surfaces. Data/eval only. |
+| `httpx2` | Error if present in runtime, Docker runtime, or CI-lite surfaces. Dev/test only. |
+| `reportlab` | Allowed as canonical runtime for export/PDF owners. |
+| `matplotlib` | Warning as `legacy_compat_transitional` unless a canonical BMI owner is documented. Do not remove in this PR. |
+| `numpy` | Warning as `transitive_only_direct_runtime_candidate` when directly declared without direct canonical runtime imports. It may remain transitive through `matplotlib`. |
+| `aiosqlite` | Warning pending DB fallback/test split. Do not remove in this PR. |
+
+`pyarrow` belongs to `requirements-data.in` / `requirements-data.txt` for
+offline Parquet-capable data builders unless a future PR documents canonical
+runtime owner evidence. Runtime, Docker runtime, CI-lite, and
+`requirements-lock.txt` must not carry `pyarrow` as a production/control-plane
+authority.
+
 The locked installer may elide an equal minimum floor, such as
 `package>=1.2.3`, only when the same selected requirement surface already pins
 `package==1.2.3` without markers. Lower or stricter security floors must remain
@@ -77,6 +123,7 @@ The validator fails when:
 - a compiled lockfile contains a non-exact requirement entry;
 - local/manual surfaces leak into shared `requirements-profile` routing;
 - required pip-audit or dependency-submission coverage is missing; or
+- the first audited ownership subset violates its severity-tier policy; or
 - this contract stops naming a registered surface.
 
 PRs that change Python dependency ownership, install routing, or security

--- a/docs/contracts/PYTHON_DEPENDENCY_SURFACES.md
+++ b/docs/contracts/PYTHON_DEPENDENCY_SURFACES.md
@@ -76,12 +76,17 @@ Findings use stable severity tiers:
 | `warning` | Suspicious but not safe to remove in this PR | Report only |
 | `info` | Documented owner or transitional debt | Report only |
 
-Stable reason codes include `ownership_ok`,
-`runtime_direct_no_canonical_owner`,
+Stable reason codes include `runtime_direct_no_canonical_owner`,
 `legacy_only_runtime_authority_forbidden`,
 `data_eval_dependency_in_runtime`, `test_dev_dependency_in_runtime`,
 `canonical_runtime_owner_documented`, `legacy_compat_transitional`, and
-`transitive_only_direct_runtime_candidate`.
+`transitive_only_direct_runtime_candidate`,
+`db_fallback_test_split_pending`.
+
+Import evidence uses exact top-level import names plus explicit aliases for
+known distribution/import-name splits such as `pydantic-core` /
+`pydantic_core`. It must not blindly replace underscores with hyphens for every
+module name.
 
 Legacy usage is evidence of transitional compatibility pressure, not runtime
 ownership. A production dependency must have canonical runtime ownership outside
@@ -93,7 +98,7 @@ canonical runtime ownership.
 
 | Package | First-pass rule |
 |---|---|
-| `pyarrow` | Error if present in runtime or CI-lite surfaces without canonical runtime owner evidence. Keep data/eval ownership separate. |
+| `pyarrow` | Error if present in runtime, Docker runtime, CI-lite, or aggregate lock surfaces without canonical runtime owner evidence. Keep data/eval ownership separate. |
 | `pandas` | Error if present in runtime, Docker runtime, or CI-lite surfaces. Data/eval only. |
 | `httpx2` | Error if present in runtime, Docker runtime, or CI-lite surfaces. Dev/test only. |
 | `reportlab` | Allowed as canonical runtime for export/PDF owners. |

--- a/docs/review/PR_2057_FIXED_MAPPING.md
+++ b/docs/review/PR_2057_FIXED_MAPPING.md
@@ -43,12 +43,18 @@ Disposition: FIXED
 Evidence: `scripts/ci/check_python_dependency_surfaces.py:120`, `scripts/ci/check_python_dependency_surfaces.py:404`, `scripts/ci/check_python_dependency_surfaces.py:408`, `tests/test_python_dependency_surfaces.py:443`, `tests/test_python_dependency_surfaces.py:491`, and `docs/contracts/PYTHON_DEPENDENCY_SURFACES.md:79`.
 Reason: Sourcery's high-level feedback identified blind underscore-to-hyphen import normalization risk and a stale `ownership_ok` reason-code doc entry. Commit `b68239aba` replaced blind import normalization with explicit distribution/import aliases, added positive and negative alias tests, removed `ownership_ok`, and added Docker-runtime `pyarrow` regression coverage found by the follow-up QA pass.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2057#pullrequestreview-4609069626 -> c3ba71934
+Disposition: FIXED
+Evidence: `tests/test_python_supply_chain_controls.py:945`, `tests/test_python_supply_chain_controls.py:949`, `scripts/ci/check_python_dependency_surfaces.py:359`, `scripts/ci/check_python_dependency_surfaces.py:383`, and `tests/test_python_supply_chain_controls.py:319`.
+Reason: CodeRabbit's Docker-runtime `pyarrow` coverage request was valid and fixed in `c3ba71934`. Its `_requirement_package_names` signature concern was not a bug: the production helper takes `(repo_root, relative_path)` and its call site passes both arguments, while `tests/test_python_supply_chain_controls.py` defines a separate local test helper that intentionally takes a single `Path`.
+
 ## Implementing Commits
 
 - `80c56590f` - `chore(deps): enforce dependency ownership`
 - `94c903e1e` - `docs(review): add dependency ownership evidence`
 - `4131cf325` - `fix(deps): satisfy dependency checker typing`
 - `b68239aba` - `fix(deps): use explicit import ownership aliases`
+- `c3ba71934` - `test(deps): guard pyarrow out of docker runtime`
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_2057_FIXED_MAPPING.md
+++ b/docs/review/PR_2057_FIXED_MAPPING.md
@@ -40,11 +40,13 @@ Post-open pass status:
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2057#pullrequestreview-4608060018 -> b68239aba
 Disposition: FIXED
+Commit: b68239aba
 Evidence: `scripts/ci/check_python_dependency_surfaces.py:120`, `scripts/ci/check_python_dependency_surfaces.py:404`, `scripts/ci/check_python_dependency_surfaces.py:408`, `tests/test_python_dependency_surfaces.py:443`, `tests/test_python_dependency_surfaces.py:491`, and `docs/contracts/PYTHON_DEPENDENCY_SURFACES.md:79`.
 Reason: Sourcery's high-level feedback identified blind underscore-to-hyphen import normalization risk and a stale `ownership_ok` reason-code doc entry. Commit `b68239aba` replaced blind import normalization with explicit distribution/import aliases, added positive and negative alias tests, removed `ownership_ok`, and added Docker-runtime `pyarrow` regression coverage found by the follow-up QA pass.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2057#pullrequestreview-4609069626 -> c3ba71934
 Disposition: FIXED
+Commit: c3ba71934
 Evidence: `tests/test_python_supply_chain_controls.py:945`, `tests/test_python_supply_chain_controls.py:949`, `scripts/ci/check_python_dependency_surfaces.py:359`, `scripts/ci/check_python_dependency_surfaces.py:383`, and `tests/test_python_supply_chain_controls.py:319`.
 Reason: CodeRabbit's Docker-runtime `pyarrow` coverage request was valid and fixed in `c3ba71934`. Its `_requirement_package_names` signature concern was not a bug: the production helper takes `(repo_root, relative_path)` and its call site passes both arguments, while `tests/test_python_supply_chain_controls.py` defines a separate local test helper that intentionally takes a single `Path`.
 
@@ -55,6 +57,7 @@ Reason: The production dependency-surface helper intentionally takes `(repo_root
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2057#discussion_r3505987623 -> c3ba71934
 Disposition: FIXED
+Commit: c3ba71934
 Evidence: `tests/test_python_supply_chain_controls.py:945` and `tests/test_python_supply_chain_controls.py:949`.
 Reason: The checked-in Docker runtime requirement input and lock surfaces are now covered by repo-level `pyarrow` absence assertions.
 
@@ -66,6 +69,7 @@ Reason: The checked-in Docker runtime requirement input and lock surfaces are no
 - `b68239aba` - `fix(deps): use explicit import ownership aliases`
 - `c3ba71934` - `test(deps): guard pyarrow out of docker runtime`
 - `13713f741` - `docs(review): map dependency ownership bot findings`
+- `456ccdfe6` - `docs(review): map dependency ownership thread comments`
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_2057_FIXED_MAPPING.md
+++ b/docs/review/PR_2057_FIXED_MAPPING.md
@@ -1,0 +1,118 @@
+# PR #2057 Fixed in Commit Mapping
+
+Canonical review-governance artifact for PR #2057:
+`chore(deps): enforce dependency ownership without expanding legacy authority`.
+
+## Scope
+
+- Enforce first-pass dependency ownership for the audited Python subset only:
+  `pyarrow`, `pandas`, `httpx2`, `reportlab`, `matplotlib`, `numpy`, and
+  `aiosqlite`.
+- Remove `pyarrow` from runtime, CI-lite, aggregate, and constraints surfaces
+  after confirming no canonical runtime owner.
+- Keep `pyarrow` in data dependency surfaces.
+- Preserve legacy compatibility as transitional evidence, not canonical runtime
+  authority.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Post-open pass status:
+
+- `qa-engineer-agent`: reviewed the dependency checker, focused tests,
+  generated requirements surfaces, and docs. No actionable defect found.
+- `bug-hunter`: reviewed pyarrow removal boundaries, warning-only severity
+  tiers, and legacy-only ownership blocking. No actionable defect found.
+- `security-auditor`: reviewed supply-chain/runtime authority boundaries,
+  local-path leakage risk, and fail-closed checker behavior. No actionable
+  defect found.
+- Codex Security diff scan `cb1de52e-4988-4fa8-a683-d214546a9a0c`: complete,
+  14/14 worklist rows covered, 0 findings.
+- `pulseplate-pr-review`: repo-governance review completed; current remaining
+  blockers are CI/governance state, not code-review actionables.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2057#pullrequestreview-4608060018
+Disposition: NOT-A-BUG
+Evidence: Sourcery generated a reviewer guide and file-level summary for this dependency-surface PR, with no inline code-review defect requiring a code or docs change.
+Reason: This bot review is governance-relevant feedback, not an actionable implementation defect.
+
+## Implementing Commits
+
+- `80c56590f` - `chore(deps): enforce dependency ownership`
+- `94c903e1e` - `docs(review): add dependency ownership evidence`
+- `4131cf325` - `fix(deps): satisfy dependency checker typing`
+
+## Local Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py --mode analyze`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/ci/check_python_dependency_surfaces.py`
+- PASS: `python3 verify_requirements.py`
+- PASS: `.venv/bin/python -m pytest -q tests/test_python_dependency_surfaces.py tests/test_python_supply_chain_controls.py`
+- PASS: `.venv/bin/python -m pytest -q tests/test_openapi_namespace_guards.py tests/test_exports.py tests/test_bmi_visualization.py`
+- PASS: `python3 scripts/ci/install_locked_python_requirements.py --preflight-only`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS: `pre-commit run --hook-stage pre-push mypy --files scripts/ci/check_python_dependency_surfaces.py`
+- PASS: `git diff --check`
+
+Private proxy local evidence:
+
+- PASS: `PULSEPLATE_PYTHON_INDEX_URL=https://packages.pulseplate.app/root/pulseplate/+simple/ python3 scripts/ci/check_private_python_proxy_health.py --requirements-file requirements.txt --requirements-file requirements-ci-lite.txt --requirements-file requirements-data.txt --project aiosqlite --project cryptography --project requests --project pyarrow --python-version 3.11 --python-version 3.12 --python-version 3.13`
+- PASS: `PULSEPLATE_PYTHON_INDEX_URL=https://packages.pulseplate.app/root/pulseplate/+simple/ python3 scripts/ci/check_private_python_proxy_health.py --requirements-file requirements.txt --requirements-file requirements-ci-lite.txt --requirements-file requirements-data.txt --requirements-file requirements-test.txt --python-version 3.11 --python-version 3.12 --python-version 3.13`
+
+Current-head CI observation at artifact creation:
+
+- `PR Body Phase2 gates`: failing only because this artifact did not exist yet.
+- `Merge readiness gate`: failing only because this artifact did not exist yet.
+- `Private Python proxy health`: failing on upstream mirror `HTTP 502`
+  responses for `cryptography`, `requests`, `pytest-xdist`, `hypothesis`, and
+  `pgvector`; `aiosqlite` returned `200`.
+- `RAG Release Gates Smoke`: failing on an unrelated scheduled/smoke lane, not
+  caused by this dependency-surface diff.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/d608be4643c6.json`
+- Packet: `artifacts/orchestration/task_packets/066b799335fb.json`
+
+The packet paths are gitignored local provenance artifacts; they are recorded
+for operator traceability and are not canonical product/runtime evidence.
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/exp-7bcba836ae3b.json`
+
+Accepted oracle-only fallback evidence:
+
+- PASS: `python3 scripts/ci/check_python_dependency_surfaces.py`
+- PASS: `python3 verify_requirements.py`
+- PASS: `python3 -m pytest -q tests/test_python_dependency_surfaces.py tests/test_python_supply_chain_controls.py`
+
+Rejected attempt:
+
+- `exp-732a3a092f3a` was rejected before oracle execution because the local
+  zero-network sandbox required `unshare` on `PATH`.
+
+## Security Notes
+
+- No route, auth, billing, export runtime, LLM, secret, workflow-token, or
+  deployment surface changed.
+- The diff reduces runtime dependency surface by removing `pyarrow` from
+  runtime, CI-lite, aggregate, and constraints surfaces while keeping data/eval
+  ownership intact.
+- Legacy import evidence remains `legacy_compat_transitional`; it cannot create
+  canonical runtime authority.
+
+## Merge Readiness
+
+- [ ] Current-head CI is green.
+- [ ] Private proxy health is green or reclassified with current evidence.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`.
+- [ ] Required review wait-window completed.
+
+Merge readiness is not claimed in this artifact.

--- a/docs/review/PR_2057_FIXED_MAPPING.md
+++ b/docs/review/PR_2057_FIXED_MAPPING.md
@@ -48,6 +48,16 @@ Disposition: FIXED
 Evidence: `tests/test_python_supply_chain_controls.py:945`, `tests/test_python_supply_chain_controls.py:949`, `scripts/ci/check_python_dependency_surfaces.py:359`, `scripts/ci/check_python_dependency_surfaces.py:383`, and `tests/test_python_supply_chain_controls.py:319`.
 Reason: CodeRabbit's Docker-runtime `pyarrow` coverage request was valid and fixed in `c3ba71934`. Its `_requirement_package_names` signature concern was not a bug: the production helper takes `(repo_root, relative_path)` and its call site passes both arguments, while `tests/test_python_supply_chain_controls.py` defines a separate local test helper that intentionally takes a single `Path`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2057#discussion_r3505987597
+Disposition: NOT-A-BUG
+Evidence: `scripts/ci/check_python_dependency_surfaces.py:359`, `scripts/ci/check_python_dependency_surfaces.py:383`, `tests/test_python_supply_chain_controls.py:319`, `tests/test_python_supply_chain_controls.py:382`, and `tests/test_python_supply_chain_controls.py:1181`.
+Reason: The production dependency-surface helper intentionally takes `(repo_root, relative_path)`, and its production call site passes both arguments. The one-argument calls are to the separate local test helper in `tests/test_python_supply_chain_controls.py`, so they do not exercise the production helper signature and cannot raise the reported `TypeError`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2057#discussion_r3505987623 -> c3ba71934
+Disposition: FIXED
+Evidence: `tests/test_python_supply_chain_controls.py:945` and `tests/test_python_supply_chain_controls.py:949`.
+Reason: The checked-in Docker runtime requirement input and lock surfaces are now covered by repo-level `pyarrow` absence assertions.
+
 ## Implementing Commits
 
 - `80c56590f` - `chore(deps): enforce dependency ownership`
@@ -55,6 +65,7 @@ Reason: CodeRabbit's Docker-runtime `pyarrow` coverage request was valid and fix
 - `4131cf325` - `fix(deps): satisfy dependency checker typing`
 - `b68239aba` - `fix(deps): use explicit import ownership aliases`
 - `c3ba71934` - `test(deps): guard pyarrow out of docker runtime`
+- `13713f741` - `docs(review): map dependency ownership bot findings`
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_2057_FIXED_MAPPING.md
+++ b/docs/review/PR_2057_FIXED_MAPPING.md
@@ -9,7 +9,8 @@ Canonical review-governance artifact for PR #2057:
   `pyarrow`, `pandas`, `httpx2`, `reportlab`, `matplotlib`, `numpy`, and
   `aiosqlite`.
 - Remove `pyarrow` from runtime, CI-lite, aggregate, and constraints surfaces
-  after confirming no canonical runtime owner.
+  after confirming no canonical runtime owner, and guard Docker runtime against
+  future `pyarrow` reintroduction.
 - Keep `pyarrow` in data dependency surfaces.
 - Preserve legacy compatibility as transitional evidence, not canonical runtime
   authority.
@@ -21,13 +22,15 @@ Canonical review-governance artifact for PR #2057:
 
 Post-open pass status:
 
-- `qa-engineer-agent`: reviewed the dependency checker, focused tests,
-  generated requirements surfaces, and docs. No actionable defect found.
+- `qa-engineer-agent`: found missing Docker-runtime `pyarrow` guard coverage
+  and an incomplete `pyarrow` docs row. Fixed in `b68239aba`; final rerun found
+  no blocking findings.
 - `bug-hunter`: reviewed pyarrow removal boundaries, warning-only severity
-  tiers, and legacy-only ownership blocking. No actionable defect found.
+  tiers, legacy-only ownership blocking, and generated requirement surfaces. No
+  blocking findings at `b68239aba`.
 - `security-auditor`: reviewed supply-chain/runtime authority boundaries,
-  local-path leakage risk, and fail-closed checker behavior. No actionable
-  defect found.
+  import-alias false-positive/negative risk, local-path leakage risk, and
+  fail-closed checker behavior. No blocking findings at `b68239aba`.
 - Codex Security diff scan `cb1de52e-4988-4fa8-a683-d214546a9a0c`: complete,
   14/14 worklist rows covered, 0 findings.
 - `pulseplate-pr-review`: repo-governance review completed; current remaining
@@ -35,16 +38,17 @@ Post-open pass status:
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2057#pullrequestreview-4608060018
-Disposition: NOT-A-BUG
-Evidence: Sourcery generated a reviewer guide and file-level summary for this dependency-surface PR, with no inline code-review defect requiring a code or docs change.
-Reason: This bot review is governance-relevant feedback, not an actionable implementation defect.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2057#pullrequestreview-4608060018 -> b68239aba
+Disposition: FIXED
+Evidence: `scripts/ci/check_python_dependency_surfaces.py:120`, `scripts/ci/check_python_dependency_surfaces.py:404`, `scripts/ci/check_python_dependency_surfaces.py:408`, `tests/test_python_dependency_surfaces.py:443`, `tests/test_python_dependency_surfaces.py:491`, and `docs/contracts/PYTHON_DEPENDENCY_SURFACES.md:79`.
+Reason: Sourcery's high-level feedback identified blind underscore-to-hyphen import normalization risk and a stale `ownership_ok` reason-code doc entry. Commit `b68239aba` replaced blind import normalization with explicit distribution/import aliases, added positive and negative alias tests, removed `ownership_ok`, and added Docker-runtime `pyarrow` regression coverage found by the follow-up QA pass.
 
 ## Implementing Commits
 
 - `80c56590f` - `chore(deps): enforce dependency ownership`
 - `94c903e1e` - `docs(review): add dependency ownership evidence`
 - `4131cf325` - `fix(deps): satisfy dependency checker typing`
+- `b68239aba` - `fix(deps): use explicit import ownership aliases`
 
 ## Local Validation Evidence
 
@@ -67,13 +71,14 @@ Private proxy local evidence:
 
 Current-head CI observation at artifact creation:
 
-- `PR Body Phase2 gates`: failing only because this artifact did not exist yet.
-- `Merge readiness gate`: failing only because this artifact did not exist yet.
-- `Private Python proxy health`: failing on upstream mirror `HTTP 502`
-  responses for `cryptography`, `requests`, `pytest-xdist`, `hypothesis`, and
-  `pgvector`; `aiosqlite` returned `200`.
-- `RAG Release Gates Smoke`: failing on an unrelated scheduled/smoke lane, not
-  caused by this dependency-surface diff.
+- Superseded run `28518112575` on `b68239aba` was cancelled by newer same-head
+  CI and is not current-head merge truth.
+- Current same-head run `28518269941` on `b68239aba` completed successfully:
+  `PR Body Phase2 gates`, `Merge readiness gate`, `Private Python proxy health`,
+  `lint`, `security`, `OpenAPI sync`, `test-pr (3.13)`, `coverage-pr`, and
+  `diff-coverage` passed.
+- A later governance-only mapping update must still be rechecked before merge;
+  this artifact does not replace the strict current-head merge-readiness wrapper.
 
 ## Lane Start Provenance
 

--- a/docs/review/PR_DEPS_OWNERSHIP_EXPERIMENT_RUNNER_EVIDENCE.md
+++ b/docs/review/PR_DEPS_OWNERSHIP_EXPERIMENT_RUNNER_EVIDENCE.md
@@ -1,0 +1,42 @@
+# Dependency Ownership Experiment Runner Evidence
+
+Branch: `codex/deps-ownership-pyarrow-cleanup`
+
+Mode: `oracle_only_governance_reviewer`
+
+## Zero-Network Attempt
+
+- Experiment ID: `exp-732a3a092f3a`
+- Result artifact: `artifacts/orchestration/experiments/results/exp-732a3a092f3a.json`
+- Status: `rejected`
+- Failure class: `infra_flake`
+- Runner error: `Network-disabled sandbox requires unshare on PATH`
+- Oracle commands executed: `0`
+
+Disposition: local infrastructure blocker. The macOS host does not provide Linux `unshare`, so the zero-network sandbox could not execute any oracle command.
+
+## Review-Required Fallback
+
+- Experiment ID: `exp-7bcba836ae3b`
+- Result artifact: `artifacts/orchestration/experiments/results/exp-7bcba836ae3b.json`
+- Status: `accepted`
+- Failure class: `null`
+- Runner mode: `oracle_only_governance_reviewer`
+- Network budget: `1`
+- Shared tree untouched: `true`
+- Contribution kind: `oracle_review`
+- Co-author required: `true`
+
+The accepted fallback used the same oracle-only governance intent and an explicit nonzero network budget to avoid the local `unshare` blocker. It is review-required evidence and does not replace local gates, current-head CI, post-open role passes, Codex Security, `pulseplate-pr-review`, or merge-readiness checks.
+
+## Oracle Commands
+
+All fallback oracle commands returned `0`:
+
+- `python3 scripts/ci/check_python_dependency_surfaces.py`
+- `python3 verify_requirements.py`
+- `python3 -m pytest -q tests/test_python_dependency_surfaces.py tests/test_python_supply_chain_controls.py`
+
+## Decision
+
+Use `exp-7bcba836ae3b` as the pre-open Experiment Runner oracle-only evidence for this PR, with the local zero-network infra limitation disclosed.

--- a/docs/review/PR_DEPS_OWNERSHIP_PREMORTEM.md
+++ b/docs/review/PR_DEPS_OWNERSHIP_PREMORTEM.md
@@ -1,0 +1,113 @@
+# Dependency Ownership Premortem
+
+Branch: `codex/deps-ownership-pyarrow-cleanup`
+
+Frame: it is 48 hours from now, and this dependency cleanup made `main` worse. The failure review below focuses on this exact diff: dependency-surface policy, runtime/CI lockfiles, and legacy ownership boundaries.
+
+## Role Pass Summary
+
+- `agent-coordinator`: scope remains dependency ownership only; no route, OpenAPI, runtime behavior, Docker, SQLite, or de-legacy extraction changes.
+- `architecture-specialist`: legacy import evidence must stay transitional; canonical ownership must come from app/bootstrap, routers, services, core, or providers, with `app/services/bmi_compat.py` treated as transitional unless a future BMI owner decision promotes it.
+- `security-auditor`: smaller runtime/CI dependency surface is positive only if generated locks avoid unrelated unsafe `pip` stanzas, local-path leakage, and fail-open validator wording.
+- `qa-engineer-agent`: acceptance requires negative tests for blocking packages and report-only tests for transitional packages.
+- `bug-hunter`: highest false-green risk is a broad validator that blocks future PRs on unaudited packages or a broad lock regeneration that hides unrelated upgrades.
+- `cursor-specialist-agent`: PR docs and future fixed mapping must use repo-relative paths only.
+
+## Findings
+
+### PM-DEPS-001: Validator becomes a broad permanent red guard
+
+Failure story: the checker starts enforcing every import/dependency mismatch in the repository. Future PRs unrelated to dependency hygiene fail on dynamic, lazy, or transitional imports, and the team starts bypassing the checker or treating it as noisy infrastructure.
+
+Underlying assumption: import evidence alone is enough to decide all dependency ownership.
+
+Early warning signs: new errors mention unaudited packages; warnings are mixed into hard failures without a severity boundary.
+
+Containment action: keep default hard failures scoped to `pyarrow`, `pandas`, `httpx2`, and legacy-only canonical authority in the audited subset.
+
+Disposition: FIXED. `scripts/ci/check_python_dependency_surfaces.py` emits `error`, `warning`, and `info` tiers and only fails `error` findings for the first audited subset.
+
+### PM-DEPS-002: Legacy BMI paths legitimize `matplotlib`
+
+Failure story: because `legacy_app.py` or root `bmi_visualization.py` references BMI visualization compatibility, reviewers conclude `matplotlib` is a canonical runtime dependency. The next cleanup cannot remove or extract it because infra docs have made legacy usage permanent authority.
+
+Underlying assumption: any runtime import is ownership evidence.
+
+Early warning signs: docs say `matplotlib` is runtime-owned by `legacy_app.py`; checker reports it as `canonical_runtime_owner_documented`.
+
+Containment action: classify legacy BMI evidence as `legacy_compat_transitional` and require a future BMI owner decision before canonical promotion.
+
+Disposition: FIXED. The checker reports current `matplotlib` as `warning:legacy_compat_transitional`, and docs state that legacy usage is transitional pressure, not ownership.
+
+### PM-DEPS-003: `pyarrow` is removed from data/eval by accident
+
+Failure story: the cleanup removes `pyarrow` from every requirements file, breaking offline data builders and Parquet-capable eval/data workflows while claiming runtime shrink success.
+
+Underlying assumption: non-runtime means unused everywhere.
+
+Early warning signs: `requirements-data.in` or `requirements-data.txt` loses `pyarrow`; data profile tests no longer assert the package.
+
+Containment action: remove `pyarrow` only from runtime, CI-lite, aggregate, and constraints surfaces while keeping data ownership explicit.
+
+Disposition: FIXED. `requirements-data.in` and `requirements-data.txt` still carry `pyarrow`; tests assert runtime/CI-lite absence and data presence.
+
+### PM-DEPS-004: Lock regeneration reintroduces unsafe `pip` pins or broad churn
+
+Failure story: `pip-compile --allow-unsafe` removes `pyarrow` but also adds `pip==...` unsafe stanzas or unrelated package upgrades. The PR becomes a hidden supply-chain change instead of an ownership cleanup.
+
+Underlying assumption: regenerated output is always acceptable as-is.
+
+Early warning signs: diffs in `requirements-ci-lite.txt` or `requirements-lock.txt` include `pip==` or unrelated version changes.
+
+Containment action: review lock diffs after compile and keep the lockfile diff limited to `pyarrow` removal.
+
+Disposition: FIXED. Generated unsafe `pip==26.1.2` stanzas were rejected; final lock diff removes only `pyarrow` stanzas from runtime/CI-lite/aggregate locks.
+
+### PM-DEPS-005: Proxy proof is misleading
+
+Failure story: the private proxy health check is reported red because local `PULSEPLATE_PYTHON_INDEX_URL` points at `/root/pypi/+simple/`, or because the default probes include test-only packages while the command omits `requirements-test.txt`. Reviewers treat that as dependency mirror breakage from this PR.
+
+Underlying assumption: the pasted proxy command is always self-contained in every local environment.
+
+Early warning signs: reason `unexpected_index_path` or `missing_exact_pin_in_requirements` appears before any package mirror failure.
+
+Containment action: run the planned requirements with canonical URL and explicit pinned projects, and run the default probe set with `requirements-test.txt` included.
+
+Disposition: NOT-A-BUG. The canonical URL targeted check passed for `aiosqlite`, `cryptography`, `requests`, and data-only `pyarrow`; the default probe set also passed once `requirements-test.txt` supplied the expected test pins.
+
+### PM-DEPS-006: Experiment Runner evidence is overstated
+
+Failure story: the PR body says Experiment Runner passed without noting that the zero-network oracle was blocked locally by missing Linux `unshare`. The evidence looks stronger than it is.
+
+Underlying assumption: all Experiment Runner accepted artifacts are equivalent.
+
+Early warning signs: local result has `failure_class=infra_flake` and no oracle results; accepted fallback uses nonzero `network_budget`.
+
+Containment action: record both artifacts and state that the accepted fallback is review-required evidence, not a replacement for local gates or current-head CI.
+
+Disposition: FIXED. `docs/review/PR_DEPS_OWNERSHIP_EXPERIMENT_RUNNER_EVIDENCE.md` records the zero-network infra failure and the accepted `network_budget=1` oracle-only fallback.
+
+## Revised Plan
+
+- Keep hard failures limited to the audited package subset.
+- Keep `matplotlib`, `numpy`, and `aiosqlite` as warning/report-only classifications.
+- Remove `pyarrow` only from runtime, CI-lite, aggregate, and constraints surfaces.
+- Preserve `reportlab` canonical export/PDF ownership.
+- Keep docs and future PR body/fixed mapping repo-relative.
+- Do not claim merge readiness until post-open roles, bot review, current-head CI, and review-thread disposition pass.
+
+## Pre-Merge Checklist
+
+- `python3 scripts/ci/check_python_dependency_surfaces.py`
+- `python3 verify_requirements.py`
+- `.venv/bin/python -m pytest -q tests/test_python_dependency_surfaces.py tests/test_python_supply_chain_controls.py`
+- `.venv/bin/python -m pytest -q tests/test_openapi_namespace_guards.py tests/test_exports.py tests/test_bmi_visualization.py`
+- `python3 scripts/ci/install_locked_python_requirements.py --preflight-only`
+- `make validate-changed`
+- `pre-commit run --all-files`
+- `git diff --check`
+- Current-head CI and post-open `qa-engineer-agent -> bug-hunter -> security-auditor`, Codex Security diff scan, and `pulseplate-pr-review`.
+
+## Decision
+
+Proceed with changes. The diff is narrow enough for PR open after local gates, with the Experiment Runner fallback clearly labeled as review-required evidence and not as merge readiness.

--- a/requirements-ci-lite.in
+++ b/requirements-ci-lite.in
@@ -37,7 +37,6 @@ psycopg[binary]>=3.2.3,<4.0.0
 email-validator>=2.3.0,<3.0.0
 cryptography>=48.0.1,<49.0.0
 nh3>=0.3.2,<1.0.0
-pyarrow>=20.0.0,<25.0.0
 setuptools>=78.1.1,<79.0.0
 
 # Control-plane CI tooling only.

--- a/requirements-ci-lite.txt
+++ b/requirements-ci-lite.txt
@@ -275,10 +275,6 @@ psycopg-binary==3.3.3
     #   psycopg
 py-serializable==2.1.0
     # via cyclonedx-python-lib
-pyarrow==23.0.1
-    # via
-    #   -c requirements.txt
-    #   -r requirements-ci-lite.in
 pycparser==2.23
     # via
     #   -c requirements.txt

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -335,10 +335,6 @@ psycopg-binary==3.3.3
     #   psycopg
 py-serializable==2.1.0
     # via cyclonedx-python-lib
-pyarrow==23.0.1
-    # via
-    #   -c requirements.txt
-    #   -r requirements.in
 pycodestyle==2.14.0
     # via flake8
 pycparser==2.23

--- a/requirements.in
+++ b/requirements.in
@@ -43,7 +43,5 @@ cryptography>=48.0.1,<49.0.0
 # Optional: Required for premium endpoints (plate visualization with HTML sanitization).
 # Runtime-guarded via _require_nh3(); raises clear error if missing.
 nh3>=0.3.2,<1.0.0
-# PyArrow wheels for Python 3.13+
-pyarrow>=20.0.0,<25.0.0
 # Security: setuptools>=78.1.1 includes patched jaraco.context>=6.1.0 (GHSA-58pv-8j8x-9vj2)
 setuptools>=78.1.1,<79.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,8 +132,6 @@ psycopg[binary]==3.3.3
     # via -r requirements.in
 psycopg-binary==3.3.3
     # via psycopg
-pyarrow==23.0.1
-    # via -r requirements.in
 pycparser==2.23
     # via cffi
 pydantic==2.13.4

--- a/scripts/ci/check_python_dependency_surfaces.py
+++ b/scripts/ci/check_python_dependency_surfaces.py
@@ -16,6 +16,7 @@ import sys
 
 from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -58,6 +59,82 @@ WORKFLOW_PATH_ENTRY_RE = re.compile(
     r"^\s*-\s*[\"']?(?P<path>requirements[-A-Za-z0-9_]*\.(?:in|txt))[\"']?\s*$"
 )
 DEPENDENCY_SUBMISSION_TRIGGER_EVENTS = ("push", "pull_request")
+
+OWNERSHIP_ERROR = "error"
+OWNERSHIP_WARNING = "warning"
+OWNERSHIP_INFO = "info"
+OWNERSHIP_SEVERITIES = (OWNERSHIP_ERROR, OWNERSHIP_WARNING, OWNERSHIP_INFO)
+
+AUDITED_OWNERSHIP_PACKAGES = (
+    "pyarrow",
+    "pandas",
+    "httpx2",
+    "reportlab",
+    "matplotlib",
+    "numpy",
+    "aiosqlite",
+)
+RUNTIME_REQUIREMENT_SURFACES = (
+    "requirements.in",
+    "requirements.txt",
+)
+CI_LITE_REQUIREMENT_SURFACES = (
+    "requirements-ci-lite.in",
+    "requirements-ci-lite.txt",
+)
+DOCKER_RUNTIME_REQUIREMENT_SURFACES = (
+    "requirements-docker-runtime.in",
+    "requirements-docker-runtime.txt",
+)
+RUNTIME_CI_LITE_REQUIREMENT_SURFACES = (
+    *RUNTIME_REQUIREMENT_SURFACES,
+    *CI_LITE_REQUIREMENT_SURFACES,
+)
+RUNTIME_DOCKER_CI_LITE_REQUIREMENT_SURFACES = (
+    *RUNTIME_REQUIREMENT_SURFACES,
+    *CI_LITE_REQUIREMENT_SURFACES,
+    *DOCKER_RUNTIME_REQUIREMENT_SURFACES,
+)
+PYARROW_FORBIDDEN_RUNTIME_SURFACES = (
+    *RUNTIME_CI_LITE_REQUIREMENT_SURFACES,
+    "requirements-lock.txt",
+)
+RUNTIME_DECLARATION_SURFACES = (
+    "requirements.in",
+    "requirements-ci-lite.in",
+    "requirements-docker-runtime.in",
+)
+CANONICAL_RUNTIME_OWNER_ROOTS = (
+    Path("app/bootstrap"),
+    Path("app/routers"),
+    Path("app/services"),
+    Path("core"),
+    Path("providers"),
+)
+LEGACY_COMPAT_OWNER_PATHS = (
+    Path("legacy_app.py"),
+    Path("bmi_visualization.py"),
+    Path("app/services/bmi_compat.py"),
+)
+LEGACY_COMPAT_TRANSITIONAL_PATHS = set(LEGACY_COMPAT_OWNER_PATHS)
+
+
+@dataclass(frozen=True)
+class DependencyOwnershipFinding:
+    """One first-pass dependency ownership audit finding."""
+
+    package: str
+    severity: str
+    reason_code: str
+    surfaces: tuple[str, ...]
+    detail: str
+
+    def to_message(self) -> str:
+        surface_text = ", ".join(self.surfaces) if self.surfaces else "repo imports"
+        return (
+            f"{self.package}: {self.severity}:{self.reason_code}: "
+            f"{self.detail} [{surface_text}]"
+        )
 
 
 @dataclass(frozen=True)
@@ -271,6 +348,116 @@ def _is_requirement_line(line: str) -> bool:
     return True
 
 
+def _normalize_package_name(package_name: str) -> str:
+    return canonicalize_name(package_name)
+
+
+def _requirement_package_names(repo_root: Path, relative_path: str | Path) -> set[str]:
+    names: set[str] = set()
+    for raw_line in _read_text(repo_root, relative_path).splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not _is_requirement_line(line):
+            continue
+        try:
+            requirement = Requirement(line)
+        except InvalidRequirement:
+            continue
+        names.add(_normalize_package_name(requirement.name))
+    return names
+
+
+def _surfaces_containing_package(
+    repo_root: Path,
+    package: str,
+    surfaces: tuple[str, ...],
+) -> tuple[str, ...]:
+    package_name = _normalize_package_name(package)
+    matches: list[str] = []
+    for surface in surfaces:
+        if not (repo_root / surface).is_file():
+            continue
+        if package_name in _requirement_package_names(repo_root, surface):
+            matches.append(surface)
+    return tuple(matches)
+
+
+def _iter_python_files(repo_root: Path, paths: tuple[Path, ...]) -> tuple[Path, ...]:
+    python_files: list[Path] = []
+    for relative_path in paths:
+        candidate = repo_root / relative_path
+        if candidate.is_file() and candidate.suffix == ".py":
+            python_files.append(relative_path)
+            continue
+        if candidate.is_dir():
+            python_files.extend(
+                path.relative_to(repo_root)
+                for path in sorted(candidate.rglob("*.py"))
+                if path.is_file()
+            )
+    return tuple(python_files)
+
+
+def _top_level_import_name(module_name: str) -> str:
+    return _normalize_package_name(module_name.split(".", 1)[0].replace("_", "-"))
+
+
+def _imports_package(repo_root: Path, relative_path: Path, package: str) -> bool:
+    package_name = _normalize_package_name(package)
+    try:
+        tree = ast.parse(
+            _read_text(repo_root, relative_path),
+            filename=str(relative_path),
+        )
+    except SyntaxError:
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _top_level_import_name(alias.name) == package_name:
+                    return True
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            if _top_level_import_name(node.module) == package_name:
+                return True
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "import_module"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+            and _top_level_import_name(node.args[0].value) == package_name
+        ):
+            return True
+    return False
+
+
+def _package_import_evidence(
+    repo_root: Path,
+    package: str,
+    paths: tuple[Path, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        str(relative_path)
+        for relative_path in _iter_python_files(repo_root, paths)
+        if _imports_package(repo_root, relative_path, package)
+    )
+
+
+def _canonical_runtime_import_evidence(repo_root: Path, package: str) -> tuple[str, ...]:
+    evidence = []
+    for relative_path in _package_import_evidence(
+        repo_root, package, CANONICAL_RUNTIME_OWNER_ROOTS
+    ):
+        if Path(relative_path) not in LEGACY_COMPAT_TRANSITIONAL_PATHS:
+            evidence.append(relative_path)
+    return tuple(evidence)
+
+
+def _legacy_compat_import_evidence(repo_root: Path, package: str) -> tuple[str, ...]:
+    return _package_import_evidence(repo_root, package, LEGACY_COMPAT_OWNER_PATHS)
+
+
 def _pip_audit_manifest_entries(script_text: str) -> set[str]:
     """Return lockfiles listed in the pip-audit manifest array."""
     entries: set[str] = set()
@@ -460,6 +647,9 @@ def _validate_docs(repo_root: Path, errors: list[str]) -> None:
             errors.append(f"{CONTRACT_DOC}: missing dependency surface {surface_file}.")
     for required_phrase in (
         "Noncanonical Aggregate Install Surfaces",
+        "Dependency Ownership Audit",
+        "legacy_compat_transitional",
+        "Legacy usage is evidence of transitional compatibility pressure",
         "requirements-all.txt",
         "requirements-lock.txt",
         "scripts/ci/check_python_dependency_surfaces.py",
@@ -477,6 +667,234 @@ def _validate_docs(repo_root: Path, errors: list[str]) -> None:
         ):
             if required_phrase not in text:
                 errors.append(f"{doc_path}: missing reference to {required_phrase}.")
+
+
+def _ownership_finding(
+    *,
+    package: str,
+    severity: str,
+    reason_code: str,
+    surfaces: tuple[str, ...],
+    detail: str,
+) -> DependencyOwnershipFinding:
+    if severity not in OWNERSHIP_SEVERITIES:
+        raise ValueError(f"Unknown dependency ownership severity: {severity}")
+    return DependencyOwnershipFinding(
+        package=package,
+        severity=severity,
+        reason_code=reason_code,
+        surfaces=surfaces,
+        detail=detail,
+    )
+
+
+def _legacy_only_runtime_authority_finding(
+    *,
+    package: str,
+    evidence: tuple[str, ...],
+) -> DependencyOwnershipFinding:
+    return _ownership_finding(
+        package=package,
+        severity=OWNERSHIP_ERROR,
+        reason_code="legacy_only_runtime_authority_forbidden",
+        surfaces=evidence,
+        detail="legacy compatibility evidence cannot create canonical runtime ownership",
+    )
+
+
+def collect_dependency_ownership_findings(
+    repo_root: Path = REPO_ROOT,
+) -> tuple[DependencyOwnershipFinding, ...]:
+    """Return first-pass audited dependency ownership findings.
+
+    This audit intentionally covers only the approved package subset. Import
+    evidence is policy context, not a generic dependency trimmer.
+    """
+
+    findings: list[DependencyOwnershipFinding] = []
+
+    pyarrow_surfaces = _surfaces_containing_package(
+        repo_root,
+        "pyarrow",
+        PYARROW_FORBIDDEN_RUNTIME_SURFACES,
+    )
+    if pyarrow_surfaces:
+        canonical_pyarrow = _canonical_runtime_import_evidence(repo_root, "pyarrow")
+        legacy_pyarrow = _legacy_compat_import_evidence(repo_root, "pyarrow")
+        if canonical_pyarrow:
+            findings.append(
+                _ownership_finding(
+                    package="pyarrow",
+                    severity=OWNERSHIP_INFO,
+                    reason_code="canonical_runtime_owner_documented",
+                    surfaces=canonical_pyarrow,
+                    detail="canonical runtime import evidence exists; do not quarantine blindly",
+                )
+            )
+        elif legacy_pyarrow:
+            findings.append(
+                _legacy_only_runtime_authority_finding(
+                    package="pyarrow",
+                    evidence=legacy_pyarrow,
+                )
+            )
+        else:
+            findings.append(
+                _ownership_finding(
+                    package="pyarrow",
+                    severity=OWNERSHIP_ERROR,
+                    reason_code="runtime_direct_no_canonical_owner",
+                    surfaces=pyarrow_surfaces,
+                    detail=(
+                        "runtime/ci-lite or aggregate surfaces include pyarrow without "
+                        "canonical app/core/provider ownership"
+                    ),
+                )
+            )
+
+    pandas_surfaces = _surfaces_containing_package(
+        repo_root,
+        "pandas",
+        RUNTIME_DOCKER_CI_LITE_REQUIREMENT_SURFACES,
+    )
+    if pandas_surfaces:
+        findings.append(
+            _ownership_finding(
+                package="pandas",
+                severity=OWNERSHIP_ERROR,
+                reason_code="data_eval_dependency_in_runtime",
+                surfaces=pandas_surfaces,
+                detail="pandas is owned by data/eval scripts and must stay out of runtime/Docker/ci-lite",
+            )
+        )
+
+    httpx2_surfaces = _surfaces_containing_package(
+        repo_root,
+        "httpx2",
+        RUNTIME_DOCKER_CI_LITE_REQUIREMENT_SURFACES,
+    )
+    if httpx2_surfaces:
+        findings.append(
+            _ownership_finding(
+                package="httpx2",
+                severity=OWNERSHIP_ERROR,
+                reason_code="test_dev_dependency_in_runtime",
+                surfaces=httpx2_surfaces,
+                detail="httpx2 is the Starlette TestClient backend and must stay test/dev-only",
+            )
+        )
+
+    reportlab_surfaces = _surfaces_containing_package(
+        repo_root,
+        "reportlab",
+        RUNTIME_DOCKER_CI_LITE_REQUIREMENT_SURFACES,
+    )
+    if reportlab_surfaces:
+        reportlab_evidence = _canonical_runtime_import_evidence(repo_root, "reportlab")
+        reportlab_legacy_evidence = _legacy_compat_import_evidence(repo_root, "reportlab")
+        if reportlab_evidence:
+            findings.append(
+                _ownership_finding(
+                    package="reportlab",
+                    severity=OWNERSHIP_INFO,
+                    reason_code="canonical_runtime_owner_documented",
+                    surfaces=reportlab_evidence,
+                    detail="export/pdf modules provide canonical runtime ownership",
+                )
+            )
+        elif reportlab_legacy_evidence:
+            findings.append(
+                _legacy_only_runtime_authority_finding(
+                    package="reportlab",
+                    evidence=reportlab_legacy_evidence,
+                )
+            )
+        else:
+            findings.append(
+                _ownership_finding(
+                    package="reportlab",
+                    severity=OWNERSHIP_ERROR,
+                    reason_code="runtime_direct_no_canonical_owner",
+                    surfaces=reportlab_surfaces,
+                    detail="reportlab is in runtime surfaces without canonical export/pdf evidence",
+                )
+            )
+
+    matplotlib_surfaces = _surfaces_containing_package(
+        repo_root,
+        "matplotlib",
+        RUNTIME_CI_LITE_REQUIREMENT_SURFACES,
+    )
+    if matplotlib_surfaces:
+        matplotlib_canonical = _canonical_runtime_import_evidence(repo_root, "matplotlib")
+        matplotlib_legacy = _legacy_compat_import_evidence(repo_root, "matplotlib")
+        if not matplotlib_canonical and matplotlib_legacy:
+            findings.append(
+                _ownership_finding(
+                    package="matplotlib",
+                    severity=OWNERSHIP_WARNING,
+                    reason_code="legacy_compat_transitional",
+                    surfaces=matplotlib_legacy,
+                    detail=(
+                        "legacy BMI visualization evidence is transitional pressure, "
+                        "not canonical runtime authority"
+                    ),
+                )
+            )
+        elif matplotlib_canonical:
+            findings.append(
+                _ownership_finding(
+                    package="matplotlib",
+                    severity=OWNERSHIP_INFO,
+                    reason_code="canonical_runtime_owner_documented",
+                    surfaces=matplotlib_canonical,
+                    detail="canonical BMI visualization owner is documented by import evidence",
+                )
+            )
+        else:
+            findings.append(
+                _ownership_finding(
+                    package="matplotlib",
+                    severity=OWNERSHIP_WARNING,
+                    reason_code="legacy_compat_transitional",
+                    surfaces=matplotlib_surfaces,
+                    detail="matplotlib remains pending the BMI visualization ownership decision",
+                )
+            )
+
+    numpy_direct_surfaces = _surfaces_containing_package(
+        repo_root,
+        "numpy",
+        RUNTIME_DECLARATION_SURFACES,
+    )
+    if numpy_direct_surfaces and not _canonical_runtime_import_evidence(repo_root, "numpy"):
+        findings.append(
+            _ownership_finding(
+                package="numpy",
+                severity=OWNERSHIP_WARNING,
+                reason_code="transitive_only_direct_runtime_candidate",
+                surfaces=numpy_direct_surfaces,
+                detail="numpy has no direct canonical runtime import evidence and may be transitive-only",
+            )
+        )
+
+    aiosqlite_surfaces = _surfaces_containing_package(
+        repo_root,
+        "aiosqlite",
+        RUNTIME_DOCKER_CI_LITE_REQUIREMENT_SURFACES,
+    )
+    if aiosqlite_surfaces:
+        findings.append(
+            _ownership_finding(
+                package="aiosqlite",
+                severity=OWNERSHIP_WARNING,
+                reason_code="db_fallback_test_split_pending",
+                surfaces=aiosqlite_surfaces,
+                detail="sqlite async fallback/test ownership needs a separate DB-surface decision",
+            )
+        )
+
+    return tuple(findings)
 
 
 def validate_repo(repo_root: Path = REPO_ROOT) -> list[str]:
@@ -509,6 +927,11 @@ def validate_repo(repo_root: Path = REPO_ROOT) -> list[str]:
     _validate_shared_profiles(repo_root, errors)
     _validate_security_coverage(repo_root, errors)
     _validate_docs(repo_root, errors)
+    errors.extend(
+        finding.to_message()
+        for finding in collect_dependency_ownership_findings(repo_root)
+        if finding.severity == OWNERSHIP_ERROR
+    )
     return errors
 
 
@@ -531,6 +954,15 @@ def main(argv: list[str] | None = None) -> int:
         for error in errors:
             print(f"- {error}")
         return 1
+
+    findings = collect_dependency_ownership_findings(args.repo_root)
+    reported_findings = [
+        finding for finding in findings if finding.severity in {OWNERSHIP_WARNING, OWNERSHIP_INFO}
+    ]
+    if reported_findings:
+        print("Python dependency ownership audit:")
+        for finding in reported_findings:
+            print(f"- {finding.to_message()}")
 
     print("PASS: Python dependency surfaces match the canonical contract.")
     return 0

--- a/scripts/ci/check_python_dependency_surfaces.py
+++ b/scripts/ci/check_python_dependency_surfaces.py
@@ -349,7 +349,7 @@ def _is_requirement_line(line: str) -> bool:
 
 
 def _normalize_package_name(package_name: str) -> str:
-    return canonicalize_name(package_name)
+    return str(canonicalize_name(package_name))
 
 
 def _requirement_package_names(repo_root: Path, relative_path: str | Path) -> set[str]:

--- a/scripts/ci/check_python_dependency_surfaces.py
+++ b/scripts/ci/check_python_dependency_surfaces.py
@@ -96,7 +96,7 @@ RUNTIME_DOCKER_CI_LITE_REQUIREMENT_SURFACES = (
     *DOCKER_RUNTIME_REQUIREMENT_SURFACES,
 )
 PYARROW_FORBIDDEN_RUNTIME_SURFACES = (
-    *RUNTIME_CI_LITE_REQUIREMENT_SURFACES,
+    *RUNTIME_DOCKER_CI_LITE_REQUIREMENT_SURFACES,
     "requirements-lock.txt",
 )
 RUNTIME_DECLARATION_SURFACES = (
@@ -117,6 +117,10 @@ LEGACY_COMPAT_OWNER_PATHS = (
     Path("app/services/bmi_compat.py"),
 )
 LEGACY_COMPAT_TRANSITIONAL_PATHS = set(LEGACY_COMPAT_OWNER_PATHS)
+PACKAGE_IMPORT_ALIASES = {
+    "pydantic-core": ("pydantic_core",),
+    "pytest-xdist": ("xdist",),
+}
 
 
 @dataclass(frozen=True)
@@ -398,11 +402,16 @@ def _iter_python_files(repo_root: Path, paths: tuple[Path, ...]) -> tuple[Path, 
 
 
 def _top_level_import_name(module_name: str) -> str:
-    return _normalize_package_name(module_name.split(".", 1)[0].replace("_", "-"))
+    return module_name.split(".", 1)[0]
+
+
+def _package_import_names(package: str) -> frozenset[str]:
+    package_name = _normalize_package_name(package)
+    return frozenset((package_name, *PACKAGE_IMPORT_ALIASES.get(package_name, ())))
 
 
 def _imports_package(repo_root: Path, relative_path: Path, package: str) -> bool:
-    package_name = _normalize_package_name(package)
+    package_import_names = _package_import_names(package)
     try:
         tree = ast.parse(
             _read_text(repo_root, relative_path),
@@ -414,10 +423,10 @@ def _imports_package(repo_root: Path, relative_path: Path, package: str) -> bool
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if _top_level_import_name(alias.name) == package_name:
+                if _top_level_import_name(alias.name) in package_import_names:
                     return True
         if isinstance(node, ast.ImportFrom) and node.module is not None:
-            if _top_level_import_name(node.module) == package_name:
+            if _top_level_import_name(node.module) in package_import_names:
                 return True
         if (
             isinstance(node, ast.Call)
@@ -426,7 +435,7 @@ def _imports_package(repo_root: Path, relative_path: Path, package: str) -> bool
             and node.args
             and isinstance(node.args[0], ast.Constant)
             and isinstance(node.args[0].value, str)
-            and _top_level_import_name(node.args[0].value) == package_name
+            and _top_level_import_name(node.args[0].value) in package_import_names
         ):
             return True
     return False

--- a/tests/test_python_dependency_surfaces.py
+++ b/tests/test_python_dependency_surfaces.py
@@ -65,6 +65,9 @@ def _write_valid_contract_repo(root: Path) -> None:
         [
             "# Python Dependency Surfaces",
             "Noncanonical Aggregate Install Surfaces",
+            "Dependency Ownership Audit",
+            "legacy_compat_transitional",
+            "Legacy usage is evidence of transitional compatibility pressure",
             "scripts/ci/check_python_dependency_surfaces.py",
             *all_surface_files,
         ]
@@ -86,6 +89,14 @@ def _write_valid_contract_repo(root: Path) -> None:
     _write_installer_profiles(root)
     _write_pip_audit_helper(root)
     _write_dependency_submission_workflow(root)
+
+
+def _append_requirement(root: Path, relative_path: str, requirement_line: str) -> None:
+    path = root / relative_path
+    path.write_text(
+        f"{path.read_text(encoding='utf-8').rstrip()}\n{requirement_line}\n",
+        encoding="utf-8",
+    )
 
 
 def _write_python_setup_action(root: Path, extra_case_labels: tuple[str, ...] = ()) -> None:
@@ -404,6 +415,125 @@ def test_dependency_surface_contract_rejects_non_exact_compiled_entry(tmp_path: 
     errors = surfaces.validate_repo(tmp_path)
 
     assert errors == ["requirements.txt: compiled entry must be exact-pinned: 'fastapi>=0.122.0'."]
+
+
+def test_dependency_ownership_audit_rejects_pyarrow_runtime_surfaces(
+    tmp_path: Path,
+) -> None:
+    _write_valid_contract_repo(tmp_path)
+    for source_file in ("requirements.in", "requirements-ci-lite.in"):
+        _append_requirement(tmp_path, source_file, "pyarrow>=20.0.0,<25.0.0")
+    for lockfile in ("requirements.txt", "requirements-ci-lite.txt", "requirements-lock.txt"):
+        _append_requirement(tmp_path, lockfile, "pyarrow==23.0.1")
+
+    errors = surfaces.validate_repo(tmp_path)
+
+    assert any("pyarrow: error:runtime_direct_no_canonical_owner" in error for error in errors)
+
+
+def test_dependency_ownership_audit_rejects_pandas_runtime_surfaces(
+    tmp_path: Path,
+) -> None:
+    _write_valid_contract_repo(tmp_path)
+    _append_requirement(tmp_path, "requirements.in", "pandas")
+    _append_requirement(tmp_path, "requirements.txt", "pandas==3.0.3")
+
+    errors = surfaces.validate_repo(tmp_path)
+
+    assert any("pandas: error:data_eval_dependency_in_runtime" in error for error in errors)
+
+
+def test_dependency_ownership_audit_rejects_httpx2_runtime_surfaces(
+    tmp_path: Path,
+) -> None:
+    _write_valid_contract_repo(tmp_path)
+    _append_requirement(tmp_path, "requirements-ci-lite.in", "httpx2>=2.3.0,<2.4.0")
+    _append_requirement(tmp_path, "requirements-ci-lite.txt", "httpx2==2.3.0")
+
+    errors = surfaces.validate_repo(tmp_path)
+
+    assert any("httpx2: error:test_dev_dependency_in_runtime" in error for error in errors)
+
+
+def test_dependency_ownership_audit_accepts_reportlab_export_owner(
+    tmp_path: Path,
+) -> None:
+    _write_valid_contract_repo(tmp_path)
+    _append_requirement(tmp_path, "requirements.in", "reportlab>=4.4.4,<5.0.0")
+    _append_requirement(tmp_path, "requirements.txt", "reportlab==4.4.10")
+    owner_path = tmp_path / "app" / "routers"
+    owner_path.mkdir(parents=True, exist_ok=True)
+    (owner_path / "plan_export.py").write_text(
+        "from reportlab.lib import colors\n", encoding="utf-8"
+    )
+
+    errors = surfaces.validate_repo(tmp_path)
+    findings = surfaces.collect_dependency_ownership_findings(tmp_path)
+
+    assert errors == []
+    assert any(
+        finding.package == "reportlab"
+        and finding.severity == surfaces.OWNERSHIP_INFO
+        and finding.reason_code == "canonical_runtime_owner_documented"
+        for finding in findings
+    )
+
+
+def test_dependency_ownership_audit_rejects_legacy_only_runtime_authority(
+    tmp_path: Path,
+) -> None:
+    _write_valid_contract_repo(tmp_path)
+    _append_requirement(tmp_path, "requirements.in", "reportlab>=4.4.4,<5.0.0")
+    _append_requirement(tmp_path, "requirements.txt", "reportlab==4.4.10")
+    (tmp_path / "legacy_app.py").write_text(
+        "from reportlab.lib import colors\n",
+        encoding="utf-8",
+    )
+
+    errors = surfaces.validate_repo(tmp_path)
+
+    assert any(
+        "reportlab: error:legacy_only_runtime_authority_forbidden" in error for error in errors
+    )
+
+
+def test_dependency_ownership_audit_reports_matplotlib_as_transitional(
+    tmp_path: Path,
+) -> None:
+    _write_valid_contract_repo(tmp_path)
+    _append_requirement(tmp_path, "requirements.in", "matplotlib>=3.10.7,<4.0.0")
+    _append_requirement(tmp_path, "requirements.txt", "matplotlib==3.10.8")
+    (tmp_path / "bmi_visualization.py").write_text("import matplotlib\n", encoding="utf-8")
+
+    errors = surfaces.validate_repo(tmp_path)
+    findings = surfaces.collect_dependency_ownership_findings(tmp_path)
+
+    assert errors == []
+    assert any(
+        finding.package == "matplotlib"
+        and finding.severity == surfaces.OWNERSHIP_WARNING
+        and finding.reason_code == "legacy_compat_transitional"
+        for finding in findings
+    )
+
+
+def test_dependency_ownership_audit_reports_numpy_as_transitive_candidate(
+    tmp_path: Path,
+) -> None:
+    _write_valid_contract_repo(tmp_path)
+    _append_requirement(tmp_path, "requirements.in", "numpy>=2.4.1,<3.0.0")
+    _append_requirement(tmp_path, "requirements.txt", "numpy==2.4.6")
+
+    errors = surfaces.validate_repo(tmp_path)
+    findings = surfaces.collect_dependency_ownership_findings(tmp_path)
+
+    assert errors == []
+    assert any(
+        finding.package == "numpy"
+        and finding.severity == surfaces.OWNERSHIP_WARNING
+        and finding.reason_code == "transitive_only_direct_runtime_candidate"
+        for finding in findings
+    )
 
 
 def test_verify_requirements_wrapper_runs_surface_validator(

--- a/tests/test_python_dependency_surfaces.py
+++ b/tests/test_python_dependency_surfaces.py
@@ -421,14 +421,47 @@ def test_dependency_ownership_audit_rejects_pyarrow_runtime_surfaces(
     tmp_path: Path,
 ) -> None:
     _write_valid_contract_repo(tmp_path)
-    for source_file in ("requirements.in", "requirements-ci-lite.in"):
+    for source_file in (
+        "requirements.in",
+        "requirements-ci-lite.in",
+        "requirements-docker-runtime.in",
+    ):
         _append_requirement(tmp_path, source_file, "pyarrow>=20.0.0,<25.0.0")
-    for lockfile in ("requirements.txt", "requirements-ci-lite.txt", "requirements-lock.txt"):
+    for lockfile in (
+        "requirements.txt",
+        "requirements-ci-lite.txt",
+        "requirements-docker-runtime.txt",
+        "requirements-lock.txt",
+    ):
         _append_requirement(tmp_path, lockfile, "pyarrow==23.0.1")
 
     errors = surfaces.validate_repo(tmp_path)
 
     assert any("pyarrow: error:runtime_direct_no_canonical_owner" in error for error in errors)
+
+
+def test_dependency_ownership_audit_rejects_pyarrow_docker_runtime_surface(
+    tmp_path: Path,
+) -> None:
+    _write_valid_contract_repo(tmp_path)
+    _append_requirement(
+        tmp_path,
+        "requirements-docker-runtime.in",
+        "pyarrow>=20.0.0,<25.0.0",
+    )
+    _append_requirement(tmp_path, "requirements-docker-runtime.txt", "pyarrow==23.0.1")
+
+    findings = surfaces.collect_dependency_ownership_findings(tmp_path)
+    errors = surfaces.validate_repo(tmp_path)
+
+    assert any("pyarrow: error:runtime_direct_no_canonical_owner" in error for error in errors)
+    assert any(
+        finding.package == "pyarrow"
+        and finding.reason_code == "runtime_direct_no_canonical_owner"
+        and finding.surfaces
+        == ("requirements-docker-runtime.in", "requirements-docker-runtime.txt")
+        for finding in findings
+    )
 
 
 def test_dependency_ownership_audit_rejects_pandas_runtime_surfaces(
@@ -453,6 +486,20 @@ def test_dependency_ownership_audit_rejects_httpx2_runtime_surfaces(
     errors = surfaces.validate_repo(tmp_path)
 
     assert any("httpx2: error:test_dev_dependency_in_runtime" in error for error in errors)
+
+
+def test_import_evidence_uses_explicit_distribution_aliases(tmp_path: Path) -> None:
+    source_file = tmp_path / "imports.py"
+
+    source_file.write_text("import pydantic_core\n", encoding="utf-8")
+    assert surfaces._imports_package(tmp_path, Path("imports.py"), "pydantic-core")
+
+
+def test_import_evidence_does_not_blindly_normalize_underscores(tmp_path: Path) -> None:
+    source_file = tmp_path / "imports.py"
+
+    source_file.write_text("import httpx_2\n", encoding="utf-8")
+    assert not surfaces._imports_package(tmp_path, Path("imports.py"), "httpx2")
 
 
 def test_dependency_ownership_audit_accepts_reportlab_export_owner(

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -108,6 +108,7 @@ LOCAL_MANUAL_EVAL_DATA_PACKAGES = (
     "datasets",
     "ragas",
     "pandas",
+    "pyarrow",
 )
 DISABLED_RAGAS_EVAL_PACKAGES = (
     "diskcache",
@@ -937,21 +938,23 @@ def test_constraints_keep_dependency_security_floors_aligned() -> None:
     assert not _requirement_package_versions(constraints_path, "safety")
     assert _requirement_package_versions(requirements_ci_lite_in, "pip-audit") == {"2.10.1"}
 
-    constraints_pyarrow = _requirement_package_versions(constraints_path, "pyarrow")
-    assert constraints_pyarrow == {"20.0.0"}
-    assert constraints_pyarrow == _requirement_package_versions(requirements_in, "pyarrow")
-    assert constraints_pyarrow == _requirement_package_versions(
-        requirements_ci_lite_in,
-        "pyarrow",
-    )
+    assert not _requirement_package_versions(constraints_path, "pyarrow")
+    assert not _requirement_package_versions(requirements_in, "pyarrow")
+    assert not _requirement_package_versions(requirements_ci_lite_in, "pyarrow")
     for lock_surface in (
         REPO_ROOT / "requirements.txt",
         REPO_ROOT / "requirements-ci-lite.txt",
         REPO_ROOT / "requirements-lock.txt",
     ):
-        pinned_versions = _requirement_package_versions(lock_surface, "pyarrow")
-        assert pinned_versions
-        assert all(Version(version) >= Version("20.0.0") for version in pinned_versions)
+        assert not _requirement_package_versions(lock_surface, "pyarrow")
+    assert _requirement_package_versions(REPO_ROOT / "requirements-data.in", "pyarrow") == {
+        "20.0.0"
+    }
+    data_lock_versions = _requirement_package_versions(
+        REPO_ROOT / "requirements-data.txt", "pyarrow"
+    )
+    assert data_lock_versions
+    assert all(Version(version) >= Version("20.0.0") for version in data_lock_versions)
 
 
 def test_ci_security_job_runs_pip_audit_from_ci_lite_toolchain() -> None:
@@ -1230,6 +1233,7 @@ def test_base_runtime_dependency_profile_excludes_vector_ml_stack() -> None:
     assert "transformers==" not in requirements_runtime
     assert "torch==" not in requirements_runtime
     assert "pgvector==" not in requirements_runtime
+    assert "pyarrow==" not in requirements_runtime
 
 
 def test_docker_runtime_dependency_profile_excludes_ci_and_vector_stack() -> None:
@@ -1390,6 +1394,11 @@ def test_dependency_docs_describe_eval_and_data_profiles_as_local_manual() -> No
     assert "scripts/build_recipe_db.py" in dependency_docs
     assert "pandas" in dependency_docs
     assert "pyarrow" in dependency_docs
+    normalized_dependency_docs = " ".join(dependency_docs.casefold().split())
+    assert "runtime, docker runtime, ci-lite, and `requirements-lock.txt`" in (
+        normalized_dependency_docs
+    )
+    assert "legacy_compat_transitional" in dependency_docs
     assert "RAGAS native execution is disabled" in dependency_docs
     assert "GHSA-95ww-475f-pr4f" in dependency_docs
     assert "GHSA-w8v5-vhqr-4h9v" in dependency_docs

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -930,6 +930,7 @@ def test_constraints_keep_dependency_security_floors_aligned() -> None:
     constraints_path = REPO_ROOT / "constraints.txt"
     requirements_in = REPO_ROOT / "requirements.in"
     requirements_ci_lite_in = REPO_ROOT / "requirements-ci-lite.in"
+    requirements_docker_runtime_in = REPO_ROOT / "requirements-docker-runtime.in"
 
     constraints_text = constraints_path.read_text(encoding="utf-8")
     assert "flake8 removed in favor of ruff" not in constraints_text
@@ -941,9 +942,11 @@ def test_constraints_keep_dependency_security_floors_aligned() -> None:
     assert not _requirement_package_versions(constraints_path, "pyarrow")
     assert not _requirement_package_versions(requirements_in, "pyarrow")
     assert not _requirement_package_versions(requirements_ci_lite_in, "pyarrow")
+    assert not _requirement_package_versions(requirements_docker_runtime_in, "pyarrow")
     for lock_surface in (
         REPO_ROOT / "requirements.txt",
         REPO_ROOT / "requirements-ci-lite.txt",
+        REPO_ROOT / "requirements-docker-runtime.txt",
         REPO_ROOT / "requirements-lock.txt",
     ):
         assert not _requirement_package_versions(lock_surface, "pyarrow")


### PR DESCRIPTION
## Goal

Enforce first-pass Python dependency ownership for the audited subset without letting legacy imports become canonical runtime authority.

## Business Reason

This reduces production/control-plane dependency bloat and supply-chain mirror burden while preserving data/eval and legacy compatibility boundaries.

## Scope

- Extend `scripts/ci/check_python_dependency_surfaces.py` with severity-tiered ownership findings for `pyarrow`, `pandas`, `httpx2`, `reportlab`, `matplotlib`, `numpy`, and `aiosqlite`.
- Hard-fail `pyarrow` in runtime, Docker runtime, CI-lite, or aggregate lock surfaces without canonical runtime ownership.
- Hard-fail `pandas` and `httpx2` in runtime, Docker runtime, or CI-lite surfaces.
- Hard-fail legacy-only runtime ownership via `legacy_only_runtime_authority_forbidden`.
- Keep `reportlab` as canonical export/PDF runtime ownership.
- Keep `matplotlib`, `numpy`, and `aiosqlite` as warning/report-only classifications.
- Remove `pyarrow` from `requirements.in`, `requirements-ci-lite.in`, `constraints.txt`, `requirements.txt`, `requirements-ci-lite.txt`, and `requirements-lock.txt`.
- Keep `pyarrow` in `requirements-data.in` and `requirements-data.txt`.
- Update dependency docs, tests, premortem evidence, and fixed mapping.

## Out Of Scope

- No `legacy_app.py` edits.
- No route, OpenAPI, Docker, SQLite, BMI extraction, or FoodDB runtime changes.
- No pyproject/uv migration.
- No removal of `matplotlib`, `reportlab`, `aiosqlite`, or `numpy`.

## Files Changed

- `scripts/ci/check_python_dependency_surfaces.py`
- `tests/test_python_dependency_surfaces.py`
- `tests/test_python_supply_chain_controls.py`
- `requirements.in`
- `requirements-ci-lite.in`
- `requirements.txt`
- `requirements-ci-lite.txt`
- `requirements-lock.txt`
- `constraints.txt`
- `docs/contracts/PYTHON_DEPENDENCY_SURFACES.md`
- `docs/DEPENDENCY_MANAGEMENT.md`
- `REQUIREMENTS.md`
- `docs/review/PR_DEPS_OWNERSHIP_PREMORTEM.md`
- `docs/review/PR_DEPS_OWNERSHIP_EXPERIMENT_RUNNER_EVIDENCE.md`
- `docs/review/PR_2057_FIXED_MAPPING.md`

## Key Decisions

- Legacy usage is transitional evidence, not ownership.
- Default validation enforces only the audited subset; broader debt remains warning/info.
- Import evidence uses exact top-level import names plus explicit distribution/import aliases, not blind underscore-to-hyphen normalization.
- `pyarrow` is data-only in this PR.
- `verify_requirements.py` remains a compatibility wrapper, not an ownership authority.
- Generated unsafe `pip==26.1.2` stanzas from local compile were rejected to avoid unrelated lock churn.

## Tests / Validation

- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `python3 scripts/ci/check_python_dependency_surfaces.py`
- PASS: `python3 verify_requirements.py`
- PASS: `.venv/bin/python -m pytest -q tests/test_python_dependency_surfaces.py tests/test_python_supply_chain_controls.py`
- PASS: `.venv/bin/python -m pytest -q tests/test_openapi_namespace_guards.py tests/test_exports.py tests/test_bmi_visualization.py`
- PASS: `python3 scripts/ci/install_locked_python_requirements.py --preflight-only`
- PASS: `make validate-changed`
- PASS: `pre-commit run --all-files`
- PASS: `pre-commit run --hook-stage pre-push mypy --files scripts/ci/check_python_dependency_surfaces.py`
- PASS: `git diff --check`
- PASS: `PULSEPLATE_PYTHON_INDEX_URL=https://packages.pulseplate.app/root/pulseplate/+simple/ python3 scripts/ci/check_private_python_proxy_health.py --requirements-file requirements.txt --requirements-file requirements-ci-lite.txt --requirements-file requirements-test.txt --python-version 3.11 --python-version 3.12 --python-version 3.13 --project aiosqlite --project cryptography --project requests --project pytest-xdist --project hypothesis --project pgvector`

Full local `make verify` intentionally not run per root `AGENTS.md` local budget rule.

## Security Notes

- Runtime and CI-lite surfaces lose `pyarrow`; data profile retains it for offline Parquet-capable builders.
- Docker runtime is guarded against future `pyarrow` reintroduction.
- No secrets, local absolute paths, workflow auth, or route behavior changed.
- Codex Security diff scan `cb1de52e-4988-4fa8-a683-d214546a9a0c`: complete, 14/14 worklist rows covered, 0 findings.

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/exp-7bcba836ae3b.json`

Accepted oracle-only fallback evidence:

- PASS: `python3 scripts/ci/check_python_dependency_surfaces.py`
- PASS: `python3 verify_requirements.py`
- PASS: `python3 -m pytest -q tests/test_python_dependency_surfaces.py tests/test_python_supply_chain_controls.py`

Rejected zero-network attempt: `exp-732a3a092f3a` was rejected before oracle execution because the local sandbox required `unshare` on `PATH`.

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/d608be4643c6.json`
- Packet: `artifacts/orchestration/task_packets/066b799335fb.json`
- Merge-ready packet: `artifacts/orchestration/task_packets/196178f43fca.json`

The packet paths are gitignored local provenance artifacts; they are recorded for traceability and are not product/runtime evidence.

## Risks / Rollback

Risk: `pyarrow` may be accidentally needed by a runtime path not represented by canonical imports.
Rollback: restore removed `pyarrow` declarations and regenerated lockfile stanzas, then rerun the same focused gates.

Risk: warning output could be mistaken for merge readiness failure.
Rollback: keep severity-tier behavior; only `error` findings fail default validation.

## Deferred / Follow-ups

- Separate BMI visualization/de-legacy decision for `matplotlib`.
- Separate DB fallback/test split decision for `aiosqlite`.
- Optional future direct-owner cleanup for `numpy` once `matplotlib` ownership is resolved.

## AGENTS.md / Process Updates

No AGENTS.md changes.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Post-open required pass completed:

- `qa-engineer-agent`: found Docker-runtime pyarrow guard/test/docs gaps; fixed in `b68239aba`; final rerun found no blockers.
- `bug-hunter`: no blocking findings at `b68239aba`.
- `security-auditor`: no blocking findings at `b68239aba`.
- Codex Security diff scan: 0 findings.
- `pulseplate-pr-review`: no actionable code-review finding beyond the fixed Sourcery/QA items.

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_2057_FIXED_MAPPING.md`
- Sourcery review `pullrequestreview-4608060018`: FIXED in `b68239aba`.

## Merge Readiness

Merge readiness is evaluated from current-head GitHub checks plus `scripts/orchestration/check_merge_ready.py --require-auth` on the latest head. Superseded/cancelled runs are not merge truth.

## Next Best Step

Wait for current-head checks on the latest head, then run the strict merge-readiness wrapper before merge.
