### PR TITLE
refactor(api): move business registration to canonical bootstrap

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -48,7 +48,9 @@ from app.routers.admin_operations import (
     ADMIN_OPERATION_ROUTE_SPECS,
     router as admin_operations_router,
 )
+from app.routers.api_key import require_app_api_key
 from app.routers.bodyfat import BODYFAT_ROUTE_SPECS, router as bodyfat_router
+from app.routers.business import BUSINESS_ROUTE_SPECS, router as business_router
 from app.routers.bmi_compat import BMI_COMPAT_ROUTE_SPECS, router as bmi_compat_router
 from app.routers.bmi_registration import BmiRouteRegistration, register_bmi_routes
 from app.routers.billing import register_billing_routes
@@ -85,7 +87,7 @@ from app.routers.test import (
 )
 from app.routers.vip_registration import register_vip_routes
 from app.schemas.direct_api_root import DirectApiRootProbe
-from app.utils.feature_flags import is_vip_module_enabled
+from app.utils.feature_flags import is_business_module_enabled, is_vip_module_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +134,10 @@ _BMI_COMPAT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
 _BODYFAT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in BODYFAT_ROUTE_SPECS
+)
+_BUSINESS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in BUSINESS_ROUTE_SPECS
 )
 _TEST_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
@@ -282,6 +288,18 @@ def _bodyfat_route_members() -> tuple[RouteMemberContract, ...]:
             include_in_schema=include_in_schema,
         )
         for path, method, include_in_schema in _BODYFAT_ROUTE_SPECS
+    )
+
+
+def _business_route_members() -> tuple[RouteMemberContract, ...]:
+    return tuple(
+        RouteMemberContract(
+            path=path,
+            method=method,
+            include_in_schema=include_in_schema,
+            required_dependencies=(require_app_api_key,) if path.endswith("/analyze") else (),
+        )
+        for path, method, include_in_schema in _BUSINESS_ROUTE_SPECS
     )
 
 
@@ -800,6 +818,20 @@ def _include_bodyfat_router_if_needed(target_app: FastAPI) -> None:
     )
 
 
+def _include_business_router_if_enabled(target_app: FastAPI) -> None:
+    """Register business routes as one explicitly feature-flagged static family."""
+
+    if not is_business_module_enabled():
+        return
+
+    ensure_route_family_registered(
+        target_app,
+        family_name="Business",
+        routers=(business_router,),
+        members=_business_route_members(),
+    )
+
+
 def _include_test_router_if_enabled(target_app: FastAPI) -> None:
     """Register non-production test routes as one hidden canonical family."""
 
@@ -990,6 +1022,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _register_bmi_routes(app)
     _include_bmi_compat_router_if_needed(app)
     _include_bodyfat_router_if_needed(app)
+    _include_business_router_if_enabled(app)
     _include_test_router_if_enabled(app)
     _include_plan_export_routers_if_needed(app)
     _include_shoplist_export_router_if_needed(app)

--- a/app/routers/business.py
+++ b/app/routers/business.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import re
 from typing import Any, Optional
 
@@ -8,20 +7,18 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from app.routers.api_key import require_app_api_key
+from app.utils.feature_flags import is_business_module_enabled
 from core.business_bayesian_analyzer import BusinessBayesianAnalyzer
 from core.i18n import normalize_lang, t
-
-# Business feature flag: enable/disable business module via env or default True
-BUSINESS_MODULE_ENABLED = os.getenv("BUSINESS_MODULE_ENABLED", "true").lower() in (
-    "1",
-    "true",
-    "yes",
-    "on",
-)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/business", tags=["business"])
+
+BUSINESS_ROUTE_SPECS = (
+    ("/api/v1/business/analyze", "POST", True),
+    ("/api/v1/business/status", "GET", True),
+)
 
 
 def _safe_error_summary(err: Exception) -> str:
@@ -98,7 +95,7 @@ async def analyze_business_code(
     Provides business insights on monetization strategies, cost optimization,
     customer acquisition, revenue growth, and customer retention.
     """
-    if not BUSINESS_MODULE_ENABLED:
+    if not is_business_module_enabled():
         detail = _localized_error(request.locale, "business_module_disabled")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -166,4 +163,4 @@ async def analyze_business_code(
 @router.get("/status")
 async def business_status() -> dict[str, Any]:
     """Check if the business module is enabled."""
-    return {"enabled": BUSINESS_MODULE_ENABLED, "module": "business_analysis"}
+    return {"enabled": is_business_module_enabled(), "module": "business_analysis"}

--- a/app/utils/feature_flags.py
+++ b/app/utils/feature_flags.py
@@ -21,6 +21,19 @@ def _is_truthy(value: Optional[str]) -> bool:
     return (value or "").strip().lower() in _TRUTHY
 
 
+def is_explicit_truthy_env_var(name: str) -> bool:
+    """Check whether an env var is present and explicitly truthy."""
+
+    raw = os.getenv(name)
+    return raw is not None and _is_truthy(raw)
+
+
+def is_business_module_enabled() -> bool:
+    """Check if the business module is explicitly enabled."""
+
+    return is_explicit_truthy_env_var("BUSINESS_MODULE_ENABLED")
+
+
 def is_vip_module_enabled() -> bool:
     """Check if VIP module is enabled via environment variable."""
     return _is_truthy(os.getenv("VIP_MODULE_ENABLED", "true"))
@@ -90,7 +103,9 @@ def is_philosophy_pragmatic_enabled() -> bool:
 
 
 __all__ = [
+    "is_business_module_enabled",
     "is_creative_research_pilot_enabled",
+    "is_explicit_truthy_env_var",
     "is_vip_module_enabled",
     "is_rag_vector_enabled",
     "is_philosophy_validation_enabled",

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -181,7 +181,7 @@ Evidence:
   - `responses=RATE_LIMIT_429_RESPONSES`
   - `@limit_if_available(RATE_LIMIT_EXPORTS)`
 
-### Conditional routers: BMI Pro / Business
+### Conditional routers: BMI Pro
 
 Anchor (stable): `app/main.py -> app/routers/bmi_registration.py` owns BMI route registration; `legacy_app.py` remains a compatibility seam for direct-call shims and mirrored attrs.
 
@@ -193,7 +193,6 @@ Evidence:
 - BMI Pro: registered by `app/main.py` via `app/routers/bmi_registration.py`, included only if `FEATURE_BMI_PRO_ENABLED` is truthy
   - canonical: `/api/v1/pro/bmi`
   - legacy alias: `/api/v1/bmi/pro`
-- Business: included only if `BUSINESS_MODULE_ENABLED` is truthy
 
 ### Bodyfat route family (canonical-owned bootstrap)
 
@@ -219,6 +218,38 @@ Runtime effect:
 - OpenAPI: the source route keeps `include_in_schema=True`, but the final
   canonical OpenAPI builder still filters `/api/v1/bodyfat` out of published
   `/openapi.json`; generated client/OpenAPI artifacts are unchanged.
+
+### Business route family (explicit feature flag, canonical-owned bootstrap)
+
+Anchor (stable): `app/main.py -> _include_business_router_if_enabled(app)` owns
+`app/routers/business.py`.
+
+Evidence:
+- `app/routers/business.py` defines `BUSINESS_ROUTE_SPECS`, source route
+  handlers for `POST /api/v1/business/analyze` and
+  `GET /api/v1/business/status`, and request-time feature checks through
+  `app.utils.feature_flags.is_business_module_enabled()`.
+- `app/utils/feature_flags.py` owns explicit-truthy parsing for
+  `BUSINESS_MODULE_ENABLED`; unset, empty, and false-like values are disabled.
+- `app/main.py -> _include_business_router_if_enabled(app)` registers the
+  business family through `ensure_route_family_registered(...)` and
+  `RouteMemberContract` only when the env var is explicitly truthy.
+- `legacy_app.py` does not import or include `app.routers.business`; the legacy
+  growth guard rejects direct, aliased, module-qualified, dynamic, and walrus
+  business router re-registration there.
+
+Runtime effect:
+- Unset/default `BUSINESS_MODULE_ENABLED`: `/api/v1/business/*` is absent.
+- Explicit truthy `BUSINESS_MODULE_ENABLED` (`1`, `true`, `yes`, `on`):
+  `POST /api/v1/business/analyze` and `GET /api/v1/business/status` are
+  routable exactly once through canonical bootstrap.
+- Auth: `/api/v1/business/analyze` keeps the app API-key dependency;
+  `/api/v1/business/status` remains unauthenticated when the route family is
+  explicitly enabled.
+- OpenAPI: the source routes keep current `include_in_schema=True` visibility,
+  but the final public OpenAPI builder still filters `/api/v1/business/*` out
+  of published `/openapi.json`; generated client/OpenAPI artifacts are expected
+  to remain unchanged.
 
 ### Test router (canonical bootstrap-owned, non-production env)
 

--- a/docs/review/PR_2061_FIXED_MAPPING.md
+++ b/docs/review/PR_2061_FIXED_MAPPING.md
@@ -94,14 +94,15 @@ source.
 - [x] Post-open `security-auditor` pass completed.
 - [x] Codex Security diff scan / finding discovery completed.
 - [x] `pulseplate-pr-review` completed.
-- [ ] CodeRabbit, Sourcery, and Cubic actionables checked and dispositioned.
-- [ ] Review threads checked, dispositioned, and resolved if any appear.
+- [x] CodeRabbit, Sourcery, and Cubic actionables checked and dispositioned.
+- [x] Review threads checked and dispositioned.
 - [ ] Current-head CI complete before readiness language.
 - [ ] Strict merge-readiness checks run after the final review/check cycle.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#discussion_r3511088671 -> 77001496e05fbabe53c371ffb6e92cb83e3858c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#pullrequestreview-4615160415
 
 ## Initial Mapping Evidence
 
@@ -187,6 +188,24 @@ Required post-open pass order remains:
 `qa-engineer-agent -> bug-hunter -> security-auditor`, followed by Codex
 Security diff scan / finding discovery and `pulseplate-pr-review`.
 
+Review thread:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#discussion_r3511088671
+
+Disposition: FIXED
+
+Finding: Codex review identified the same stale
+`app.routers.business.BUSINESS_MODULE_ENABLED` patch target in
+`tests/test_coverage_boost_final.py`.
+
+Commit: `77001496e05fbabe53c371ffb6e92cb83e3858c7`
+
+Evidence: `tests/test_coverage_boost_final.py` now enables the feature through
+`monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")`, matching the new
+canonical feature-flag helper. Targeted validation passed with
+`pytest -q tests/test_coverage_boost_final.py -k business_router_edge_paths`,
+and the post-fix branch validation passed with `make validate-changed` and
+`pre-commit run --all-files`.
+
 Disposition: NOT-A-BUG
 
 Role: `bug-hunter`
@@ -250,6 +269,42 @@ Artifacts:
 - Context: `artifacts/orchestration/pr_review/pr_2061_context_after_push.json`
 - Markdown report: `artifacts/orchestration/pr_review/pr_2061_review_after_push.md`
 - JSON report: `artifacts/orchestration/pr_review/pr_2061_review_after_push.json`
+
+## Sourcery Review Disposition
+
+Review:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#pullrequestreview-4615160415
+
+Disposition: NOT-A-BUG
+
+Finding: Sourcery suggested keeping
+`test_analyze_business_code_oversized_payload_internal` as a native async
+pytest test and suggested exposing a higher-level public registration API
+instead of testing `app.main` private bootstrap helpers directly.
+
+Evidence: The sync `asyncio.run(...)` test shape follows `tests/AGENTS.md`,
+which forbids adding async pytest markers to pre-commit-selected tests unless
+the hook environment is proven to load `pytest-asyncio`. The direct
+`app.main` helper assertions are intentional in this migration PR: the changed
+contract is canonical bootstrap ownership and fail-closed route-family
+registration, so tests assert the narrow private seam instead of adding a new
+production API only for test ergonomics. Focused validation and
+`pre-commit run --all-files` passed with this shape.
+
+## External Bot Status Disposition
+
+Disposition: NOT-A-BUG
+
+Finding: CodeRabbit provided a summary-only comment, Cubic reported a completed
+neutral/success advisory status, and Sourcery's high-level review was
+dispositioned above.
+
+Evidence: `gh api repos/Katsiarynakavaleuskaya/PulsePlate/pulls/2061/comments`
+returned one actionable inline review comment, the Codex P1 thread fixed in
+`77001496e05fbabe53c371ffb6e92cb83e3858c7`. The Sourcery review URL is mapped
+as `NOT-A-BUG` above. No additional CodeRabbit or Cubic inline actionables were
+present in the GitHub pull request comments fetched during the current-head
+merge-readiness failure triage.
 
 ## Merge Readiness
 

--- a/docs/review/PR_2061_FIXED_MAPPING.md
+++ b/docs/review/PR_2061_FIXED_MAPPING.md
@@ -106,6 +106,12 @@ Disposition: FIXED
 Commit: 77001496e05fbabe53c371ffb6e92cb83e3858c7
 Evidence: `tests/test_coverage_boost_final.py` uses `monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")`; targeted pytest, `make validate-changed`, and `pre-commit run --all-files` passed.
 
+Disposition: FIXED
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#discussion_r3511698704 -> 3f58ff443
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#pullrequestreview-4615911898 -> 3f58ff443
+Commit: 3f58ff443
+Evidence: `tests/test_business_registration_bootstrap.py` restores `app_main.app` routes, `openapi`, and `openapi_schema`; focused pytest, `make validate-changed`, and `pre-commit run --all-files` passed.
+
 Disposition: NOT-A-BUG
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#pullrequestreview-4615160415
 Evidence: Sourcery's async-test suggestion conflicts with `tests/AGENTS.md` hook guidance for pre-commit-selected tests, and the bootstrap-helper suggestion would add production API outside this narrow route-ownership PR.
@@ -331,6 +337,29 @@ focused pytest passed, and local `diff-cover coverage.xml
 --compare-branch=origin/main --fail-under=97` reported
 `app/main.py (100%)`, `app/routers/business.py (100%)`, and total changed
 source coverage `100%`.
+
+## CodeRabbit State Restoration Closure
+
+Review thread:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#discussion_r3511698704
+
+Review:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#pullrequestreview-4615911898
+
+Disposition: FIXED
+
+Finding: CodeRabbit correctly flagged that
+`test_enabled_business_routes_stay_hidden_from_public_openapi` mutated the
+shared `app_main.app` singleton through `ensure_canonical_app_bootstrap(...)`
+without restoring `router.routes`, `openapi`, or `openapi_schema`.
+
+Commit: `3f58ff443`
+
+Evidence: `tests/test_business_registration_bootstrap.py` now snapshots and
+restores the shared app route table plus OpenAPI state in a `finally` block.
+Focused pytest passed for `tests/test_business_registration_bootstrap.py` and
+`tests/test_route_family_bootstrap.py`; `make validate-changed` and
+`pre-commit run --all-files` also passed after the fix.
 
 ## Merge Readiness
 

--- a/docs/review/PR_2061_FIXED_MAPPING.md
+++ b/docs/review/PR_2061_FIXED_MAPPING.md
@@ -101,8 +101,15 @@ source.
 
 ## Fixed in Commit Mapping
 
+Disposition: FIXED
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#discussion_r3511088671 -> 77001496e05fbabe53c371ffb6e92cb83e3858c7
+Commit: 77001496e05fbabe53c371ffb6e92cb83e3858c7
+Evidence: `tests/test_coverage_boost_final.py` uses `monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")`; targeted pytest, `make validate-changed`, and `pre-commit run --all-files` passed.
+
+Disposition: NOT-A-BUG
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#pullrequestreview-4615160415
+Evidence: Sourcery's async-test suggestion conflicts with `tests/AGENTS.md` hook guidance for pre-commit-selected tests, and the bootstrap-helper suggestion would add production API outside this narrow route-ownership PR.
+Reason: Current test shape intentionally covers the private canonical bootstrap seam changed by this PR without widening runtime API surface.
 
 ## Initial Mapping Evidence
 

--- a/docs/review/PR_2061_FIXED_MAPPING.md
+++ b/docs/review/PR_2061_FIXED_MAPPING.md
@@ -40,8 +40,8 @@ app-factory refactor is included.
 
 ## Lane Start Provenance
 
+- Packet: `artifacts/orchestration/task_packets/d880f5d825dd.json`
 - Starter: `scripts/orchestration/start_pr_lane.sh`
-- Task packet: `artifacts/orchestration/task_packets/d880f5d825dd.json`
 - Role order executed pre-open:
   `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor`
 - Packet creation was treated as provenance/routing only; role passes were
@@ -87,8 +87,8 @@ source.
 ## Discussion Thread Pass
 
 - [x] Initial fixed-mapping artifact created after PR open.
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - [ ] Post-open `qa-engineer-agent` pass completed.
 - [ ] Post-open `bug-hunter` pass completed.
 - [ ] Post-open `security-auditor` pass completed.
@@ -100,6 +100,10 @@ source.
 - [ ] Strict merge-readiness checks run after the final review/check cycle.
 
 ## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Initial Mapping Evidence
 
 Disposition: NOT-A-BUG
 

--- a/docs/review/PR_2061_FIXED_MAPPING.md
+++ b/docs/review/PR_2061_FIXED_MAPPING.md
@@ -96,8 +96,8 @@ source.
 - [x] `pulseplate-pr-review` completed.
 - [x] CodeRabbit, Sourcery, and Cubic actionables checked and dispositioned.
 - [x] Review threads checked and dispositioned.
-- [ ] Current-head CI complete before readiness language.
-- [ ] Strict merge-readiness checks run after the final review/check cycle.
+- [x] Current-head CI complete before readiness language.
+- [x] Strict merge-readiness checks run after the final review/check cycle.
 
 ## Fixed in Commit Mapping
 
@@ -363,13 +363,15 @@ Focused pytest passed for `tests/test_business_registration_bootstrap.py` and
 
 ## Merge Readiness
 
-Not ready yet.
+Ready for final merge execution after the strict current-head wrapper is rerun
+against the final pushed commit.
 
 - Local focused gates: PASS.
-- Fixed mapping artifact: created.
-- Current-head GitHub CI: pending.
-- Post-open role/security review: pending.
-- Review thread / bot actionable disposition: pending.
-- Strict merge-readiness wrapper: pending.
+- Fixed mapping artifact: PASS.
+- Post-open role/security review: PASS.
+- Review thread / bot actionable disposition: PASS.
+- Current-head GitHub CI: PASS on head `41b2bd84131c998c1ddb099a305a51aeecb13829`.
+- Strict merge-readiness wrapper: PASS on head `41b2bd84131c998c1ddb099a305a51aeecb13829`.
 
-No merge-readiness, ready, green, or mergeable claim is made by this artifact.
+If this artifact receives another commit before merge, rerun current-head CI
+classification and the strict merge-readiness wrapper before merge execution.

--- a/docs/review/PR_2061_FIXED_MAPPING.md
+++ b/docs/review/PR_2061_FIXED_MAPPING.md
@@ -89,11 +89,11 @@ source.
 - [x] Initial fixed-mapping artifact created after PR open.
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- [ ] Post-open `qa-engineer-agent` pass completed.
-- [ ] Post-open `bug-hunter` pass completed.
-- [ ] Post-open `security-auditor` pass completed.
-- [ ] Codex Security diff scan / finding discovery completed.
-- [ ] `pulseplate-pr-review` completed.
+- [x] Post-open `qa-engineer-agent` pass completed after rerun.
+- [x] Post-open `bug-hunter` pass completed.
+- [x] Post-open `security-auditor` pass completed.
+- [x] Codex Security diff scan / finding discovery completed.
+- [x] `pulseplate-pr-review` completed.
 - [ ] CodeRabbit, Sourcery, and Cubic actionables checked and dispositioned.
 - [ ] Review threads checked, dispositioned, and resolved if any appear.
 - [ ] Current-head CI complete before readiness language.
@@ -167,17 +167,89 @@ Evidence: `make validate-changed` was rerun after implementation commit
 
 ## Post-open Role Review Evidence
 
-Pending. Required post-open pass order remains:
+Disposition: FIXED
+
+Role: `qa-engineer-agent`
+
+Finding: `tests/test_coverage_boost_final.py` still patched the removed
+`app.routers.business.BUSINESS_MODULE_ENABLED` module attribute, encoding the
+old business feature-flag contract.
+
+Commit: `77001496e`
+
+Evidence: `tests/test_coverage_boost_final.py` now uses
+`monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")`. Targeted validation
+passed with `pytest -q tests/test_coverage_boost_final.py -k
+business_router_edge_paths`, and post-commit `make validate-changed` selected
+and passed `tests/test_coverage_boost_final.py`.
+
+Required post-open pass order remains:
 `qa-engineer-agent -> bug-hunter -> security-auditor`, followed by Codex
 Security diff scan / finding discovery and `pulseplate-pr-review`.
 
+Disposition: NOT-A-BUG
+
+Role: `bug-hunter`
+
+Finding: No actionable runtime regression findings after the QA fix.
+
+Evidence: The bug-hunter pass verified canonical business registration in
+`app/main.py`, the `require_app_api_key` route-family dependency for
+`POST /api/v1/business/analyze`, request-time disabled behavior in
+`app/routers/business.py`, and final OpenAPI filtering for
+`/api/v1/business/*`. It reran focused pytest, direct route-table checks for
+enabled and unset env states, `scripts/ci/check_legacy_growth_guard.py`, and
+generated OpenAPI/client zero-diff checks.
+
+Disposition: NOT-A-BUG
+
+Role: `security-auditor`
+
+Finding: No actionable security findings after the QA fix.
+
+Evidence: The security-auditor pass verified that
+`/api/v1/business/analyze` still carries `require_app_api_key`, business route
+registration is explicit-truthy and default-disabled, public OpenAPI filtering
+excludes `/api/v1/business/*`, and the legacy-growth guard rejects business
+router reintroduction. It reran the focused business bootstrap tests, default
+disabled/enabled route probes, `scripts/ci/check_legacy_growth_guard.py`, and
+`git diff --check origin/main...HEAD`.
+
 ## Codex Security Evidence
 
-Pending.
+Disposition: NOT-A-BUG
+
+Finding: Codex Security diff scan found no reportable security findings.
+
+Evidence:
+
+- Scan ID: `0775a86e-aac6-471a-aebb-da641ee6982d`
+- Mode: diff scan for `e253631c20ff2a8a052685b697e9e2acacd5dcf9..77001496e05fbabe53c371ffb6e92cb83e3858c7`
+- Reportable findings: `0`
+- Reviewed source-like rows: `4/4`
+- Report:
+  `/private/var/folders/bw/12x002vn67v2bvjpbhbtm8480000gn/T/codex-security-scans-e01Jen/move-business-registration-to-canonical-bootstrap/77001496e05fbabe53c371ffb6e92cb83e3858c7_20260702T073012Z_nothpny3/report.md`
 
 ## pulseplate-pr-review Disposition
 
-Pending.
+Disposition: NOT-A-BUG
+
+Finding: The advisory dry-run report flagged a `note` for large diff risk
+because the diff has 719 changed lines, above the 300-line review-risk
+threshold.
+
+Evidence: This PR is the approved narrow business-route canonical-bootstrap
+slice. The larger line count is primarily deterministic bootstrap, route-family,
+legacy-growth, and authz test coverage plus the required fixed-mapping artifact.
+Focused tests, `make validate-changed`, pre-commit, post-open role passes, and
+Codex Security diff scan completed; the dry-run report recorded no correctness,
+security, architecture, or QA findings beyond the review-planning size note.
+
+Artifacts:
+
+- Context: `artifacts/orchestration/pr_review/pr_2061_context_after_push.json`
+- Markdown report: `artifacts/orchestration/pr_review/pr_2061_review_after_push.md`
+- JSON report: `artifacts/orchestration/pr_review/pr_2061_review_after_push.json`
 
 ## Merge Readiness
 

--- a/docs/review/PR_2061_FIXED_MAPPING.md
+++ b/docs/review/PR_2061_FIXED_MAPPING.md
@@ -313,6 +313,25 @@ as `NOT-A-BUG` above. No additional CodeRabbit or Cubic inline actionables were
 present in the GitHub pull request comments fetched during the current-head
 merge-readiness failure triage.
 
+## Current-head CI Diff-coverage Closure
+
+Disposition: FIXED
+
+Finding: Fresh current-head CI `diff-coverage` failed at run
+`28574995138`, job `84724590497`, with missing changed source lines
+`app/main.py:825`, `app/routers/business.py:98`, and
+`app/routers/business.py:166`.
+
+Commit: `bdaea1b68`
+
+Evidence: `tests/test_route_family_bootstrap.py` now includes CI-selected
+route-contract probes for the disabled business bootstrap no-op, direct
+disabled analyze guard, and request-time business status response. Local
+focused pytest passed, and local `diff-cover coverage.xml
+--compare-branch=origin/main --fail-under=97` reported
+`app/main.py (100%)`, `app/routers/business.py (100%)`, and total changed
+source coverage `100%`.
+
 ## Merge Readiness
 
 Not ready yet.

--- a/docs/review/PR_2061_FIXED_MAPPING.md
+++ b/docs/review/PR_2061_FIXED_MAPPING.md
@@ -1,0 +1,189 @@
+# PR #2061 Fixed in Commit Mapping SoT
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061
+
+Branch: `codex/move-business-registration-to-canonical-bootstrap`
+
+## Summary
+
+This PR moves business route registration ownership from `legacy_app.py` to the
+canonical `app.main` bootstrap and changes `BUSINESS_MODULE_ENABLED` to an
+explicit-truthy feature flag contract. The business routes stay absent by
+default, `/api/v1/business/analyze` keeps `require_app_api_key`, `/status`
+keeps its existing unauthenticated behavior when enabled, and final public
+OpenAPI remains free of `/api/v1/business/*`.
+
+## Scope
+
+- Add reusable explicit-truthy env parsing in `app.utils.feature_flags`.
+- Add `BUSINESS_ROUTE_SPECS` in `app/routers/business.py`.
+- Register the business route family from `app/main.py` through
+  `ensure_route_family_registered(...)` only when the business feature flag is
+  explicitly truthy.
+- Remove business router import/registration ownership from `legacy_app.py`.
+- Tighten the legacy-growth guard allowlist and regression coverage for direct,
+  aliased, module-qualified, dynamic, and walrus reintroduction patterns.
+- Add focused business bootstrap tests and update backend routing docs.
+
+## Out Of Scope
+
+No Bayesian analyzer, nutrition, shopping, FoodDB, frontend, iOS, macOS, auth
+redesign, generated OpenAPI/client artifact changes, middleware, lifespan, or
+app-factory refactor is included.
+
+## Implementation Commits
+
+- `322584475a96f25dfee803979c471a92992206c4` - moves business route
+  registration to canonical bootstrap, removes legacy ownership, adds the
+  explicit feature-flag helper, tightens guards, updates docs, and adds focused
+  route-family tests.
+
+## Lane Start Provenance
+
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Task packet: `artifacts/orchestration/task_packets/d880f5d825dd.json`
+- Role order executed pre-open:
+  `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor`
+- Packet creation was treated as provenance/routing only; role passes were
+  executed explicitly before implementation.
+
+## Experiment Runner Evidence
+
+Artifact:
+`artifacts/orchestration/experiments/results/exp-866cae82ee55.json`
+
+- Mode: `oracle_only_governance_reviewer`
+- Status: `accepted`
+- Experiment ID: `exp-866cae82ee55`
+- Source diff applied: `true`
+- Oracle commands executed: `3`
+- Contribution kind: `oracle_review`
+- Co-author required: `true`
+- Commit trailer present in `322584475a96f25dfee803979c471a92992206c4`.
+
+Zero-network local attempt:
+`artifacts/orchestration/experiments/results/exp-2b53d4ed97f6.json` recorded
+`status=rejected`, `failure_class=infra_flake`, because the macOS local
+network-disabled sandbox lacked Linux `unshare`. The accepted packet used
+`network_budget=1`; oracle commands remained local deterministic checks.
+
+## Local Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `pytest -q tests/test_business_registration_bootstrap.py tests/test_business_router.py tests/test_business_router_coverage.py tests/test_legacy_growth_guard.py`
+- PASS: `pytest -q tests/test_business_registration_bootstrap.py tests/test_business_router.py tests/test_business_router_coverage.py tests/test_legacy_growth_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
+- PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS: `DEV_PYTHON=<repo .venv python> make openapi-check`
+- PASS: `pytest -q tests/test_openapi_determinism.py::test_openapi_pipeline_uses_current_python_for_make tests/test_openapi_determinism.py::test_openapi_and_schema_ts_are_deterministic`
+- PASS: `git diff --check`
+- PASS: `DEV_PYTHON=<repo .venv python> VENV_PYTHON=<repo .venv python> make validate-changed`
+- PASS: `pre-commit run --all-files`
+
+Full local `make verify` was intentionally not run under the repository local
+full-verify budget rule. Heavy/current-head CI remains the merge evidence
+source.
+
+## Discussion Thread Pass
+
+- [x] Initial fixed-mapping artifact created after PR open.
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+- [ ] Post-open `qa-engineer-agent` pass completed.
+- [ ] Post-open `bug-hunter` pass completed.
+- [ ] Post-open `security-auditor` pass completed.
+- [ ] Codex Security diff scan / finding discovery completed.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] CodeRabbit, Sourcery, and Cubic actionables checked and dispositioned.
+- [ ] Review threads checked, dispositioned, and resolved if any appear.
+- [ ] Current-head CI complete before readiness language.
+- [ ] Strict merge-readiness checks run after the final review/check cycle.
+
+## Fixed in Commit Mapping
+
+Disposition: NOT-A-BUG
+
+Finding: No actionable review threads existed at initial PR creation.
+
+Evidence: PR #2061 was opened after focused local gates, pre-open role passes,
+premortem, and accepted Experiment Runner oracle evidence. Post-open review
+passes and bot thread disposition remain pending in this artifact until they
+are actually complete.
+
+## Premortem Finding Closure
+
+Disposition: FIXED
+
+Finding: Moving business registration could accidentally default-enable hidden
+business routes.
+
+Evidence: `app/main.py` registers the business route family only when
+`is_business_module_enabled()` returns true, and
+`tests/test_business_registration_bootstrap.py` covers unset, empty, false,
+`0`, `no`, and `off` as absent.
+
+Disposition: FIXED
+
+Finding: Route dependency behavior could drift during ownership migration.
+
+Evidence: `tests/test_business_registration_bootstrap.py` verifies
+`/api/v1/business/analyze` contains the same `require_app_api_key` callable in
+the route dependency graph and verifies `/status` remains callable without auth
+when the module is enabled.
+
+Disposition: FIXED
+
+Finding: Source route visibility could leak business routes into public
+OpenAPI.
+
+Evidence: `BUSINESS_ROUTE_SPECS` preserves current source visibility, and
+`tests/test_business_registration_bootstrap.py` verifies final `app.openapi()`
+does not expose `/api/v1/business/*`. `make openapi-check` also produced zero
+generated artifact diff.
+
+Disposition: FIXED
+
+Finding: Legacy guard allowlists could continue to permit business router
+reintroduction.
+
+Evidence: `scripts/ci/check_legacy_growth_guard.py` removes the business router
+legacy facts, and `tests/test_legacy_growth_guard.py` covers direct, aliased,
+module-qualified, dynamic, and walrus reintroduction patterns.
+
+Disposition: NOT-A-BUG
+
+Finding: `make validate-changed` can false-green before an implementation
+commit because the branch-diff selector may not see staged-only changes.
+
+Evidence: `make validate-changed` was rerun after implementation commit
+`322584475a96f25dfee803979c471a92992206c4`; it selected and passed
+`tests/security/test_api_authz_contract_static.py`,
+`tests/test_business_registration_bootstrap.py`, `tests/test_business_router.py`,
+`tests/test_business_router_coverage.py`, and `tests/test_legacy_growth_guard.py`.
+
+## Post-open Role Review Evidence
+
+Pending. Required post-open pass order remains:
+`qa-engineer-agent -> bug-hunter -> security-auditor`, followed by Codex
+Security diff scan / finding discovery and `pulseplate-pr-review`.
+
+## Codex Security Evidence
+
+Pending.
+
+## pulseplate-pr-review Disposition
+
+Pending.
+
+## Merge Readiness
+
+Not ready yet.
+
+- Local focused gates: PASS.
+- Fixed mapping artifact: created.
+- Current-head GitHub CI: pending.
+- Post-open role/security review: pending.
+- Review thread / bot actionable disposition: pending.
+- Strict merge-readiness wrapper: pending.
+
+No merge-readiness, ready, green, or mergeable claim is made by this artifact.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -49,7 +49,6 @@ from app.http_error_details import (
     INVALID_PREMIUM_PLATE_INPUT_DETAIL,
 )
 from app.routers.api_key import api_key_header
-from app.routers.business import router as business_router
 from app.routers.catalog import router as catalog_router
 from app.routers.foods import router as foods_router
 from app.routers.nutrition_recommendations import router as nutrition_recommendations_router
@@ -4296,10 +4295,3 @@ if EXPORTS_ENABLED:
 
 
 # Bodyfat, BMI, and BMI Pro route registration is owned by app.main canonical bootstrap.
-
-# Include Business router (with feature flag). Defaults to disabled for safety.
-
-_business_flag = os.getenv("BUSINESS_MODULE_ENABLED")
-BUSINESS_MODULE_ENABLED = _is_truthy(_business_flag) if _business_flag is not None else False
-if BUSINESS_MODULE_ENABLED and business_router:
-    app.include_router(business_router)

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -109,7 +109,6 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("registration", "include_router", "bayes_adherence.router", ""),
         LegacyFact("registration", "include_router", "nutrition_log.router", ""),
         LegacyFact("registration", "include_router", "legacy_nutrition_alias_router", ""),
-        LegacyFact("registration", "include_router", "business_router", ""),
     }
 )
 
@@ -120,7 +119,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
         LegacyFact("router_import", "app.routers", "vip", "_vip_mod"),
         LegacyFact("router_import", "app.routers.api_key", "api_key_header", ""),
         LegacyFact("router_import", "app.routers.bmi", "bmi_calculate_handler", ""),
-        LegacyFact("router_import", "app.routers.business", "router", "business_router"),
         LegacyFact("router_import", "app.routers.catalog", "router", "catalog_router"),
         LegacyFact("router_import", "app.routers.foods", "router", "foods_router"),
         LegacyFact(

--- a/tests/security/_api_authz_contracts.py
+++ b/tests/security/_api_authz_contracts.py
@@ -246,6 +246,7 @@ API_AUTHZ_CONTRACTS: tuple[ApiAuthzContract, ...] = (
         MinimumTier.NONE,
         PrincipalSource.OPERATOR_CREDENTIAL,
         OwnershipPolicy.OPERATOR_GLOBAL,
+        ApiExposure.HIDDEN_RUNTIME,
     ),
     _contract(
         "POST",

--- a/tests/test_business_registration_bootstrap.py
+++ b/tests/test_business_registration_bootstrap.py
@@ -245,10 +245,18 @@ def test_enabled_business_routes_stay_hidden_from_public_openapi(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
+    original_routes = list(app_main.app.router.routes)
+    original_openapi = app_main.app.openapi
+    original_openapi_schema = app_main.app.openapi_schema
 
-    app_main.ensure_canonical_app_bootstrap(app_main.app)
-    app_main.app.openapi_schema = None
+    try:
+        app_main.ensure_canonical_app_bootstrap(app_main.app)
+        app_main.app.openapi_schema = None
 
-    paths = set(app_main.app.openapi().get("paths", {}))
+        paths = set(app_main.app.openapi().get("paths", {}))
 
-    assert paths.isdisjoint(_EXPECTED_BUSINESS_ROUTE_PATHS)
+        assert paths.isdisjoint(_EXPECTED_BUSINESS_ROUTE_PATHS)
+    finally:
+        app_main.app.router.routes = original_routes
+        app_main.app.openapi = original_openapi
+        app_main.app.openapi_schema = original_openapi_schema

--- a/tests/test_business_registration_bootstrap.py
+++ b/tests/test_business_registration_bootstrap.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+import app.main as app_main
+from app.bootstrap.route_family import route_has_dependency_call
+from app.effective_routes import (
+    is_api_route_candidate,
+    iter_effective_route_candidates,
+    route_include_in_schema,
+    route_methods,
+    route_path,
+)
+from app.routers.api_key import require_app_api_key
+from app.utils.feature_flags import is_business_module_enabled
+
+_EXPECTED_BUSINESS_ROUTE_KEYS = {
+    (path, method) for path, method, _include_in_schema in app_main._BUSINESS_ROUTE_SPECS
+}
+_EXPECTED_BUSINESS_ROUTE_PATHS = {path for path, _method in _EXPECTED_BUSINESS_ROUTE_KEYS}
+
+
+@pytest.fixture(autouse=True)
+def _clear_business_route_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BUSINESS_MODULE_ENABLED", raising=False)
+
+
+def _set_business_flag(monkeypatch: pytest.MonkeyPatch, raw: str | None) -> None:
+    if raw is None:
+        monkeypatch.delenv("BUSINESS_MODULE_ENABLED", raising=False)
+        return
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", raw)
+
+
+def _business_routes(target_app: FastAPI) -> list[object]:
+    return [
+        route
+        for route in iter_effective_route_candidates(target_app.routes)
+        if is_api_route_candidate(route) and route_path(route) in _EXPECTED_BUSINESS_ROUTE_PATHS
+    ]
+
+
+def _registered_business_route_counts(target_app: FastAPI) -> Counter[tuple[str, str]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for route in _business_routes(target_app):
+        for method in route_methods(route):
+            key = (route_path(route), method)
+            if key in _EXPECTED_BUSINESS_ROUTE_KEYS:
+                counts[key] += 1
+    return counts
+
+
+def _business_route(target_app: FastAPI, path: str, method: str) -> object:
+    matches = [
+        route
+        for route in _business_routes(target_app)
+        if route_path(route) == path and method in route_methods(route)
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _assert_business_routes_registered_once(target_app: FastAPI) -> None:
+    counts = _registered_business_route_counts(target_app)
+    assert set(counts) == _EXPECTED_BUSINESS_ROUTE_KEYS
+    assert all(count == 1 for count in counts.values())
+
+    analyze_route = _business_route(target_app, "/api/v1/business/analyze", "POST")
+    status_route = _business_route(target_app, "/api/v1/business/status", "GET")
+    assert route_has_dependency_call(analyze_route, require_app_api_key)
+    assert not route_has_dependency_call(status_route, require_app_api_key)
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected_enabled"),
+    [
+        (None, False),
+        ("", False),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("true", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        (" TRUE ", True),
+    ],
+)
+def test_business_route_registration_env_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_value: str | None,
+    expected_enabled: bool,
+) -> None:
+    _set_business_flag(monkeypatch, raw_value)
+    target_app = FastAPI()
+
+    assert is_business_module_enabled() is expected_enabled
+
+    app_main._include_business_router_if_enabled(target_app)
+
+    if expected_enabled:
+        _assert_business_routes_registered_once(target_app)
+    else:
+        assert _business_routes(target_app) == []
+
+
+def test_business_route_registration_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
+    target_app = FastAPI()
+
+    app_main._include_business_router_if_enabled(target_app)
+    app_main._include_business_router_if_enabled(target_app)
+
+    _assert_business_routes_registered_once(target_app)
+
+
+def test_business_router_source_specs_match_current_visibility() -> None:
+    route_specs: set[tuple[str, str, bool]] = set()
+    for route in app_main.business_router.routes:
+        assert isinstance(route, APIRoute)
+        for method in route.methods or set():
+            key = (str(route.path), str(method).upper())
+            if key in _EXPECTED_BUSINESS_ROUTE_KEYS:
+                route_specs.add((str(route.path), str(method).upper(), route.include_in_schema))
+
+    assert route_specs == set(app_main._BUSINESS_ROUTE_SPECS)
+
+
+def test_business_registration_rejects_partial_existing_family(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
+    target_app = FastAPI()
+    path, method, include_in_schema = app_main._BUSINESS_ROUTE_SPECS[0]
+
+    async def _partial_business_route() -> dict[str, str]:
+        return {"status": "partial"}
+
+    target_app.add_api_route(
+        path,
+        _partial_business_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(RuntimeError, match="Partial business route registration detected"):
+        app_main._include_business_router_if_enabled(target_app)
+
+
+def test_business_registration_rejects_existing_wrong_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
+    target_app = FastAPI()
+
+    async def _wrong_method_business_route() -> dict[str, str]:
+        return {"status": "wrong-method"}
+
+    target_app.add_api_route(
+        "/api/v1/business/analyze",
+        _wrong_method_business_route,
+        methods=["PUT"],
+    )
+
+    with pytest.raises(RuntimeError, match="Partial business route registration detected"):
+        app_main._include_business_router_if_enabled(target_app)
+
+
+def test_business_registration_rejects_foreign_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
+    target_app = FastAPI()
+
+    for spec_path, method, include_in_schema in app_main._BUSINESS_ROUTE_SPECS:
+
+        async def _foreign_business_route(current_route_path: str = spec_path) -> dict[str, str]:
+            return {"path": current_route_path}
+
+        target_app.add_api_route(
+            spec_path,
+            _foreign_business_route,
+            methods=[method],
+            include_in_schema=include_in_schema,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different business handler",
+    ):
+        app_main._include_business_router_if_enabled(target_app)
+
+
+def test_business_registration_rejects_source_visibility_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
+    source_route = next(iter(app_main.business_router.routes))
+    assert isinstance(source_route, APIRoute)
+    monkeypatch.setattr(source_route, "include_in_schema", False)
+
+    with pytest.raises(RuntimeError, match="Business router does not preserve OpenAPI visibility"):
+        app_main._include_business_router_if_enabled(FastAPI())
+
+
+def test_business_analyze_keeps_api_key_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "yes")
+    target_app = FastAPI()
+
+    app_main._include_business_router_if_enabled(target_app)
+
+    analyze_route = _business_route(target_app, "/api/v1/business/analyze", "POST")
+    assert route_has_dependency_call(analyze_route, require_app_api_key)
+
+
+def test_business_status_remains_unauthenticated_and_reflects_request_time_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "on")
+    target_app = FastAPI()
+    app_main._include_business_router_if_enabled(target_app)
+    client = TestClient(target_app)
+
+    response = client.get("/api/v1/business/status")
+    assert response.status_code == 200
+    assert response.json() == {"enabled": True, "module": "business_analysis"}
+
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "false")
+    response = client.get("/api/v1/business/status")
+    assert response.status_code == 200
+    assert response.json() == {"enabled": False, "module": "business_analysis"}
+
+
+def test_enabled_business_routes_stay_hidden_from_public_openapi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
+
+    app_main.ensure_canonical_app_bootstrap(app_main.app)
+    app_main.app.openapi_schema = None
+
+    paths = set(app_main.app.openapi().get("paths", {}))
+
+    assert paths.isdisjoint(_EXPECTED_BUSINESS_ROUTE_PATHS)

--- a/tests/test_business_router.py
+++ b/tests/test_business_router.py
@@ -66,14 +66,14 @@ class TestBusinessRouterIsolated:
         self.app.dependency_overrides[require_app_api_key] = _raise_forbidden
 
     def test_status_enabled_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
         resp = self.client.get("/api/v1/business/status")
         assert resp.status_code == 200, resp.text
         assert resp.json() == {"enabled": True, "module": "business_analysis"}
 
     def test_status_enabled_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", False)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "false")
 
         resp = self.client.get("/api/v1/business/status")
         assert resp.status_code == 200, resp.text
@@ -81,14 +81,14 @@ class TestBusinessRouterIsolated:
 
     def test_analyze_422_missing_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_ok()
-        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
         resp = self.client.post("/api/v1/business/analyze", json={"test_name": "t1"})
         assert resp.status_code == 422
 
     def test_analyze_403_when_api_key_guard_rejects(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_forbidden()
-        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
         resp = self.client.post(
             "/api/v1/business/analyze",
@@ -323,7 +323,7 @@ class TestBusinessRouterIsolated:
 
     def test_analyze_503_when_module_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_ok()
-        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", False)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "false")
 
         def _business_module_disabled(_locale: object, _key: object) -> str:
             return "business_module_disabled"
@@ -343,7 +343,7 @@ class TestBusinessRouterIsolated:
 
     def test_analyze_413_payload_too_large(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_ok()
-        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
         def _payload_too_large(_locale: object, _key: object) -> str:
             return "business_payload_too_large"
@@ -365,7 +365,7 @@ class TestBusinessRouterIsolated:
     def test_analyze_200_payload_at_size_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Exact 100KB payload should be accepted (boundary test for < vs <=)."""
         self._auth_ok()
-        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
         expected = [
             _AnalyzerResult(
@@ -400,7 +400,7 @@ class TestBusinessRouterIsolated:
 
     def test_analyze_happy_path_maps_results(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_ok()
-        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
         expected = [
             _AnalyzerResult(
@@ -449,7 +449,7 @@ class TestBusinessRouterIsolated:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         self._auth_ok()
-        monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", True)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
         monkeypatch.setattr(
             self.mod,
             "_localized_error",

--- a/tests/test_business_router_coverage.py
+++ b/tests/test_business_router_coverage.py
@@ -8,6 +8,7 @@ Tests verify:
 - HTTPException pass-through
 """
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -90,7 +91,7 @@ class TestBusinessAnalysisEndpoint:
 
     def test_business_module_disabled_returns_503(self, test_client, monkeypatch) -> None:
         """When module disabled, should return 503 before attempting analysis."""
-        monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", False)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "false")
 
         response = test_client.post(
             "/api/v1/business/analyze",
@@ -103,7 +104,7 @@ class TestBusinessAnalysisEndpoint:
 
     def test_oversized_payload_rejected_with_413(self, test_client, monkeypatch) -> None:
         """Payloads > 100KB should be rejected with 413 (manual check) to prevent DoS."""
-        monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
         # Create exactly 100,001 bytes of code
         oversized_code = "x" * 100_001
@@ -118,15 +119,14 @@ class TestBusinessAnalysisEndpoint:
         assert response.status_code == 413
 
 
-@pytest.mark.asyncio
-async def test_analyze_business_code_oversized_payload_internal(
+def test_analyze_business_code_oversized_payload_internal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Internal guard: oversized payloads raise 413 even when using direct model construction."""
     from app.routers.business import BusinessAnalysisRequest, analyze_business_code
 
     # Ensure module-level flag allows analysis
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
     oversized_code = "x" * 100_001
 
@@ -138,9 +138,11 @@ async def test_analyze_business_code_oversized_payload_internal(
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await analyze_business_code(
-            request,
-            _api_key=API_KEY_HEADERS["X-API-Key"],
+        asyncio.run(
+            analyze_business_code(
+                request,
+                _api_key=API_KEY_HEADERS["X-API-Key"],
+            )
         )
 
     assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
@@ -149,7 +151,7 @@ async def test_analyze_business_code_oversized_payload_internal(
 
 def test_exactly_100kb_payload_accepted(test_client, monkeypatch) -> None:
     """Payload of exactly 100KB should be accepted."""
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
     with patch("app.routers.business.BusinessBayesianAnalyzer") as MockAnalyzer:
         mock_instance = MockAnalyzer.return_value
@@ -183,7 +185,7 @@ def test_business_analysis_invalid_api_key_rejected(test_client, monkeypatch) ->
     from app.main import app as main_app
     from app.routers.api_key import require_app_api_key
 
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
     def _reject_invalid() -> str:
         raise HTTPException(status_code=403, detail="Invalid API Key")
@@ -207,7 +209,7 @@ def test_analyzer_exception_wrapped_as_500(test_client, monkeypatch, caplog) -> 
     """Non-HTTP exceptions from analyzer should be wrapped as 500."""
     import logging
 
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
     with patch("app.routers.business.BusinessBayesianAnalyzer") as MockAnalyzer:
         mock_instance = MockAnalyzer.return_value
@@ -230,7 +232,7 @@ def test_analyzer_exception_wrapped_as_500(test_client, monkeypatch, caplog) -> 
 
 def test_http_exception_passed_through_unchanged(test_client, monkeypatch) -> None:
     """HTTPException from analyzer should pass through without wrapping."""
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
     with patch("app.routers.business.BusinessBayesianAnalyzer") as MockAnalyzer:
         mock_instance = MockAnalyzer.return_value
@@ -254,14 +256,14 @@ def test_http_exception_passed_through_unchanged(test_client, monkeypatch) -> No
 def test_status_endpoint_reflects_module_state(test_client, monkeypatch) -> None:
     """Status endpoint should accurately reflect BUSINESS_MODULE_ENABLED."""
     # Test when enabled
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
     response = test_client.get("/api/v1/business/status")
     assert response.status_code == 200
     assert response.json()["enabled"] is True
     assert response.json()["module"] == "business_analysis"
 
     # Test when disabled
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", False)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "false")
     response = test_client.get("/api/v1/business/status")
     assert response.status_code == 200
     assert response.json()["enabled"] is False
@@ -272,7 +274,7 @@ def test_error_type_handling_when_analyzer_returns_error(test_client, monkeypatc
     """Verify error_type conversion when analysis returns error results."""
     from core.business_bayesian_analyzer import BusinessErrorType
 
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
     with patch("app.routers.business.BusinessBayesianAnalyzer") as MockAnalyzer:
         mock_instance = MockAnalyzer.return_value
@@ -308,7 +310,7 @@ def test_multiple_results_returned_as_list(test_client, monkeypatch) -> None:
     """Analyzer can return multiple results for different aspects."""
     from core.business_bayesian_analyzer import BusinessCategory
 
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
     with patch("app.routers.business.BusinessBayesianAnalyzer") as MockAnalyzer:
         mock_instance = MockAnalyzer.return_value
@@ -355,7 +357,7 @@ def test_log_injection_prevented_in_error_logging(test_client, monkeypatch, capl
     """Test that malicious test_name values are sanitized before logging."""
     import logging
 
-    monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
 
     with patch("app.routers.business.BusinessBayesianAnalyzer") as MockAnalyzer:
         mock_instance = MockAnalyzer.return_value

--- a/tests/test_coverage_boost_final.py
+++ b/tests/test_coverage_boost_final.py
@@ -73,7 +73,7 @@ class TestCoverageFinalBoost:
         """Cover business router edge cases."""
         from app.routers.api_key import require_app_api_key
 
-        monkeypatch.setattr("app.routers.business.BUSINESS_MODULE_ENABLED", True)
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
         test_client.app.dependency_overrides[require_app_api_key] = lambda: "test-api-key"
         try:
             with patch("app.routers.business.BusinessBayesianAnalyzer") as MockAnalyzer:

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -638,6 +638,87 @@ def test_legacy_growth_guard_rejects_aliased_bodyfat_router_registration() -> No
     ]
 
 
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            textwrap.dedent("""
+                from app.routers.business import router as business_router
+
+                app.include_router(business_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:business_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.business:router -> business_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from app.routers.business import router as canonical_business_router
+
+                app.include_router(canonical_business_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:canonical_business_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.business:router -> canonical_business_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import app.routers.business as business_routes
+
+                app.include_router(business_routes.router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:business_routes.router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:import:app.routers.business -> business_routes",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                business_router = importlib.import_module("app.routers.business").router
+                app.include_router(business_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:business_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.business -> business_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                if (business_router := importlib.import_module("app.routers.business").router):
+                    app.include_router(business_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:business_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.business -> business_router",
+            ],
+        ),
+    ],
+)
+def test_legacy_growth_guard_rejects_business_router_reintroduction(
+    source: str,
+    expected: list[str],
+) -> None:
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == expected
+
+
 def test_legacy_growth_guard_rejects_module_qualified_bodyfat_router_registration() -> None:
     source = textwrap.dedent("""
         import app.routers.bodyfat as bodyfat_routes
@@ -666,6 +747,8 @@ def test_legacy_growth_guard_rejects_dynamic_bodyfat_router_hidden_as_allowed_na
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router",
     ]
@@ -680,6 +763,8 @@ def test_legacy_growth_guard_rejects_dunder_import_bodyfat_router_hidden_as_allo
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router",
     ]
@@ -696,6 +781,8 @@ def test_legacy_growth_guard_rejects_aliased_import_module_bodyfat_router() -> N
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router",
     ]
@@ -712,6 +799,8 @@ def test_legacy_growth_guard_rejects_aliased_builtin_import_bodyfat_router() -> 
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router",
     ]
@@ -729,6 +818,8 @@ def test_legacy_growth_guard_rejects_simple_import_module_alias_bodyfat_router()
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router",
     ]
@@ -744,6 +835,8 @@ def test_legacy_growth_guard_rejects_simple_dunder_import_alias_bodyfat_router()
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router",
     ]
@@ -760,6 +853,8 @@ def test_legacy_growth_guard_rejects_destructured_dynamic_bodyfat_router() -> No
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router",
     ]
@@ -776,6 +871,8 @@ def test_legacy_growth_guard_rejects_walrus_dynamic_bodyfat_router() -> None:
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router",
     ]
@@ -793,6 +890,8 @@ def test_legacy_growth_guard_rejects_walrus_import_function_alias_bodyfat_router
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router",
     ]
@@ -909,6 +1008,8 @@ def test_legacy_growth_guard_rejects_nested_dynamic_bodyfat_router_composition()
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:business_router",
         "legacy_app.py: unexpected app.routers import growth: "
         "router_import:dynamic:app.routers.bodyfat -> business_router.include_router",
     ]

--- a/tests/test_route_family_bootstrap.py
+++ b/tests/test_route_family_bootstrap.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Sequence
 
 import pytest
-from fastapi import APIRouter, Depends, FastAPI, WebSocket
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, WebSocket
+from fastapi.testclient import TestClient
 
 from app.bootstrap.route_family import (
     RouteMemberContract,
@@ -353,3 +355,61 @@ def test_callable_matcher_uses_module_and_qualname_after_identity() -> None:
     assert same_callable_by_module_and_qualname(_expected, _expected)
     assert same_callable_by_module_and_qualname(_equivalent, _expected)
     assert not same_callable_by_module_and_qualname(None, _expected)
+
+
+def test_business_bootstrap_noops_when_feature_flag_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app import main as app_main
+
+    monkeypatch.delenv("BUSINESS_MODULE_ENABLED", raising=False)
+    app = FastAPI()
+
+    app_main._include_business_router_if_enabled(app)
+
+    assert not any(
+        str(getattr(route, "path", "")).startswith("/api/v1/business") for route in app.routes
+    )
+
+
+def test_business_analyze_direct_call_rejects_disabled_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers.business import BusinessAnalysisRequest, analyze_business_code
+
+    monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "false")
+    request = BusinessAnalysisRequest(code="def test(): pass", test_name="disabled")
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(analyze_business_code(request, "placeholder"))
+
+    assert exc_info.value.status_code == 503
+
+
+def test_business_status_route_reports_request_time_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers.business import router as business_router
+
+    app = FastAPI()
+    app.include_router(business_router)
+    client = TestClient(app)
+
+    try:
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "true")
+        enabled_response = client.get("/api/v1/business/status")
+        assert enabled_response.status_code == 200
+        assert enabled_response.json() == {
+            "enabled": True,
+            "module": "business_analysis",
+        }
+
+        monkeypatch.setenv("BUSINESS_MODULE_ENABLED", "false")
+        disabled_response = client.get("/api/v1/business/status")
+        assert disabled_response.status_code == 200
+        assert disabled_response.json() == {
+            "enabled": False,
+            "module": "business_analysis",
+        }
+    finally:
+        client.close()


### PR DESCRIPTION
## Goal
Move business route registration ownership out of `legacy_app.py` and into canonical `app.main` bootstrap while fixing the feature-flag contract to explicit truthy enablement only.

## Business Reason
This keeps legacy routes as compatibility aliases only, reduces route ownership ambiguity, and makes the business module fail closed unless an operator explicitly enables it.

## Scope
- Add canonical feature flag helpers in `app.utils.feature_flags`.
- Register the business route family from `app.main` through `ensure_route_family_registered()`.
- Remove `business_router` import/registration and local business flag parsing from `legacy_app.py`.
- Add focused bootstrap tests for route presence, duplicate prevention, family validation, dependency contracts, and public OpenAPI hiding.
- Tighten the legacy-growth guard and update backend routing map documentation.

## Out of Scope
- Bayesian analyzer behavior or quality.
- Nutrition, shopping, FoodDB, frontend, iOS, macOS.
- Auth redesign or `/status` auth change.
- Generated OpenAPI/client artifact changes.
- Middleware, lifespan, app factory, or full route-system refactor.

## Files Changed
- `app/main.py`
- `app/routers/business.py`
- `app/utils/feature_flags.py`
- `legacy_app.py`
- `scripts/ci/check_legacy_growth_guard.py`
- `tests/test_business_registration_bootstrap.py`
- `tests/test_business_router.py`
- `tests/test_business_router_coverage.py`
- `tests/test_coverage_boost_final.py`
- `tests/test_legacy_growth_guard.py`
- `tests/security/_api_authz_contracts.py`
- `docs/architecture/backend_routing_map.md`
- `docs/review/PR_2061_FIXED_MAPPING.md`

## Key Decisions
- `BUSINESS_MODULE_ENABLED` is enabled only by explicit truthy values: `1`, `true`, `yes`, `on`.
- `BUSINESS_ROUTE_SPECS` preserves current source route visibility; final public OpenAPI remains filtered.
- `/api/v1/business/analyze` keeps `require_app_api_key` in the route dependency graph.
- `/api/v1/business/status` remains unauthenticated when the module is enabled.
- `legacy_app.py` no longer owns business import or registration.

## Tests / Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_business_registration_bootstrap.py tests/test_business_router.py tests/test_business_router_coverage.py tests/test_legacy_growth_guard.py`
- `pytest -q tests/test_business_registration_bootstrap.py tests/test_business_router.py tests/test_business_router_coverage.py tests/test_legacy_growth_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
- `python3 scripts/ci/check_legacy_growth_guard.py`
- `DEV_PYTHON=<repo .venv python> make openapi-check`
- `pytest -q tests/test_openapi_determinism.py::test_openapi_pipeline_uses_current_python_for_make tests/test_openapi_determinism.py::test_openapi_and_schema_ts_are_deterministic`
- `pytest -q tests/test_coverage_boost_final.py -k business_router_edge_paths`
- `pytest -q tests/test_route_family_bootstrap.py`
- `pytest -q tests/test_business_registration_bootstrap.py tests/test_route_family_bootstrap.py`
- focused local coverage + `diff-cover coverage.xml --compare-branch=origin/main --fail-under=97` -> changed source coverage `100%`
- `git diff --check`
- `DEV_PYTHON=<repo .venv python> VENV_PYTHON=<repo .venv python> make validate-changed`
- `pre-commit run --all-files`
- `python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 2061 --require-auth`
- `python3 scripts/ci/check_pr_merge_readiness.py --pr-number 2061 --repo Katsiarynakavaleuskaya/PulsePlate`

Full local `make verify` was intentionally not run under the repository local full-verify budget rule. Heavy/current-head CI remains the merge evidence source.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/d880f5d825dd.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`

## Governance Evidence
- Role dispatch order executed pre-open: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor`
- Premortem artifact: `artifacts/orchestration/premortem/business-registration-bootstrap-premortem.md`
- Experiment Runner accepted oracle artifact: `artifacts/orchestration/experiments/results/exp-866cae82ee55.json`
- Experiment Runner note: local macOS network-disabled sandbox lacks Linux `unshare`, so the accepted packet used `network_budget=1`; oracle commands were local deterministic checks.
- Post-open role pass: `qa-engineer-agent -> bug-hunter -> security-auditor`
- Codex Security scan: `0775a86e-aac6-471a-aebb-da641ee6982d`, reportable findings `0`
- `pulseplate-pr-review`: completed; only advisory large-diff planning note, dispositioned in fixed mapping.
- Current-head `diff-coverage` failure from run `28574995138`, job `84724590497`, fixed by `bdaea1b68` and mapped in the canonical artifact.
- Final current-head CI run `28583621356` passed on head `032f93025`; strict merge-readiness wrapper passed after that run.
- Codex review P1 thread fixed in `77001496e05fbabe53c371ffb6e92cb83e3858c7` and resolved after mapping.
- CodeRabbit state-restoration thread fixed in `3f58ff443` and resolved after mapping.
- Sourcery review disposition recorded as `NOT-A-BUG` in the canonical mapping artifact.

## Security Notes
- Default behavior is fail-closed: business routes are absent unless `BUSINESS_MODULE_ENABLED` is explicitly truthy.
- `/analyze` still requires `require_app_api_key`.
- `/status` auth behavior is unchanged.
- Public OpenAPI remains free of `/api/v1/business/*`.
- Legacy-growth guard now rejects business router reintroduction patterns.

## Risks / Rollback
- Risk: hidden business route registration could drift from the source router contract. Mitigation: focused route-family tests cover missing, wrong-method, foreign-handler, dependency, and visibility-drift cases.
- Rollback: revert this PR; legacy business registration is not required for the default-disabled path, and the feature remains operator-gated.

## Deferred / Follow-ups
- Full local `make verify` remains deferred by policy.
- Fixed mapping artifact: `docs/review/PR_2061_FIXED_MAPPING.md`.

## AGENTS / Instructions Updates
None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed
- [x] Codex Security diff scan / finding discovery completed
- [x] `pulseplate-pr-review` completed
- [x] CodeRabbit, Sourcery, and Cubic actionables checked and dispositioned
- [x] Review threads checked, mapped, and resolved where applicable

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2061_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#discussion_r3511088671 -> 77001496e05fbabe53c371ffb6e92cb83e3858c7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#pullrequestreview-4615160415
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#discussion_r3511698704 -> 3f58ff443
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2061#pullrequestreview-4615911898 -> 3f58ff443

## Merge Readiness
Ready for merge execution. Local focused gates, post-open role/security review, bot disposition mapping, current-head CI on `032f93025`, and strict `check_merge_ready.py --require-auth --experiment-runner-evidence-mode required` have passed. Superseded historical failures are classified non-blocking by the current-head wrapper.

## Next Best Step
Merge PR #2061, sync local `main`, remove the temporary branch/worktree, and delete lane-local artifacts/trash.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Business routes are registered only when the business feature flag is explicitly set to a truthy value.
  * Auth behavior is consistent: `POST /api/v1/business/analyze` requires an app API key when enabled; `GET /api/v1/business/status` exposes the enabled/disabled state.
  * Enabled business routes remain excluded from the public OpenAPI schema.

* **Bug Fixes**
  * Business availability/status now consistently follow the same feature-flag source.

* **Tests / Documentation**
  * Expanded business bootstrap, routing/auth, and OpenAPI visibility test coverage; updated backend routing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

