### PR TITLE
fix(security): remove gzip from production Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,7 @@ jobs:
           python3 scripts/ci/check_docker_runtime_dependency_surface.py \
             --image pulseplate:test \
             --blocked-debian-package apt \
+            --blocked-debian-package gzip \
             --blocked-debian-package gpgv \
             --blocked-debian-package libacl1 \
             --blocked-debian-package libattr1 \
@@ -550,6 +551,22 @@ jobs:
         id: image-ref
         run: |
           echo "ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Check Docker publish runtime dependency surface
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_docker_runtime_dependency_surface.py \
+            --image ${{ steps.image-ref.outputs.ref }} \
+            --blocked-debian-package apt \
+            --blocked-debian-package gzip \
+            --blocked-debian-package gpgv \
+            --blocked-debian-package libacl1 \
+            --blocked-debian-package libattr1 \
+            --blocked-debian-package libgnutls30 \
+            --blocked-debian-package libsqlite3-0 \
+            --blocked-debian-package perl-base \
+            --blocked-debian-prefix perl-modules- \
+            --output-json docker-publish-runtime-dependency-surface.json
 
       # Image scan fails closed on HIGH/CRITICAL findings and scanner/SARIF errors.
       # Do not change output path without updating hashFiles('trivy-image.sarif')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -553,10 +553,12 @@ jobs:
           echo "ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Check Docker publish runtime dependency surface
+        env:
+          IMAGE_REF: ${{ steps.image-ref.outputs.ref }}
         run: |
           set -euo pipefail
           python3 scripts/ci/check_docker_runtime_dependency_surface.py \
-            --image ${{ steps.image-ref.outputs.ref }} \
+            --image "${IMAGE_REF}" \
             --blocked-debian-package apt \
             --blocked-debian-package gzip \
             --blocked-debian-package gpgv \

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -74,6 +74,7 @@ jobs:
           python3 scripts/ci/check_docker_runtime_dependency_surface.py \
             --image pulseplate:trivy-scan-${{ github.sha }} \
             --blocked-debian-package apt \
+            --blocked-debian-package gzip \
             --blocked-debian-package gpgv \
             --blocked-debian-package libacl1 \
             --blocked-debian-package libattr1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -377,11 +377,11 @@ if importlib.util.find_spec("pip") is not None:
     sys.exit(1)
 PY
 
-# RU: Убираем package-manager TLS, ACL/attr, Debian SQLite и Perl runtime surface только из production;
+# RU: Убираем package-manager TLS, ACL/attr, Debian SQLite, gzip и Perl runtime surface только из production;
 # RU: runtime-base/development остаются с apt для dev/staging workflows. apt/gpgv/perl-base
 # RU: essential для Debian, поэтому удаление намеренно ограничено final production stage
 # RU: и проверяется fail-closed.
-# EN: Remove the package-manager TLS, ACL/attr, Debian SQLite, and Perl runtime
+# EN: Remove the package-manager TLS, ACL/attr, Debian SQLite, gzip, and Perl runtime
 # EN: surface only from production; runtime-base/development keep apt for dev/staging workflows.
 # EN: apt/gpgv/perl-base are Debian-essential, so this removal is intentionally limited
 # EN: to the final production stage and checked fail-closed.
@@ -389,6 +389,7 @@ PY
 RUN perl_module_packages="$(dpkg-query -W -f='${Package}\n' 'perl-modules-*' 2>/dev/null || true)" \
     && dpkg --purge --force-depends --force-remove-essential \
         apt \
+        gzip \
         gpgv \
         libacl1 \
         libattr1 \
@@ -397,14 +398,22 @@ RUN perl_module_packages="$(dpkg-query -W -f='${Package}\n' 'perl-modules-*' 2>/
         perl-base \
         ${perl_module_packages} \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && for package in apt gpgv libacl1 libattr1 libgnutls30 libsqlite3-0 perl-base ${perl_module_packages}; do \
+    && for package in apt gzip gpgv libacl1 libattr1 libgnutls30 libsqlite3-0 perl-base ${perl_module_packages}; do \
         status="$(dpkg-query -W -f='${db:Status-Abbrev}' "${package}" 2>/dev/null || true)"; \
         if [ "${status#ii}" != "${status}" ]; then \
             echo "${package} remains installed after production package pruning" >&2; \
             exit 1; \
         fi; \
     done \
+    && for binary in gzip gunzip zcat; do \
+        if command -v "${binary}" >/dev/null 2>&1; then \
+            echo "${binary} binary remains after production package pruning" >&2; \
+            exit 1; \
+        fi; \
+    done \
     && /usr/local/bin/python - <<'PY'
+import gzip
+import io
 import ssl
 import sqlite3
 import sys
@@ -417,6 +426,11 @@ if version < (3, 53, 2):
     sys.stderr.write(
         f"Python sqlite3 loaded SQLite {sqlite3.sqlite_version}, expected >= 3.53.2\n"
     )
+    sys.exit(1)
+payload = b"pulseplate gzip stdlib smoke"
+compressed = gzip.compress(payload, mtime=0)
+if gzip.GzipFile(fileobj=io.BytesIO(compressed), mode="rb").read() != payload:
+    sys.stderr.write("Python gzip stdlib smoke failed after production package pruning\n")
     sys.exit(1)
 PY
 # SECURITY: production-package-pruning-end

--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -712,6 +712,35 @@ Route-family registrars should fail closed on:
 - A focused live route-table test that fails on duplicate paid-tier
   method/path entries.
 
+## 27) Premortem must close production risks in code, not just documents
+
+### Problem
+Premortem can drift into a governance artifact: the PR contains a risk document,
+the risks have disposition words, and the lane appears compliant, but no new
+production invariant, workflow guard, or test was added. That turns premortem
+into paperwork instead of a prediction exercise against the actual diff.
+
+### Rule
+For non-trivial PRs, premortem starts from "how this exact diff could make
+`main` worse in production within 48 hours." Each credible failure story must
+end in one of these closures:
+
+1. code, workflow, or test change that makes the failure fail closed
+2. explicit stop-condition in the PR evidence when the risk cannot be proven
+   pre-merge
+3. backlog item only when the risk is genuinely out of scope and safe to defer
+
+Do not count a premortem as complete because the document exists. Count it only
+when at least one real production failure mode was actively challenged, and any
+credible current-PR risk was fixed or blocked by a guard.
+
+### Use instead
+
+- Diff-first failure stories tied to changed files and CI/runtime behavior.
+- Contract tests for every workflow or runtime invariant added by the premortem.
+- PR evidence that separates pre-merge proof from post-merge proof when a lane
+  such as publish cannot run automatically on pull requests.
+
 ---
 
 ## Repo Commands Reference

--- a/docs/review/PR_2062_FIXED_MAPPING.md
+++ b/docs/review/PR_2062_FIXED_MAPPING.md
@@ -21,7 +21,7 @@ backlog tracking, and a diff-first premortem with code closures.
 - [x] Post-open `security-auditor` pass completed.
 - [x] Codex Security diff scan / finding discovery completed.
 - [ ] `pulseplate-pr-review` completed.
-- [ ] CodeRabbit actionable review comments checked and dispositioned.
+- [x] CodeRabbit actionable review comments checked and dispositioned.
 - [ ] Sourcery actionable review comments checked and dispositioned.
 - [ ] Cubic actionable review comments checked and dispositioned.
 - [ ] Current-head CI complete before readiness language.
@@ -29,7 +29,15 @@ backlog tracking, and a diff-first premortem with code closures.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2062#discussion_r3511718210 -> 5583e6f337156606d1f681f9e74b17fbc9e222ce
+Disposition: FIXED
+Commit: 5583e6f337156606d1f681f9e74b17fbc9e222ce
+Evidence: `docs/security/CVE-2026-41992-gzip.md` now cites concrete `file:line` anchors for Dockerfile package pruning, build/publish/trivy workflow guards, runtime-surface tests, and no-suppression tests.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2062#discussion_r3511718203 -> 95428f1d98820893000c60f48258381bc3bbd262
+Disposition: FIXED
+Commit: 95428f1d98820893000c60f48258381bc3bbd262
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now records `Target PR: PR #2062` with the PR URL and keeps the branch slug in a separate `Branch:` field.
 
 ## Role-Agent Finding Dispositions
 

--- a/docs/review/PR_2062_FIXED_MAPPING.md
+++ b/docs/review/PR_2062_FIXED_MAPPING.md
@@ -58,11 +58,15 @@ Evidence: `docs/review/PR_2062_FIXED_MAPPING.md` replaced the no-actionable sent
 Disposition: NOT-A-BUG
 Evidence: Sourcery posted a rate-limit notice, not actionable code-review feedback for this diff. The PR status context reports `Sourcery review` as pass, and no Sourcery code comments require code or documentation changes.
 
-- Cubic status check: https://www.cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2062
-Disposition: NOT-A-BUG
-Evidence: Cubic exposed a neutral/skipped status check and no actionable review comments in the GitHub PR review/comment surfaces inspected for PR #2062.
-
 ## Role-Agent Finding Dispositions
+
+Disposition: NOT-A-BUG
+Source: Cubic status check
+Evidence: Cubic exposed a neutral/skipped status check and no actionable review
+comments in the GitHub PR review/comment surfaces inspected for PR #2062. Cubic
+does not produce a GitHub PR review/comment URL accepted by the canonical Fixed
+in Commit Mapping parser, so it is tracked here as status evidence rather than
+as a mapping entry.
 
 Disposition: FIXED
 Source: post-open `qa-engineer-agent`

--- a/docs/review/PR_2062_FIXED_MAPPING.md
+++ b/docs/review/PR_2062_FIXED_MAPPING.md
@@ -39,6 +39,11 @@ Disposition: FIXED
 Commit: 95428f1d98820893000c60f48258381bc3bbd262
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now records `Target PR: PR #2062` with the PR URL and keeps the branch slug in a separate `Branch:` field.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2062#discussion_r3511776681 -> d5e1f60c25cbedd7bc2471d723340330498073d1
+Disposition: FIXED
+Commit: d5e1f60c25cbedd7bc2471d723340330498073d1
+Evidence: `docs/review/PR_2062_FIXED_MAPPING.md` replaced the no-actionable sentinel with concrete CodeRabbit review-thread mappings and disposition proof.
+
 ## Role-Agent Finding Dispositions
 
 Disposition: FIXED

--- a/docs/review/PR_2062_FIXED_MAPPING.md
+++ b/docs/review/PR_2062_FIXED_MAPPING.md
@@ -1,0 +1,106 @@
+# PR #2062 Fixed in Commit Mapping SoT
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2062
+
+Branch: `codex/fix-main-docker-publish-gzip-cve-2026-41992`
+
+## Summary
+
+This PR removes Debian `gzip` from the final production Docker image surface to
+remediate Trivy `CVE-2026-41992` without `.trivyignore` or Rego suppression. It
+adds fail-closed package/binary assertions, build/publish/standalone Trivy
+runtime-surface guards, focused tests, a production package-removal disposition,
+backlog tracking, and a diff-first premortem with code closures.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed.
+- [x] Fixed in commit mapping completed.
+- [x] Post-open `qa-engineer-agent` pass completed.
+- [x] Post-open `bug-hunter` pass completed.
+- [x] Post-open `security-auditor` pass completed.
+- [x] Codex Security diff scan / finding discovery completed.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] CodeRabbit actionable review comments checked and dispositioned.
+- [ ] Sourcery actionable review comments checked and dispositioned.
+- [ ] Cubic actionable review comments checked and dispositioned.
+- [ ] Current-head CI complete before readiness language.
+- [ ] Strict merge-readiness checks run after the final review/check cycle.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Role-Agent Finding Dispositions
+
+Disposition: FIXED
+Source: post-open `qa-engineer-agent`
+Evidence: This artifact adds the missing canonical mapping file required by PR
+Phase2 and merge-readiness governance for PR #2062.
+
+Disposition: FIXED
+Source: post-open `qa-engineer-agent`
+Evidence: `docs/security/CVE-2026-41992-gzip.md` now uses concrete `file:line`
+evidence anchors for Dockerfile package pruning, build/publish/trivy workflow
+guards, runtime-surface tests, and no-suppression tests.
+
+Disposition: NOT-A-BUG
+Source: post-open `qa-engineer-agent`
+Evidence: The QA pass found no actionable test-adequacy issue for the Docker
+`gzip` behavior. It confirmed that PR body evidence boundaries are truthful:
+ordinary PR CI is not cited as publish proof, and image-level proof remains
+manual branch `trivy.yml` dispatch or post-merge `main` publish evidence.
+
+Disposition: NOT-A-BUG
+Source: pre-open and post-open `bug-hunter`
+Evidence: The final diff keeps the publish image guard before Trivy, GHCR login,
+push, SBOM, and attestations, and the premortem/backlog/security docs keep the
+same no-suppression disposition. No actionable bug-hunter finding remains after
+the security-doc anchor fix.
+
+Disposition: NOT-A-BUG
+Source: pre-open and post-open `security-auditor`
+Evidence: The final diff removes `gzip` from the production package surface,
+checks Debian package absence, checks `gzip`/`gunzip`/`zcat` binary absence,
+keeps Python stdlib `gzip` smoke coverage, and does not add `.trivyignore` or
+`trivy/ignore-policy.rego` suppression.
+
+Disposition: NOT-A-BUG
+Source: Codex Security diff scan / finding discovery
+Evidence: Codex Security scan `b126c050-0cc0-4070-ab1f-c83d66b76b59` completed
+with 0 findings and 10/10 diff surfaces covered. The scan focused on
+production-image package surface, publish workflow ordering before GHCR push,
+scanner suppression surfaces, and truthful evidence boundaries.
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/exp-f8a00f94aae2.json`
+- Experiment ID: `exp-f8a00f94aae2`
+- Mode: `oracle_only_governance_reviewer`
+- Status: accepted
+- Source diff applied: true
+- Oracles: 3/3 passed
+- Co-author required: yes, `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Premortem Code Closure
+
+- `docs/review/PR_MAIN_DOCKER_GZIP_CVE_PREMORTEM.md` records the concrete
+  production failure story that publish could build a separate image path
+  without the runtime dependency-surface guard.
+- `.github/workflows/build.yml` closes that risk in code by checking
+  `${{ steps.image-ref.outputs.ref }}` before Trivy, GHCR login, push, SBOM, or
+  attestations.
+- `tests/test_docker_workflow_build_path_contract.py` asserts the publish guard
+  ordering and `--blocked-debian-package gzip` argument.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/66070820b5a9.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+
+## Merge Readiness
+
+Not claimed. This artifact records post-open dispositions and local evidence
+only. Current-head PR CI, manual branch `trivy.yml` image-level proof or
+post-merge `main` publish evidence, and final review-bot disposition checks
+must complete before any readiness language.

--- a/docs/review/PR_2062_FIXED_MAPPING.md
+++ b/docs/review/PR_2062_FIXED_MAPPING.md
@@ -20,7 +20,7 @@ backlog tracking, and a diff-first premortem with code closures.
 - [x] Post-open `bug-hunter` pass completed.
 - [x] Post-open `security-auditor` pass completed.
 - [x] Codex Security diff scan / finding discovery completed.
-- [ ] `pulseplate-pr-review` completed.
+- [x] `pulseplate-pr-review` completed.
 - [x] CodeRabbit actionable review comments checked and dispositioned.
 - [x] Sourcery actionable review comments checked and dispositioned.
 - [x] Cubic actionable review comments checked and dispositioned.
@@ -102,6 +102,19 @@ Evidence: Codex Security scan `b126c050-0cc0-4070-ab1f-c83d66b76b59` completed
 with 0 findings and 10/10 diff surfaces covered. The scan focused on
 production-image package surface, publish workflow ordering before GHCR push,
 scanner suppression surfaces, and truthful evidence boundaries.
+
+Disposition: NOT-A-BUG
+Source: `pulseplate-pr-review`
+Evidence: The dry-run report completed for head
+`5471f088e96c6dca6562723ad2a0603875d18752` and emitted one advisory
+large-diff planning note: 11 changed files / 468 changed lines exceeded the
+300-line review-risk threshold. The diff remains one coherent Docker security
+lane: production package pruning, Docker workflow runtime-surface guards,
+focused tests, CVE disposition, backlog anchor, premortem closure, and fixed
+mapping. No split is needed for merge safety; proof is the focused Docker tests,
+`python3 scripts/orchestration/check_agent_consistency.py`,
+`make validate-changed`, `pre-commit run --all-files`, and current-head CI/Trivy
+before readiness language.
 
 ## Experiment Runner Evidence
 

--- a/docs/review/PR_2062_FIXED_MAPPING.md
+++ b/docs/review/PR_2062_FIXED_MAPPING.md
@@ -22,12 +22,22 @@ backlog tracking, and a diff-first premortem with code closures.
 - [x] Codex Security diff scan / finding discovery completed.
 - [ ] `pulseplate-pr-review` completed.
 - [x] CodeRabbit actionable review comments checked and dispositioned.
-- [ ] Sourcery actionable review comments checked and dispositioned.
-- [ ] Cubic actionable review comments checked and dispositioned.
+- [x] Sourcery actionable review comments checked and dispositioned.
+- [x] Cubic actionable review comments checked and dispositioned.
 - [ ] Current-head CI complete before readiness language.
 - [ ] Strict merge-readiness checks run after the final review/check cycle.
 
 ## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2062#pullrequestreview-4615936341 -> b7353977e414f88840bb9c13c764726ce71cd662
+Disposition: FIXED
+Commit: b7353977e414f88840bb9c13c764726ce71cd662
+Evidence: The review-level CodeRabbit summary contained three actionable items. `docs/roadmap/BACKLOG_LEDGER.md` now targets PR #2062, `docs/security/CVE-2026-41992-gzip.md` now has concrete file:line anchors, and `.github/workflows/build.yml` now passes the publish image reference through `env: IMAGE_REF` before the shell `run:` block. `tests/test_docker_workflow_build_path_contract.py` asserts the env binding and forbids `steps.image-ref.outputs.ref` inside that runtime-surface guard script.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2062#pullrequestreview-4616005241 -> d5e1f60c25cbedd7bc2471d723340330498073d1
+Disposition: FIXED
+Commit: d5e1f60c25cbedd7bc2471d723340330498073d1
+Evidence: The later CodeRabbit review-level summary requested concrete fixed-mapping entries. `docs/review/PR_2062_FIXED_MAPPING.md` now lists each actionable CodeRabbit thread with disposition-specific proof and post-comment commit SHAs.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2062#discussion_r3511718210 -> 5583e6f337156606d1f681f9e74b17fbc9e222ce
 Disposition: FIXED
@@ -43,6 +53,14 @@ Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now records `Target PR: PR #2062` wit
 Disposition: FIXED
 Commit: d5e1f60c25cbedd7bc2471d723340330498073d1
 Evidence: `docs/review/PR_2062_FIXED_MAPPING.md` replaced the no-actionable sentinel with concrete CodeRabbit review-thread mappings and disposition proof.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2062#pullrequestreview-4615879762
+Disposition: NOT-A-BUG
+Evidence: Sourcery posted a rate-limit notice, not actionable code-review feedback for this diff. The PR status context reports `Sourcery review` as pass, and no Sourcery code comments require code or documentation changes.
+
+- Cubic status check: https://www.cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2062
+Disposition: NOT-A-BUG
+Evidence: Cubic exposed a neutral/skipped status check and no actionable review comments in the GitHub PR review/comment surfaces inspected for PR #2062.
 
 ## Role-Agent Finding Dispositions
 

--- a/docs/review/PR_MAIN_DOCKER_GZIP_CVE_PREMORTEM.md
+++ b/docs/review/PR_MAIN_DOCKER_GZIP_CVE_PREMORTEM.md
@@ -1,0 +1,90 @@
+# Main Docker gzip CVE Premortem
+
+Mode: `pr-premortem`
+Skill: `pulseplate-premortem-risk-review`
+Packet: `artifacts/orchestration/task_packets/66070820b5a9.json`
+Branch: `codex/fix-main-docker-publish-gzip-cve-2026-41992`
+Date: 2026-07-02
+
+## Frame
+
+It is 48 hours from now. This hotfix made the Docker publish lane worse while
+trying to remediate `CVE-2026-41992`. We are looking backward to understand why.
+
+This premortem is diff-first: a finding is useful only when it drives code/test
+closure, or when the lane records a concrete stop-condition that prevents a
+false readiness claim.
+
+## Findings
+
+### P1: The publish image path skipped the package-surface guard
+
+Failure story: Pull-request CI proves `pulseplate:test` with
+`check_docker_runtime_dependency_surface.py`, but the `publish` job builds a
+separate production image path and then goes straight to Trivy. If a future
+workflow edit changes tags, target, or build inputs, the publish image could
+reintroduce `gzip` and only fail later as a scanner finding, after the guard
+failed to give actionable package-inventory evidence.
+
+Closure: FIXED in code. The `publish` job now runs
+`check_docker_runtime_dependency_surface.py` against
+`${{ steps.image-ref.outputs.ref }}` before the Trivy image scan, GHCR login,
+push, SBOM, or attestations. The workflow contract test asserts that ordering
+and the blocked `gzip` package argument.
+
+### P1: The PR removed the Debian package but left a system gzip binary behind
+
+Failure story: Trivy no longer reports the expected dpkg package state in the
+runtime-surface check, but `/bin/gzip`, `gunzip`, or `zcat` still exists through
+a base-image alias or unexpected package relationship. The PR appears locally
+green while the published image still exposes the vulnerable command-line
+surface.
+
+Closure: FIXED. The Dockerfile production pruning block now fails closed if
+`gzip`, `gunzip`, or `zcat` remains resolvable, and the Dockerfile contract test
+guards the binary check.
+
+### P1: Removing system gzip broke application-level compressed food-data handling
+
+Failure story: The production image removes system `gzip`, but an app path
+implicitly relied on the shell binary for `.gz` food-data artifacts. The publish
+scan passes, but runtime OFF/FDC ingestion later fails.
+
+Closure: FIXED. Existing app code uses Python stdlib `gzip`, and the Dockerfile
+now runs a production-stage stdlib gzip round-trip smoke after pruning.
+
+### P1: The lane claimed publish proof from PR checks that do not run publish
+
+Failure story: The PR is called ready because pull-request Docker build checks
+pass, but `.github/workflows/build.yml` skips `publish` on pull requests and
+standalone `trivy.yml` is not PR-triggered. The real `main` publish lane stays
+red after merge.
+
+Closure: NOT-A-BUG with process evidence. The PR must state that pre-merge
+image-level proof requires manual `trivy.yml` dispatch on the PR branch or must
+remain post-merge `main` publish evidence. No readiness claim may cite ordinary
+PR CI as publish proof.
+
+### P2: The CVE was hidden with a broad suppression instead of remediated
+
+Failure story: A future maintainer sees the open code-scanning alert and adds a
+`.trivyignore` or Rego rule that suppresses `CVE-2026-41992` without removing the
+vulnerable package, creating a permanent blind spot.
+
+Closure: FIXED. This diff does not touch `.trivyignore` or `trivy/ignore-policy.rego`;
+tests assert `CVE-2026-41992` and `gzip` are not broadly ignored, and the backlog
+entry records production package removal as the disposition.
+
+## Decision
+
+Proceed with changes. The implementation is narrow and the identified failure
+modes are closed by fail-closed Dockerfile assertions, workflow runtime-surface
+guards, focused tests, and explicit PR evidence boundaries.
+
+## Pre-Open Checklist
+
+- Focused Docker/Trivy tests pass with the repo venv.
+- `check_agent_consistency.py`, `make validate-changed`, and `pre-commit run --all-files` pass.
+- Experiment Runner oracle-only evidence is produced after the coherent diff.
+- PR body records that publish/#617 closure requires manual branch Trivy dispatch
+  or post-merge main publish evidence.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -200,7 +200,8 @@ If it is not recorded here — it does not exist.
 - [ ] P1: Container image gzip CVE remediation (CVE-2026-41992)
   - Owner: @katsiaryna_kavaleuskaya (Security/SRE)
   - Priority: P1
-  - Target PR: codex/fix-main-docker-publish-gzip-cve-2026-41992
+  - Target PR: PR #2062 — https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2062
+  - Branch: codex/fix-main-docker-publish-gzip-cve-2026-41992
   - Status: In progress
   - Area: security / container / supply-chain
   - Reason (EN): Main Docker publish Trivy reports `gzip 1.12-1` for `CVE-2026-41992` with blank fixed-version metadata. Debian bookworm, trixie, and sid still mark their current `gzip` lines vulnerable, so this emergency lane remediates by production package removal instead of adding `.trivyignore` or `trivy/ignore-policy.rego` suppression.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -196,6 +196,17 @@ If it is not recorded here — it does not exist.
   - Links: `Dockerfile`, `.dockerignore`, `.github/workflows/build.yml`, `.github/workflows/trivy.yml`, `scripts/ci/docker_source_artifacts.json`, `scripts/ci/fetch_docker_source_artifacts.py`, `scripts/ci/check_docker_runtime_dependency_surface.py`, `.trivyignore`, `trivy/ignore-policy.rego`, `docs/security/CVE-2026-sqlite-runtime-removal.md`
   - DoD: CI/local Docker lanes run explicit source-artifact preparation before Docker build; Dockerfile performs no live upstream download; production image loads SQLite >=3.53.2 through Python `sqlite3`; production image removes Debian `libsqlite3-0`; Docker runtime dependency-surface guard fails if `libsqlite3-0` returns; broad `.trivyignore` SQLite CVE entries are removed; current-head Docker build/runtime-surface/Trivy image scan pass before any readiness claim.
 
+<a id="ledger-p1-container-gzip-cve-remediation"></a>
+- [ ] P1: Container image gzip CVE remediation (CVE-2026-41992)
+  - Owner: @katsiaryna_kavaleuskaya (Security/SRE)
+  - Priority: P1
+  - Target PR: codex/fix-main-docker-publish-gzip-cve-2026-41992
+  - Status: In progress
+  - Area: security / container / supply-chain
+  - Reason (EN): Main Docker publish Trivy reports `gzip 1.12-1` for `CVE-2026-41992` with blank fixed-version metadata. Debian bookworm, trixie, and sid still mark their current `gzip` lines vulnerable, so this emergency lane remediates by production package removal instead of adding `.trivyignore` or `trivy/ignore-policy.rego` suppression.
+  - Links: `Dockerfile`, `.github/workflows/build.yml`, `.github/workflows/trivy.yml`, `scripts/ci/check_docker_runtime_dependency_surface.py`, `.trivyignore`, `trivy/ignore-policy.rego`, `docs/security/CVE-2026-41992-gzip.md`
+  - DoD: Production image removes `gzip`; Dockerfile fails closed if `gzip`, `gunzip`, or `zcat` binaries remain; Python stdlib `gzip` smoke still passes; Docker build and publish runtime dependency-surface guards fail if `gzip` returns; do not suppress CVE-2026-41992; current-head Docker build/runtime-surface/Trivy image scan pass before any readiness claim.
+
 <a id="ledger-p1-private-pypi-proxy-mirror-parity"></a>
 - [ ] P1: Private PyPI proxy mirror parity and origin stability (packages host only — marketing 521 stays intentional)
   - Owner: @katsiaryna_kavaleuskaya (SRE/DevOps)

--- a/docs/security/CVE-2026-41992-gzip.md
+++ b/docs/security/CVE-2026-41992-gzip.md
@@ -32,19 +32,26 @@ continues to work after system package pruning.
 
 ## Evidence
 
-- `Dockerfile`: production package pruning removes `gzip`, checks package and
-  binary absence, and runs a Python stdlib `gzip` smoke.
-- `.github/workflows/build.yml`: Docker runtime dependency-surface guard blocks
-  `gzip`.
-- `.github/workflows/trivy.yml`: Trivy image lane blocks `gzip`.
-- `tests/test_docker_workflow_build_path_contract.py`: guards the Dockerfile
-  pruning block and workflow package block lists.
-- `tests/test_docker_runtime_dependency_surface.py`: verifies exact Debian
-  package blocking covers `gzip`.
-- `tests/test_trivy_ignore_policy_expiry.py`: guards this production-removal
-  disposition and verifies `CVE-2026-41992` is not broadly ignored.
-- `trivy/ignore-policy.rego`: no active `CVE-2026-41992` suppression was added.
-- `.trivyignore`: no active `CVE-2026-41992` broad ignore was added.
+- `Dockerfile:389`: production package pruning removes `gzip`; `Dockerfile:401`
+  checks package absence, `Dockerfile:408` checks `gzip`/`gunzip`/`zcat` binary
+  absence, and `Dockerfile:430` runs a Python stdlib `gzip` smoke.
+- `.github/workflows/build.yml:129`: Docker build runtime dependency-surface
+  guard blocks `gzip`; `.github/workflows/build.yml:555` blocks it on the
+  publish image before Trivy/GHCR push.
+- `.github/workflows/trivy.yml:71`: standalone Trivy image lane blocks `gzip`.
+- `tests/test_docker_workflow_build_path_contract.py:207`: guards the
+  Dockerfile pruning block; `tests/test_docker_workflow_build_path_contract.py:564`
+  guards publish scan ordering and blocked-package args.
+- `tests/test_docker_runtime_dependency_surface.py:114`: verifies exact Debian
+  package blocking covers `gzip`; `tests/test_docker_runtime_dependency_surface.py:288`
+  verifies CLI parsing accepts `--blocked-debian-package gzip`.
+- `tests/test_trivy_ignore_policy_expiry.py:215`: guards Rego policy absence for
+  remediated CVEs; `tests/test_trivy_ignore_policy_expiry.py:235` guards
+  `.trivyignore` absence; `tests/test_trivy_ignore_policy_expiry.py:344` guards
+  this production-removal disposition.
+- `trivy/ignore-policy.rego:1`: no active `CVE-2026-41992` suppression was
+  added.
+- `.trivyignore:1`: no active `CVE-2026-41992` broad ignore was added.
 
 ## Validation Note
 

--- a/docs/security/CVE-2026-41992-gzip.md
+++ b/docs/security/CVE-2026-41992-gzip.md
@@ -1,0 +1,61 @@
+# CVE-2026-41992 - gzip / production package removal disposition
+
+**Status:** RESOLVED for the production Docker target by package removal
+**Suppression expires:** N/A (suppression not added)
+**Last reviewed:** 2026-07-02
+
+## Vulnerability Details
+
+- **CVE ID:** CVE-2026-41992
+- **Package:** `gzip`
+- **Installed version observed by Trivy:** `1.12-1`
+- **Severity:** HIGH
+- **Debian Tracker:** <https://security-tracker.debian.org/tracker/CVE-2026-41992>
+- **Source Package:** `gzip`
+
+## Production Disposition
+
+The final `production` Docker target no longer retains `gzip`. The production
+stage purges the Debian package and then fails closed if the package remains
+installed or if the `gzip`, `gunzip`, and `zcat` command-line binaries remain
+resolvable in the final image.
+
+This replaces any old waiver posture. `runtime-base` and development layers may
+still keep Debian compression tooling for build/dev workflows, but the published
+production image must not contain the vulnerable system `gzip` package while the
+Debian bookworm package line has no fixed version.
+
+PulsePlate application code that handles compressed food-data artifacts uses
+Python stdlib `gzip`, not the system `gzip` binary. The Dockerfile keeps a
+production-stage stdlib round-trip smoke so that app-level compression support
+continues to work after system package pruning.
+
+## Evidence
+
+- `Dockerfile`: production package pruning removes `gzip`, checks package and
+  binary absence, and runs a Python stdlib `gzip` smoke.
+- `.github/workflows/build.yml`: Docker runtime dependency-surface guard blocks
+  `gzip`.
+- `.github/workflows/trivy.yml`: Trivy image lane blocks `gzip`.
+- `tests/test_docker_workflow_build_path_contract.py`: guards the Dockerfile
+  pruning block and workflow package block lists.
+- `tests/test_docker_runtime_dependency_surface.py`: verifies exact Debian
+  package blocking covers `gzip`.
+- `tests/test_trivy_ignore_policy_expiry.py`: guards this production-removal
+  disposition and verifies `CVE-2026-41992` is not broadly ignored.
+- `trivy/ignore-policy.rego`: no active `CVE-2026-41992` suppression was added.
+- `.trivyignore`: no active `CVE-2026-41992` broad ignore was added.
+
+## Validation Note
+
+Local Docker validation requires a running Docker daemon and a canonical
+`PULSEPLATE_PYTHON_INDEX_URL`. If local Docker is unavailable, current-head
+GitHub Actions Docker build, runtime surface check, and Trivy image scan are the
+required image-level proof before readiness claims.
+
+## Removal Condition
+
+This advisory remains as historical context for the production package-removal
+decision. If `gzip` re-enters the final production image, the runtime surface
+guard must fail and the PR must either remove it again or open a new exact,
+timeboxed disposition with current Debian/Trivy evidence.

--- a/tests/test_docker_runtime_dependency_surface.py
+++ b/tests/test_docker_runtime_dependency_surface.py
@@ -113,6 +113,7 @@ def test_find_blocked_packages_flags_ci_and_vector_stack() -> None:
 
 def test_find_blocked_debian_packages_flags_exact_package_names() -> None:
     installed = {
+        "gzip": "1.12-1",
         "libc6": "2.36-9+deb12u13",
         "libgnutls30": "3.7.9-2+deb12u6",
         "libsqlite3-0": "3.40.1-2+deb12u2",
@@ -123,9 +124,10 @@ def test_find_blocked_debian_packages_flags_exact_package_names() -> None:
 
     assert runtime_surface.find_blocked_debian_packages(
         installed,
-        ("libgnutls30", "libsqlite3-0", "missing-package", "perl-base"),
+        ("gzip", "libgnutls30", "libsqlite3-0", "missing-package", "perl-base"),
         ("perl-modules-",),
     ) == (
+        "gzip=1.12-1",
         "libgnutls30=3.7.9-2+deb12u6",
         "libsqlite3-0=3.40.1-2+deb12u2",
         "perl-base=5.36.0-7+deb12u3",
@@ -159,6 +161,7 @@ def test_build_result_fails_for_blocked_debian_package(monkeypatch: pytest.Monke
         "inspect_image_debian_packages",
         lambda _image: {
             "apt": "2.6.1",
+            "gzip": "1.12-1",
             "gpgv": "2.2.40-1.1",
             "libgnutls30": "3.7.9-2+deb12u6",
             "libsqlite3-0": "3.40.1-2+deb12u2",
@@ -171,15 +174,16 @@ def test_build_result_fails_for_blocked_debian_package(monkeypatch: pytest.Monke
     result = runtime_surface.build_result(
         "pulseplate:test",
         ("pytest",),
-        ("apt", "gpgv", "libgnutls30", "libsqlite3-0", "perl-base"),
+        ("apt", "gzip", "gpgv", "libgnutls30", "libsqlite3-0", "perl-base"),
         ("perl-modules-",),
     )
 
     assert result.blocked == ()
-    assert result.installed_debian_count == 7
+    assert result.installed_debian_count == 8
     assert result.blocked_debian_packages == (
         "apt=2.6.1",
         "gpgv=2.2.40-1.1",
+        "gzip=1.12-1",
         "libgnutls30=3.7.9-2+deb12u6",
         "libsqlite3-0=3.40.1-2+deb12u2",
         "perl-base=5.36.0-7+deb12u3",
@@ -288,6 +292,8 @@ def test_main_accepts_blocked_debian_packages(monkeypatch: pytest.MonkeyPatch) -
             "--blocked-debian-package",
             "apt",
             "--blocked-debian-package",
+            "gzip",
+            "--blocked-debian-package",
             "gpgv",
             "--blocked-debian-package",
             "libgnutls30",
@@ -305,6 +311,7 @@ def test_main_accepts_blocked_debian_packages(monkeypatch: pytest.MonkeyPatch) -
     assert captured["blocked_prefixes"] == runtime_surface.DEFAULT_BLOCKED_PREFIXES
     assert captured["blocked_debian_packages"] == (
         "apt",
+        "gzip",
         "gpgv",
         "libgnutls30",
         "libsqlite3-0",

--- a/tests/test_docker_workflow_build_path_contract.py
+++ b/tests/test_docker_workflow_build_path_contract.py
@@ -205,7 +205,7 @@ def test_build_workflow_does_not_expose_github_token_to_pr_baseline_script() -> 
 
 
 def test_production_dockerfile_prunes_package_manager_surface() -> None:
-    """Production target removes package-manager, ACL/attr, and Perl runtime packages."""
+    """Production target removes package-manager, gzip, ACL/attr, and Perl runtime packages."""
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
     production_section = dockerfile.split("FROM runtime-base AS production", 1)[1]
     production_section = production_section.split("FROM production AS staging", 1)[0]
@@ -219,8 +219,13 @@ def test_production_dockerfile_prunes_package_manager_surface() -> None:
     assert "dpkg --purge --force-depends --force-remove-essential" in pruning_block
     assert "perl_module_packages=" in pruning_block
     assert "'perl-modules-*'" in pruning_block
+    assert (
+        "for package in apt gzip gpgv libacl1 libattr1 libgnutls30 "
+        "libsqlite3-0 perl-base ${perl_module_packages}; do"
+    ) in pruning_block
     for package in (
         "apt",
+        "gzip",
         "gpgv",
         "libacl1",
         "libattr1",
@@ -231,13 +236,17 @@ def test_production_dockerfile_prunes_package_manager_surface() -> None:
         assert f"        {package} \\" in pruning_block
         assert f" {package} " in pruning_block
     assert "dpkg-query -W -f='${db:Status-Abbrev}'" in pruning_block
+    assert "for binary in gzip gunzip zcat" in pruning_block
+    assert 'command -v "${binary}"' in pruning_block
+    assert "import gzip" in pruning_block
+    assert "gzip.compress(payload, mtime=0)" in pruning_block
     assert "import ssl" in pruning_block
     assert "import sqlite3" in pruning_block
     assert "expected >= 3.53.2" in pruning_block
 
 
 def test_build_workflow_blocks_removed_acl_attr_runtime_packages() -> None:
-    """Docker runtime surface guard fails if base-image ACL/attr packages return."""
+    """Docker runtime surface guard fails if removed packages return."""
     workflow = _load_workflow(WORKFLOWS_DIR / "build.yml")
     jobs = workflow["jobs"]
     assert isinstance(jobs, dict)
@@ -248,7 +257,7 @@ def test_build_workflow_blocks_removed_acl_attr_runtime_packages() -> None:
     run_script = surface_step["run"]
     assert isinstance(run_script, str)
 
-    for package in ("libacl1", "libattr1"):
+    for package in ("gzip", "libacl1", "libattr1"):
         assert f"--blocked-debian-package {package}" in run_script
 
 
@@ -480,6 +489,7 @@ def test_docker_runtime_surface_guard_blocks_perl_runtime_packages() -> None:
 
         assert f"--image {image_ref}" in run_script
         assert "--blocked-debian-package apt" in run_script
+        assert "--blocked-debian-package gzip" in run_script
         assert "--blocked-debian-package gpgv" in run_script
         assert "--blocked-debian-package libacl1" in run_script
         assert "--blocked-debian-package libattr1" in run_script
@@ -562,6 +572,9 @@ def test_publish_image_scan_fails_closed() -> None:
     assert isinstance(publish_steps, list)
     build_scan_step = _step_by_name(publish_job, "Build Docker image for publish scan")
     image_ref_step = _step_by_name(publish_job, "Set image ref for SBOM and image scan")
+    publish_surface_step = _step_by_name(
+        publish_job, "Check Docker publish runtime dependency surface"
+    )
     scan_step = _step_by_name(
         publish_job,
         "Run Trivy vulnerability scanner (image scan, fail-closed)",
@@ -578,8 +591,11 @@ def test_publish_image_scan_fails_closed() -> None:
         publish_job, "Set image ref for SBOM and image scan"
     )
     assert _step_index(publish_job, "Set image ref for SBOM and image scan") < _step_index(
-        publish_job, "Run Trivy vulnerability scanner (image scan, fail-closed)"
+        publish_job, "Check Docker publish runtime dependency surface"
     )
+    assert _step_index(
+        publish_job, "Check Docker publish runtime dependency surface"
+    ) < _step_index(publish_job, "Run Trivy vulnerability scanner (image scan, fail-closed)")
     assert _step_index(
         publish_job, "Run Trivy vulnerability scanner (image scan, fail-closed)"
     ) < _step_index(publish_job, "Fail when Trivy image SARIF is missing")
@@ -622,6 +638,7 @@ def test_publish_image_scan_fails_closed() -> None:
             assert step_with["push"] is False
 
     assert "GITHUB_TOKEN" not in build_scan_step.get("env", {})
+    assert "GITHUB_TOKEN" not in publish_surface_step.get("env", {})
     assert "GITHUB_TOKEN" not in scan_step.get("env", {})
     assert login_step["uses"].startswith("docker/login-action@")
     assert _step_index(publish_job, "Log in to GHCR") > _step_index(
@@ -631,6 +648,24 @@ def test_publish_image_scan_fails_closed() -> None:
     image_ref_run = image_ref_step["run"]
     assert isinstance(image_ref_run, str)
     assert "sha-${{ github.sha }}" in image_ref_run
+
+    publish_surface_run = publish_surface_step["run"]
+    assert isinstance(publish_surface_run, str)
+    assert "check_docker_runtime_dependency_surface.py" in publish_surface_run
+    assert "--image ${{ steps.image-ref.outputs.ref }}" in publish_surface_run
+    assert "--blocked-debian-package gzip" in publish_surface_run
+    for package in (
+        "apt",
+        "gpgv",
+        "libacl1",
+        "libattr1",
+        "libgnutls30",
+        "libsqlite3-0",
+        "perl-base",
+    ):
+        assert f"--blocked-debian-package {package}" in publish_surface_run
+    assert "--blocked-debian-prefix perl-modules-" in publish_surface_run
+    assert "docker-publish-runtime-dependency-surface.json" in publish_surface_run
 
     scan_step_with = scan_step["with"]
     assert isinstance(scan_step_with, dict)

--- a/tests/test_docker_workflow_build_path_contract.py
+++ b/tests/test_docker_workflow_build_path_contract.py
@@ -652,7 +652,9 @@ def test_publish_image_scan_fails_closed() -> None:
     publish_surface_run = publish_surface_step["run"]
     assert isinstance(publish_surface_run, str)
     assert "check_docker_runtime_dependency_surface.py" in publish_surface_run
-    assert "--image ${{ steps.image-ref.outputs.ref }}" in publish_surface_run
+    assert publish_surface_step["env"] == {"IMAGE_REF": "${{ steps.image-ref.outputs.ref }}"}
+    assert '--image "${IMAGE_REF}"' in publish_surface_run
+    assert "steps.image-ref.outputs.ref" not in publish_surface_run
     assert "--blocked-debian-package gzip" in publish_surface_run
     for package in (
         "apt",

--- a/tests/test_trivy_ignore_policy_expiry.py
+++ b/tests/test_trivy_ignore_policy_expiry.py
@@ -18,6 +18,7 @@ SECURITY_DOC_ARCHIVE_TAR_PATH = (
 SECURITY_DOC_SQLITE_PATH = REPO_ROOT / "docs" / "security" / "CVE-2026-sqlite-runtime-removal.md"
 SECURITY_DOC_GPGV_24882_PATH = REPO_ROOT / "docs" / "security" / "CVE-2026-24882-gpgv.md"
 SECURITY_DOC_GPGV_24883_PATH = REPO_ROOT / "docs" / "security" / "CVE-2026-24883-gpgv.md"
+SECURITY_DOC_GZIP_PATH = REPO_ROOT / "docs" / "security" / "CVE-2026-41992-gzip.md"
 SECURITY_DOC_FARADAY_PATH = REPO_ROOT / "docs" / "security" / "CVE-2026-54297-faraday-fastlane.md"
 BACKLOG_PATH = REPO_ROOT / "docs" / "roadmap" / "BACKLOG_LEDGER.md"
 
@@ -52,6 +53,7 @@ REMOVED_ACL_ATTR_CVES = (
     "CVE-2026-54369",
     "CVE-2026-54371",
 )
+REMOVED_GZIP_CVES = ("CVE-2026-41992",)
 REMOVED_ACL_ATTR_PACKAGES = (
     "libacl1",
     "libattr1",
@@ -85,6 +87,14 @@ def _ledger_gpgv_entry() -> str:
     )
     next_item = backlog_text.find("\n- [", ledger_start + 1)
     ledger_end = next_item if next_item != -1 else len(backlog_text)
+    return backlog_text[ledger_start:ledger_end]
+
+
+def _ledger_gzip_entry() -> str:
+    backlog_text = BACKLOG_PATH.read_text(encoding="utf-8")
+    ledger_start = backlog_text.index('<a id="ledger-p1-container-gzip-cve-remediation"></a>')
+    next_anchor = backlog_text.find("<a id=", ledger_start + 1)
+    ledger_end = next_anchor if next_anchor != -1 else len(backlog_text)
     return backlog_text[ledger_start:ledger_end]
 
 
@@ -211,6 +221,7 @@ def test_removed_perl_runtime_cves_are_not_suppressed_in_rego_policy() -> None:
         + REMEDIATED_SQLITE_CVES
         + REMOVED_PRODUCTION_TOOLING_CVES
         + REMOVED_ACL_ATTR_CVES
+        + REMOVED_GZIP_CVES
     ):
         assert cve not in policy
     assert "perl-base" not in policy
@@ -218,6 +229,7 @@ def test_removed_perl_runtime_cves_are_not_suppressed_in_rego_policy() -> None:
     assert "libsqlite3-0" not in policy
     for package in REMOVED_ACL_ATTR_PACKAGES:
         assert package not in policy
+    assert "gzip" not in policy
 
 
 def test_remediated_container_cves_are_not_broadly_ignored_in_trivyignore() -> None:
@@ -229,12 +241,14 @@ def test_remediated_container_cves_are_not_broadly_ignored_in_trivyignore() -> N
         + REMEDIATED_SQLITE_CVES
         + REMOVED_PRODUCTION_TOOLING_CVES
         + REMOVED_ACL_ATTR_CVES
+        + REMOVED_GZIP_CVES
     ):
         assert cve not in trivyignore
     assert "SQLite" not in trivyignore
     assert "libsqlite3-0" not in trivyignore
     for package in REMOVED_ACL_ATTR_PACKAGES:
         assert package not in trivyignore
+    assert "gzip" not in trivyignore
     assert "gpgv retained as Debian system dependency" not in trivyignore
     assert "libgnutls30 is installed in the Debian production image" not in trivyignore
 
@@ -325,6 +339,26 @@ def test_gpgv_docs_and_backlog_record_production_package_removal() -> None:
     assert "codex/fix-main-trivy-container-cves" in ledger_entry
     assert "Final production image removes `gpgv`" in ledger_entry
     assert "do not suppress CVE-2026-24883" in ledger_entry
+
+
+def test_gzip_docs_and_backlog_record_production_package_removal() -> None:
+    doc_text = SECURITY_DOC_GZIP_PATH.read_text(encoding="utf-8")
+    ledger_entry = _ledger_gzip_entry()
+
+    assert "CVE-2026-41992" in doc_text
+    assert "RESOLVED for the production Docker target by package removal" in doc_text
+    assert "The final `production` Docker target no longer retains `gzip`" in doc_text
+    assert "`gzip`, `gunzip`, and `zcat`" in doc_text
+    assert "Python stdlib `gzip`" in doc_text
+    assert "old waiver posture" in doc_text
+    assert "Why This CVE is Suppressed" not in doc_text
+    assert "temporary, exact Trivy Rego policy suppression" not in doc_text
+
+    assert "Container image gzip CVE remediation (CVE-2026-41992)" in ledger_entry
+    assert "codex/fix-main-docker-publish-" in ledger_entry
+    assert "gzip-cve-2026-41992" in ledger_entry
+    assert "Production image removes `gzip`" in ledger_entry
+    assert "do not suppress CVE-2026-41992" in ledger_entry
 
 
 def test_faraday_fastlane_suppression_tracks_1_10_6_scanner_lag() -> None:


### PR DESCRIPTION
## Summary

Removes Debian \`gzip\` from the final \`production\` Docker image surface to remediate Trivy \`CVE-2026-41992\` without \`.trivyignore\` or Rego suppression.

- [x] I reviewed \`docs/ENGINEERING_LESSONS.md\` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [x] Docs
- [x] Linked issues/PRs: code-scanning alert #617; Debian tracker \`CVE-2026-41992\`

## Risk & Impact

- [ ] User-facing change
- [ ] Data model/migration
- [x] Security-sensitive
- [ ] Performance-sensitive

No API, OpenAPI, DB, env var, frontend, iOS, macOS, or product runtime behavior change is intended.

## Scope

- Purge \`gzip\` in the final \`production\` Docker stage only; \`runtime-base\` and development layers remain unchanged.
- Fail closed if Debian \`gzip\` remains installed or if \`gzip\`, \`gunzip\`, or \`zcat\` remain resolvable in the final image.
- Keep Python stdlib \`gzip\` working with a production-stage round-trip smoke.
- Add \`gzip\` to Docker build, publish, and standalone Trivy runtime dependency-surface guards.
- Add production package-removal disposition docs, backlog tracking, and a diff-first premortem with code closures.

## Out of Scope

- Scanner suppression or broad waivers.
- Base-image replacement.
- Product/runtime route behavior changes.
- Automatic proof that \`Docker Build and Push / publish\` passes on PRs; that job is not PR-triggered.

## Key Decisions

- Package removal is the narrow remediation because Debian bookworm/trixie/sid currently show no fixed \`gzip\` package for \`CVE-2026-41992\`.
- Premortem finding was closed in code: the publish job now runs \`check_docker_runtime_dependency_surface.py\` against the publish image ref before Trivy, GHCR login, push, SBOM, or attestations.
- Evidence boundary: ordinary PR CI can prove build/runtime-surface guard behavior, but image-level publish proof requires manual \`trivy.yml\` dispatch on this branch or post-merge \`main\` publish evidence.

## Test Plan

- [x] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [x] Manual verification steps

Local evidence:

- \`pytest -q tests/test_docker_workflow_build_path_contract.py tests/test_docker_runtime_dependency_surface.py tests/test_trivy_ignore_policy_expiry.py\` -> PASS, 47 passed
- \`python3 scripts/orchestration/check_agent_consistency.py\` -> PASS
- \`git diff --check\` -> PASS
- \`make validate-changed\` -> PASS
- \`pre-commit run --all-files\` -> PASS
- Commit/pre-push hooks -> PASS, including backend pre-push, full-repo bandit, and repo docker build test hook
- Experiment Runner oracle-only \`exp-f8a00f94aae2\` -> accepted, 3/3 oracle commands passed
- Codex Security diff scan \`b126c050-0cc0-4070-ab1f-c83d66b76b59\` -> complete, 10/10 surfaces covered, 0 findings

Not run locally:

- Full local production Docker image scan with Trivy. Image-level proof remains pending on manual branch \`trivy.yml\` workflow_dispatch or post-merge \`main\` publish.

## CI Gates

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

Current-head GitHub CI is running after latest mapping-format commit `b8042106db20e89d0ebf22a3b71688f1588ed68b`; do not treat pending rows as evidence.

## Split Justification

- Why this PR cannot be split safely: the Dockerfile removal, workflow guards, tests, disposition doc, backlog entry, and premortem code closure are one remediation unit for the same CVE.
- What invariant, contract, or rollout constraint requires one PR: no-suppression CVE remediation needs package removal and guard coverage together.
- What follow-up PRs remain after this large change: none for this package-removal diff; post-merge proof must verify \`Docker Build and Push / publish\` and alert #617 closure.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_2062_FIXED_MAPPING.md`

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in \`Fixed in Commit Mapping\`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

This PR is opened non-draft for review, not claimed merge-ready.

## Deferred / Follow-ups

- [x] Ledger item(s): \`docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-container-gzip-cve-remediation\`
- [ ] GitHub issue(s): none

Post-merge follow-up evidence:

- Verify \`Docker Build and Push / publish\` on \`main\`.
- Confirm code-scanning alert #617 closes or no longer appears for the current main image.

## Security Notes

No \`.trivyignore\` or \`trivy/ignore-policy.rego\` suppression was added. Tests assert \`CVE-2026-41992\` and \`gzip\` are not broadly ignored.

## Risks / Rollback

Rollback is a revert of the full PR branch through current head `b8042106db20e89d0ebf22a3b71688f1588ed68b`. If CI shows \`gzip\` still present in dpkg inventory or as \`gzip\`/\`gunzip\`/\`zcat\`, stop and inspect the final production image before any readiness claim.

## Additional Context

Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes Debian `gzip` from the production Docker image and adds fail-closed guards across build, publish, and standalone Trivy to remediate CVE-2026-41992 without suppressions. No runtime change; Python stdlib `gzip` is smoke-tested.

- **Bug Fixes**
  - Purge `gzip` in the production stage; fail if the package or `gzip`/`gunzip`/`zcat` remain.
  - Add a Python stdlib `gzip` round-trip smoke in the Dockerfile.
  - Block `gzip` in runtime-surface checks in `.github/workflows/build.yml` and `trivy.yml`; add a publish-image guard using `IMAGE_REF` before Trivy/GHCR login/push.
  - Update tests for Dockerfile pruning, publish-guard ordering/args/env, no `GITHUB_TOKEN` exposure, and non-suppression policy.
  - Docs: add a security disposition with file:line anchors; refine the fixed-mapping evidence to exclude external status checks and record `pulseplate-pr-review`; link the backlog ledger entry to PR #2062; add a premortem and an engineering lesson on closing risks in code/tests.

<sup>Written for commit b8042106db20e89d0ebf22a3b71688f1588ed68b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened the production Docker image so `gzip` (and `gunzip`, `zcat`) are removed, with fail-closed behavior if they remain.
  * Added stronger image pruning verification to ensure blocked runtime surfaces aren’t present.
* **New Features**
  * Added/extended CI runtime dependency-surface checks in both build and publish lanes to block `gzip` detection.
* **Documentation**
  * Updated security and engineering/review guidance with `gzip` remediation and risk-closure expectations.
* **Tests**
  * Expanded CI and policy tests to include `gzip` removal, surface blocking, and non-reference validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
