### PR TITLE
refactor(api): move shopping-list registration to canonical bootstrap

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -88,8 +88,13 @@ from app.routers.restaurants import (
     RESTAURANT_MODERATION_ROUTE_SPECS,
     moderation_router as restaurant_moderation_router,
 )
+from app.routers.shoplist_day import SHOPLIST_DAY_ROUTE_SPECS, router as shoplist_day_router
 from app.routers.shoplist_export import router as shoplist_export_router
 from app.routers.shoplist_export_routes import SHOPLIST_ROUTE_SPECS
+from app.routers.shopping_list_pro import (
+    SHOPPING_LIST_PRO_ROUTE_SPECS,
+    router as shopping_list_pro_router,
+)
 from app.routers.test import (
     TEST_ROUTE_SPECS,
     _ensure_non_production as ensure_test_routes_non_production,
@@ -176,6 +181,14 @@ _PLAN_EXPORT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
 _SHOPLIST_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in SHOPLIST_ROUTE_SPECS
+)
+_SHOPLIST_DAY_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in SHOPLIST_DAY_ROUTE_SPECS
+)
+_SHOPPING_LIST_PRO_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in SHOPPING_LIST_PRO_ROUTE_SPECS
 )
 _RESTAURANT_MODERATION_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
@@ -284,6 +297,21 @@ def _shoplist_export_route_members(
             required_dependencies=(api_key_dependency,),
         )
         for path, method, include_in_schema in _SHOPLIST_ROUTE_SPECS
+    )
+
+
+def _shopping_list_route_members() -> tuple[RouteMemberContract, ...]:
+    return tuple(
+        RouteMemberContract(
+            path=path,
+            method=method,
+            include_in_schema=include_in_schema,
+            required_dependencies=(require_pro_tier,),
+        )
+        for path, method, include_in_schema in (
+            *_SHOPPING_LIST_PRO_ROUTE_SPECS,
+            *_SHOPLIST_DAY_ROUTE_SPECS,
+        )
     )
 
 
@@ -860,6 +888,17 @@ def _include_shoplist_export_router_if_needed(target_app: FastAPI) -> None:
     )
 
 
+def _include_shopping_list_routers_if_needed(target_app: FastAPI) -> None:
+    """Register paid shopping-list routes as one protected static family."""
+
+    ensure_route_family_registered(
+        target_app,
+        family_name="Shopping list",
+        routers=(shopping_list_pro_router, shoplist_day_router),
+        members=_shopping_list_route_members(),
+    )
+
+
 def _include_nutrition_state_routers_if_needed(target_app: FastAPI) -> None:
     """Register nutrition/adherence state routes as one protected static family."""
 
@@ -1095,6 +1134,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _include_test_router_if_enabled(app)
     _include_plan_export_routers_if_needed(app)
     _include_shoplist_export_router_if_needed(app)
+    _include_shopping_list_routers_if_needed(app)
     _include_legacy_export_alias_router_if_needed(app)
     _include_restaurant_moderation_router_if_needed(app)
 

--- a/app/routers/shoplist_day.py
+++ b/app/routers/shoplist_day.py
@@ -19,6 +19,10 @@ from app.schemas.shopping_list import ShopLang, ShoplistDayResponse
 from app.core.shoplist_day.day_generator import generate_day_items
 from app.core.shoplist_day.provider import fetch_day_plan
 
+SHOPLIST_DAY_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/pro/shoplist/day", "GET", True),
+)
+
 router = APIRouter(prefix="/api/v1/pro/shoplist", tags=["pro", "shoplist-day"])
 
 
@@ -52,4 +56,4 @@ async def get_shoplist_day(
     return ShoplistDayResponse(date=day.isoformat(), lang=lang, items=items, warnings=[])
 
 
-__all__ = ["router"]
+__all__ = ["SHOPLIST_DAY_ROUTE_SPECS", "router"]

--- a/app/routers/shopping_list_pro.py
+++ b/app/routers/shopping_list_pro.py
@@ -17,6 +17,10 @@ from app.schemas.fitchef import (
 )
 from app.schemas.shopping_list import ShoppingListDTO, ShoppingListRequest
 
+SHOPPING_LIST_PRO_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/pro/meal/shopping-list", "POST", True),
+)
+
 router = APIRouter(prefix="/api/v1/pro/meal", tags=["pro", "shopping-list"])
 
 
@@ -90,4 +94,4 @@ async def generate_shopping_list(request: ShoppingListRequest) -> ShoppingListDT
     return result.shopping_list
 
 
-__all__ = ["router"]
+__all__ = ["SHOPPING_LIST_PRO_ROUTE_SPECS", "router"]

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -166,14 +166,32 @@ Runtime effect:
   route-family drift now fail startup/bootstrap instead of creating a partial
   runtime.
 
-### Shopping list generators (always included; tier handled inside)
+### Shopping list generators (canonical bootstrap-owned)
 
-Anchor (stable): `legacy_app.py -> include_router(shopping_list_pro_router, shoplist_day_router)`
+Anchor (stable): `app/main.py -> _include_shopping_list_routers_if_needed(app)`
 
-Evidence: `legacy_app.py:845-849`
+Evidence:
+- `app/bootstrap/route_family.py` — shared `RouteMemberContract` and
+  `ensure_route_family_registered(...)` guard for exact static route-family registration.
+- `app/main.py` — `_include_shopping_list_routers_if_needed(app)` registers
+  `shopping_list_pro_router` and `shoplist_day_router` as one `Shopping list`
+  family with `require_pro_tier` as a required route-member dependency.
+- `app/routers/shopping_list_pro.py` — owns the `POST /api/v1/pro/meal/shopping-list`
+  handler and `SHOPPING_LIST_PRO_ROUTE_SPECS`.
+- `app/routers/shoplist_day.py` — owns the iOS MVP `GET /api/v1/pro/shoplist/day`
+  handler and `SHOPLIST_DAY_ROUTE_SPECS`.
 
-- `app/routers/shopping_list_pro.py`
-- `app/routers/shoplist_day.py` (iOS MVP path)
+Runtime effect:
+- `POST /api/v1/pro/meal/shopping-list`
+- `GET /api/v1/pro/shoplist/day`
+
+OpenAPI effect:
+- Source `APIRoute.include_in_schema` remains `True` for both routes.
+- Canonical bootstrap validates idempotency, partial registration, duplicate/foreign
+  handlers, method drift, OpenAPI visibility drift, and `require_pro_tier` dependency drift.
+- `legacy_app.py` no longer imports or registers the shopping-list routers; the
+  legacy growth guard rejects direct, aliased, module-qualified, dynamic,
+  destructured, or walrus-style reintroduction.
 
 ### Insight endpoints (LLM) + providers wiring (legacy_app → llm → providers)
 

--- a/docs/review/PR_2066_FIXED_MAPPING.md
+++ b/docs/review/PR_2066_FIXED_MAPPING.md
@@ -46,8 +46,8 @@ Out of scope:
 - [x] Post-open `qa-engineer-agent` pass completed.
 - [x] Post-open `bug-hunter` pass completed.
 - [x] Post-open `security-auditor` pass completed.
-- [ ] Codex Security diff scan / finding discovery completed.
-- [ ] `pulseplate-pr-review` completed.
+- [x] Codex Security diff scan / finding discovery completed.
+- [x] `pulseplate-pr-review` completed.
 - [ ] CodeRabbit actionable review comments checked and dispositioned.
 - [ ] Sourcery actionable review comments checked and dispositioned.
 - [ ] Cubic actionable review comments checked and dispositioned.
@@ -159,13 +159,39 @@ scope widening. It confirmed that the premortem closures are code/test-backed.
 
 ## Codex Security
 
-Pending. A Codex Security diff scan / finding discovery pass is still required
-before any merge-readiness claim.
+Disposition: NOT-A-BUG
+
+Evidence:
+
+- Scan ID: `21647199-e9cc-44b4-b4f2-82f9ea9fa40c`
+- Mode: branch diff over
+  `0e5b8c62e4dc2e8286b393d5d0ce15409a87b2a6...5c10e731a1791c53ea61f68bba7e846ca319dc6f`
+- Coverage: 5/5 reviewed surfaces closed.
+- Findings: 0 reportable findings.
+- Report:
+  `/private/var/folders/bw/12x002vn67v2bvjpbhbtm8480000gn/T/codex-security-scans-nU0tuF/move-shopping-list-registration-to-canonical-bootstrap/5c10e731a1791c53ea61f68bba7e846ca319dc6f_20260702T220104Z_9sujpp6k/report.md`
+- Reviewed surfaces:
+  `app/main.py`, `app/routers/shopping_list_pro.py`,
+  `app/routers/shoplist_day.py`, `legacy_app.py`, and
+  `scripts/ci/check_legacy_growth_guard.py`.
 
 ## PulsePlate PR Review
 
-Pending. A `pulseplate-pr-review` pass is still required before any
-merge-readiness claim.
+Disposition: NOT-A-BUG
+
+Evidence:
+
+- Report: `/tmp/pulseplate_pr_review_report_2066.md`
+- Context: `/tmp/pulseplate_pr_review_context_2066.json`
+- The dry-run reported one advisory `large-diff-risk` note because the PR has
+  648 added lines. This is expected for this bounded slice: most added lines are
+  targeted tests plus the PR fixed-mapping artifact, and the runtime scope
+  remains the two paid shopping-list route registrations.
+- Gate evidence: `make validate-changed`, `pre-commit run --all-files`, and the
+  focused shopping/auth/OpenAPI/legacy guard pytest bundle passed.
+- Calibration check:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_pr_review_report.py tests/test_pr_review_context.py`
+  passed.
 
 ## Local Evidence
 
@@ -179,6 +205,8 @@ merge-readiness claim.
   `artifacts/orchestration/experiments/results/exp-e478f895d5a7.json`
 - PASS: `make validate-changed`
 - PASS: `pre-commit run --all-files`
+- PASS:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_pr_review_report.py tests/test_pr_review_context.py`
 - PASS: pre-push hooks during `git push`, including backend pre-push tests,
   full-repo Bandit pre-push, and docker build test.
 
@@ -192,6 +220,6 @@ merge-readiness claim.
 
 ## Merge Readiness
 
-Not claimed. Current-head CI, Codex Security diff scan, `pulseplate-pr-review`,
-bot review disposition, review-thread disposition checks, and strict
-merge-readiness governance remain required before any merge-readiness claim.
+Not claimed. Current-head CI, bot review disposition, review-thread disposition
+checks, and strict merge-readiness governance remain required before any
+merge-readiness claim.

--- a/docs/review/PR_2066_FIXED_MAPPING.md
+++ b/docs/review/PR_2066_FIXED_MAPPING.md
@@ -236,8 +236,10 @@ Reason: Codex Security completed a branch-diff scan with zero reportable finding
   `0e5b8c62e4dc2e8286b393d5d0ce15409a87b2a6...5c10e731a1791c53ea61f68bba7e846ca319dc6f`
 - Coverage: 5/5 reviewed surfaces closed.
 - Findings: 0 reportable findings.
-- Report:
-  `/private/var/folders/bw/12x002vn67v2bvjpbhbtm8480000gn/T/codex-security-scans-nU0tuF/move-shopping-list-registration-to-canonical-bootstrap/5c10e731a1791c53ea61f68bba7e846ca319dc6f_20260702T220104Z_9sujpp6k/report.md`
+- Report evidence: Codex Security workbench scan
+  `21647199-e9cc-44b4-b4f2-82f9ea9fa40c` completed with canonical
+  `scan-manifest.json`, `coverage.json`, `findings.json`, markdown report, and
+  SARIF projection available through the scan record.
 - Reviewed surfaces:
   `app/main.py`, `app/routers/shopping_list_pro.py`,
   `app/routers/shoplist_day.py`, `legacy_app.py`, and
@@ -249,8 +251,10 @@ Disposition: NOT-A-BUG
 Evidence:
 Reason: The only review note was an advisory large-diff warning; the runtime scope stayed bounded and validation passed.
 
-- Report: `/tmp/pulseplate_pr_review_report_2066.md`
-- Context: `/tmp/pulseplate_pr_review_context_2066.json`
+- Report command:
+  `python3 scripts/orchestration/pr_review_report.py --context <pr_review_context_json> --format markdown --packet-id 6191c7a0e812 --packet-path artifacts/orchestration/task_packets/6191c7a0e812.json`
+- Context command:
+  `python3 scripts/orchestration/pr_review_context.py --pr 2066 --repo-root "$PWD" --output <pr_review_context_json>`
 - The dry-run reported one advisory `large-diff-risk` note because the PR has
   648 added lines. This is expected for this bounded slice: most added lines are
   targeted tests plus the PR fixed-mapping artifact, and the runtime scope

--- a/docs/review/PR_2066_FIXED_MAPPING.md
+++ b/docs/review/PR_2066_FIXED_MAPPING.md
@@ -56,13 +56,14 @@ Out of scope:
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516273298 -> `633eeca00`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516357104
 
 ## Implementation Evidence
 
 Disposition: FIXED
 
-Commit: `ac0338460`
+Commit: `ac033846008ac1157be48f64551bd0eaab0f8c7d`
 
 Evidence:
 
@@ -124,10 +125,45 @@ Evidence:
 - Oracle command: focused route-family, legacy-growth, authz, and OpenAPI
   pytest bundle.
 - Shared tree untouched: true
-- Co-author required: true and present in commit `ac0338460`.
+- Co-author required: true and present in commit
+  `ac033846008ac1157be48f64551bd0eaab0f8c7d`.
 - Note: earlier packet `exp-dd7f551071bc` rejected as local infra before oracle
   execution because the network-disabled sandbox required `unshare` on PATH.
   The accepted packet used `network_budget=1` and ran the same oracle.
+
+## Review Comment Dispositions
+
+### Sourcery Assertion Diagnostics
+
+Disposition: FIXED
+
+Comment:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516273298
+
+Commit: `633eeca00`
+
+Evidence:
+
+- `tests/test_shopping_list_registration_bootstrap.py` now includes an assertion
+  message for `_shopping_list_route(...)` failures with method, path, match
+  count, and matched route summaries.
+- PASS:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_shopping_list_registration_bootstrap.py tests/test_legacy_growth_guard.py`
+
+### Codex Experiment Runner Trailer Evidence
+
+Disposition: NOT-A-BUG
+
+Comment:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516357104
+
+Evidence:
+
+- `git log --pretty=format:'%H %s%n%b' -1 ac033846008ac1157be48f64551bd0eaab0f8c7d`
+  shows the required trailer:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+- The later mapping-only commits do not contain material Experiment Runner
+  contribution and therefore do not need the trailer.
 
 ## Post-Open Role Findings
 

--- a/docs/review/PR_2066_FIXED_MAPPING.md
+++ b/docs/review/PR_2066_FIXED_MAPPING.md
@@ -56,15 +56,29 @@ Out of scope:
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516273298 -> `633eeca00`
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: See `Review Comment Dispositions` below.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516273298 -> 633eeca00
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516357092 -> 7d20c13e0
+
+Disposition: NOT-A-BUG
+Evidence: The implementation commit contains the required Experiment Runner trailer.
+Reason: The comment was based on stale commit interpretation; the current branch history includes the required trailer on the material implementation commit, while later mapping-only commits do not require Experiment Runner attribution.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516357104
+
+Disposition: NOT-A-BUG
+Evidence: Existing route-family bootstrap tests exercise private `app.main` registration helpers directly, and legacy growth guard tests assert exact diagnostic strings as guard contract output.
+Reason: Exposing a public shopping-list registration helper would widen the API surface for a canonical-bootstrap-only seam, and loosening exact legacy-guard diagnostic assertions would weaken the re-growth guard contract rather than making this PR safer.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#pullrequestreview-4621363293
 
 ## Implementation Evidence
 
 Disposition: FIXED
-
-Commit: `ac033846008ac1157be48f64551bd0eaab0f8c7d`
-
+Commit: ac033846008ac1157be48f64551bd0eaab0f8c7d
 Evidence:
 
 - `app/main.py` imports the two shopping source routers and route specs, builds
@@ -136,12 +150,9 @@ Evidence:
 ### Sourcery Assertion Diagnostics
 
 Disposition: FIXED
-
 Comment:
 https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516273298
-
-Commit: `633eeca00`
-
+Commit: 633eeca00
 Evidence:
 
 - `tests/test_shopping_list_registration_bootstrap.py` now includes an assertion
@@ -150,14 +161,21 @@ Evidence:
 - PASS:
   `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_shopping_list_registration_bootstrap.py tests/test_legacy_growth_guard.py`
 
+### Sourcery High-Level Feedback
+
+Disposition: NOT-A-BUG
+Comment:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#pullrequestreview-4621363293
+Evidence: Existing route-family tests such as `tests/test_nutrition_state_registration_bootstrap.py`, `tests/test_business_registration_bootstrap.py`, and `tests/test_test_route_registration_bootstrap.py` exercise private `app.main` registration helpers directly; `tests/test_legacy_growth_guard.py` intentionally asserts exact guard diagnostics.
+Reason: A public shopping-list bootstrap helper would broaden the route-registration API for a private composition-root seam, while regex/substring matching for legacy growth diagnostics would make the executable guard less precise.
+
 ### Codex Experiment Runner Trailer Evidence
 
 Disposition: NOT-A-BUG
-
 Comment:
 https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516357104
-
 Evidence:
+Reason: The current branch history already contains the required trailer on the material implementation commit.
 
 - `git log --pretty=format:'%H %s%n%b' -1 ac033846008ac1157be48f64551bd0eaab0f8c7d`
   shows the required trailer:
@@ -165,39 +183,53 @@ Evidence:
 - The later mapping-only commits do not contain material Experiment Runner
   contribution and therefore do not need the trailer.
 
+### Codex Mapping Commit Evidence
+
+Disposition: FIXED
+Comment:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516357092
+Commit: 7d20c13e0
+Evidence:
+
+- `docs/review/PR_2066_FIXED_MAPPING.md` now records the implementation proof
+  as full in-branch commit
+  `ac033846008ac1157be48f64551bd0eaab0f8c7d`.
+- Current branch history contains that implementation commit before the mapping
+  updates.
+
 ## Post-Open Role Findings
 
 ### QA Engineer Agent
 
 Disposition: NOT-A-BUG
-
 Evidence: Post-open QA found no blocking QA findings in the route-registration
 diff. It verified canonical registration, legacy import/include removal, exact
 route specs, executable duplicate/partial/auth/OpenAPI tests, legacy re-growth
 tests, and bounded scope.
+Reason: QA did not identify a defect requiring code or docs changes.
 
 ### Bug Hunter
 
 Disposition: NOT-A-BUG
-
 Evidence: Post-open bug-hunter found no escaped regression in import order, live
 route ownership, duplicate route handling, dependency detection, legacy growth
 guard coverage, or product logic scope. It also ran a live `app.main` route
 probe and extra legacy-growth probes.
+Reason: Bug-hunter did not identify a defect requiring code or docs changes.
 
 ### Security Auditor
 
 Disposition: NOT-A-BUG
-
 Evidence: Post-open security-auditor found no blocking security finding in
 paid-route authz, handler shadowing, OpenAPI exposure, legacy seam re-growth, or
 scope widening. It confirmed that the premortem closures are code/test-backed.
+Reason: Security-auditor did not identify a defect requiring code or docs changes.
 
 ## Codex Security
 
 Disposition: NOT-A-BUG
-
 Evidence:
+Reason: Codex Security completed a branch-diff scan with zero reportable findings.
 
 - Scan ID: `21647199-e9cc-44b4-b4f2-82f9ea9fa40c`
 - Mode: branch diff over
@@ -214,8 +246,8 @@ Evidence:
 ## PulsePlate PR Review
 
 Disposition: NOT-A-BUG
-
 Evidence:
+Reason: The only review note was an advisory large-diff warning; the runtime scope stayed bounded and validation passed.
 
 - Report: `/tmp/pulseplate_pr_review_report_2066.md`
 - Context: `/tmp/pulseplate_pr_review_context_2066.json`

--- a/docs/review/PR_2066_FIXED_MAPPING.md
+++ b/docs/review/PR_2066_FIXED_MAPPING.md
@@ -1,0 +1,197 @@
+# PR #2066 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066
+
+Branch: `codex/move-shopping-list-registration-to-canonical-bootstrap`
+
+## Scope
+
+PR #2066 moves only the paid shopping-list route registration family from
+`legacy_app.py` to canonical `app/main.py` bootstrap.
+
+In scope:
+
+- `POST /api/v1/pro/meal/shopping-list`
+- `GET /api/v1/pro/shoplist/day`
+- Source route specs for the two source routers
+- `ensure_route_family_registered(...)` registration through one `Shopping list`
+  route family
+- Legacy growth guard allowlist shrinkage and reintroduction tests
+- Backend routing map ownership update
+
+Out of scope:
+
+- `shoplist_export`, VIP shoplist, FoodDB/catalog, FitChef algorithms/runtime,
+  `weekly_plan_id` DB support, OpenAPI/client generated artifacts, frontend,
+  iOS, macOS, deploy, and AI runtime.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/e9cd2b93e4e2.json`
+- Post-open packet: `artifacts/orchestration/task_packets/6191c7a0e812.json`
+- Branch base: `origin/main` at `0e5b8c62e4dc2e8286b393d5d0ce15409a87b2a6`
+- Branch: `codex/move-shopping-list-registration-to-canonical-bootstrap`
+- Pre-open role order executed:
+  `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`
+- Post-open role order executed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Fixed in commit mapping artifact created after GitHub assigned PR number
+  `#2066`.
+- [x] Initial PR open: no GitHub review threads were resolved before mapping.
+- [x] Post-open `qa-engineer-agent` pass completed.
+- [x] Post-open `bug-hunter` pass completed.
+- [x] Post-open `security-auditor` pass completed.
+- [ ] Codex Security diff scan / finding discovery completed.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] CodeRabbit actionable review comments checked and dispositioned.
+- [ ] Sourcery actionable review comments checked and dispositioned.
+- [ ] Cubic actionable review comments checked and dispositioned.
+- [ ] Current-head CI complete before readiness language.
+- [ ] Strict merge-readiness checks run after the final review/check cycle.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Implementation Evidence
+
+Disposition: FIXED
+
+Commit: `ac0338460`
+
+Evidence:
+
+- `app/main.py` imports the two shopping source routers and route specs, builds
+  `_shopping_list_route_members()`, and registers both endpoints through
+  `_include_shopping_list_routers_if_needed(...)`.
+- `app/routers/shopping_list_pro.py` defines
+  `SHOPPING_LIST_PRO_ROUTE_SPECS` for
+  `POST /api/v1/pro/meal/shopping-list`.
+- `app/routers/shoplist_day.py` defines `SHOPLIST_DAY_ROUTE_SPECS` for
+  `GET /api/v1/pro/shoplist/day`.
+- `legacy_app.py` no longer imports or includes `shopping_list_pro_router` or
+  `shoplist_day_router`.
+- `scripts/ci/check_legacy_growth_guard.py` removes the two shopping-list
+  registration allowlist facts and their router-import allowlist facts.
+- `tests/test_shopping_list_registration_bootstrap.py` covers empty-app and
+  live-app registration, idempotency, partial registration, duplicate
+  method/path, foreign handler, wrong method, OpenAPI visibility drift, and
+  missing `require_pro_tier` dependency failures.
+- `tests/test_legacy_growth_guard.py` rejects direct, aliased,
+  module-qualified, dynamic import, destructuring, and walrus-style
+  shopping-list router reintroduction.
+
+## Premortem Findings
+
+- Duplicate or partial registration - FIXED by removing both legacy
+  imports/includes, registering the pair as one atomic `Shopping list` family,
+  and adding idempotency, partial, duplicate, wrong-method, foreign-handler, and
+  live bootstrapped-app tests.
+- Paid-route authorization drift - FIXED by
+  `RouteMemberContract.required_dependencies=(require_pro_tier,)` and tests
+  that inspect both decorator-level and endpoint-parameter dependency forms with
+  `route_has_dependency_call(...)`.
+- OpenAPI/iOS drift - FIXED by source route specs and tests asserting exact
+  path, method, and `include_in_schema` visibility plus OpenAPI determinism.
+- Legacy seam re-growth - FIXED by shrinking the legacy growth guard allowlist
+  and adding negative tests for direct, aliased, module-qualified, dynamic,
+  destructuring, and walrus reintroduction.
+- Scope creep into product behavior - FIXED by keeping the runtime diff to
+  registration/constants only; no FitChef, DB, schema, generated client,
+  frontend, iOS, deploy, or AI runtime files changed.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/exp-e478f895d5a7.json`
+- Artifact:
+  `artifacts/orchestration/experiments/results/exp-e478f895d5a7.json`
+- Mode: `oracle_only_governance_reviewer`
+- Status: accepted
+- Source diff paths:
+  - `app/main.py`
+  - `app/routers/shoplist_day.py`
+  - `app/routers/shopping_list_pro.py`
+  - `docs/architecture/backend_routing_map.md`
+  - `legacy_app.py`
+  - `scripts/ci/check_legacy_growth_guard.py`
+  - `tests/test_legacy_growth_guard.py`
+  - `tests/test_shopping_list_registration_bootstrap.py`
+- Oracle command: focused route-family, legacy-growth, authz, and OpenAPI
+  pytest bundle.
+- Shared tree untouched: true
+- Co-author required: true and present in commit `ac0338460`.
+- Note: earlier packet `exp-dd7f551071bc` rejected as local infra before oracle
+  execution because the network-disabled sandbox required `unshare` on PATH.
+  The accepted packet used `network_budget=1` and ran the same oracle.
+
+## Post-Open Role Findings
+
+### QA Engineer Agent
+
+Disposition: NOT-A-BUG
+
+Evidence: Post-open QA found no blocking QA findings in the route-registration
+diff. It verified canonical registration, legacy import/include removal, exact
+route specs, executable duplicate/partial/auth/OpenAPI tests, legacy re-growth
+tests, and bounded scope.
+
+### Bug Hunter
+
+Disposition: NOT-A-BUG
+
+Evidence: Post-open bug-hunter found no escaped regression in import order, live
+route ownership, duplicate route handling, dependency detection, legacy growth
+guard coverage, or product logic scope. It also ran a live `app.main` route
+probe and extra legacy-growth probes.
+
+### Security Auditor
+
+Disposition: NOT-A-BUG
+
+Evidence: Post-open security-auditor found no blocking security finding in
+paid-route authz, handler shadowing, OpenAPI exposure, legacy seam re-growth, or
+scope widening. It confirmed that the premortem closures are code/test-backed.
+
+## Codex Security
+
+Pending. A Codex Security diff scan / finding discovery pass is still required
+before any merge-readiness claim.
+
+## PulsePlate PR Review
+
+Pending. A `pulseplate-pr-review` pass is still required before any
+merge-readiness claim.
+
+## Local Evidence
+
+- PASS:
+  `python3 scripts/orchestration/check_preflight.py --mode analyze --path app/main.py --path legacy_app.py --path app/routers/shopping_list_pro.py --path app/routers/shoplist_day.py --path scripts/ci/check_legacy_growth_guard.py --path tests/test_legacy_growth_guard.py`
+  with local-only `PULSEPLATE_PYTHON_INDEX_URL` shape warning.
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS:
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_shopping_list_registration_bootstrap.py tests/test_shoplist_day_endpoint.py tests/test_shopping_list_pro_router.py tests/test_legacy_growth_guard.py tests/test_route_family_bootstrap.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py tests/test_pro_vip_route_dependency_guard.py tests/test_openapi_determinism.py`
+- PASS: Experiment Runner oracle-only reviewer artifact
+  `artifacts/orchestration/experiments/results/exp-e478f895d5a7.json`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS: pre-push hooks during `git push`, including backend pre-push tests,
+  full-repo Bandit pre-push, and docker build test.
+
+## CI Observation
+
+- Current-head CI run `28623833903` initially failed `PR Body Phase2 gates` and
+  `Merge readiness gate` because the PR body/artifact Phase2 mapping surface was
+  not present yet.
+- This artifact and its PR body mirror are the intended governance fix. A fresh
+  current-head CI run is still required before any readiness language.
+
+## Merge Readiness
+
+Not claimed. Current-head CI, Codex Security diff scan, `pulseplate-pr-review`,
+bot review disposition, review-thread disposition checks, and strict
+merge-readiness governance remain required before any merge-readiness claim.

--- a/docs/review/PR_2066_FIXED_MAPPING.md
+++ b/docs/review/PR_2066_FIXED_MAPPING.md
@@ -62,6 +62,7 @@ Evidence: See `Review Comment Dispositions` below.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516273298 -> 633eeca00
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516357092 -> 7d20c13e0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516444236 -> cc729464f
 
 Disposition: NOT-A-BUG
 Evidence: The implementation commit contains the required Experiment Runner trailer.
@@ -174,7 +175,9 @@ Reason: A public shopping-list bootstrap helper would broaden the route-registra
 Disposition: NOT-A-BUG
 Comment:
 https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516357104
-Evidence:
+Evidence: The material implementation commit
+`ac033846008ac1157be48f64551bd0eaab0f8c7d` contains the required Experiment
+Runner trailer.
 Reason: The current branch history already contains the required trailer on the material implementation commit.
 
 - `git log --pretty=format:'%H %s%n%b' -1 ac033846008ac1157be48f64551bd0eaab0f8c7d`
@@ -196,6 +199,28 @@ Evidence:
   `ac033846008ac1157be48f64551bd0eaab0f8c7d`.
 - Current branch history contains that implementation commit before the mapping
   updates.
+
+### Codex Local Artifact Path Evidence
+
+Disposition: FIXED
+Comment:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516444236
+Commit: cc729464f
+Evidence: `docs/review/PR_2066_FIXED_MAPPING.md` now uses the Codex Security
+scan ID plus reproducible PR-review commands instead of machine-local
+filesystem report paths.
+
+- Evidence check:
+  `docs/review/PR_2066_FIXED_MAPPING.md` no longer contains machine-local
+  absolute report paths.
+- Evidence check:
+  the PR body no longer contains machine-local absolute report paths.
+- PASS:
+  `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 2066 --commit-range origin/main..HEAD`
+- PASS:
+  `python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 2066`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
 
 ## Post-Open Role Findings
 
@@ -228,7 +253,9 @@ Reason: Security-auditor did not identify a defect requiring code or docs change
 ## Codex Security
 
 Disposition: NOT-A-BUG
-Evidence:
+Evidence: Codex Security scan `21647199-e9cc-44b4-b4f2-82f9ea9fa40c`
+completed the branch-diff review with 5/5 reviewed surfaces closed and zero
+reportable findings.
 Reason: Codex Security completed a branch-diff scan with zero reportable findings.
 
 - Scan ID: `21647199-e9cc-44b4-b4f2-82f9ea9fa40c`
@@ -248,7 +275,9 @@ Reason: Codex Security completed a branch-diff scan with zero reportable finding
 ## PulsePlate PR Review
 
 Disposition: NOT-A-BUG
-Evidence:
+Evidence: `pulseplate-pr-review` produced only the advisory `large-diff-risk`
+note while the runtime diff remained bounded to the two paid shopping-list route
+registrations and targeted validation passed.
 Reason: The only review note was an advisory large-diff warning; the runtime scope stayed bounded and validation passed.
 
 - Report command:

--- a/docs/review/PR_2066_FIXED_MAPPING.md
+++ b/docs/review/PR_2066_FIXED_MAPPING.md
@@ -67,13 +67,11 @@ Evidence: See `Review Comment Dispositions` below.
 Disposition: NOT-A-BUG
 Evidence: The implementation commit contains the required Experiment Runner trailer.
 Reason: The comment was based on stale commit interpretation; the current branch history includes the required trailer on the material implementation commit, while later mapping-only commits do not require Experiment Runner attribution.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#discussion_r3516357104
 
 Disposition: NOT-A-BUG
 Evidence: Existing route-family bootstrap tests exercise private `app.main` registration helpers directly, and legacy growth guard tests assert exact diagnostic strings as guard contract output.
 Reason: Exposing a public shopping-list registration helper would widen the API surface for a canonical-bootstrap-only seam, and loosening exact legacy-guard diagnostic assertions would weaken the re-growth guard contract rather than making this PR safer.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2066#pullrequestreview-4621363293
 
 ## Implementation Evidence

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -54,8 +54,6 @@ from app.routers.foods import router as foods_router
 from app.routers.nutrition_recommendations import router as nutrition_recommendations_router
 from app.routers.recipes import router as recipes_router
 from app.routers.restaurants import router as restaurants_router
-from app.routers.shoplist_day import router as shoplist_day_router
-from app.routers.shopping_list_pro import router as shopping_list_pro_router
 from app.routers.users import router as users_router
 from app.schemas.bmr import BMRRequest, BMRRequestLegacy, BMRResponse
 from app.schemas.bmi_compat import BMIRequest, BMIRequestV1
@@ -920,12 +918,7 @@ app.include_router(catalog_router)
 
 # PRO/VIP route registration is owned by app.main canonical bootstrap.
 # Compatibility attrs above are populated there after successful registration.
-
-# Include PRO Shopping List Generator router
-app.include_router(shopping_list_pro_router)
-
-# Include Day Shopping List router (iOS MVP)
-app.include_router(shoplist_day_router)
+# Shopping-list route registration is owned by app.main canonical bootstrap.
 
 # Premium week router registration is now handled in
 # app.routers.pro_registration.register_pro_routes() for centralized registration.

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -104,8 +104,6 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("registration", "include_router", "recipes_router", ""),
         LegacyFact("registration", "include_router", "users_router", ""),
         LegacyFact("registration", "include_router", "catalog_router", ""),
-        LegacyFact("registration", "include_router", "shopping_list_pro_router", ""),
-        LegacyFact("registration", "include_router", "shoplist_day_router", ""),
     }
 )
 
@@ -131,13 +129,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
         ),
         LegacyFact("router_import", "app.routers.recipes", "router", "recipes_router"),
         LegacyFact("router_import", "app.routers.restaurants", "router", "restaurants_router"),
-        LegacyFact("router_import", "app.routers.shoplist_day", "router", "shoplist_day_router"),
-        LegacyFact(
-            "router_import",
-            "app.routers.shopping_list_pro",
-            "router",
-            "shopping_list_pro_router",
-        ),
         LegacyFact("router_import", "app.routers.users", "router", "users_router"),
         LegacyFact(
             "router_import",

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -833,6 +833,119 @@ def test_legacy_growth_guard_rejects_nutrition_state_router_reintroduction(
     assert errors == expected
 
 
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            textwrap.dedent("""
+                from app.routers.shopping_list_pro import router as shopping_list_pro_router
+
+                app.include_router(shopping_list_pro_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:shopping_list_pro_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.shopping_list_pro:router -> "
+                "shopping_list_pro_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from app.routers.shoplist_day import router as shoplist_day_router
+
+                app.include_router(shoplist_day_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:shoplist_day_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.shoplist_day:router -> shoplist_day_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from app.routers.shopping_list_pro import router as canonical_shopping_router
+
+                app.include_router(canonical_shopping_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:canonical_shopping_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.shopping_list_pro:router -> "
+                "canonical_shopping_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import app.routers.shoplist_day as shoplist_day_module
+
+                app.include_router(shoplist_day_module.router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:shoplist_day_module.router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:import:app.routers.shoplist_day -> shoplist_day_module",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                shopping_router = importlib.import_module("app.routers.shopping_list_pro").router
+                app.include_router(shopping_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:shopping_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.shopping_list_pro -> shopping_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                shopping_router, _ = (
+                    importlib.import_module("app.routers.shoplist_day").router,
+                    None,
+                )
+                app.include_router(shopping_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:shopping_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.shoplist_day -> shopping_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from importlib import import_module
+
+                if (shopping_router := import_module("app.routers.shoplist_day").router):
+                    app.include_router(shopping_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:shopping_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.shoplist_day -> shopping_router",
+            ],
+        ),
+    ],
+)
+def test_legacy_growth_guard_rejects_shopping_list_router_reintroduction(
+    source: str,
+    expected: list[str],
+) -> None:
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == expected
+
+
 def test_legacy_growth_guard_rejects_module_qualified_bodyfat_router_registration() -> None:
     source = textwrap.dedent("""
         import app.routers.bodyfat as bodyfat_routes

--- a/tests/test_shopping_list_registration_bootstrap.py
+++ b/tests/test_shopping_list_registration_bootstrap.py
@@ -56,7 +56,14 @@ def _shopping_list_route(target_app: FastAPI, path: str, method: str) -> object:
         for route in _shopping_list_routes(target_app)
         if route_path(route) == path and method in route_methods(route)
     ]
-    assert len(matches) == 1
+    route_summaries = [
+        f"{route_path(route)}:{sorted(route_methods(route))}:{route_endpoint(route).__module__}"
+        for route in matches
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one shopping-list route for {method} {path}; "
+        f"found {len(matches)}: {route_summaries}"
+    )
     return matches[0]
 
 

--- a/tests/test_shopping_list_registration_bootstrap.py
+++ b/tests/test_shopping_list_registration_bootstrap.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.routing import APIRoute
+
+import app.main as app_main
+from app.bootstrap.route_family import route_has_dependency_call
+from app.effective_routes import (
+    is_api_route_candidate,
+    iter_effective_route_candidates,
+    route_endpoint,
+    route_include_in_schema,
+    route_methods,
+    route_path,
+)
+
+_EXPECTED_ROUTE_SPECS = (
+    *app_main._SHOPPING_LIST_PRO_ROUTE_SPECS,
+    *app_main._SHOPLIST_DAY_ROUTE_SPECS,
+)
+_EXPECTED_ROUTE_KEYS = {
+    (path, method) for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS
+}
+_EXPECTED_ROUTE_PATHS = {path for path, _method in _EXPECTED_ROUTE_KEYS}
+_EXPECTED_ENDPOINT_MODULES = {
+    ("/api/v1/pro/meal/shopping-list", "POST"): "app.routers.shopping_list_pro",
+    ("/api/v1/pro/shoplist/day", "GET"): "app.routers.shoplist_day",
+}
+
+
+def _shopping_list_routes(target_app: FastAPI) -> list[object]:
+    return [
+        route
+        for route in iter_effective_route_candidates(target_app.routes)
+        if is_api_route_candidate(route) and route_path(route) in _EXPECTED_ROUTE_PATHS
+    ]
+
+
+def _registered_route_counts(target_app: FastAPI) -> Counter[tuple[str, str]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for route in _shopping_list_routes(target_app):
+        for method in route_methods(route):
+            key = (route_path(route), method)
+            if key in _EXPECTED_ROUTE_KEYS:
+                counts[key] += 1
+    return counts
+
+
+def _shopping_list_route(target_app: FastAPI, path: str, method: str) -> object:
+    matches = [
+        route
+        for route in _shopping_list_routes(target_app)
+        if route_path(route) == path and method in route_methods(route)
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _source_route(path: str, method: str) -> APIRoute:
+    for router in (app_main.shopping_list_pro_router, app_main.shoplist_day_router):
+        for route in router.routes:
+            if not isinstance(route, APIRoute):
+                continue
+            if str(route.path) == path and method in (route.methods or set()):
+                return route
+    raise AssertionError(f"missing source route: {method} {path}")
+
+
+def _clone_endpoint_without_dependency(
+    source_endpoint: Callable[..., object],
+) -> Callable[..., object]:
+    async def _endpoint_without_dependency() -> dict[str, str]:
+        return {"status": "stub"}
+
+    _endpoint_without_dependency.__module__ = source_endpoint.__module__
+    _endpoint_without_dependency.__qualname__ = source_endpoint.__qualname__
+    return _endpoint_without_dependency
+
+
+def _assert_shopping_list_routes_registered_once(target_app: FastAPI) -> None:
+    counts = _registered_route_counts(target_app)
+    assert set(counts) == _EXPECTED_ROUTE_KEYS
+    assert all(count == 1 for count in counts.values())
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _shopping_list_route(target_app, path, method)
+        assert route_include_in_schema(route) is include_in_schema
+        endpoint = route_endpoint(route)
+        assert getattr(endpoint, "__module__", None) == _EXPECTED_ENDPOINT_MODULES[(path, method)]
+        assert route_has_dependency_call(route, app_main.require_pro_tier)
+
+
+def test_empty_app_registers_all_shopping_list_routes_once() -> None:
+    target_app = FastAPI()
+
+    app_main._include_shopping_list_routers_if_needed(target_app)
+
+    _assert_shopping_list_routes_registered_once(target_app)
+
+
+def test_bootstrapped_app_registers_all_shopping_list_routes_once() -> None:
+    _assert_shopping_list_routes_registered_once(app_main.app)
+
+
+def test_shopping_list_registration_is_idempotent() -> None:
+    target_app = FastAPI()
+
+    app_main._include_shopping_list_routers_if_needed(target_app)
+    app_main._include_shopping_list_routers_if_needed(target_app)
+
+    _assert_shopping_list_routes_registered_once(target_app)
+
+
+def test_shopping_list_members_assert_tier_dependency() -> None:
+    members = {
+        (member.path, member.method): member for member in app_main._shopping_list_route_members()
+    }
+
+    assert set(members) == _EXPECTED_ROUTE_KEYS
+    for member in members.values():
+        assert member.required_dependencies == (app_main.require_pro_tier,)
+
+
+def test_shopping_list_source_routers_keep_tier_guard() -> None:
+    for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _source_route(path, method)
+
+        assert route_has_dependency_call(route, app_main.require_pro_tier)
+
+
+def test_shopping_list_router_source_specs_match_current_visibility() -> None:
+    route_specs: set[tuple[str, str, bool]] = set()
+    for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _source_route(path, method)
+        route_specs.add((str(route.path), method, route.include_in_schema))
+
+    assert route_specs == set(_EXPECTED_ROUTE_SPECS)
+
+
+def test_shopping_list_registration_rejects_partial_existing_family() -> None:
+    target_app = FastAPI()
+    path, method, include_in_schema = _EXPECTED_ROUTE_SPECS[0]
+
+    async def _partial_shopping_list_route() -> dict[str, str]:
+        return {"status": "partial"}
+
+    target_app.add_api_route(
+        path,
+        _partial_shopping_list_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(RuntimeError, match="Partial shopping list route registration detected"):
+        app_main._include_shopping_list_routers_if_needed(target_app)
+
+
+def test_shopping_list_registration_rejects_duplicate_method_path() -> None:
+    target_app = FastAPI()
+    app_main._include_shopping_list_routers_if_needed(target_app)
+    path, method, include_in_schema = _EXPECTED_ROUTE_SPECS[0]
+
+    async def _duplicate_shopping_list_route() -> dict[str, str]:
+        return {"status": "duplicate"}
+
+    target_app.add_api_route(
+        path,
+        _duplicate_shopping_list_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different shopping list handler",
+    ):
+        app_main._include_shopping_list_routers_if_needed(target_app)
+
+
+def test_shopping_list_registration_rejects_foreign_handlers() -> None:
+    target_app = FastAPI()
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+
+        async def _foreign_shopping_list_route(
+            current_route_path: str = path,
+        ) -> dict[str, str]:
+            return {"path": current_route_path}
+
+        target_app.add_api_route(
+            path,
+            _foreign_shopping_list_route,
+            methods=[method],
+            include_in_schema=include_in_schema,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different shopping list handler",
+    ):
+        app_main._include_shopping_list_routers_if_needed(target_app)
+
+
+def test_shopping_list_registration_rejects_existing_wrong_method() -> None:
+    target_app = FastAPI()
+
+    async def _wrong_method_shopping_list_route() -> dict[str, str]:
+        return {"status": "wrong-method"}
+
+    target_app.add_api_route(
+        "/api/v1/pro/meal/shopping-list",
+        _wrong_method_shopping_list_route,
+        methods=["PUT"],
+    )
+
+    with pytest.raises(RuntimeError, match="Partial shopping list route registration detected"):
+        app_main._include_shopping_list_routers_if_needed(target_app)
+
+
+def test_shopping_list_registration_rejects_visibility_drift() -> None:
+    target_app = FastAPI()
+    app_main._include_shopping_list_routers_if_needed(target_app)
+    path, method, _include_in_schema = _EXPECTED_ROUTE_SPECS[0]
+    route = _shopping_list_route(target_app, path, method)
+    setattr(route, "include_in_schema", False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve shopping list OpenAPI visibility",
+    ):
+        app_main._include_shopping_list_routers_if_needed(target_app)
+
+
+@pytest.mark.parametrize("missing_key", sorted(_EXPECTED_ROUTE_KEYS))
+def test_shopping_list_registration_rejects_missing_require_pro_tier(
+    missing_key: tuple[str, str],
+) -> None:
+    target_app = FastAPI()
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+        source_endpoint = _source_route(path, method).endpoint
+        endpoint = (
+            _clone_endpoint_without_dependency(source_endpoint)
+            if (path, method) == missing_key
+            else source_endpoint
+        )
+        dependencies = [] if (path, method) == missing_key else [Depends(app_main.require_pro_tier)]
+        target_app.add_api_route(
+            path,
+            endpoint,
+            methods=[method],
+            include_in_schema=include_in_schema,
+            dependencies=dependencies,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve shopping list required dependency",
+    ):
+        app_main._include_shopping_list_routers_if_needed(target_app)


### PR DESCRIPTION
## Goal
Move paid shopping-list route registration out of `legacy_app.py` and into canonical bootstrap ownership in `app/main.py`.

## Business reason
This is not cleanup for its own sake. It removes split registration ownership for paid shopping endpoints so future iOS/source-of-plan work has one fail-closed backend entrypoint with explicit route-family contracts.

## Scope
- Move only:
  - `POST /api/v1/pro/meal/shopping-list`
  - `GET /api/v1/pro/shoplist/day`
- Add source route specs in `app/routers/shopping_list_pro.py` and `app/routers/shoplist_day.py`.
- Register both routers as one `Shopping list` family through `ensure_route_family_registered(...)`.
- Remove the two legacy shopping-list router imports/includes from `legacy_app.py`.
- Shrink `check_legacy_growth_guard.py` allowlists and add negative tests for legacy re-growth.
- Update `docs/architecture/backend_routing_map.md` with repo-relative routing ownership evidence.

## Out of scope
- `shoplist_export`, VIP shoplist, FoodDB/catalog, FitChef algorithms/runtime, `weekly_plan_id` DB support, OpenAPI/client generated artifacts, frontend, iOS, macOS, deploy, and AI runtime.

## Key decisions
- Treat the two paid shopping endpoints as one atomic route family named `Shopping list`.
- Preserve `require_pro_tier` as a source route/member contract, not as a bootstrap wrapper dependency.
- Preserve source path/method/OpenAPI visibility exactly; no generated OpenAPI/client artifact changes.

## Real premortem findings closed by code/tests
- Duplicate or partial registration could leave one shopping route in `legacy_app.py` while canonical bootstrap adds or validates another, creating handler shadowing or false route confidence. Closed by removing both legacy imports/includes and adding idempotency, partial-registration, duplicate-method/path, wrong-method, foreign-handler, and live bootstrapped-app tests.
- Paid-route authorization drift could drop `require_pro_tier` on either paid endpoint or alter the dependency style used by `fetch_day_plan(pro_ctx=...)`. Closed by `RouteMemberContract.required_dependencies=(require_pro_tier,)` and tests that inspect both decorator-level and endpoint-parameter dependency forms via `route_has_dependency_call(...)`.
- OpenAPI/iOS drift could change path, method, or `include_in_schema` without generated artifact updates. Closed by source route specs and tests asserting source router path/method/schema visibility plus OpenAPI determinism.
- Legacy seam re-growth could reintroduce direct or hidden shopping-list router registration in `legacy_app.py`. Closed by shrinking the guard allowlist and adding direct, aliased, module-qualified, dynamic import, destructuring, and walrus-style negative tests.
- Scope creep could mix registration ownership with shopping product semantics. Closed by limiting changed runtime files to route constants/registration only; no FitChef, DB, schema, generated client, frontend, iOS, deploy, or AI runtime files changed.

## Tests / validation
- `python3 scripts/orchestration/check_preflight.py --mode analyze --path app/main.py --path legacy_app.py --path app/routers/shopping_list_pro.py --path app/routers/shoplist_day.py --path scripts/ci/check_legacy_growth_guard.py --path tests/test_legacy_growth_guard.py` passed. Local warning only: noncanonical `PULSEPLATE_PYTHON_INDEX_URL` shape.
- `python3 scripts/orchestration/check_agent_consistency.py` passed.
- Focused pytest bundle passed:
  - `tests/test_shopping_list_registration_bootstrap.py`
  - `tests/test_shoplist_day_endpoint.py`
  - `tests/test_shopping_list_pro_router.py`
  - `tests/test_legacy_growth_guard.py`
  - `tests/test_route_family_bootstrap.py`
  - `tests/security/test_api_auth_tier_contract_pack.py`
  - `tests/security/test_api_authz_contract_static.py`
  - `tests/test_pro_vip_route_dependency_guard.py`
  - `tests/test_openapi_determinism.py`
- Experiment Runner oracle-only review accepted the staged diff: `exp-e478f895d5a7`, one focused pytest oracle executed and passed in isolated checkout.
- `make validate-changed` passed after commit.
- `pre-commit run --all-files` passed.
- Pre-push hooks passed, including backend pre-push tests, full-repo Bandit pre-push, and docker build test.

## Security notes
This PR reduces paid-route authorization drift by moving registration ownership into canonical bootstrap while preserving source router behavior. It adds fail-closed tests for missing `require_pro_tier`, duplicate/shadowed handlers, partial family registration, OpenAPI visibility drift, and legacy seam re-growth.

## Risks / rollback
Rollback is mechanical: revert commit `ac0338460`. No DB migration, schema change, product algorithm change, generated client update, or deployment change is involved.

## Deferred / follow-ups
- No new deferred runtime work in this PR.
- Product behavior work such as `weekly_plan_id` DB support or shopping-list usefulness remains intentionally outside this registration PR.

## AGENTS.md or agent-instruction updates
None.

## Next best step
Run the mandatory post-open review chain: `qa-engineer-agent -> bug-hunter -> security-auditor`, then Codex Security diff scan / finding discovery and `pulseplate-pr-review`. Do not claim merge readiness until current-head GitHub CI, CodeRabbit, Sourcery, Cubic, review-thread disposition, and strict merge-readiness gates are current and clean.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/e9cd2b93e4e2.json`
- Post-open packet: `artifacts/orchestration/task_packets/6191c7a0e812.json`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2066_FIXED_MAPPING.md`

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/exp-e478f895d5a7.json`

## Post-Open Review Evidence
- [x] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
- [x] Codex Security diff scan / finding discovery completed: scan `21647199-e9cc-44b4-b4f2-82f9ea9fa40c`, 5/5 surfaces reviewed, 0 reportable findings.
- [x] `pulseplate-pr-review` completed. One advisory large-diff note was dispositioned as NOT-A-BUG because the added lines are targeted tests plus mapping evidence and runtime scope stayed bounded to the two shopping-list registrations.
- Canonical mapping artifact: `docs/review/PR_2066_FIXED_MAPPING.md`.

## Bot Review Dispositions
- Sourcery inline route assertion diagnostic: FIXED in `633eeca00`.
- Sourcery high-level helper/message suggestions: NOT-A-BUG with evidence/reason in `docs/review/PR_2066_FIXED_MAPPING.md`; no public helper added because this remains a private canonical-bootstrap seam, and exact legacy-growth diagnostics are treated as guard contract output.
- Codex mapping SHA comment: FIXED; implementation proof now uses full in-branch commit `ac033846008ac1157be48f64551bd0eaab0f8c7d`.
- Codex Experiment Runner trailer comment: NOT-A-BUG with commit-log evidence that the material implementation commit already has the required trailer.
- Bot-facing replies were posted with concrete `Disposition`, `Evidence`, and `Reason`; not label-only.

## Merge Readiness
Not claimed. Current-head CI, CodeRabbit, Sourcery, Cubic, review-thread disposition, and strict merge-readiness gates remain required before any merge-readiness language.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved paid shopping-list route registration to canonical bootstrap in `app/main.py`, grouping `POST /api/v1/pro/meal/shopping-list` and `GET /api/v1/pro/shoplist/day` into one protected “Shopping list” family. OpenAPI and runtime behavior remain unchanged.

- **Refactors**
  - Register both routes via `_include_shopping_list_routers_if_needed(...)` using `SHOPPING_LIST_PRO_ROUTE_SPECS` and `SHOPLIST_DAY_ROUTE_SPECS` through `ensure_route_family_registered(...)`.
  - Enforce `require_pro_tier` via `RouteMemberContract`; fail-closed on partial registration, duplicates, foreign handlers, wrong methods, or visibility drift.
  - Remove legacy includes from `legacy_app.py`; tighten `scripts/ci/check_legacy_growth_guard.py` and add negative tests; update `docs/architecture/backend_routing_map.md` and add `docs/review/PR_2066_FIXED_MAPPING.md` (bot review dispositions kept contiguous); add focused bootstrap tests with clearer route assertion diagnostics.

<sup>Written for commit 86660cdcfbc6bc556c9999add83337d39eada76e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paid shopping-list routes to the canonical app startup flow.
  * Shopping-list endpoints are now available via a protected pro-tier route family.
* **Bug Fixes**
  * Prevented the legacy app from re-registering shopping-list routes, avoiding duplicates, partial setups, handler conflicts, and method/visibility drift.
  * Ensured shopping-list route registration is idempotent and properly requires pro-tier access.
* **Documentation**
  * Updated backend routing docs to reflect canonical bootstrap ownership and pro-tier gating.
* **Tests**
  * Added/expanded tests covering shopping-list bootstrap behavior and legacy growth-guard rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


