### PR TITLE
feat(orchestration): bridge approved creative hypotheses to specification candidates

### DIFF
--- a/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
+++ b/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
@@ -3,8 +3,9 @@
 <!-- markdownlint-disable MD013 -->
 
 **Status:** PR-6 first applied-candidate lane, local private-pilot loop
-operator, and local Experiment Runner PR creative-context attachment. Repo-only
-governance contract. No runtime impact.
+operator, local Experiment Runner PR creative-context attachment, and approved
+creative-hypothesis specification bridge. Repo-only governance contract. No
+runtime impact.
 
 **Scope:** Define the authority boundary between a promoted `creative_research`
 output, a PR-1 implementation specification, PR-2 local candidate-patch
@@ -12,7 +13,9 @@ generation, PR-3 human-approved non-draft PR handoff tooling, PR-4 telemetry,
 PR-5 read-only review-disposition integration, the PR-6 local
 applied-candidate run-plan wrapper, and a local private-pilot lifecycle
 operator, plus a local PR creative-context artifact layer for Experiment
-Runner hypothesis generation and agent routing. PR-2
+Runner hypothesis generation and agent routing, and a local bridge from human
+approved creative hypotheses into existing PR-1 specification candidate
+artifacts. PR-2
 authorizes only isolated local candidate-patch generation/evaluation. PR-3
 authorizes only the separate local promotion tool that can create a new
 `experiment/*` branch, push it without force, and open a non-draft PR after
@@ -31,7 +34,13 @@ generate bounded hypotheses or ingest validated operator-supplied local model
 hypothesis JSON, route normalized hypotheses to agents, emit coordinator
 dispatch handoffs, and prepare a human approval reservation; it does not
 authorize candidate patches, repository writes, workflow changes, provider
-calls, model adapters, semantic-cache use, or PR/GitHub mutations.
+calls, model adapters, semantic-cache use, or PR/GitHub mutations. The approved
+creative-hypothesis bridge may consume that human approval reservation only to
+build a validated `CreativeCodeCandidatePacket`, deterministic local metrics,
+and existing PR-1 prepare artifacts; it does not widen candidate mutable
+surfaces, execute agents, finalize bundles, generate patches, call providers,
+write PR/GitHub/Slack state, write product runtime truth, write graph truth, or
+open the semantic-cache gate.
 
 ---
 
@@ -46,6 +55,7 @@ calls, model adapters, semantic-cache use, or PR/GitHub mutations.
 | `promotion` | Promotes a candidate into canonical repo behavior through human review, PR governance, and merge gates. | PR-3 opens the review handoff only. Canonical behavior still requires normal PR review and merge gates. |
 | `private-pilot-lifecycle` | Reads sanitized lifecycle metadata and emits local next-action artifacts. | Allowed only through the private-pilot loop operator; no candidate generation or GitHub write authority. |
 | `pr-creative-context` | Expands eligible PR context into 3-5 hypotheses, validates operator-supplied local hypothesis JSON, assigns normalized hypothesis IDs, records cross-domain analogies, emits agent routing/coordinator dispatch, and prepares approval reservations. | Allowed only through local sanitized Experiment Runner creative-context artifacts; no repo-side provider/model call, patch generation, workflow mutation, semantic cache, or GitHub write authority. |
+| `approved-hypothesis-spec-bridge` | Converts a human-approved creative hypothesis into a validated PR-0 creative-code candidate and existing PR-1 prepare artifacts. | Allowed only through local `creative_hypothesis_spec_bridge.py`; no mutable-surface widening, provider calls, patch generation, PR writes, role execution, finalization, semantic cache, graph truth, or product runtime authority. |
 
 PR-0 sets:
 
@@ -68,6 +78,10 @@ review-thread, merge, release, and Slack/GitHub authority flags remain closed.
 The PR creative-context layer adds bounded hypothesis/routing artifacts only;
 active model/operator intake remains local and validated; auto-workflow
 attachment remains a separate follow-up PR.
+The approved-hypothesis bridge adds only local candidate/specification handoff
+artifacts after human approval; approval targets outside the current
+`CreativeCodeCandidatePacket` mutable allowlist become immutable oracles, and
+the bridge fails closed when no allowed mutable target remains.
 
 Premortem is part of this creative line, not a documentation closeout ritual.
 For Experiment Runner creative-context work, premortem should forecast plausible
@@ -162,6 +176,20 @@ The Experiment Runner PR creative-context artifacts are:
 - `artifacts/orchestration/experiments/creative_context/<context-id>/oracle_attachment.json`
 - `artifacts/orchestration/experiments/creative_context/<context-id>/agent_consumption_summary.json`
 
+The approved creative-hypothesis specification bridge artifacts are:
+
+- `docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json`
+- `docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json`
+- `scripts/orchestration/creative_hypothesis_spec_bridge_contract.py`
+- `scripts/orchestration/creative_hypothesis_spec_bridge.py`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/creative_hypothesis_specification_bridge.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/creative_code_candidate_packet.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/bridge_metrics.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_prepare/source_packet.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_prepare/variants.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_prepare/skeptic_reviews.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_prepare/context_pack.json`
+
 `patch_request.json` remains a PR-2 `CreativeCodePatchBuildRequest` handoff
 artifact. It is built and validated only after PR-1 emits
 `spec_runs/<candidate-id>/bundle.json`, because its identity and fingerprint are
@@ -205,6 +233,12 @@ PR-0 is a contract-only start point.
 - PR-1: emit deterministic implementation specification bundles from promoted
   creative research; no patches, provider calls, repo writes, runtime truth,
   review disposition authority, or merge-readiness evidence.
+- Approved-hypothesis specification bridge: consume human-approved
+  `CreativeHypothesisApproval` artifacts and emit a validated
+  `CreativeCodeCandidatePacket`, deterministic local bridge metrics, and
+  existing PR-1 prepare artifacts; no agent execution, finalize, candidate
+  patches, provider calls, workflow changes, repository writes, product runtime
+  truth, semantic cache, graph truth, or mutable-surface widening.
 - PR-2: generate isolated candidate patches only in sandboxed evaluation
   workspaces with exact source-bundle fingerprint binding, exact `origin/main`
   base SHA, fixed Codex CLI argv/env, strict patch policy validation, direct
@@ -237,6 +271,11 @@ PR-0 is a contract-only start point.
   workflows, call providers, call product runtime, create branches, open PRs,
   post comments, resolve threads, edit fixed mappings, merge, or claim
   readiness.
+- Bridge follow-ups remain separate reviewed PRs: attach agent skeptic reviews
+  and `finalize`, ingest bridge metrics into the existing telemetry /
+  learning-loop rollup, and explore graph/multimodal lineage only after
+  repo-reviewed evidence contracts define asset lineage, fingerprints,
+  idempotency, and replay/admission behavior.
 
 Minimum future telemetry fields are defined now for the later train and must not be emitted before PR-1:
 

--- a/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
+++ b/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
@@ -79,9 +79,11 @@ The PR creative-context layer adds bounded hypothesis/routing artifacts only;
 active model/operator intake remains local and validated; auto-workflow
 attachment remains a separate follow-up PR.
 The approved-hypothesis bridge adds only local candidate/specification handoff
-artifacts after human approval; approval targets outside the current
-`CreativeCodeCandidatePacket` mutable allowlist become immutable oracles, and
-the bridge fails closed when no allowed mutable target remains.
+artifacts after human approval. The approval must bind to the exact source
+hypothesis packet id, packet fingerprint, and selected hypothesis fingerprint;
+approval targets outside the current `CreativeCodeCandidatePacket` mutable
+allowlist become immutable oracles, and the bridge fails closed when no allowed
+mutable target remains.
 
 Premortem is part of this creative line, not a documentation closeout ritual.
 For Experiment Runner creative-context work, premortem should forecast plausible
@@ -190,6 +192,12 @@ The approved creative-hypothesis specification bridge artifacts are:
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_prepare/skeptic_reviews.json`
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_prepare/context_pack.json`
 
+Bridge output directories must be exactly
+`artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/`; bridge refs,
+candidate packets, metrics, and prepare directories must agree on that id.
+Build-only artifacts may only allow `prepare_specification`; agent skeptic
+review is the next action only after the four PR-1 prepare artifacts exist.
+
 `patch_request.json` remains a PR-2 `CreativeCodePatchBuildRequest` handoff
 artifact. It is built and validated only after PR-1 emits
 `spec_runs/<candidate-id>/bundle.json`, because its identity and fingerprint are
@@ -234,7 +242,8 @@ PR-0 is a contract-only start point.
   creative research; no patches, provider calls, repo writes, runtime truth,
   review disposition authority, or merge-readiness evidence.
 - Approved-hypothesis specification bridge: consume human-approved
-  `CreativeHypothesisApproval` artifacts and emit a validated
+  `CreativeHypothesisApproval` artifacts that bind to the current source packet
+  and selected hypothesis fingerprints, then emit a validated
   `CreativeCodeCandidatePacket`, deterministic local bridge metrics, and
   existing PR-1 prepare artifacts; no agent execution, finalize, candidate
   patches, provider calls, workflow changes, repository writes, product runtime

--- a/docs/orchestration/contracts/EXPERIMENT_RUNNER_PR_CREATIVE_CONTEXT_CONTRACT.md
+++ b/docs/orchestration/contracts/EXPERIMENT_RUNNER_PR_CREATIVE_CONTEXT_CONTRACT.md
@@ -17,6 +17,16 @@ may produce structured hypothesis JSON outside the repo, while the repo only
 validates, normalizes, fingerprints, and routes that JSON. The repo does not
 call a provider/model and does not retain raw prompts or raw model payloads.
 
+The approved next handoff after a human `CreativeHypothesisApproval` is the
+separate local bridge in
+`scripts/orchestration/creative_hypothesis_spec_bridge.py`. That bridge may
+build a validated `CreativeCodeCandidatePacket`, deterministic local metrics,
+and existing PR-1 prepare artifacts only when the approval decision is
+`approve_for_pr1_specification` with `next_step=create_pr1_specification`.
+Approval remains specification handoff authority only; it is not patch,
+repository-write, PR, agent-execution, provider, product-runtime, cache, graph,
+or merge authority.
+
 ## Authority Boundary
 
 Allowed:
@@ -85,10 +95,13 @@ Schemas:
 - `creative_hypothesis_coordinator_dispatch.v1.schema.json`
 - `creative_hypothesis_agent_consumption_summary.v1.schema.json`
 - `creative_hypothesis_approval.v1.schema.json`
+- `creative_hypothesis_specification_bridge.v1.schema.json`
+- `creative_hypothesis_spec_bridge_metrics.v1.schema.json`
 
 Runtime contract:
 
 - `scripts/orchestration/experiment_runner_pr_creative_context_contract.py`
+- `scripts/orchestration/creative_hypothesis_spec_bridge_contract.py`
 
 CLI:
 
@@ -101,6 +114,10 @@ python -m scripts.orchestration.experiment_runner_pr_creative_context dispatch-c
 python -m scripts.orchestration.experiment_runner_pr_creative_context summarize
 python -m scripts.orchestration.experiment_runner_pr_creative_context prepare
 python -m scripts.orchestration.experiment_runner_pr_creative_context validate
+python -m scripts.orchestration.creative_hypothesis_spec_bridge build-candidate
+python -m scripts.orchestration.creative_hypothesis_spec_bridge prepare-specification
+python -m scripts.orchestration.creative_hypothesis_spec_bridge build-and-prepare
+python -m scripts.orchestration.creative_hypothesis_spec_bridge validate
 ```
 
 `prepare` writes only these filenames:
@@ -126,6 +143,27 @@ invalidating otherwise valid operator/model JSON.
 `model_intake.json` beside it. Operators may override that sidecar path with
 `--normalized-intake-output`; stdout-only mode does not create a sidecar unless
 an explicit sidecar output is provided.
+
+`creative_hypothesis_spec_bridge build-candidate` consumes an existing
+`context_map.json`, `hypothesis_packet.json`, `coordinator_dispatch.json`, and
+`approval.json`, then writes only:
+
+- `creative_hypothesis_specification_bridge.json`;
+- `creative_code_candidate_packet.json`;
+- `bridge_metrics.json`.
+
+`creative_hypothesis_spec_bridge build-and-prepare` additionally delegates to
+the existing PR-1 `creative_code_spec_pipeline.prepare(...)` implementation and
+writes only these prepare artifacts under `spec_prepare/`:
+
+- `source_packet.json`;
+- `variants.json`;
+- `skeptic_reviews.json`;
+- `context_pack.json`.
+
+The bridge never calls `finalize`, patch builders, promotion tooling, role
+dispatch, providers, product runtime, workflow dispatch, GitHub/Slack write
+paths, or cache/graph truth systems.
 
 ## Operator Model Intake
 

--- a/docs/orchestration/contracts/EXPERIMENT_RUNNER_PR_CREATIVE_CONTEXT_CONTRACT.md
+++ b/docs/orchestration/contracts/EXPERIMENT_RUNNER_PR_CREATIVE_CONTEXT_CONTRACT.md
@@ -22,7 +22,9 @@ separate local bridge in
 `scripts/orchestration/creative_hypothesis_spec_bridge.py`. That bridge may
 build a validated `CreativeCodeCandidatePacket`, deterministic local metrics,
 and existing PR-1 prepare artifacts only when the approval decision is
-`approve_for_pr1_specification` with `next_step=create_pr1_specification`.
+`approve_for_pr1_specification` with `next_step=create_pr1_specification` and
+the approval is bound to the current `source_hypothesis_packet_id`,
+`source_hypothesis_packet_fingerprint`, and selected `hypothesis_fingerprint`.
 Approval remains specification handoff authority only; it is not patch,
 repository-write, PR, agent-execution, provider, product-runtime, cache, graph,
 or merge authority.
@@ -165,6 +167,11 @@ The bridge never calls `finalize`, patch builders, promotion tooling, role
 dispatch, providers, product runtime, workflow dispatch, GitHub/Slack write
 paths, or cache/graph truth systems.
 
+Build-only bridge artifacts keep `spec_prepare.prepared=false` and
+`next_allowed_action=prepare_specification`. Only after
+`prepare-specification` writes the four deterministic PR-1 artifacts may the
+bridge mark `prepared=true` and expose `next_allowed_action=agent_skeptic_review`.
+
 ## Operator Model Intake
 
 `CreativeHypothesisOperatorModelIntake` is an advisory, unverified local input
@@ -272,7 +279,10 @@ and targeted gates unless one of the rerun reasons is present.
 `CreativeHypothesisApproval` is a reservation, not a mutation grant. An
 approval may authorize only `create_pr1_specification`. It must keep
 `generate_patch=false`; PR-2 patch generation requires a later explicit gate and
-approved specification evidence.
+approved specification evidence. PR-1 approvals must bind to the exact
+hypothesis packet id, packet fingerprint, and selected hypothesis fingerprint;
+stale approvals for the same reusable `hypothesis_id` cannot authorize a
+changed packet.
 
 ## Rollback
 

--- a/docs/orchestration/contracts/creative_hypothesis_approval.v1.schema.json
+++ b/docs/orchestration/contracts/creative_hypothesis_approval.v1.schema.json
@@ -10,7 +10,10 @@
     "policy_version",
     "approval_id",
     "idempotency_key",
+    "source_hypothesis_packet_id",
+    "source_hypothesis_packet_fingerprint",
     "hypothesis_id",
+    "hypothesis_fingerprint",
     "decision",
     "approved_target_surfaces",
     "approved_agents",
@@ -26,7 +29,16 @@
     "policy_version": { "const": "experiment-runner-pr-creative-context-v1" },
     "approval_id": { "$ref": "#/$defs/safe_id" },
     "idempotency_key": { "$ref": "#/$defs/safe_id" },
+    "source_hypothesis_packet_id": {
+      "anyOf": [{ "$ref": "#/$defs/safe_id" }, { "type": "null" }]
+    },
+    "source_hypothesis_packet_fingerprint": {
+      "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }]
+    },
     "hypothesis_id": { "$ref": "#/$defs/safe_id" },
+    "hypothesis_fingerprint": {
+      "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }]
+    },
     "decision": { "enum": ["approve_for_pr1_specification", "reject", "defer"] },
     "approved_target_surfaces": { "$ref": "#/$defs/repo_paths" },
     "approved_agents": {
@@ -49,6 +61,9 @@
       "then": {
         "properties": {
           "next_step": { "const": "create_pr1_specification" },
+          "source_hypothesis_packet_id": { "$ref": "#/$defs/safe_id" },
+          "source_hypothesis_packet_fingerprint": { "$ref": "#/$defs/sha256" },
+          "hypothesis_fingerprint": { "$ref": "#/$defs/sha256" },
           "approved_target_surfaces": {
             "minItems": 1,
             "items": { "$ref": "#/$defs/approvable_pr1_target_path" }
@@ -90,6 +105,7 @@
       "maxLength": 128,
       "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
     },
+    "sha256": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
     "repo_path": {
       "type": "string",
       "pattern": "^[A-Za-z0-9_.-][A-Za-z0-9_./-]*$",

--- a/docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json
+++ b/docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json",
+  "title": "CreativeHypothesisSpecBridgeMetrics",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "metrics_id",
+    "idempotency_key",
+    "source",
+    "bridge_id",
+    "candidate_id",
+    "selected_hypothesis_id",
+    "status",
+    "blocked_reason",
+    "counts",
+    "cost_metadata",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_hypothesis_spec_bridge_metrics" },
+    "policy_version": { "const": "creative-hypothesis-spec-bridge-v1" },
+    "metrics_id": { "$ref": "#/$defs/safe_id" },
+    "idempotency_key": { "$ref": "#/$defs/safe_id" },
+    "source": { "$ref": "#/$defs/source" },
+    "bridge_id": { "$ref": "#/$defs/safe_id" },
+    "candidate_id": { "$ref": "#/$defs/safe_id" },
+    "selected_hypothesis_id": { "$ref": "#/$defs/safe_id" },
+    "status": { "enum": ["candidate_built", "prepared", "blocked"] },
+    "blocked_reason": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "enum": [
+            "approval_not_pr1_specification",
+            "approved_agents_not_dispatched",
+            "approved_targets_not_hypothesis_subset",
+            "candidate_target_oracle_overlap",
+            "dispatch_packet_mismatch",
+            "dispatch_row_missing",
+            "fingerprint_mismatch",
+            "hypothesis_not_found",
+            "invalid_candidate_packet",
+            "no_allowed_mutable_target",
+            "spec_prepare_failed"
+          ]
+        }
+      ]
+    },
+    "counts": { "$ref": "#/$defs/counts" },
+    "cost_metadata": { "$ref": "#/$defs/cost_metadata" },
+    "authority": { "$ref": "#/$defs/bridge_authority" },
+    "sanitized": { "const": true }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "blocked" } }, "required": ["status"] },
+      "then": { "properties": { "blocked_reason": { "not": { "type": "null" } } } }
+    },
+    {
+      "if": {
+        "properties": { "status": { "enum": ["candidate_built", "prepared"] } },
+        "required": ["status"]
+      },
+      "then": { "properties": { "blocked_reason": { "type": "null" } } }
+    }
+  ],
+  "$defs": {
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "sha256": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "context_map_id",
+        "context_map_fingerprint",
+        "hypothesis_packet_id",
+        "hypothesis_packet_fingerprint",
+        "coordinator_dispatch_id",
+        "coordinator_dispatch_fingerprint",
+        "approval_id",
+        "approval_fingerprint",
+        "candidate_fingerprint"
+      ],
+      "properties": {
+        "context_map_id": { "$ref": "#/$defs/safe_id" },
+        "context_map_fingerprint": { "$ref": "#/$defs/sha256" },
+        "hypothesis_packet_id": { "$ref": "#/$defs/safe_id" },
+        "hypothesis_packet_fingerprint": { "$ref": "#/$defs/sha256" },
+        "coordinator_dispatch_id": { "$ref": "#/$defs/safe_id" },
+        "coordinator_dispatch_fingerprint": { "$ref": "#/$defs/sha256" },
+        "approval_id": { "$ref": "#/$defs/safe_id" },
+        "approval_fingerprint": { "$ref": "#/$defs/sha256" },
+        "candidate_fingerprint": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hypothesis_count",
+        "approved_target_count",
+        "candidate_target_count",
+        "immutable_oracle_count",
+        "variant_count",
+        "prepare_files_written",
+        "pending_skeptic_review_count"
+      ],
+      "properties": {
+        "hypothesis_count": { "type": "integer", "minimum": 0, "maximum": 5 },
+        "approved_target_count": { "type": "integer", "minimum": 0 },
+        "candidate_target_count": { "type": "integer", "minimum": 0 },
+        "immutable_oracle_count": { "type": "integer", "minimum": 0 },
+        "variant_count": { "enum": [3, 4, 5] },
+        "prepare_files_written": { "type": "integer", "minimum": 0, "maximum": 4 },
+        "pending_skeptic_review_count": { "type": "integer", "minimum": 0, "maximum": 15 }
+      }
+    },
+    "cost_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_cost_available",
+        "provider_call_count",
+        "provider_cost_basis"
+      ],
+      "properties": {
+        "provider_cost_available": { "const": false },
+        "provider_call_count": { "const": 0 },
+        "provider_cost_basis": { "const": "not_available_local_no_provider_calls" }
+      }
+    },
+    "bridge_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "build_creative_code_candidate_packet",
+        "call_product_runtime",
+        "call_provider",
+        "change_client_runtime",
+        "change_openapi",
+        "claim_merge_readiness",
+        "create_branch",
+        "dispatch_to_agents",
+        "edit_fixed_mapping",
+        "emit_local_artifacts",
+        "execute_agent_tasks",
+        "execute_pr2_patch_builder",
+        "execute_pr3_promotion",
+        "finalize_specification_bundle",
+        "generate_candidate_patch",
+        "generate_patch",
+        "mark_pr_ready",
+        "merge",
+        "modify_github_app",
+        "modify_slack",
+        "modify_workflows",
+        "open_draft_pr",
+        "open_pr",
+        "post_github_comment",
+        "push",
+        "read_sanitized_context",
+        "read_secrets",
+        "release",
+        "resolve_threads",
+        "run_specification_prepare",
+        "use_semantic_cache",
+        "workflow_dispatch",
+        "write_branch",
+        "write_repository",
+        "write_shared_worktree"
+      ],
+      "properties": {
+        "build_creative_code_candidate_packet": { "const": true },
+        "emit_local_artifacts": { "const": true },
+        "read_sanitized_context": { "const": true },
+        "run_specification_prepare": { "const": true },
+        "call_product_runtime": { "const": false },
+        "call_provider": { "const": false },
+        "change_client_runtime": { "const": false },
+        "change_openapi": { "const": false },
+        "claim_merge_readiness": { "const": false },
+        "create_branch": { "const": false },
+        "dispatch_to_agents": { "const": false },
+        "edit_fixed_mapping": { "const": false },
+        "execute_agent_tasks": { "const": false },
+        "execute_pr2_patch_builder": { "const": false },
+        "execute_pr3_promotion": { "const": false },
+        "finalize_specification_bundle": { "const": false },
+        "generate_candidate_patch": { "const": false },
+        "generate_patch": { "const": false },
+        "mark_pr_ready": { "const": false },
+        "merge": { "const": false },
+        "modify_github_app": { "const": false },
+        "modify_slack": { "const": false },
+        "modify_workflows": { "const": false },
+        "open_draft_pr": { "const": false },
+        "open_pr": { "const": false },
+        "post_github_comment": { "const": false },
+        "push": { "const": false },
+        "read_secrets": { "const": false },
+        "release": { "const": false },
+        "resolve_threads": { "const": false },
+        "use_semantic_cache": { "const": false },
+        "workflow_dispatch": { "const": false },
+        "write_branch": { "const": false },
+        "write_repository": { "const": false },
+        "write_shared_worktree": { "const": false }
+      }
+    }
+  }
+}

--- a/docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json
+++ b/docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json
@@ -118,9 +118,9 @@
       ],
       "properties": {
         "hypothesis_count": { "type": "integer", "minimum": 0, "maximum": 5 },
-        "approved_target_count": { "type": "integer", "minimum": 0 },
-        "candidate_target_count": { "type": "integer", "minimum": 0 },
-        "immutable_oracle_count": { "type": "integer", "minimum": 0 },
+        "approved_target_count": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "candidate_target_count": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "immutable_oracle_count": { "type": "integer", "minimum": 0, "maximum": 100 },
         "variant_count": { "enum": [3, 4, 5] },
         "prepare_files_written": { "type": "integer", "minimum": 0, "maximum": 4 },
         "pending_skeptic_review_count": { "type": "integer", "minimum": 0, "maximum": 15 }

--- a/docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json
+++ b/docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json
@@ -45,6 +45,7 @@
             "dispatch_row_missing",
             "fingerprint_mismatch",
             "hypothesis_not_found",
+            "hypothesis_packet_not_generated",
             "invalid_candidate_packet",
             "no_allowed_mutable_target",
             "spec_prepare_failed"

--- a/docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json
+++ b/docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json
@@ -41,7 +41,9 @@
     "repo_path": {
       "type": "string",
       "minLength": 1,
-      "not": { "pattern": "^(?:/|~|[A-Za-z][A-Za-z0-9+.-]*:)|(?:^|/)\\.\\.(?:/|$)|\\\\|[\\u0000-\\u001F\\u007F]" }
+      "not": {
+        "pattern": "^(?:/|~|[A-Za-z][A-Za-z0-9+.-]*:)|(?:^|/)\\.\\.?(?:/|$)|\\\\|[\\u0000-\\u001F\\u007F]|^(?:\\.git|\\.venv|worktrees|artifacts)(?:/|$)"
+      }
     },
     "spec_bridge_artifact_ref": {
       "type": "string",
@@ -160,8 +162,18 @@
         },
         "prepared": { "type": "boolean" },
         "finalized": { "const": false },
-        "next_allowed_action": { "const": "agent_skeptic_review" }
-      }
+        "next_allowed_action": { "enum": ["prepare_specification", "agent_skeptic_review"] }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "prepared": { "const": false } }, "required": ["prepared"] },
+          "then": { "properties": { "next_allowed_action": { "const": "prepare_specification" } } }
+        },
+        {
+          "if": { "properties": { "prepared": { "const": true } }, "required": ["prepared"] },
+          "then": { "properties": { "next_allowed_action": { "const": "agent_skeptic_review" } } }
+        }
+      ]
     },
     "bridge_authority": {
       "type": "object",

--- a/docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json
+++ b/docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json
@@ -1,0 +1,245 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_hypothesis_specification_bridge.v1.schema.json",
+  "title": "CreativeHypothesisSpecificationBridge",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "bridge_id",
+    "idempotency_key",
+    "source",
+    "selected_hypothesis",
+    "candidate_packet",
+    "spec_prepare",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_hypothesis_specification_bridge" },
+    "policy_version": { "const": "creative-hypothesis-spec-bridge-v1" },
+    "bridge_id": { "$ref": "#/$defs/safe_id" },
+    "idempotency_key": { "$ref": "#/$defs/safe_id" },
+    "source": { "$ref": "#/$defs/source" },
+    "selected_hypothesis": { "$ref": "#/$defs/selected_hypothesis" },
+    "candidate_packet": { "$ref": "#/$defs/candidate_packet_ref" },
+    "spec_prepare": { "$ref": "#/$defs/spec_prepare" },
+    "authority": { "$ref": "#/$defs/bridge_authority" },
+    "sanitized": { "const": true }
+  },
+  "$defs": {
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "sha256": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "repo_path": {
+      "type": "string",
+      "minLength": 1,
+      "not": { "pattern": "^(?:/|~|[A-Za-z][A-Za-z0-9+.-]*:)|(?:^|/)\\.\\.(?:/|$)|\\\\|[\\u0000-\\u001F\\u007F]" }
+    },
+    "spec_bridge_artifact_ref": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/.+$",
+      "not": { "pattern": "(?:^|/)\\.\\.(?:/|$)|\\\\|[\\u0000-\\u001F\\u007F]" }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "context_map_id",
+        "context_map_fingerprint",
+        "hypothesis_packet_id",
+        "hypothesis_packet_fingerprint",
+        "coordinator_dispatch_id",
+        "coordinator_dispatch_fingerprint",
+        "approval_id",
+        "approval_fingerprint"
+      ],
+      "properties": {
+        "context_map_id": { "$ref": "#/$defs/safe_id" },
+        "context_map_fingerprint": { "$ref": "#/$defs/sha256" },
+        "hypothesis_packet_id": { "$ref": "#/$defs/safe_id" },
+        "hypothesis_packet_fingerprint": { "$ref": "#/$defs/sha256" },
+        "coordinator_dispatch_id": { "$ref": "#/$defs/safe_id" },
+        "coordinator_dispatch_fingerprint": { "$ref": "#/$defs/sha256" },
+        "approval_id": { "$ref": "#/$defs/safe_id" },
+        "approval_fingerprint": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "selected_hypothesis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hypothesis_id",
+        "hypothesis_fingerprint",
+        "approved_target_surfaces",
+        "candidate_target_surface",
+        "immutable_oracles",
+        "approved_agents",
+        "dispatch_agents",
+        "variant_count"
+      ],
+      "properties": {
+        "hypothesis_id": { "$ref": "#/$defs/safe_id" },
+        "hypothesis_fingerprint": { "$ref": "#/$defs/sha256" },
+        "approved_target_surfaces": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/repo_path" }
+        },
+        "candidate_target_surface": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/repo_path" }
+        },
+        "immutable_oracles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/repo_path" }
+        },
+        "approved_agents": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "dispatch_agents": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "variant_count": { "enum": [3, 4, 5] }
+      }
+    },
+    "candidate_packet_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "candidate_fingerprint",
+        "candidate_packet_ref"
+      ],
+      "properties": {
+        "candidate_id": { "$ref": "#/$defs/safe_id" },
+        "candidate_fingerprint": { "$ref": "#/$defs/sha256" },
+        "candidate_packet_ref": { "$ref": "#/$defs/spec_bridge_artifact_ref" }
+      }
+    },
+    "spec_prepare": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_dir_ref",
+        "expected_files",
+        "prepared",
+        "finalized",
+        "next_allowed_action"
+      ],
+      "properties": {
+        "run_dir_ref": { "$ref": "#/$defs/spec_bridge_artifact_ref" },
+        "expected_files": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "prefixItems": [
+            { "const": "source_packet.json" },
+            { "const": "variants.json" },
+            { "const": "skeptic_reviews.json" },
+            { "const": "context_pack.json" }
+          ]
+        },
+        "prepared": { "type": "boolean" },
+        "finalized": { "const": false },
+        "next_allowed_action": { "const": "agent_skeptic_review" }
+      }
+    },
+    "bridge_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "build_creative_code_candidate_packet",
+        "call_product_runtime",
+        "call_provider",
+        "change_client_runtime",
+        "change_openapi",
+        "claim_merge_readiness",
+        "create_branch",
+        "dispatch_to_agents",
+        "edit_fixed_mapping",
+        "emit_local_artifacts",
+        "execute_agent_tasks",
+        "execute_pr2_patch_builder",
+        "execute_pr3_promotion",
+        "finalize_specification_bundle",
+        "generate_candidate_patch",
+        "generate_patch",
+        "mark_pr_ready",
+        "merge",
+        "modify_github_app",
+        "modify_slack",
+        "modify_workflows",
+        "open_draft_pr",
+        "open_pr",
+        "post_github_comment",
+        "push",
+        "read_sanitized_context",
+        "read_secrets",
+        "release",
+        "resolve_threads",
+        "run_specification_prepare",
+        "use_semantic_cache",
+        "workflow_dispatch",
+        "write_branch",
+        "write_repository",
+        "write_shared_worktree"
+      ],
+      "properties": {
+        "build_creative_code_candidate_packet": { "const": true },
+        "emit_local_artifacts": { "const": true },
+        "read_sanitized_context": { "const": true },
+        "run_specification_prepare": { "const": true },
+        "call_product_runtime": { "const": false },
+        "call_provider": { "const": false },
+        "change_client_runtime": { "const": false },
+        "change_openapi": { "const": false },
+        "claim_merge_readiness": { "const": false },
+        "create_branch": { "const": false },
+        "dispatch_to_agents": { "const": false },
+        "edit_fixed_mapping": { "const": false },
+        "execute_agent_tasks": { "const": false },
+        "execute_pr2_patch_builder": { "const": false },
+        "execute_pr3_promotion": { "const": false },
+        "finalize_specification_bundle": { "const": false },
+        "generate_candidate_patch": { "const": false },
+        "generate_patch": { "const": false },
+        "mark_pr_ready": { "const": false },
+        "merge": { "const": false },
+        "modify_github_app": { "const": false },
+        "modify_slack": { "const": false },
+        "modify_workflows": { "const": false },
+        "open_draft_pr": { "const": false },
+        "open_pr": { "const": false },
+        "post_github_comment": { "const": false },
+        "push": { "const": false },
+        "read_secrets": { "const": false },
+        "release": { "const": false },
+        "resolve_threads": { "const": false },
+        "use_semantic_cache": { "const": false },
+        "workflow_dispatch": { "const": false },
+        "write_branch": { "const": false },
+        "write_repository": { "const": false },
+        "write_shared_worktree": { "const": false }
+      }
+    }
+  }
+}

--- a/docs/review/PR_2070_FIXED_MAPPING.md
+++ b/docs/review/PR_2070_FIXED_MAPPING.md
@@ -42,6 +42,12 @@ Evidence: `scripts/orchestration/creative_hypothesis_spec_bridge.py` now verifie
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522016530 -> 0f357a1c65baf920675b0b5ba761faeacd932275
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522016533 -> 0f357a1c65baf920675b0b5ba761faeacd932275
 
+Disposition: FIXED
+Commit: 4f17738bf5ac7e580f8da6b16c719be51c2953d1
+Evidence: `scripts/orchestration/creative_hypothesis_spec_bridge_contract.py` now rejects non-`hypotheses_generated` packets before candidate construction, and `scripts/orchestration/creative_hypothesis_spec_bridge.py` rejects `prepare-specification` reruns once a bridge is prepared. `tests/test_creative_hypothesis_spec_bridge.py` covers blocked packets and confirms already-prepared bridges do not rewrite `skeptic_reviews.json`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522197531 -> 4f17738bf5ac7e580f8da6b16c719be51c2953d1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522197532 -> 4f17738bf5ac7e580f8da6b16c719be51c2953d1
+
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md` follow-up bridge authority schema single-source entry.
 Reason: The `bridge_authority` schema/Python duplication is a maintainability cleanup, not a runtime safety gap in this slice; deduplication needs a separate contract-maintenance PR so closed-schema validation is not weakened while addressing review feedback.
@@ -57,8 +63,8 @@ Summary: accepted oracle-only review, no repository mutation by the runner, `sha
 
 Disposition: FIXED
 Role: architecture-specialist
-Commit: 391538779, 0f357a1c6
-Evidence: `CreativeHypothesisApproval` now binds approved PR-1 handoff to the exact source hypothesis packet id/fingerprint and selected hypothesis fingerprint; the bridge rejects stale approvals, mismatched candidate packets, non-canonical output directories, swapped metrics, stale prepare artifacts, and premature `agent_skeptic_review` handoff before prepare completes. Covered by `tests/test_creative_hypothesis_spec_bridge.py` and `tests/test_experiment_runner_pr_creative_context.py`.
+Commit: 391538779, 0f357a1c6, 4f17738bf
+Evidence: `CreativeHypothesisApproval` now binds approved PR-1 handoff to the exact source hypothesis packet id/fingerprint and selected hypothesis fingerprint; the bridge rejects stale approvals, mismatched candidate packets, non-canonical output directories, swapped metrics, stale prepare artifacts, blocked packets, already-prepared reruns, and premature `agent_skeptic_review` handoff before prepare completes. Covered by `tests/test_creative_hypothesis_spec_bridge.py` and `tests/test_experiment_runner_pr_creative_context.py`.
 
 ## Lane Start Provenance
 

--- a/docs/review/PR_2070_FIXED_MAPPING.md
+++ b/docs/review/PR_2070_FIXED_MAPPING.md
@@ -27,6 +27,13 @@ Artifact: `artifacts/orchestration/experiments/results/approved-hypothesis-spec-
 
 Summary: accepted oracle-only review, no repository mutation by the runner, `shared_tree_untouched=true`, `mutated_paths=[]`, and `coauthor_required=true`. The implementation commit includes the canonical Experiment Runner co-author trailer.
 
+## Post-Open Role Finding Disposition Evidence
+
+Disposition: FIXED
+Role: architecture-specialist
+Commit: 391538779
+Evidence: `CreativeHypothesisApproval` now binds approved PR-1 handoff to the exact source hypothesis packet id/fingerprint and selected hypothesis fingerprint; the bridge rejects stale approvals, mismatched candidate packets, non-canonical output directories, and premature `agent_skeptic_review` handoff before prepare completes. Covered by `tests/test_creative_hypothesis_spec_bridge.py` and `tests/test_experiment_runner_pr_creative_context.py`.
+
 ## Lane Start Provenance
 
 Packet: `artifacts/orchestration/task_packets/1ecc9fd44a92.json`
@@ -47,9 +54,10 @@ Post-open role order executed:
 
 - `python3 scripts/orchestration/check_preflight.py` - PASS with existing local private-index shape warning only.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. .venv/bin/activate && pytest -q tests/test_creative_hypothesis_spec_bridge.py` - PASS, 21 passed.
+- `. .venv/bin/activate && pytest -q tests/test_creative_hypothesis_spec_bridge.py tests/test_experiment_runner_pr_creative_context.py` - PASS.
 - `. .venv/bin/activate && pytest -q tests/test_experiment_runner_pr_creative_context.py tests/test_creative_code_contract.py tests/test_creative_code_specification.py tests/test_agent_learning_loop.py` - PASS.
-- `make validate-changed` - PASS, selected `tests/test_creative_hypothesis_spec_bridge.py`, 21 passed.
+- `python3 -m json.tool docs/orchestration/contracts/creative_hypothesis_approval.v1.schema.json`, `python3 -m json.tool docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json`, `python3 -m json.tool docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json`, and `git diff --check` - PASS.
+- `make validate-changed` - PASS, selected `tests/test_creative_hypothesis_spec_bridge.py`, 24 passed.
 - `pre-commit run --all-files` - PASS.
 
 ## Merge Readiness

--- a/docs/review/PR_2070_FIXED_MAPPING.md
+++ b/docs/review/PR_2070_FIXED_MAPPING.md
@@ -16,6 +16,32 @@ Evidence: `scripts/orchestration/creative_hypothesis_spec_bridge.py`, `scripts/o
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#pullrequestreview-4628189000 -> 327e17108490
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#pullrequestreview-4628277419 -> 327e17108490
 
+Disposition: FIXED
+Commit: 9897baf61a1bd4e891278a534bd443ed7406242f
+Evidence: `scripts/orchestration/creative_hypothesis_spec_bridge_contract.py` requires `candidate_packet_ref` and `spec_prepare.run_dir_ref` to match the derived `spec_bridge/<bridge-id>` artifact refs, and `tests/test_creative_hypothesis_spec_bridge.py` covers cross-bridge ref rejection for validate and prepare.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971518 -> 9897baf61a1bd4e891278a534bd443ed7406242f
+
+Disposition: FIXED
+Commit: 391538779c85072bc59ed5587af56d79169a9b1a
+Evidence: `CreativeHypothesisApproval` now carries source packet/hypothesis fingerprints, bridge validation enforces selected-hypothesis invariants, CLI output is restricted to the canonical bridge directory, and candidate/bridge parity checks compare provenance, targets, immutable oracles, agents, and variant count. Covered by `tests/test_creative_hypothesis_spec_bridge.py` and `tests/test_experiment_runner_pr_creative_context.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971506 -> 391538779c85072bc59ed5587af56d79169a9b1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971509 -> 391538779c85072bc59ed5587af56d79169a9b1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971510 -> 391538779c85072bc59ed5587af56d79169a9b1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971513 -> 391538779c85072bc59ed5587af56d79169a9b1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971519 -> 391538779c85072bc59ed5587af56d79169a9b1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971523 -> 391538779c85072bc59ed5587af56d79169a9b1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522016537 -> 391538779c85072bc59ed5587af56d79169a9b1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522092423 -> 391538779c85072bc59ed5587af56d79169a9b1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522092425 -> 391538779c85072bc59ed5587af56d79169a9b1a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522092428 -> 391538779c85072bc59ed5587af56d79169a9b1a
+
+Disposition: FIXED
+Commit: 0f357a1c65baf920675b0b5ba761faeacd932275
+Evidence: `scripts/orchestration/creative_hypothesis_spec_bridge.py` now verifies metrics lineage before prepare, rejects unexpected files in `spec_prepare/`, ties `metrics.status` and prepare counts to bridge `prepared` state during validation, and records blocked metrics without preparing mixed artifacts. Covered by new regression tests in `tests/test_creative_hypothesis_spec_bridge.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522016528 -> 0f357a1c65baf920675b0b5ba761faeacd932275
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522016530 -> 0f357a1c65baf920675b0b5ba761faeacd932275
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3522016533 -> 0f357a1c65baf920675b0b5ba761faeacd932275
+
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md` follow-up bridge authority schema single-source entry.
 Reason: The `bridge_authority` schema/Python duplication is a maintainability cleanup, not a runtime safety gap in this slice; deduplication needs a separate contract-maintenance PR so closed-schema validation is not weakened while addressing review feedback.
@@ -31,8 +57,8 @@ Summary: accepted oracle-only review, no repository mutation by the runner, `sha
 
 Disposition: FIXED
 Role: architecture-specialist
-Commit: 391538779
-Evidence: `CreativeHypothesisApproval` now binds approved PR-1 handoff to the exact source hypothesis packet id/fingerprint and selected hypothesis fingerprint; the bridge rejects stale approvals, mismatched candidate packets, non-canonical output directories, and premature `agent_skeptic_review` handoff before prepare completes. Covered by `tests/test_creative_hypothesis_spec_bridge.py` and `tests/test_experiment_runner_pr_creative_context.py`.
+Commit: 391538779, 0f357a1c6
+Evidence: `CreativeHypothesisApproval` now binds approved PR-1 handoff to the exact source hypothesis packet id/fingerprint and selected hypothesis fingerprint; the bridge rejects stale approvals, mismatched candidate packets, non-canonical output directories, swapped metrics, stale prepare artifacts, and premature `agent_skeptic_review` handoff before prepare completes. Covered by `tests/test_creative_hypothesis_spec_bridge.py` and `tests/test_experiment_runner_pr_creative_context.py`.
 
 ## Lane Start Provenance
 
@@ -57,7 +83,7 @@ Post-open role order executed:
 - `. .venv/bin/activate && pytest -q tests/test_creative_hypothesis_spec_bridge.py tests/test_experiment_runner_pr_creative_context.py` - PASS.
 - `. .venv/bin/activate && pytest -q tests/test_experiment_runner_pr_creative_context.py tests/test_creative_code_contract.py tests/test_creative_code_specification.py tests/test_agent_learning_loop.py` - PASS.
 - `python3 -m json.tool docs/orchestration/contracts/creative_hypothesis_approval.v1.schema.json`, `python3 -m json.tool docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json`, `python3 -m json.tool docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json`, and `git diff --check` - PASS.
-- `make validate-changed` - PASS, selected `tests/test_creative_hypothesis_spec_bridge.py`, 24 passed.
+- `make validate-changed` - PASS, selected `tests/test_creative_hypothesis_spec_bridge.py` and `tests/test_experiment_runner_pr_creative_context.py`.
 - `pre-commit run --all-files` - PASS.
 
 ## Merge Readiness

--- a/docs/review/PR_2070_FIXED_MAPPING.md
+++ b/docs/review/PR_2070_FIXED_MAPPING.md
@@ -1,0 +1,57 @@
+# PR 2070 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 327e17108490
+Evidence: `scripts/orchestration/creative_hypothesis_spec_bridge.py`, `scripts/orchestration/creative_hypothesis_spec_bridge_contract.py`, `docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json`, `scripts/AGENTS.md`, `docs/roadmap/BACKLOG_LEDGER.md`, and `tests/test_creative_hypothesis_spec_bridge.py` address the actionable CodeRabbit findings: removed the unused import, aligned metrics count bounds with Python validation, tightened spec-bridge artifact refs to the safe bridge-id shape, named the primary bridge bundle artifact, narrowed the finalize follow-up, and made shared-artifact tests use unique bridge ids. Focused tests, `make validate-changed`, and `pre-commit run --all-files` passed before this mapping artifact was added.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971386 -> 327e17108490
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971396 -> 327e17108490
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#discussion_r3521971400 -> 327e17108490
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#pullrequestreview-4628189000 -> 327e17108490
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#pullrequestreview-4628277419 -> 327e17108490
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md` follow-up bridge authority schema single-source entry.
+Reason: The `bridge_authority` schema/Python duplication is a maintainability cleanup, not a runtime safety gap in this slice; deduplication needs a separate contract-maintenance PR so closed-schema validation is not weakened while addressing review feedback.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2070#issuecomment-4879521373
+
+## Experiment Runner Evidence
+
+Artifact: `artifacts/orchestration/experiments/results/approved-hypothesis-spec-bridge-oracle-result-final2.json`
+
+Summary: accepted oracle-only review, no repository mutation by the runner, `shared_tree_untouched=true`, `mutated_paths=[]`, and `coauthor_required=true`. The implementation commit includes the canonical Experiment Runner co-author trailer.
+
+## Lane Start Provenance
+
+Packet: `artifacts/orchestration/task_packets/1ecc9fd44a92.json`
+
+Role dispatch:
+`python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/1ecc9fd44a92.json --pretty`
+
+Pre-open role order executed:
+`agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent`
+
+Post-open packet:
+`artifacts/orchestration/task_packets/6a1a89324bab.json`
+
+Post-open role order executed:
+`agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> architecture-specialist`
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` - PASS with existing local private-index shape warning only.
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
+- `. .venv/bin/activate && pytest -q tests/test_creative_hypothesis_spec_bridge.py` - PASS, 21 passed.
+- `. .venv/bin/activate && pytest -q tests/test_experiment_runner_pr_creative_context.py tests/test_creative_code_contract.py tests/test_creative_code_specification.py tests/test_agent_learning_loop.py` - PASS.
+- `make validate-changed` - PASS, selected `tests/test_creative_hypothesis_spec_bridge.py`, 21 passed.
+- `pre-commit run --all-files` - PASS.
+
+## Merge Readiness
+
+Not claimed. Current-head CI, bot review status after the mapping commit, and review-thread resolution still need their normal post-push pass.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -10951,8 +10951,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Governed creative-code execution lane (PR-0 through PR-6)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (research-to-implementation leverage with closed authority)
-  - Target PR: PR-0 `feat/experiment-runner-creative-code-authority-pr0` -> PR-1 `codex/creative-code-specification-pr1` -> PR-2 `#2022` -> PR-3 `#2030` -> PR-4 `#2044` -> PR-5 `#2048` -> PR-6 `codex/creative-code-first-applied-candidate-pr6` -> private-pilot loop operator `codex/creative-code-private-pilot-loop-operator` -> GitHub App capability gate `codex/experiment-runner-github-app-capability-gate`
-  - Status: PR-0 merged baseline; PR-1 merged as a repo-only specification-bundle control-plane layer; PR-2 merged in PR `#2022` as a local sandboxed candidate-patch builder; PR-3 merged in PR `#2030` as human-approved non-draft PR promotion tooling; PR-4 merged in PR `#2044` at `a7e19b78c7d36b783ec2575ab0eab9f1402f2a0d` as local candidate evaluation telemetry and rejection taxonomy; PR-5 merged in PR `#2048` at `71af9d208b26435352fc821b79a2d78cebb319f5` as read-only local review-disposition integration; PR-6 is active as the first governed applied creative-code candidate lane targeting `docs/prompts/cv/program.md` through normal PR governance; the private-pilot loop operator adds sanitized local lifecycle state and checklist-only next-candidate planning without write/push/PR/thread/fixed-mapping/provider/runtime authority; the GitHub App capability gate slice feeds that state with a strict sanitized read-only permission report requiring Pull requests read and Checks read while keeping Actions write optional for fixed workflow dispatch only
+  - Target PR: PR-0 `feat/experiment-runner-creative-code-authority-pr0` -> PR-1 `codex/creative-code-specification-pr1` -> PR-2 `#2022` -> PR-3 `#2030` -> PR-4 `#2044` -> PR-5 `#2048` -> PR-6 `codex/creative-code-first-applied-candidate-pr6` -> private-pilot loop operator `codex/creative-code-private-pilot-loop-operator` -> GitHub App capability gate `codex/experiment-runner-github-app-capability-gate` -> approved creative-hypothesis specification bridge `codex/experiment-runner-approved-hypothesis-spec-bridge`
+  - Status: PR-0 merged baseline; PR-1 merged as a repo-only specification-bundle control-plane layer; PR-2 merged in PR `#2022` as a local sandboxed candidate-patch builder; PR-3 merged in PR `#2030` as human-approved non-draft PR promotion tooling; PR-4 merged in PR `#2044` at `a7e19b78c7d36b783ec2575ab0eab9f1402f2a0d` as local candidate evaluation telemetry and rejection taxonomy; PR-5 merged in PR `#2048` at `71af9d208b26435352fc821b79a2d78cebb319f5` as read-only local review-disposition integration; PR-6 is active as the first governed applied creative-code candidate lane targeting `docs/prompts/cv/program.md` through normal PR governance; the private-pilot loop operator adds sanitized local lifecycle state and checklist-only next-candidate planning without write/push/PR/thread/fixed-mapping/provider/runtime authority; the GitHub App capability gate slice feeds that state with a strict sanitized read-only permission report requiring Pull requests read and Checks read while keeping Actions write optional for fixed workflow dispatch only; the approved creative-hypothesis specification bridge consumes human-approved local creative-context artifacts and emits only a validated candidate packet, deterministic local metrics, and existing PR-1 prepare artifacts
   - Dependencies:
     - [P1: Creative research eval lane under governed experimentation epic](#ledger-p1-creative-research-eval-lane)
     - [P1: Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
@@ -10978,6 +10978,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/contracts/creative_code_telemetry_rollup.v1.schema.json`
     - `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.schema.json`
     - `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json`
+    - `docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json`
+    - `docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json`
     - `docs/orchestration/CREATIVE_CODE_REVIEW_DISPOSITION_PR5_PREMORTEM.md`
     - `docs/orchestration/contracts/CREATIVE_CODE_REVIEW_DISPOSITION_CONTRACT.md`
     - `docs/orchestration/contracts/creative_code_review_feedback_record.v1.schema.json`
@@ -11005,6 +11007,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `scripts/orchestration/creative_code_private_pilot_loop_contract.py`
     - `scripts/orchestration/creative_code_private_pilot_loop_operator.py`
     - `scripts/orchestration/github_app_private_pilot_capability.py`
+    - `scripts/orchestration/creative_hypothesis_spec_bridge_contract.py`
+    - `scripts/orchestration/creative_hypothesis_spec_bridge.py`
     - `tests/test_creative_code_contract.py`
     - `tests/test_creative_code_patch_builder.py`
     - `tests/test_creative_code_pr_promotion.py`
@@ -11012,6 +11016,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `tests/test_creative_code_review_disposition.py`
     - `tests/test_creative_code_applied_candidate_pr6.py`
     - `tests/test_creative_code_private_pilot_loop.py`
+    - `tests/test_creative_hypothesis_spec_bridge.py`
   - PR train:
     - PR-0: closed authority contract, schema, reference packet, validator, and tests; no model calls, patches, workflows, Slack/GitHub settings, or `experiment_runner.py` changes.
     - PR-1: emit deterministic implementation specification bundles from promoted creative research, with skeptic reviews, synthesis, telemetry summary, safe local artifact I/O, and fingerprint-only rejection indexes; no candidate patches, provider calls, repo writes, runtime truth, review-thread disposition authority, or merge-readiness evidence.
@@ -11021,6 +11026,25 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - PR-5: add local read-only review-disposition integration through `CreativeCodeReviewFeedbackRecord`, `CreativeCodeReviewDispositionPacket`, and `CreativeCodeRepairLaunchPacket`; only `create_pr1_specification=true` may be prepared for later human review, while patch generation, branch writes, PR creation, review-thread resolution, fixed-mapping edits, merge authority, runtime changes, Slack/GitHub App authority, and readiness claims remain forbidden.
     - PR-6: run the first governed applied creative-code candidate through normal PR governance, starting from a local run-plan wrapper that validates the PR-5 launch packet, binds the target surface exactly to `docs/prompts/cv/program.md`, and then keeps the generated candidate mutation surface to that prompt/program document.
     - Private-pilot loop operator: collect sanitized PR/check/review state plus PR-4 / PR-5 / PR-6 artifact refs, consume an optional sanitized GitHub App read-only capability report, decide the next action, and optionally emit a checklist-only candidate plan; no PR-1 / PR-2 / PR-3 command is executed by the operator.
+    - Approved creative-hypothesis specification bridge: build a validated `CreativeCodeCandidatePacket`, deterministic `bridge_metrics.json`, and existing PR-1 `prepare` artifacts from `CreativeHypothesisApproval(decision=approve_for_pr1_specification, next_step=create_pr1_specification)`; no agent execution, `finalize`, candidate patches, provider calls, workflow changes, repository writes, product runtime truth, semantic cache, graph truth, or mutable-surface widening.
+    - Follow-up bridge skeptic/finalize:
+      - Priority: P1 automation leverage.
+      - Owner: orchestration.
+      - Target PR: separate reviewed PR after the approved-hypothesis bridge.
+      - Reason: bridge output intentionally leaves skeptic-review attachment and `finalize` outside this slice so agent review evidence can be attached under coordinator-owned governance.
+      - DoD: agent skeptic-review artifacts are attached to the PR-1 prepare output, `finalize` remains explicit and validated, and no patch, branch, PR, provider, runtime, or review-thread authority is added.
+    - Follow-up bridge metrics ingestion:
+      - Priority: P1 learning-loop leverage.
+      - Owner: orchestration.
+      - Target PR: separate reviewed PR after the approved-hypothesis bridge.
+      - Reason: bridge metrics are deterministic local sidecars but are not yet ingested into the existing telemetry / learning-loop rollup.
+      - DoD: bridge metrics ingest into the existing advisory telemetry / learning-loop rollup with redaction, bounded fields, no runtime telemetry, no product truth, no semantic-cache use, and no graph truth.
+    - Follow-up graph/multimodal lineage exploration:
+      - Priority: P2 research leverage.
+      - Owner: orchestration.
+      - Target PR: separate design/contract PR only after evidence lineage contracts exist.
+      - Reason: graph and multimodal lineage may be useful for agent learning, but this lane requires repo-reviewed asset lineage, fingerprint, idempotency, replay, and admission contracts before implementation.
+      - DoD: proposal stays contract-first and non-runtime until reviewed evidence contracts define allowed assets, upstream assets, fingerprints, idempotency keys, replay/admission behavior, and rollback boundaries.
     - Follow-up auto-oracle attach:
       - Priority: P1 automation leverage.
       - Owner: orchestration.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -11027,18 +11027,24 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - PR-6: run the first governed applied creative-code candidate through normal PR governance, starting from a local run-plan wrapper that validates the PR-5 launch packet, binds the target surface exactly to `docs/prompts/cv/program.md`, and then keeps the generated candidate mutation surface to that prompt/program document.
     - Private-pilot loop operator: collect sanitized PR/check/review state plus PR-4 / PR-5 / PR-6 artifact refs, consume an optional sanitized GitHub App read-only capability report, decide the next action, and optionally emit a checklist-only candidate plan; no PR-1 / PR-2 / PR-3 command is executed by the operator.
     - Approved creative-hypothesis specification bridge: build a validated `CreativeCodeCandidatePacket`, deterministic `bridge_metrics.json`, and existing PR-1 `prepare` artifacts from `CreativeHypothesisApproval(decision=approve_for_pr1_specification, next_step=create_pr1_specification)`; no agent execution, `finalize`, candidate patches, provider calls, workflow changes, repository writes, product runtime truth, semantic cache, graph truth, or mutable-surface widening.
-    - Follow-up bridge skeptic/finalize:
+    - Follow-up bridge finalize evidence attachment:
       - Priority: P1 automation leverage.
       - Owner: orchestration.
       - Target PR: separate reviewed PR after the approved-hypothesis bridge.
-      - Reason: bridge output intentionally leaves skeptic-review attachment and `finalize` outside this slice so agent review evidence can be attached under coordinator-owned governance.
-      - DoD: agent skeptic-review artifacts are attached to the PR-1 prepare output, `finalize` remains explicit and validated, and no patch, branch, PR, provider, runtime, or review-thread authority is added.
+      - Reason: bridge output emits pending `skeptic_reviews.json`; downstream reviewer evidence attachment and explicit `finalize` remain outside this slice under coordinator-owned governance.
+      - DoD: reviewer evidence is attached before explicit `finalize`, and no patch, branch, PR, provider, runtime, or review-thread authority is added.
     - Follow-up bridge metrics ingestion:
       - Priority: P1 learning-loop leverage.
       - Owner: orchestration.
       - Target PR: separate reviewed PR after the approved-hypothesis bridge.
       - Reason: bridge metrics are deterministic local sidecars but are not yet ingested into the existing telemetry / learning-loop rollup.
       - DoD: bridge metrics ingest into the existing advisory telemetry / learning-loop rollup with redaction, bounded fields, no runtime telemetry, no product truth, no semantic-cache use, and no graph truth.
+    - Follow-up bridge authority schema single-source:
+      - Priority: P2 maintainability.
+      - Owner: orchestration.
+      - Target PR: separate reviewed contract-maintenance PR after the approved-hypothesis bridge.
+      - Reason: `bridge_authority` remains intentionally closed in both JSON schemas and Python constants for this slice; deduplicating it needs a shared-fragment or generation contract without weakening closed-schema validation.
+      - DoD: the bridge authority key partition is generated from, or validated against, one canonical source while both JSON schemas remain closed and no bridge authority is widened.
     - Follow-up graph/multimodal lineage exploration:
       - Priority: P2 research leverage.
       - Owner: orchestration.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -50,6 +50,7 @@
   `creative_hypothesis_spec_bridge.py` CLI may only consume validated
   creative-context context maps, hypothesis packets, coordinator dispatch
   handoffs, and human approval packets; emit a validated
+  `creative_hypothesis_specification_bridge.json`,
   `CreativeCodeCandidatePacket`, deterministic `bridge_metrics.json`, and
   existing PR-1 `creative_code_spec_pipeline.prepare` artifacts; and validate
   those artifacts. It must not widen `CreativeCodeCandidatePacket.target_surface`

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -45,6 +45,20 @@
   single-pass-per-material-diff; later comments use fixed mapping and targeted
   gates unless the security-relevant diff changes, the coordinator records an
   evidence-backed reroute, or the operator explicitly requests another run.
+- Approved creative-hypothesis specification bridge artifacts stay local under
+  `artifacts/orchestration/creative_code/spec_bridge/`. The
+  `creative_hypothesis_spec_bridge.py` CLI may only consume validated
+  creative-context context maps, hypothesis packets, coordinator dispatch
+  handoffs, and human approval packets; emit a validated
+  `CreativeCodeCandidatePacket`, deterministic `bridge_metrics.json`, and
+  existing PR-1 `creative_code_spec_pipeline.prepare` artifacts; and validate
+  those artifacts. It must not widen `CreativeCodeCandidatePacket.target_surface`
+  beyond the existing `validate_mutable_candidate_surface(...)` allowlist,
+  execute agents, finalize bundles, generate patches, create/write branches,
+  push, open or edit PRs, resolve review threads, edit fixed mappings, claim
+  readiness, merge, release, call providers, call product runtime, change
+  workflows, use semantic cache, write graph truth, or mutate GitHub App /
+  Slack settings.
 - The runner must apply patches only inside an isolated temporary checkout and must leave the shared working tree untouched.
 - Mutable surfaces, immutable oracles, budgets, and promotion boundaries are defined by `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or relax them here.
 - Runner mutation of `scripts/ci/**`, `docs/review/**`, `AGENTS.md`, merge

--- a/scripts/orchestration/creative_hypothesis_spec_bridge.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge.py
@@ -119,6 +119,11 @@ def _resolve_output_dir(
         raise CreativeHypothesisSpecBridgeCliError(
             "output directory must stay under creative-code spec_bridge artifacts."
         )
+    expected_output_dir = root / bridge_id
+    if resolved_candidate != expected_output_dir.resolve(strict=False):
+        raise CreativeHypothesisSpecBridgeCliError(
+            "output directory must be the canonical spec_bridge/<bridge-id> directory."
+        )
     if candidate.name != bridge_id:
         raise CreativeHypothesisSpecBridgeCliError(
             "output directory leaf must equal the derived bridge id."
@@ -343,6 +348,40 @@ def _assert_candidate_matches_bridge(
     if observed_fingerprint != candidate_ref["candidate_fingerprint"]:
         raise CreativeHypothesisSpecBridgeCliError(
             "fingerprint_mismatch: candidate packet fingerprint does not match bridge."
+        )
+    selected = cast_mapping(bridge["selected_hypothesis"])
+    source = cast_mapping(normalized_candidate["source_creative_research"])
+    bridge_source = cast_mapping(bridge["source"])
+    expected_pairs = {
+        "source bundle id": (source["bundle_id"], bridge_source["hypothesis_packet_id"]),
+        "source hypothesis id": (source["candidate_id"], selected["hypothesis_id"]),
+        "source hypothesis fingerprint": (
+            source["fingerprint"],
+            selected["hypothesis_fingerprint"],
+        ),
+        "variant count": (
+            normalized_candidate["variant_count"],
+            selected["variant_count"],
+        ),
+    }
+    for label, (observed, expected) in expected_pairs.items():
+        if observed != expected:
+            raise CreativeHypothesisSpecBridgeCliError(
+                f"fingerprint_mismatch: candidate {label} does not match bridge."
+            )
+    if normalized_candidate["target_surface"] != selected["candidate_target_surface"]:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: candidate target_surface does not match bridge."
+        )
+    if normalized_candidate["immutable_oracles"] != selected["immutable_oracles"]:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: candidate immutable_oracles do not match bridge."
+        )
+    approved_agents = set(cast(list[str], selected["approved_agents"]))
+    dispatch_agents = set(cast(list[str], selected["dispatch_agents"]))
+    if not approved_agents.issubset(dispatch_agents):
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: bridge approved agents are not present in dispatch agents."
         )
 
 

--- a/scripts/orchestration/creative_hypothesis_spec_bridge.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge.py
@@ -347,6 +347,44 @@ def _assert_candidate_matches_bridge(
         )
 
 
+def _assert_metrics_matches_bridge_and_candidate(
+    *,
+    metrics: Mapping[str, Any],
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+) -> None:
+    normalized_metrics = validate_bridge_metrics(metrics)
+    normalized_candidate = validate_creative_code_candidate_packet(dict(candidate))
+    source = cast_mapping(normalized_metrics["source"])
+    if normalized_metrics["bridge_id"] != bridge["bridge_id"]:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: metrics bridge id does not match bridge."
+        )
+    if normalized_metrics["candidate_id"] != normalized_candidate["candidate_id"]:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: metrics candidate id does not match candidate."
+        )
+    if source["candidate_fingerprint"] != fingerprint_payload(dict(normalized_candidate)):
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: metrics candidate fingerprint does not match candidate."
+        )
+    bridge_source = cast_mapping(bridge["source"])
+    for key in (
+        "context_map_id",
+        "context_map_fingerprint",
+        "hypothesis_packet_id",
+        "hypothesis_packet_fingerprint",
+        "coordinator_dispatch_id",
+        "coordinator_dispatch_fingerprint",
+        "approval_id",
+        "approval_fingerprint",
+    ):
+        if source[key] != bridge_source[key]:
+            raise CreativeHypothesisSpecBridgeCliError(
+                f"fingerprint_mismatch: metrics {key} does not match bridge."
+            )
+
+
 def cast_mapping(value: Any) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise CreativeHypothesisSpecBridgeCliError("expected JSON object.")
@@ -432,16 +470,30 @@ def _cmd_build_and_prepare(args: argparse.Namespace) -> int:
 
 
 def _cmd_validate(args: argparse.Namespace) -> int:
-    bridge = validate_creative_hypothesis_specification_bridge(read_json_object(args.bridge))
+    bridge, output_dir = _read_bridge_with_dir(args.bridge)
     if args.candidate:
-        validate_creative_code_candidate_packet(read_creative_code_candidate_packet(args.candidate))
+        candidate_path = _resolve_bridge_file(args.candidate)
+        candidate = validate_creative_code_candidate_packet(
+            read_creative_code_candidate_packet(candidate_path)
+        )
     else:
         candidate_path = _repo_ref_to_file(
             str(cast_mapping(bridge["candidate_packet"])["candidate_packet_ref"])
         )
-        validate_creative_code_candidate_packet(read_creative_code_candidate_packet(candidate_path))
+        candidate = validate_creative_code_candidate_packet(
+            read_creative_code_candidate_packet(candidate_path)
+        )
+    _assert_candidate_matches_bridge(bridge=bridge, candidate=candidate)
     if args.metrics:
-        validate_bridge_metrics(read_json_object(args.metrics))
+        metrics_path = _resolve_bridge_file(args.metrics)
+        metrics = validate_bridge_metrics(read_json_object(metrics_path))
+    else:
+        metrics = validate_bridge_metrics(read_json_object(output_dir / METRICS_FILENAME))
+    _assert_metrics_matches_bridge_and_candidate(
+        metrics=metrics,
+        bridge=bridge,
+        candidate=candidate,
+    )
     print(SUCCESS_VALIDATE_OUTPUT)
     return 0
 

--- a/scripts/orchestration/creative_hypothesis_spec_bridge.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge.py
@@ -279,6 +279,43 @@ def _pending_skeptic_review_count(run_dir: Path) -> int:
     )
 
 
+def _reject_unexpected_prepare_entries(run_dir: Path) -> None:
+    if not run_dir.exists():
+        return
+    if not run_dir.is_dir():
+        raise CreativeHypothesisSpecBridgeCliError(
+            "spec_prepare_failed: spec_prepare ref must be a directory."
+        )
+    expected = set(PREPARE_FILENAMES)
+    unexpected = sorted(child.name for child in run_dir.iterdir() if child.name not in expected)
+    if unexpected:
+        joined = ", ".join(unexpected)
+        raise CreativeHypothesisSpecBridgeCliError(
+            f"spec_prepare_failed: unexpected spec_prepare artifact(s): {joined}."
+        )
+
+
+def _write_blocked_prepare_metrics(
+    *,
+    metrics: Mapping[str, Any],
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    output_dir: Path,
+    run_dir: Path,
+    blocked_reason: str,
+) -> None:
+    blocked_metrics = update_bridge_metrics_for_prepare(
+        metrics=metrics,
+        bridge=bridge,
+        candidate=candidate,
+        status=BLOCKED_STATUS,
+        blocked_reason=blocked_reason,
+        prepare_files_written=_count_prepare_files(run_dir),
+        pending_skeptic_review_count=_pending_skeptic_review_count(run_dir),
+    )
+    _write_json_atomic(output_dir / METRICS_FILENAME, blocked_metrics)
+
+
 def _prepare_from_bridge(
     *,
     bridge: Mapping[str, Any],
@@ -292,31 +329,36 @@ def _prepare_from_bridge(
     run_dir = _repo_ref_to_dir(run_dir_ref)
     try:
         _assert_candidate_matches_bridge(bridge=bridge, candidate=candidate)
-    except CreativeHypothesisSpecBridgeCliError as exc:
-        blocked_metrics = update_bridge_metrics_for_prepare(
+        _assert_metrics_matches_bridge_and_candidate(
             metrics=metrics,
             bridge=bridge,
             candidate=candidate,
-            status=BLOCKED_STATUS,
-            blocked_reason="fingerprint_mismatch",
-            prepare_files_written=_count_prepare_files(run_dir),
-            pending_skeptic_review_count=_pending_skeptic_review_count(run_dir),
         )
-        _write_json_atomic(output_dir / METRICS_FILENAME, blocked_metrics)
+    except CreativeHypothesisSpecBridgeCliError as exc:
+        _write_blocked_prepare_metrics(
+            metrics=metrics,
+            bridge=bridge,
+            candidate=candidate,
+            output_dir=output_dir,
+            run_dir=run_dir,
+            blocked_reason="fingerprint_mismatch",
+        )
         raise exc
     try:
+        _reject_unexpected_prepare_entries(run_dir)
         creative_code_spec_pipeline.prepare(candidate_path, run_dir)
-    except creative_code_spec_pipeline.CreativeCodeSpecPipelineError as exc:
-        blocked_metrics = update_bridge_metrics_for_prepare(
+    except (
+        CreativeHypothesisSpecBridgeCliError,
+        creative_code_spec_pipeline.CreativeCodeSpecPipelineError,
+    ) as exc:
+        _write_blocked_prepare_metrics(
             metrics=metrics,
             bridge=bridge,
             candidate=candidate,
-            status=BLOCKED_STATUS,
+            output_dir=output_dir,
+            run_dir=run_dir,
             blocked_reason="spec_prepare_failed",
-            prepare_files_written=_count_prepare_files(run_dir),
-            pending_skeptic_review_count=_pending_skeptic_review_count(run_dir),
         )
-        _write_json_atomic(output_dir / METRICS_FILENAME, blocked_metrics)
         raise CreativeHypothesisSpecBridgeCliError(f"spec_prepare_failed: {exc}") from exc
     prepared_bridge = mark_bridge_prepared(bridge)
     prepared_metrics = update_bridge_metrics_for_prepare(
@@ -394,6 +436,8 @@ def _assert_metrics_matches_bridge_and_candidate(
     normalized_metrics = validate_bridge_metrics(metrics)
     normalized_candidate = validate_creative_code_candidate_packet(dict(candidate))
     source = cast_mapping(normalized_metrics["source"])
+    spec_prepare = cast_mapping(bridge["spec_prepare"])
+    bridge_prepared = bool(spec_prepare["prepared"])
     if normalized_metrics["bridge_id"] != bridge["bridge_id"]:
         raise CreativeHypothesisSpecBridgeCliError(
             "fingerprint_mismatch: metrics bridge id does not match bridge."
@@ -427,6 +471,19 @@ def _assert_metrics_matches_bridge_and_candidate(
                 f"fingerprint_mismatch: metrics {key} does not match bridge."
             )
     counts = cast_mapping(normalized_metrics["counts"])
+    if bridge_prepared:
+        if normalized_metrics["status"] != PREPARED_STATUS:
+            raise CreativeHypothesisSpecBridgeCliError(
+                "fingerprint_mismatch: prepared bridge requires prepared metrics."
+            )
+        if counts["prepare_files_written"] != len(PREPARE_FILENAMES):
+            raise CreativeHypothesisSpecBridgeCliError(
+                "fingerprint_mismatch: prepared bridge requires all prepare files."
+            )
+    elif normalized_metrics["status"] == PREPARED_STATUS:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: unprepared bridge cannot use prepared metrics."
+        )
     expected_counts = {
         "approved_target_count": len(selected_hypothesis["approved_target_surfaces"]),
         "candidate_target_count": len(normalized_candidate["target_surface"]),
@@ -438,6 +495,32 @@ def _assert_metrics_matches_bridge_and_candidate(
             raise CreativeHypothesisSpecBridgeCliError(
                 f"fingerprint_mismatch: metrics {key} does not match bridge/candidate."
             )
+
+
+def _assert_prepare_dir_matches_bridge_and_metrics(
+    *,
+    bridge: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+) -> None:
+    normalized_metrics = validate_bridge_metrics(metrics)
+    spec_prepare = cast_mapping(bridge["spec_prepare"])
+    run_dir = _repo_ref_to_dir(str(spec_prepare["run_dir_ref"]))
+    _reject_unexpected_prepare_entries(run_dir)
+    prepare_files_written = _count_prepare_files(run_dir)
+    pending_skeptic_review_count = _pending_skeptic_review_count(run_dir)
+    counts = cast_mapping(normalized_metrics["counts"])
+    if counts["prepare_files_written"] != prepare_files_written:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: metrics prepare_files_written does not match spec_prepare."
+        )
+    if counts["pending_skeptic_review_count"] != pending_skeptic_review_count:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: metrics pending_skeptic_review_count does not match spec_prepare."
+        )
+    if spec_prepare["prepared"] and prepare_files_written != len(PREPARE_FILENAMES):
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: prepared bridge requires complete spec_prepare files."
+        )
 
 
 def cast_mapping(value: Any) -> Mapping[str, Any]:
@@ -552,6 +635,7 @@ def _cmd_validate(args: argparse.Namespace) -> int:
         bridge=bridge,
         candidate=candidate,
     )
+    _assert_prepare_dir_matches_bridge_and_metrics(bridge=bridge, metrics=metrics)
     print(SUCCESS_VALIDATE_OUTPUT)
     return 0
 

--- a/scripts/orchestration/creative_hypothesis_spec_bridge.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge.py
@@ -324,7 +324,12 @@ def _prepare_from_bridge(
     output_dir: Path,
 ) -> dict[str, Any]:
     candidate_ref = str(cast_mapping(bridge["candidate_packet"])["candidate_packet_ref"])
-    run_dir_ref = str(cast_mapping(bridge["spec_prepare"])["run_dir_ref"])
+    spec_prepare = cast_mapping(bridge["spec_prepare"])
+    if spec_prepare["prepared"]:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "spec_prepare_already_prepared: prepare-specification requires an unprepared bridge."
+        )
+    run_dir_ref = str(spec_prepare["run_dir_ref"])
     candidate_path = _repo_ref_to_file(candidate_ref)
     run_dir = _repo_ref_to_dir(run_dir_ref)
     try:

--- a/scripts/orchestration/creative_hypothesis_spec_bridge.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge.py
@@ -364,6 +364,11 @@ def _assert_metrics_matches_bridge_and_candidate(
         raise CreativeHypothesisSpecBridgeCliError(
             "fingerprint_mismatch: metrics candidate id does not match candidate."
         )
+    selected_hypothesis = cast_mapping(bridge["selected_hypothesis"])
+    if normalized_metrics["selected_hypothesis_id"] != selected_hypothesis["hypothesis_id"]:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: metrics selected hypothesis id does not match bridge."
+        )
     if source["candidate_fingerprint"] != fingerprint_payload(dict(normalized_candidate)):
         raise CreativeHypothesisSpecBridgeCliError(
             "fingerprint_mismatch: metrics candidate fingerprint does not match candidate."
@@ -382,6 +387,18 @@ def _assert_metrics_matches_bridge_and_candidate(
         if source[key] != bridge_source[key]:
             raise CreativeHypothesisSpecBridgeCliError(
                 f"fingerprint_mismatch: metrics {key} does not match bridge."
+            )
+    counts = cast_mapping(normalized_metrics["counts"])
+    expected_counts = {
+        "approved_target_count": len(selected_hypothesis["approved_target_surfaces"]),
+        "candidate_target_count": len(normalized_candidate["target_surface"]),
+        "immutable_oracle_count": len(normalized_candidate["immutable_oracles"]),
+        "variant_count": normalized_candidate["variant_count"],
+    }
+    for key, expected in expected_counts.items():
+        if counts[key] != expected:
+            raise CreativeHypothesisSpecBridgeCliError(
+                f"fingerprint_mismatch: metrics {key} does not match bridge/candidate."
             )
 
 
@@ -435,8 +452,10 @@ def _cmd_build_candidate(args: argparse.Namespace) -> int:
 
 def _cmd_prepare_specification(args: argparse.Namespace) -> int:
     bridge, output_dir = _read_bridge_with_dir(args.bridge)
-    candidate = read_creative_code_candidate_packet(output_dir / CANDIDATE_FILENAME)
-    metrics = validate_bridge_metrics(read_json_object(output_dir / METRICS_FILENAME))
+    candidate_path = _resolve_bridge_file(output_dir / CANDIDATE_FILENAME)
+    candidate = read_creative_code_candidate_packet(candidate_path)
+    metrics_path = _resolve_bridge_file(output_dir / METRICS_FILENAME)
+    metrics = validate_bridge_metrics(read_json_object(metrics_path))
     _prepare_from_bridge(
         bridge=bridge,
         candidate=candidate,
@@ -488,7 +507,8 @@ def _cmd_validate(args: argparse.Namespace) -> int:
         metrics_path = _resolve_bridge_file(args.metrics)
         metrics = validate_bridge_metrics(read_json_object(metrics_path))
     else:
-        metrics = validate_bridge_metrics(read_json_object(output_dir / METRICS_FILENAME))
+        metrics_path = _resolve_bridge_file(output_dir / METRICS_FILENAME)
+        metrics = validate_bridge_metrics(read_json_object(metrics_path))
     _assert_metrics_matches_bridge_and_candidate(
         metrics=metrics,
         bridge=bridge,

--- a/scripts/orchestration/creative_hypothesis_spec_bridge.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge.py
@@ -24,7 +24,6 @@ from scripts.orchestration.creative_code_contract import (
 )
 from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
     BLOCKED_STATUS,
-    BRIDGE_SUCCESS_STATUS,
     PREPARED_STATUS,
     PREPARE_FILENAMES,
     CreativeHypothesisSpecBridgeError,

--- a/scripts/orchestration/creative_hypothesis_spec_bridge.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Local bridge from approved creative hypotheses to PR-1 specification inputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any, Mapping, cast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.evidence.fingerprints import fingerprint_payload
+from scripts.orchestration import creative_code_spec_pipeline
+from scripts.orchestration.creative_code_contract import (
+    CreativeCodeContractError,
+    read_creative_code_candidate_packet,
+    validate_creative_code_candidate_packet,
+)
+from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
+    BLOCKED_STATUS,
+    BRIDGE_SUCCESS_STATUS,
+    PREPARED_STATUS,
+    PREPARE_FILENAMES,
+    CreativeHypothesisSpecBridgeError,
+    build_creative_hypothesis_spec_bridge_bundle,
+    mark_bridge_prepared,
+    update_bridge_metrics_for_prepare,
+    validate_bridge_metrics,
+    validate_creative_hypothesis_specification_bridge,
+)
+from scripts.orchestration.experiment_runner_pr_creative_context_contract import (
+    ExperimentRunnerCreativeContextContractError,
+    read_json_object,
+    reject_unsafe_creative_context_value,
+)
+
+SPEC_BRIDGE_ROOT = creative_code_spec_pipeline.ARTIFACT_ROOT / "spec_bridge"
+CREATIVE_CONTEXT_ROOT = (
+    REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "creative_context"
+)
+BRIDGE_FILENAME = "creative_hypothesis_specification_bridge.json"
+CANDIDATE_FILENAME = "creative_code_candidate_packet.json"
+METRICS_FILENAME = "bridge_metrics.json"
+SUCCESS_BUILD_OUTPUT = "PASS: creative-hypothesis specification bridge candidate built"
+SUCCESS_PREPARE_OUTPUT = "PASS: creative-hypothesis specification bridge prepare complete"
+SUCCESS_BUILD_PREPARE_OUTPUT = (
+    "PASS: creative-hypothesis specification bridge candidate built and prepared"
+)
+SUCCESS_VALIDATE_OUTPUT = "PASS: creative-hypothesis specification bridge artifacts valid"
+
+
+class CreativeHypothesisSpecBridgeCliError(ValueError):
+    """Raised when bridge CLI file I/O cannot safely complete."""
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _existing_components(path: Path) -> list[Path]:
+    components: list[Path] = []
+    current_path = Path(path.anchor) if path.anchor else Path(".")
+    parts = path.parts[1:] if path.anchor else path.parts
+    for part in parts:
+        current_path = current_path / part
+        if current_path.exists() or current_path.is_symlink():
+            components.append(current_path)
+    return components
+
+
+def _reject_symlink_components(path: Path, *, label: str) -> None:
+    for component in _existing_components(path):
+        if component.is_symlink():
+            raise CreativeHypothesisSpecBridgeCliError(f"{label} must not traverse symlinks.")
+
+
+def _ensure_spec_bridge_root() -> Path:
+    _reject_symlink_components(SPEC_BRIDGE_ROOT, label="spec bridge root")
+    SPEC_BRIDGE_ROOT.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_components(SPEC_BRIDGE_ROOT, label="spec bridge root")
+    root = Path(SPEC_BRIDGE_ROOT.resolve(strict=True))
+    if not root.is_dir():
+        raise CreativeHypothesisSpecBridgeCliError("spec bridge root must be a directory.")
+    return root
+
+
+def _resolve_output_dir(
+    raw_output_dir: Path | None,
+    *,
+    bridge_id: str,
+    create: bool,
+) -> Path:
+    root = _ensure_spec_bridge_root()
+    if raw_output_dir is None:
+        candidate = root / bridge_id
+    elif raw_output_dir.is_absolute():
+        candidate = raw_output_dir
+    elif raw_output_dir.parts[:4] == (
+        "artifacts",
+        "orchestration",
+        "creative_code",
+        "spec_bridge",
+    ):
+        candidate = REPO_ROOT / raw_output_dir
+    else:
+        candidate = root / raw_output_dir
+    _reject_symlink_components(candidate, label="spec bridge output directory")
+    resolved_candidate = candidate.resolve(strict=False)
+    if not _is_relative_to(resolved_candidate, root):
+        raise CreativeHypothesisSpecBridgeCliError(
+            "output directory must stay under creative-code spec_bridge artifacts."
+        )
+    if candidate.name != bridge_id:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "output directory leaf must equal the derived bridge id."
+        )
+    if create:
+        candidate.mkdir(parents=True, exist_ok=True)
+        _reject_symlink_components(candidate, label="spec bridge output directory")
+    resolved = candidate.resolve(strict=True)
+    if not _is_relative_to(resolved, root) or not resolved.is_dir():
+        raise CreativeHypothesisSpecBridgeCliError(
+            "output directory must stay under creative-code spec_bridge artifacts."
+        )
+    return resolved
+
+
+def _resolve_bridge_file(path: Path) -> Path:
+    candidate = path if path.is_absolute() else REPO_ROOT / path
+    _reject_symlink_components(candidate, label="bridge input")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise CreativeHypothesisSpecBridgeCliError("bridge input must exist.") from exc
+    if not _is_relative_to(resolved, REPO_ROOT.resolve()):
+        raise CreativeHypothesisSpecBridgeCliError("bridge input must stay inside the repository.")
+    if not resolved.is_file() or resolved.suffix != ".json":
+        raise CreativeHypothesisSpecBridgeCliError("bridge input must be a JSON file.")
+    return resolved
+
+
+def _resolve_creative_context_input(raw_path: Path, *, expected_filename: str) -> Path:
+    candidate = raw_path if raw_path.is_absolute() else REPO_ROOT / raw_path
+    _reject_symlink_components(candidate, label="creative context bridge input")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "creative context bridge input must exist."
+        ) from exc
+    repo_root = REPO_ROOT.resolve()
+    if not _is_relative_to(resolved, repo_root):
+        raise CreativeHypothesisSpecBridgeCliError(
+            "creative context bridge input must stay inside the repository."
+        )
+    creative_context_root = CREATIVE_CONTEXT_ROOT.resolve(strict=False)
+    if not _is_relative_to(resolved, creative_context_root):
+        raise CreativeHypothesisSpecBridgeCliError(
+            "creative context bridge input must stay under creative_context artifacts."
+        )
+    if resolved.name != expected_filename:
+        raise CreativeHypothesisSpecBridgeCliError(
+            f"creative context bridge input filename must be {expected_filename}."
+        )
+    if not resolved.is_file() or resolved.suffix != ".json":
+        raise CreativeHypothesisSpecBridgeCliError(
+            "creative context bridge input must be a JSON file."
+        )
+    return resolved
+
+
+def _repo_ref_to_file(ref: str) -> Path:
+    candidate = REPO_ROOT / ref
+    _reject_symlink_components(candidate, label="bridge artifact ref")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise CreativeHypothesisSpecBridgeCliError("bridge artifact ref must exist.") from exc
+    if not _is_relative_to(resolved, REPO_ROOT.resolve()):
+        raise CreativeHypothesisSpecBridgeCliError(
+            "bridge artifact ref must stay inside the repository."
+        )
+    if not resolved.is_file():
+        raise CreativeHypothesisSpecBridgeCliError("bridge artifact ref must be a file.")
+    return resolved
+
+
+def _repo_ref_to_dir(ref: str) -> Path:
+    candidate = REPO_ROOT / ref
+    _reject_symlink_components(candidate, label="bridge artifact directory ref")
+    resolved = candidate.resolve(strict=False)
+    if not _is_relative_to(resolved, REPO_ROOT.resolve()):
+        raise CreativeHypothesisSpecBridgeCliError(
+            "bridge artifact directory ref must stay inside the repository."
+        )
+    return candidate
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    reject_unsafe_creative_context_value(dict(payload), label="spec_bridge_output")
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_name = temp_file.name
+            json.dump(payload, temp_file, indent=2, sort_keys=True)
+            temp_file.write("\n")
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_name, path)
+        temp_name = None
+    finally:
+        if temp_name is not None:
+            try:
+                Path(temp_name).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _write_bridge_outputs(
+    output_dir: Path,
+    *,
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+) -> None:
+    _write_json_atomic(output_dir / CANDIDATE_FILENAME, candidate)
+    _write_json_atomic(output_dir / BRIDGE_FILENAME, bridge)
+    _write_json_atomic(output_dir / METRICS_FILENAME, metrics)
+
+
+def _read_bridge_with_dir(path: Path) -> tuple[dict[str, Any], Path]:
+    bridge_path = _resolve_bridge_file(path)
+    bridge = validate_creative_hypothesis_specification_bridge(read_json_object(bridge_path))
+    output_dir = bridge_path.parent
+    derived_dir = _resolve_output_dir(output_dir, bridge_id=str(bridge["bridge_id"]), create=False)
+    if derived_dir != output_dir.resolve(strict=True):
+        raise CreativeHypothesisSpecBridgeCliError("bridge path does not match derived output dir.")
+    return bridge, derived_dir
+
+
+def _count_prepare_files(run_dir: Path) -> int:
+    return sum(1 for name in PREPARE_FILENAMES if (run_dir / name).is_file())
+
+
+def _pending_skeptic_review_count(run_dir: Path) -> int:
+    reviews_path = run_dir / "skeptic_reviews.json"
+    if not reviews_path.is_file():
+        return 0
+    payload = json.loads(reviews_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise CreativeHypothesisSpecBridgeCliError("skeptic_reviews.json must be an array.")
+    return sum(
+        1
+        for row in payload
+        if isinstance(row, dict)
+        and row.get("decision") != "pass"
+        and "skeptic_review_required" in row.get("blockers", [])
+    )
+
+
+def _prepare_from_bridge(
+    *,
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+    output_dir: Path,
+) -> dict[str, Any]:
+    candidate_ref = str(cast_mapping(bridge["candidate_packet"])["candidate_packet_ref"])
+    run_dir_ref = str(cast_mapping(bridge["spec_prepare"])["run_dir_ref"])
+    candidate_path = _repo_ref_to_file(candidate_ref)
+    run_dir = _repo_ref_to_dir(run_dir_ref)
+    try:
+        _assert_candidate_matches_bridge(bridge=bridge, candidate=candidate)
+    except CreativeHypothesisSpecBridgeCliError as exc:
+        blocked_metrics = update_bridge_metrics_for_prepare(
+            metrics=metrics,
+            bridge=bridge,
+            candidate=candidate,
+            status=BLOCKED_STATUS,
+            blocked_reason="fingerprint_mismatch",
+            prepare_files_written=_count_prepare_files(run_dir),
+            pending_skeptic_review_count=_pending_skeptic_review_count(run_dir),
+        )
+        _write_json_atomic(output_dir / METRICS_FILENAME, blocked_metrics)
+        raise exc
+    try:
+        creative_code_spec_pipeline.prepare(candidate_path, run_dir)
+    except creative_code_spec_pipeline.CreativeCodeSpecPipelineError as exc:
+        blocked_metrics = update_bridge_metrics_for_prepare(
+            metrics=metrics,
+            bridge=bridge,
+            candidate=candidate,
+            status=BLOCKED_STATUS,
+            blocked_reason="spec_prepare_failed",
+            prepare_files_written=_count_prepare_files(run_dir),
+            pending_skeptic_review_count=_pending_skeptic_review_count(run_dir),
+        )
+        _write_json_atomic(output_dir / METRICS_FILENAME, blocked_metrics)
+        raise CreativeHypothesisSpecBridgeCliError(f"spec_prepare_failed: {exc}") from exc
+    prepared_bridge = mark_bridge_prepared(bridge)
+    prepared_metrics = update_bridge_metrics_for_prepare(
+        metrics=metrics,
+        bridge=prepared_bridge,
+        candidate=candidate,
+        status=PREPARED_STATUS,
+        blocked_reason=None,
+        prepare_files_written=_count_prepare_files(run_dir),
+        pending_skeptic_review_count=_pending_skeptic_review_count(run_dir),
+    )
+    _write_json_atomic(output_dir / BRIDGE_FILENAME, prepared_bridge)
+    _write_json_atomic(output_dir / METRICS_FILENAME, prepared_metrics)
+    return {"bridge": prepared_bridge, "metrics": prepared_metrics}
+
+
+def _assert_candidate_matches_bridge(
+    *,
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+) -> None:
+    candidate_ref = cast_mapping(bridge["candidate_packet"])
+    normalized_candidate = validate_creative_code_candidate_packet(dict(candidate))
+    if normalized_candidate["candidate_id"] != candidate_ref["candidate_id"]:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: candidate packet id does not match bridge."
+        )
+    observed_fingerprint = fingerprint_payload(dict(normalized_candidate))
+    if observed_fingerprint != candidate_ref["candidate_fingerprint"]:
+        raise CreativeHypothesisSpecBridgeCliError(
+            "fingerprint_mismatch: candidate packet fingerprint does not match bridge."
+        )
+
+
+def cast_mapping(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise CreativeHypothesisSpecBridgeCliError("expected JSON object.")
+    return value
+
+
+def _build_bundle_from_args(args: argparse.Namespace) -> dict[str, dict[str, Any]]:
+    context_map = _resolve_creative_context_input(
+        args.context_map,
+        expected_filename="context_map.json",
+    )
+    hypothesis_packet = _resolve_creative_context_input(
+        args.hypothesis_packet,
+        expected_filename="hypothesis_packet.json",
+    )
+    coordinator_dispatch = _resolve_creative_context_input(
+        args.coordinator_dispatch,
+        expected_filename="coordinator_dispatch.json",
+    )
+    approval = _resolve_creative_context_input(args.approval, expected_filename="approval.json")
+    return cast(
+        dict[str, dict[str, Any]],
+        build_creative_hypothesis_spec_bridge_bundle(
+            context_map=read_json_object(context_map),
+            hypothesis_packet=read_json_object(hypothesis_packet),
+            coordinator_dispatch=read_json_object(coordinator_dispatch),
+            approval=read_json_object(approval),
+            variant_count=args.variant_count,
+        ),
+    )
+
+
+def _cmd_build_candidate(args: argparse.Namespace) -> int:
+    bundle = _build_bundle_from_args(args)
+    bridge = bundle["bridge"]
+    output_dir = _resolve_output_dir(
+        args.output_dir, bridge_id=str(bridge["bridge_id"]), create=True
+    )
+    _write_bridge_outputs(
+        output_dir,
+        bridge=bridge,
+        candidate=bundle["candidate"],
+        metrics=bundle["metrics"],
+    )
+    print(SUCCESS_BUILD_OUTPUT)
+    return 0
+
+
+def _cmd_prepare_specification(args: argparse.Namespace) -> int:
+    bridge, output_dir = _read_bridge_with_dir(args.bridge)
+    candidate = read_creative_code_candidate_packet(output_dir / CANDIDATE_FILENAME)
+    metrics = validate_bridge_metrics(read_json_object(output_dir / METRICS_FILENAME))
+    _prepare_from_bridge(
+        bridge=bridge,
+        candidate=candidate,
+        metrics=metrics,
+        output_dir=output_dir,
+    )
+    print(SUCCESS_PREPARE_OUTPUT)
+    return 0
+
+
+def _cmd_build_and_prepare(args: argparse.Namespace) -> int:
+    bundle = _build_bundle_from_args(args)
+    bridge = bundle["bridge"]
+    output_dir = _resolve_output_dir(
+        args.output_dir, bridge_id=str(bridge["bridge_id"]), create=True
+    )
+    _write_bridge_outputs(
+        output_dir,
+        bridge=bridge,
+        candidate=bundle["candidate"],
+        metrics=bundle["metrics"],
+    )
+    _prepare_from_bridge(
+        bridge=bridge,
+        candidate=bundle["candidate"],
+        metrics=bundle["metrics"],
+        output_dir=output_dir,
+    )
+    print(SUCCESS_BUILD_PREPARE_OUTPUT)
+    return 0
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    bridge = validate_creative_hypothesis_specification_bridge(read_json_object(args.bridge))
+    if args.candidate:
+        validate_creative_code_candidate_packet(read_creative_code_candidate_packet(args.candidate))
+    else:
+        candidate_path = _repo_ref_to_file(
+            str(cast_mapping(bridge["candidate_packet"])["candidate_packet_ref"])
+        )
+        validate_creative_code_candidate_packet(read_creative_code_candidate_packet(candidate_path))
+    if args.metrics:
+        validate_bridge_metrics(read_json_object(args.metrics))
+    print(SUCCESS_VALIDATE_OUTPUT)
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_build_inputs(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument("--context-map", type=Path, required=True)
+        subparser.add_argument("--hypothesis-packet", type=Path, required=True)
+        subparser.add_argument("--coordinator-dispatch", type=Path, required=True)
+        subparser.add_argument("--approval", type=Path, required=True)
+        subparser.add_argument(
+            "--variant-count",
+            type=int,
+            choices=sorted({3, 4, 5}),
+            required=True,
+        )
+        subparser.add_argument("--output-dir", type=Path)
+
+    build_parser = subparsers.add_parser("build-candidate")
+    add_build_inputs(build_parser)
+    build_parser.set_defaults(func=_cmd_build_candidate)
+
+    prepare_parser = subparsers.add_parser("prepare-specification")
+    prepare_parser.add_argument("--bridge", type=Path, required=True)
+    prepare_parser.set_defaults(func=_cmd_prepare_specification)
+
+    build_prepare_parser = subparsers.add_parser("build-and-prepare")
+    add_build_inputs(build_prepare_parser)
+    build_prepare_parser.set_defaults(func=_cmd_build_and_prepare)
+
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("--bridge", type=Path, required=True)
+    validate_parser.add_argument("--candidate", type=Path)
+    validate_parser.add_argument("--metrics", type=Path)
+    validate_parser.set_defaults(func=_cmd_validate)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (
+        CreativeCodeContractError,
+        CreativeHypothesisSpecBridgeCliError,
+        CreativeHypothesisSpecBridgeError,
+        ExperimentRunnerCreativeContextContractError,
+    ) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
@@ -391,7 +391,7 @@ def update_bridge_metrics_for_prepare(
         if key not in {"metrics_id", "idempotency_key"}
     }
     body["source"] = {
-        **cast(dict[str, Any], body["source"]),
+        **cast(dict[str, Any], normalized_bridge["source"]),
         "candidate_fingerprint": fingerprint_payload(
             cast(dict[str, Any], dict(normalized_candidate))
         ),
@@ -400,7 +400,13 @@ def update_bridge_metrics_for_prepare(
     body["candidate_id"] = normalized_candidate["candidate_id"]
     body["status"] = status
     body["blocked_reason"] = blocked_reason
+    selected = cast(Mapping[str, Any], normalized_bridge["selected_hypothesis"])
+    body["selected_hypothesis_id"] = selected["hypothesis_id"]
     counts = dict(cast(Mapping[str, Any], body["counts"]))
+    counts["approved_target_count"] = len(selected["approved_target_surfaces"])
+    counts["candidate_target_count"] = len(normalized_candidate["target_surface"])
+    counts["immutable_oracle_count"] = len(normalized_candidate["immutable_oracles"])
+    counts["variant_count"] = normalized_candidate["variant_count"]
     counts["prepare_files_written"] = prepare_files_written
     counts["pending_skeptic_review_count"] = pending_skeptic_review_count
     body["counts"] = counts

--- a/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
@@ -9,7 +9,7 @@ generate patches, dispatch agents, finalize specifications, or claim readiness.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 import re
 from typing import Any, cast
 
@@ -629,7 +629,7 @@ def _candidate_targets_from_approval(
         try:
             normalized = validate_mutable_candidate_surface([target])
         except ValueError:
-            non_mutable_targets.append(target)
+            non_mutable_targets.append(PurePosixPath(target).as_posix())
             continue
         if any(_is_protected_candidate_target(path) for path in normalized):
             non_mutable_targets.extend(normalized)
@@ -1375,7 +1375,7 @@ def _normalize_repo_path(raw_path: Any, *, label: str, allow_artifact_ref: bool)
         raise CreativeHypothesisSpecBridgeError(f"{label} must not contain control characters.")
     if "\\" in value:
         raise CreativeHypothesisSpecBridgeError(f"{label} must use POSIX separators.")
-    if value.startswith(("/", "~")) or Path(value).is_absolute():
+    if value.startswith(("/", "~")) or PurePosixPath(value).is_absolute():
         raise CreativeHypothesisSpecBridgeError(f"{label} must be repo-relative.")
     if SCHEME_RE.match(value):
         raise CreativeHypothesisSpecBridgeError(f"{label} must not be a URL or scheme path.")
@@ -1390,7 +1390,12 @@ def _normalize_repo_path(raw_path: Any, *, label: str, allow_artifact_ref: bool)
     if normalized == "artifacts" or normalized.startswith("artifacts/"):
         if not allow_artifact_ref:
             raise CreativeHypothesisSpecBridgeError(f"{label} points to a local artifact path.")
-        if not normalized.startswith("artifacts/orchestration/creative_code/spec_bridge/"):
+        artifact_parts = PurePosixPath(normalized).parts
+        if (
+            len(artifact_parts) < 6
+            or artifact_parts[:4] != ("artifacts", "orchestration", "creative_code", "spec_bridge")
+            or not ID_RE.fullmatch(artifact_parts[4])
+        ):
             raise CreativeHypothesisSpecBridgeError(
                 f"{label} must reference a spec_bridge local artifact."
             )

--- a/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
@@ -1,0 +1,1366 @@
+"""Contracts for bridging approved creative hypotheses into PR-1 candidates.
+
+The bridge is a local orchestration adapter. It consumes already-sanitized
+creative-context artifacts, builds a validated CreativeCodeCandidatePacket, and
+emits deterministic local metrics. It does not call providers, write branches,
+generate patches, dispatch agents, finalize specifications, or claim readiness.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+import re
+from typing import Any, cast
+
+from core.evidence.fingerprints import build_asset_id, build_idempotency_key, fingerprint_payload
+from scripts.orchestration.creative_code_contract import (
+    AUTHORITY_FALSE_KEYS as CANDIDATE_AUTHORITY_FALSE_KEYS,
+    AUTHORITY_TRUE_KEYS as CANDIDATE_AUTHORITY_TRUE_KEYS,
+    FUTURE_TELEMETRY_FIELDS,
+    GATE_STATUS as CANDIDATE_GATE_STATUS,
+    PACKET_TYPE as CANDIDATE_PACKET_TYPE,
+    POLICY_VERSION as CANDIDATE_POLICY_VERSION,
+    PROTECTED_TARGET_SURFACE_EXACT_PATHS,
+    PROTECTED_TARGET_SURFACE_FILENAMES,
+    PROTECTED_TARGET_SURFACE_PREFIXES,
+    SCHEMA_VERSION,
+    CreativeCodeContractError,
+    validate_creative_code_candidate_packet,
+)
+from scripts.orchestration.experiment_contract import validate_mutable_candidate_surface
+from scripts.orchestration.experiment_runner_pr_creative_context_contract import (
+    ExperimentRunnerCreativeContextContractError,
+    reject_unsafe_creative_context_value,
+    validate_creative_hypothesis_approval,
+    validate_creative_hypothesis_coordinator_dispatch,
+    validate_creative_hypothesis_packet,
+    validate_creative_protocol_context_map,
+)
+
+BRIDGE_ARTIFACT_TYPE = "creative_hypothesis_specification_bridge"
+METRICS_ARTIFACT_TYPE = "creative_hypothesis_spec_bridge_metrics"
+POLICY_VERSION = "creative-hypothesis-spec-bridge-v1"
+BRIDGE_SUCCESS_STATUS = "candidate_built"
+PREPARED_STATUS = "prepared"
+BLOCKED_STATUS = "blocked"
+VALID_STATUSES = frozenset({BRIDGE_SUCCESS_STATUS, PREPARED_STATUS, BLOCKED_STATUS})
+VARIANT_COUNTS = frozenset({3, 4, 5})
+PREPARE_FILENAMES = (
+    "source_packet.json",
+    "variants.json",
+    "skeptic_reviews.json",
+    "context_pack.json",
+)
+NO_ALLOWED_MUTABLE_TARGET = "no_allowed_mutable_target"
+BRIDGE_FAILURE_REASONS = frozenset(
+    {
+        "approval_not_pr1_specification",
+        "approved_agents_not_dispatched",
+        "approved_targets_not_hypothesis_subset",
+        "candidate_target_oracle_overlap",
+        "dispatch_packet_mismatch",
+        "dispatch_row_missing",
+        "fingerprint_mismatch",
+        "hypothesis_not_found",
+        "invalid_candidate_packet",
+        NO_ALLOWED_MUTABLE_TARGET,
+        "spec_prepare_failed",
+    }
+)
+
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+SHA256_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+FORBIDDEN_VALUE_RE = re.compile(
+    r"(semantic[-_ ]?cache|graph[-_ ]?truth|runtime[-_ ]?telemetry|"
+    r"product[-_ ]?runtime[-_ ]?truth|raw[-_ ]?provider|raw[-_ ]?prompt|"
+    r"raw[-_ ]?response|raw[-_ ]?patch)",
+    re.IGNORECASE,
+)
+
+BRIDGE_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "bridge_id",
+        "idempotency_key",
+        "source",
+        "selected_hypothesis",
+        "candidate_packet",
+        "spec_prepare",
+        "authority",
+        "sanitized",
+    }
+)
+SOURCE_KEYS = frozenset(
+    {
+        "context_map_id",
+        "context_map_fingerprint",
+        "hypothesis_packet_id",
+        "hypothesis_packet_fingerprint",
+        "coordinator_dispatch_id",
+        "coordinator_dispatch_fingerprint",
+        "approval_id",
+        "approval_fingerprint",
+    }
+)
+SELECTED_HYPOTHESIS_KEYS = frozenset(
+    {
+        "hypothesis_id",
+        "hypothesis_fingerprint",
+        "approved_target_surfaces",
+        "candidate_target_surface",
+        "immutable_oracles",
+        "approved_agents",
+        "dispatch_agents",
+        "variant_count",
+    }
+)
+CANDIDATE_REF_KEYS = frozenset({"candidate_id", "candidate_fingerprint", "candidate_packet_ref"})
+SPEC_PREPARE_KEYS = frozenset(
+    {"run_dir_ref", "expected_files", "prepared", "finalized", "next_allowed_action"}
+)
+METRICS_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "metrics_id",
+        "idempotency_key",
+        "source",
+        "bridge_id",
+        "candidate_id",
+        "selected_hypothesis_id",
+        "status",
+        "blocked_reason",
+        "counts",
+        "cost_metadata",
+        "authority",
+        "sanitized",
+    }
+)
+METRICS_SOURCE_KEYS = SOURCE_KEYS | frozenset({"candidate_fingerprint"})
+METRICS_COUNTS_KEYS = frozenset(
+    {
+        "hypothesis_count",
+        "approved_target_count",
+        "candidate_target_count",
+        "immutable_oracle_count",
+        "variant_count",
+        "prepare_files_written",
+        "pending_skeptic_review_count",
+    }
+)
+COST_METADATA_KEYS = frozenset(
+    {"provider_cost_available", "provider_call_count", "provider_cost_basis"}
+)
+BRIDGE_AUTHORITY_TRUE_KEYS = frozenset(
+    {
+        "read_sanitized_context",
+        "emit_local_artifacts",
+        "build_creative_code_candidate_packet",
+        "run_specification_prepare",
+    }
+)
+BRIDGE_AUTHORITY_FALSE_KEYS = frozenset(
+    {
+        "call_product_runtime",
+        "call_provider",
+        "change_client_runtime",
+        "change_openapi",
+        "claim_merge_readiness",
+        "create_branch",
+        "dispatch_to_agents",
+        "edit_fixed_mapping",
+        "execute_agent_tasks",
+        "execute_pr2_patch_builder",
+        "execute_pr3_promotion",
+        "finalize_specification_bundle",
+        "generate_candidate_patch",
+        "generate_patch",
+        "mark_pr_ready",
+        "merge",
+        "modify_github_app",
+        "modify_slack",
+        "modify_workflows",
+        "open_draft_pr",
+        "open_pr",
+        "post_github_comment",
+        "push",
+        "read_secrets",
+        "release",
+        "resolve_threads",
+        "use_semantic_cache",
+        "workflow_dispatch",
+        "write_branch",
+        "write_repository",
+        "write_shared_worktree",
+    }
+)
+BRIDGE_AUTHORITY_KEYS = BRIDGE_AUTHORITY_TRUE_KEYS | BRIDGE_AUTHORITY_FALSE_KEYS
+
+
+class CreativeHypothesisSpecBridgeError(ValueError):
+    """Raised when bridge inputs or outputs violate local handoff authority."""
+
+    def __init__(self, message: str, *, blocked_reason: str | None = None) -> None:
+        super().__init__(message)
+        self.blocked_reason = blocked_reason
+
+
+def default_bridge_authority() -> dict[str, bool]:
+    """Return the only authority allowed for this local bridge."""
+
+    authority = {key: False for key in sorted(BRIDGE_AUTHORITY_FALSE_KEYS)}
+    authority.update({key: True for key in sorted(BRIDGE_AUTHORITY_TRUE_KEYS)})
+    return dict(sorted(authority.items()))
+
+
+def build_creative_hypothesis_spec_bridge_bundle(
+    *,
+    context_map: Mapping[str, Any],
+    hypothesis_packet: Mapping[str, Any],
+    coordinator_dispatch: Mapping[str, Any],
+    approval: Mapping[str, Any],
+    variant_count: int,
+) -> dict[str, dict[str, Any]]:
+    """Build bridge, candidate, and metrics artifacts from approved local inputs."""
+
+    if variant_count not in VARIANT_COUNTS:
+        raise CreativeHypothesisSpecBridgeError("variant_count must be one of 3, 4, or 5.")
+    sources = _validate_sources(
+        context_map=context_map,
+        hypothesis_packet=hypothesis_packet,
+        coordinator_dispatch=coordinator_dispatch,
+        approval=approval,
+    )
+    normalized_context = sources["context_map"]
+    normalized_packet = sources["hypothesis_packet"]
+    normalized_dispatch = sources["coordinator_dispatch"]
+    normalized_approval = sources["approval"]
+    if (
+        normalized_approval["decision"] != "approve_for_pr1_specification"
+        or normalized_approval["next_step"] != "create_pr1_specification"
+    ):
+        raise CreativeHypothesisSpecBridgeError(
+            "approval_not_pr1_specification: only approved PR-1 specification "
+            "handoffs may build candidates.",
+            blocked_reason="approval_not_pr1_specification",
+        )
+
+    hypothesis = _find_hypothesis(
+        normalized_packet,
+        str(normalized_approval["hypothesis_id"]),
+    )
+    approved_targets = _require_approved_targets_subset(normalized_approval, hypothesis)
+    dispatch_row = _find_dispatch_row(
+        normalized_dispatch,
+        str(normalized_approval["hypothesis_id"]),
+    )
+    dispatch_agents = _dispatch_agents(dispatch_row)
+    approved_agents = [str(agent) for agent in normalized_approval["approved_agents"]]
+    missing_agents = sorted(set(approved_agents) - set(dispatch_agents))
+    if missing_agents:
+        raise CreativeHypothesisSpecBridgeError(
+            "approved_agents_not_dispatched: approved agents must be present in "
+            "the coordinator dispatch row.",
+            blocked_reason="approved_agents_not_dispatched",
+        )
+
+    candidate_targets, non_mutable_targets = _candidate_targets_from_approval(approved_targets)
+    if not candidate_targets:
+        raise CreativeHypothesisSpecBridgeError(
+            f"{NO_ALLOWED_MUTABLE_TARGET}: approval did not contain a target accepted "
+            "by the current creative-code mutable allowlist.",
+            blocked_reason=NO_ALLOWED_MUTABLE_TARGET,
+        )
+    immutable_oracles = _immutable_oracles_from_hypothesis(
+        hypothesis=hypothesis,
+        non_mutable_approved_targets=non_mutable_targets,
+    )
+    _reject_target_oracle_overlap(candidate_targets, immutable_oracles)
+
+    candidate = _build_candidate_packet(
+        packet=normalized_packet,
+        hypothesis=hypothesis,
+        target_surface=candidate_targets,
+        immutable_oracles=immutable_oracles,
+        variant_count=variant_count,
+    )
+    bridge = _build_bridge_artifact(
+        context_map=normalized_context,
+        hypothesis_packet=normalized_packet,
+        coordinator_dispatch=normalized_dispatch,
+        approval=normalized_approval,
+        hypothesis=hypothesis,
+        approved_targets=approved_targets,
+        candidate_targets=candidate_targets,
+        immutable_oracles=immutable_oracles,
+        approved_agents=approved_agents,
+        dispatch_agents=dispatch_agents,
+        variant_count=variant_count,
+        candidate=candidate,
+        prepared=False,
+    )
+    metrics = build_bridge_metrics(
+        bridge=bridge,
+        candidate=candidate,
+        hypothesis_packet=normalized_packet,
+        approval=normalized_approval,
+        status=BRIDGE_SUCCESS_STATUS,
+        prepare_files_written=0,
+        pending_skeptic_review_count=0,
+    )
+    return {"bridge": bridge, "candidate": candidate, "metrics": metrics}
+
+
+def mark_bridge_prepared(bridge: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a validated copy of a bridge artifact with prepare marked complete."""
+
+    normalized = validate_creative_hypothesis_specification_bridge(bridge)
+    prepared = dict(normalized)
+    spec_prepare = dict(cast(Mapping[str, Any], prepared["spec_prepare"]))
+    spec_prepare["prepared"] = True
+    spec_prepare["finalized"] = False
+    prepared["spec_prepare"] = spec_prepare
+    _validate_bridge_identity(prepared)
+    reject_bridge_payload_safety(prepared, label="CreativeHypothesisSpecificationBridge")
+    return prepared
+
+
+def build_bridge_metrics(
+    *,
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    hypothesis_packet: Mapping[str, Any],
+    approval: Mapping[str, Any],
+    status: str,
+    prepare_files_written: int,
+    pending_skeptic_review_count: int,
+    blocked_reason: str | None = None,
+) -> dict[str, Any]:
+    """Build deterministic bridge observability sidecar."""
+
+    normalized_bridge = validate_creative_hypothesis_specification_bridge(bridge)
+    normalized_candidate = validate_creative_code_candidate_packet(dict(candidate))
+    normalized_packet = validate_creative_hypothesis_packet(hypothesis_packet)
+    normalized_approval = validate_creative_hypothesis_approval(approval)
+    metrics = _metrics_body(
+        bridge=normalized_bridge,
+        candidate=normalized_candidate,
+        hypothesis_packet=normalized_packet,
+        approval=normalized_approval,
+        status=status,
+        prepare_files_written=prepare_files_written,
+        pending_skeptic_review_count=pending_skeptic_review_count,
+        blocked_reason=blocked_reason,
+    )
+    metrics_id, idempotency_key = _artifact_identity(
+        metrics,
+        artifact_type=METRICS_ARTIFACT_TYPE,
+        upstream_ids=(
+            str(normalized_bridge["bridge_id"]),
+            str(normalized_candidate["candidate_id"]),
+        ),
+    )
+    metrics["metrics_id"] = metrics_id
+    metrics["idempotency_key"] = idempotency_key
+    return validate_bridge_metrics(metrics)
+
+
+def update_bridge_metrics_for_prepare(
+    *,
+    metrics: Mapping[str, Any],
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    status: str,
+    prepare_files_written: int,
+    pending_skeptic_review_count: int,
+    blocked_reason: str | None = None,
+) -> dict[str, Any]:
+    """Update an existing metrics sidecar after a prepare attempt."""
+
+    normalized_metrics = validate_bridge_metrics(metrics)
+    normalized_bridge = validate_creative_hypothesis_specification_bridge(bridge)
+    normalized_candidate = validate_creative_code_candidate_packet(dict(candidate))
+    body = {
+        key: value
+        for key, value in normalized_metrics.items()
+        if key not in {"metrics_id", "idempotency_key"}
+    }
+    body["source"] = {
+        **cast(dict[str, Any], body["source"]),
+        "candidate_fingerprint": fingerprint_payload(
+            cast(dict[str, Any], dict(normalized_candidate))
+        ),
+    }
+    body["bridge_id"] = normalized_bridge["bridge_id"]
+    body["candidate_id"] = normalized_candidate["candidate_id"]
+    body["status"] = status
+    body["blocked_reason"] = blocked_reason
+    counts = dict(cast(Mapping[str, Any], body["counts"]))
+    counts["prepare_files_written"] = prepare_files_written
+    counts["pending_skeptic_review_count"] = pending_skeptic_review_count
+    body["counts"] = counts
+    metrics_id, idempotency_key = _artifact_identity(
+        body,
+        artifact_type=METRICS_ARTIFACT_TYPE,
+        upstream_ids=(str(body["bridge_id"]), str(body["candidate_id"])),
+    )
+    body["metrics_id"] = metrics_id
+    body["idempotency_key"] = idempotency_key
+    return validate_bridge_metrics(body)
+
+
+def validate_creative_hypothesis_specification_bridge(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate a bridge artifact."""
+
+    label = "CreativeHypothesisSpecificationBridge"
+    _require_exact_keys(payload, BRIDGE_TOP_LEVEL_KEYS, label=label)
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(
+            payload,
+            "artifact_type",
+            BRIDGE_ARTIFACT_TYPE,
+            label=label,
+        ),
+        "policy_version": _require_const(payload, "policy_version", POLICY_VERSION, label=label),
+        "bridge_id": _require_id(payload, "bridge_id", label=label),
+        "idempotency_key": _require_id(payload, "idempotency_key", label=label),
+        "source": _normalize_source_block(payload["source"], label=f"{label}.source"),
+        "selected_hypothesis": _normalize_selected_hypothesis(
+            payload["selected_hypothesis"],
+            label=f"{label}.selected_hypothesis",
+        ),
+        "candidate_packet": _normalize_candidate_ref(
+            payload["candidate_packet"],
+            label=f"{label}.candidate_packet",
+        ),
+        "spec_prepare": _normalize_spec_prepare(
+            payload["spec_prepare"],
+            label=f"{label}.spec_prepare",
+        ),
+        "authority": _normalize_bridge_authority(payload["authority"], label=f"{label}.authority"),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    _validate_bridge_identity(normalized)
+    reject_bridge_payload_safety(normalized, label=label)
+    return normalized
+
+
+def validate_bridge_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate bridge metrics sidecar."""
+
+    label = "CreativeHypothesisSpecBridgeMetrics"
+    _require_exact_keys(payload, METRICS_TOP_LEVEL_KEYS, label=label)
+    status = _require_token(payload, "status", label=label)
+    if status not in VALID_STATUSES:
+        raise CreativeHypothesisSpecBridgeError(f"{label}.status is unsupported.")
+    blocked_reason = _require_optional_token(
+        payload["blocked_reason"], label=f"{label}.blocked_reason"
+    )
+    if status == BLOCKED_STATUS:
+        if blocked_reason not in BRIDGE_FAILURE_REASONS:
+            raise CreativeHypothesisSpecBridgeError(
+                f"{label}.blocked_reason must identify a known blocked reason."
+            )
+    elif blocked_reason is not None:
+        raise CreativeHypothesisSpecBridgeError(
+            f"{label}.blocked_reason must be null unless status is blocked."
+        )
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(
+            payload,
+            "artifact_type",
+            METRICS_ARTIFACT_TYPE,
+            label=label,
+        ),
+        "policy_version": _require_const(payload, "policy_version", POLICY_VERSION, label=label),
+        "metrics_id": _require_id(payload, "metrics_id", label=label),
+        "idempotency_key": _require_id(payload, "idempotency_key", label=label),
+        "source": _normalize_metrics_source(payload["source"], label=f"{label}.source"),
+        "bridge_id": _require_id(payload, "bridge_id", label=label),
+        "candidate_id": _require_id(payload, "candidate_id", label=label),
+        "selected_hypothesis_id": _require_id(payload, "selected_hypothesis_id", label=label),
+        "status": status,
+        "blocked_reason": blocked_reason,
+        "counts": _normalize_metrics_counts(payload["counts"], label=f"{label}.counts"),
+        "cost_metadata": _normalize_cost_metadata(
+            payload["cost_metadata"],
+            label=f"{label}.cost_metadata",
+        ),
+        "authority": _normalize_bridge_authority(payload["authority"], label=f"{label}.authority"),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    _validate_metrics_identity(normalized)
+    reject_bridge_payload_safety(normalized, label=label)
+    return normalized
+
+
+def reject_bridge_payload_safety(value: Any, *, label: str) -> None:
+    """Reject unsafe bridge text while allowing explicit false authority keys."""
+
+    reject_unsafe_creative_context_value(value, label=label)
+    if isinstance(value, str):
+        if FORBIDDEN_VALUE_RE.search(value):
+            raise CreativeHypothesisSpecBridgeError(f"{label} contains unsafe bridge text.")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_bridge_payload_safety(item, label=f"{label}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            reject_bridge_payload_safety(item, label=f"{label}.{key}")
+
+
+def _validate_sources(
+    *,
+    context_map: Mapping[str, Any],
+    hypothesis_packet: Mapping[str, Any],
+    coordinator_dispatch: Mapping[str, Any],
+    approval: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    try:
+        normalized_context = validate_creative_protocol_context_map(context_map)
+        normalized_packet = validate_creative_hypothesis_packet(hypothesis_packet)
+        normalized_dispatch = validate_creative_hypothesis_coordinator_dispatch(
+            coordinator_dispatch
+        )
+        normalized_approval = validate_creative_hypothesis_approval(approval)
+    except ExperimentRunnerCreativeContextContractError as exc:
+        raise CreativeHypothesisSpecBridgeError(str(exc)) from exc
+    context_fingerprint = fingerprint_payload(cast(dict[str, Any], normalized_context))
+    if normalized_packet["context_map_id"] != normalized_context["context_id"]:
+        raise CreativeHypothesisSpecBridgeError(
+            "fingerprint_mismatch: hypothesis packet context_map_id does not match context map.",
+            blocked_reason="fingerprint_mismatch",
+        )
+    if normalized_packet["context_map_fingerprint"] != context_fingerprint:
+        raise CreativeHypothesisSpecBridgeError(
+            "fingerprint_mismatch: hypothesis packet context_map_fingerprint does not "
+            "match context map.",
+            blocked_reason="fingerprint_mismatch",
+        )
+    packet_fingerprint = fingerprint_payload(cast(dict[str, Any], normalized_packet))
+    if normalized_dispatch["source_hypothesis_packet_id"] != normalized_packet["packet_id"]:
+        raise CreativeHypothesisSpecBridgeError(
+            "dispatch_packet_mismatch: coordinator dispatch references a different packet.",
+            blocked_reason="dispatch_packet_mismatch",
+        )
+    if normalized_dispatch["source_hypothesis_packet_fingerprint"] != packet_fingerprint:
+        raise CreativeHypothesisSpecBridgeError(
+            "fingerprint_mismatch: coordinator dispatch fingerprint does not match packet.",
+            blocked_reason="fingerprint_mismatch",
+        )
+    return {
+        "context_map": normalized_context,
+        "hypothesis_packet": normalized_packet,
+        "coordinator_dispatch": normalized_dispatch,
+        "approval": normalized_approval,
+    }
+
+
+def _find_hypothesis(packet: Mapping[str, Any], hypothesis_id: str) -> dict[str, Any]:
+    for row in packet["hypotheses"]:
+        hypothesis = cast(dict[str, Any], row)
+        if hypothesis["hypothesis_id"] == hypothesis_id:
+            return hypothesis
+    raise CreativeHypothesisSpecBridgeError(
+        "hypothesis_not_found: approved hypothesis must exist in the hypothesis packet.",
+        blocked_reason="hypothesis_not_found",
+    )
+
+
+def _find_dispatch_row(dispatch: Mapping[str, Any], hypothesis_id: str) -> dict[str, Any]:
+    for row in dispatch["dispatch"]:
+        dispatch_row = cast(dict[str, Any], row)
+        if dispatch_row["hypothesis_id"] == hypothesis_id:
+            return dispatch_row
+    raise CreativeHypothesisSpecBridgeError(
+        "dispatch_row_missing: coordinator dispatch must include the approved hypothesis.",
+        blocked_reason="dispatch_row_missing",
+    )
+
+
+def _require_approved_targets_subset(
+    approval: Mapping[str, Any],
+    hypothesis: Mapping[str, Any],
+) -> list[str]:
+    approved_targets = [str(path) for path in approval["approved_target_surfaces"]]
+    hypothesis_targets = {str(path) for path in hypothesis["target_surfaces"]}
+    if not set(approved_targets).issubset(hypothesis_targets):
+        raise CreativeHypothesisSpecBridgeError(
+            "approved_targets_not_hypothesis_subset: approved targets must be a subset "
+            "of the selected hypothesis targets.",
+            blocked_reason="approved_targets_not_hypothesis_subset",
+        )
+    return sorted(approved_targets)
+
+
+def _dispatch_agents(dispatch_row: Mapping[str, Any]) -> list[str]:
+    agents = {
+        str(dispatch_row["primary_agent"]),
+        *(str(agent) for agent in dispatch_row["review_agents"]),
+        *(str(agent) for agent in dispatch_row["cross_domain_agents"]),
+    }
+    return sorted(agents)
+
+
+def _candidate_targets_from_approval(
+    approved_targets: Sequence[str],
+) -> tuple[list[str], list[str]]:
+    candidate_targets: list[str] = []
+    non_mutable_targets: list[str] = []
+    for target in approved_targets:
+        try:
+            normalized = validate_mutable_candidate_surface([target])
+        except ValueError:
+            non_mutable_targets.append(target)
+            continue
+        if any(_is_protected_candidate_target(path) for path in normalized):
+            non_mutable_targets.extend(normalized)
+            continue
+        candidate_targets.extend(normalized)
+    return sorted(set(candidate_targets)), sorted(set(non_mutable_targets))
+
+
+def _is_protected_candidate_target(path: str) -> bool:
+    return (
+        path in PROTECTED_TARGET_SURFACE_EXACT_PATHS
+        or PurePosixPath(path).name in PROTECTED_TARGET_SURFACE_FILENAMES
+        or any(path.startswith(prefix) for prefix in PROTECTED_TARGET_SURFACE_PREFIXES)
+    )
+
+
+def _immutable_oracles_from_hypothesis(
+    *,
+    hypothesis: Mapping[str, Any],
+    non_mutable_approved_targets: Sequence[str],
+) -> list[str]:
+    oracles = {
+        *(str(path) for path in hypothesis["tests_or_oracles"]),
+        *(str(path) for path in non_mutable_approved_targets),
+    }
+    return sorted(oracles)
+
+
+def _reject_target_oracle_overlap(targets: Sequence[str], oracles: Sequence[str]) -> None:
+    for target in targets:
+        for oracle in oracles:
+            if _paths_overlap(target, oracle):
+                raise CreativeHypothesisSpecBridgeError(
+                    "candidate_target_oracle_overlap: target_surface must stay disjoint "
+                    "from immutable_oracles.",
+                    blocked_reason="candidate_target_oracle_overlap",
+                )
+
+
+def _paths_overlap(left: str, right: str) -> bool:
+    left_prefix = left.rstrip("/") + "/"
+    right_prefix = right.rstrip("/") + "/"
+    return left == right or left.startswith(right_prefix) or right.startswith(left_prefix)
+
+
+def _build_candidate_packet(
+    *,
+    packet: Mapping[str, Any],
+    hypothesis: Mapping[str, Any],
+    target_surface: Sequence[str],
+    immutable_oracles: Sequence[str],
+    variant_count: int,
+) -> dict[str, Any]:
+    candidate_body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "packet_type": CANDIDATE_PACKET_TYPE,
+        "policy_version": CANDIDATE_POLICY_VERSION,
+        "gate_status": CANDIDATE_GATE_STATUS,
+        "authority_class": "code-specification",
+        "source_creative_research": {
+            "bundle_id": packet["packet_id"],
+            "candidate_id": hypothesis["hypothesis_id"],
+            "promotion_decision": "promote",
+            "fingerprint": fingerprint_payload(cast(dict[str, Any], dict(hypothesis))),
+            "evidence_ref": (
+                "docs/orchestration/contracts/" "EXPERIMENT_RUNNER_PR_CREATIVE_CONTEXT_CONTRACT.md"
+            ),
+        },
+        "variant_count": variant_count,
+        "sandbox_required": True,
+        "human_review_required": True,
+        "fallback": (
+            "Discard this specification candidate and keep the approved hypothesis "
+            "as advisory planning input."
+        ),
+        "target_surface": sorted(set(target_surface)),
+        "immutable_oracles": sorted(set(immutable_oracles)),
+        "authority": _candidate_authority(),
+        "scientific_claim_status": "hypothesis_only",
+        "evidence_bundle": {
+            "artifact_refs": [
+                "docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md",
+                "docs/orchestration/contracts/CREATIVE_CODE_CANDIDATE_CONTRACT.md",
+                (
+                    "docs/orchestration/contracts/"
+                    "EXPERIMENT_RUNNER_PR_CREATIVE_CONTEXT_CONTRACT.md"
+                ),
+                (
+                    "docs/orchestration/contracts/"
+                    "creative_hypothesis_specification_bridge.v1.schema.json"
+                ),
+            ],
+            "required_tests": sorted(
+                {
+                    "tests/test_creative_hypothesis_spec_bridge.py",
+                    "tests/test_creative_code_contract.py",
+                    "tests/test_creative_code_specification.py",
+                    *(
+                        str(path)
+                        for path in hypothesis["tests_or_oracles"]
+                        if str(path).startswith("tests/")
+                    ),
+                }
+            ),
+            "negative_controls": sorted(
+                {
+                    "non_pr1_approval_rejected",
+                    "no_allowed_mutable_target_rejected",
+                    "patch_generation_authority_rejected",
+                    *(str(item) for item in hypothesis["negative_controls"]),
+                }
+            ),
+        },
+        "future_telemetry_contract": {
+            "emit_no_earlier_than": "PR-1",
+            "minimum_fields": list(FUTURE_TELEMETRY_FIELDS),
+        },
+    }
+    candidate_id, idempotency_key = _artifact_identity(
+        candidate_body,
+        artifact_type=CANDIDATE_PACKET_TYPE,
+        upstream_ids=(
+            str(packet["packet_id"]),
+            str(hypothesis["hypothesis_id"]),
+        ),
+        policy_version=CANDIDATE_POLICY_VERSION,
+    )
+    candidate = {
+        **candidate_body,
+        "candidate_id": candidate_id,
+        "idempotency_key": idempotency_key,
+    }
+    try:
+        return cast(dict[str, Any], validate_creative_code_candidate_packet(candidate))
+    except CreativeCodeContractError as exc:
+        raise CreativeHypothesisSpecBridgeError(
+            f"invalid_candidate_packet: {exc}",
+            blocked_reason="invalid_candidate_packet",
+        ) from exc
+
+
+def _candidate_authority() -> dict[str, bool]:
+    authority = {key: False for key in CANDIDATE_AUTHORITY_FALSE_KEYS}
+    authority.update({key: True for key in CANDIDATE_AUTHORITY_TRUE_KEYS})
+    return dict(sorted(authority.items()))
+
+
+def _build_bridge_artifact(
+    *,
+    context_map: Mapping[str, Any],
+    hypothesis_packet: Mapping[str, Any],
+    coordinator_dispatch: Mapping[str, Any],
+    approval: Mapping[str, Any],
+    hypothesis: Mapping[str, Any],
+    approved_targets: Sequence[str],
+    candidate_targets: Sequence[str],
+    immutable_oracles: Sequence[str],
+    approved_agents: Sequence[str],
+    dispatch_agents: Sequence[str],
+    variant_count: int,
+    candidate: Mapping[str, Any],
+    prepared: bool,
+) -> dict[str, Any]:
+    candidate_fingerprint = fingerprint_payload(cast(dict[str, Any], dict(candidate)))
+    source = {
+        "context_map_id": context_map["context_id"],
+        "context_map_fingerprint": fingerprint_payload(cast(dict[str, Any], dict(context_map))),
+        "hypothesis_packet_id": hypothesis_packet["packet_id"],
+        "hypothesis_packet_fingerprint": fingerprint_payload(
+            cast(dict[str, Any], dict(hypothesis_packet))
+        ),
+        "coordinator_dispatch_id": coordinator_dispatch["dispatch_id"],
+        "coordinator_dispatch_fingerprint": fingerprint_payload(
+            cast(dict[str, Any], dict(coordinator_dispatch))
+        ),
+        "approval_id": approval["approval_id"],
+        "approval_fingerprint": fingerprint_payload(cast(dict[str, Any], dict(approval))),
+    }
+    bridge_body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": BRIDGE_ARTIFACT_TYPE,
+        "policy_version": POLICY_VERSION,
+        "source": source,
+        "selected_hypothesis": {
+            "hypothesis_id": hypothesis["hypothesis_id"],
+            "hypothesis_fingerprint": fingerprint_payload(cast(dict[str, Any], dict(hypothesis))),
+            "approved_target_surfaces": sorted(set(approved_targets)),
+            "candidate_target_surface": sorted(set(candidate_targets)),
+            "immutable_oracles": sorted(set(immutable_oracles)),
+            "approved_agents": sorted(set(approved_agents)),
+            "dispatch_agents": sorted(set(dispatch_agents)),
+            "variant_count": variant_count,
+        },
+        "candidate_packet": {
+            "candidate_id": candidate["candidate_id"],
+            "candidate_fingerprint": candidate_fingerprint,
+            "candidate_packet_ref": "",
+        },
+        "spec_prepare": {
+            "run_dir_ref": "",
+            "expected_files": list(PREPARE_FILENAMES),
+            "prepared": prepared,
+            "finalized": False,
+            "next_allowed_action": "agent_skeptic_review",
+        },
+        "authority": default_bridge_authority(),
+        "sanitized": True,
+    }
+    bridge_id, idempotency_key = _artifact_identity(
+        _bridge_identity_payload(bridge_body),
+        artifact_type=BRIDGE_ARTIFACT_TYPE,
+        upstream_ids=(
+            str(hypothesis_packet["packet_id"]),
+            str(approval["approval_id"]),
+            str(candidate["candidate_id"]),
+        ),
+    )
+    artifact_root_ref = f"artifacts/orchestration/creative_code/spec_bridge/{bridge_id}"
+    bridge = {
+        **bridge_body,
+        "bridge_id": bridge_id,
+        "idempotency_key": idempotency_key,
+    }
+    bridge["candidate_packet"] = {
+        **bridge["candidate_packet"],
+        "candidate_packet_ref": f"{artifact_root_ref}/creative_code_candidate_packet.json",
+    }
+    bridge["spec_prepare"] = {
+        **bridge["spec_prepare"],
+        "run_dir_ref": f"{artifact_root_ref}/spec_prepare",
+    }
+    return validate_creative_hypothesis_specification_bridge(bridge)
+
+
+def _metrics_body(
+    *,
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    hypothesis_packet: Mapping[str, Any],
+    approval: Mapping[str, Any],
+    status: str,
+    prepare_files_written: int,
+    pending_skeptic_review_count: int,
+    blocked_reason: str | None,
+) -> dict[str, Any]:
+    source = {
+        **cast(dict[str, Any], bridge["source"]),
+        "candidate_fingerprint": fingerprint_payload(cast(dict[str, Any], dict(candidate))),
+    }
+    selected = cast(Mapping[str, Any], bridge["selected_hypothesis"])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": METRICS_ARTIFACT_TYPE,
+        "policy_version": POLICY_VERSION,
+        "source": source,
+        "bridge_id": bridge["bridge_id"],
+        "candidate_id": candidate["candidate_id"],
+        "selected_hypothesis_id": selected["hypothesis_id"],
+        "status": status,
+        "blocked_reason": blocked_reason,
+        "counts": {
+            "hypothesis_count": hypothesis_packet["hypothesis_count"],
+            "approved_target_count": len(approval["approved_target_surfaces"]),
+            "candidate_target_count": len(candidate["target_surface"]),
+            "immutable_oracle_count": len(candidate["immutable_oracles"]),
+            "variant_count": candidate["variant_count"],
+            "prepare_files_written": prepare_files_written,
+            "pending_skeptic_review_count": pending_skeptic_review_count,
+        },
+        "cost_metadata": {
+            "provider_cost_available": False,
+            "provider_call_count": 0,
+            "provider_cost_basis": "not_available_local_no_provider_calls",
+        },
+        "authority": default_bridge_authority(),
+        "sanitized": True,
+    }
+
+
+def _bridge_identity_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    candidate_packet = cast(Mapping[str, Any], payload["candidate_packet"])
+    spec_prepare = cast(Mapping[str, Any], payload["spec_prepare"])
+    return {
+        "schema_version": payload["schema_version"],
+        "artifact_type": payload["artifact_type"],
+        "policy_version": payload["policy_version"],
+        "source": payload["source"],
+        "selected_hypothesis": payload["selected_hypothesis"],
+        "candidate_packet": {
+            "candidate_id": candidate_packet["candidate_id"],
+            "candidate_fingerprint": candidate_packet["candidate_fingerprint"],
+        },
+        "spec_prepare": {
+            "expected_files": spec_prepare["expected_files"],
+            "next_allowed_action": spec_prepare["next_allowed_action"],
+        },
+        "authority": payload["authority"],
+        "sanitized": payload["sanitized"],
+    }
+
+
+def _artifact_identity(
+    payload: Mapping[str, Any],
+    *,
+    artifact_type: str,
+    upstream_ids: tuple[str, ...] = (),
+    policy_version: str = POLICY_VERSION,
+) -> tuple[str, str]:
+    fingerprint = cast(str, fingerprint_payload(cast(dict[str, Any], dict(payload))))
+    return (
+        build_asset_id(
+            asset_type=artifact_type,
+            rail="orchestration",
+            version=SCHEMA_VERSION,
+            policy_version=policy_version,
+            fingerprint=fingerprint,
+            upstream_ids=upstream_ids,
+        ),
+        build_idempotency_key(
+            asset_type=artifact_type,
+            rail="orchestration",
+            version=SCHEMA_VERSION,
+            policy_version=policy_version,
+            fingerprint=fingerprint,
+            upstream_ids=upstream_ids,
+        ),
+    )
+
+
+def _validate_bridge_identity(payload: Mapping[str, Any]) -> None:
+    expected_id, expected_idempotency_key = _artifact_identity(
+        _bridge_identity_payload(payload),
+        artifact_type=BRIDGE_ARTIFACT_TYPE,
+        upstream_ids=(
+            str(cast(Mapping[str, Any], payload["source"])["hypothesis_packet_id"]),
+            str(cast(Mapping[str, Any], payload["source"])["approval_id"]),
+            str(cast(Mapping[str, Any], payload["candidate_packet"])["candidate_id"]),
+        ),
+    )
+    if payload["bridge_id"] != expected_id:
+        raise CreativeHypothesisSpecBridgeError("bridge_id does not match content.")
+    if payload["idempotency_key"] != expected_idempotency_key:
+        raise CreativeHypothesisSpecBridgeError("idempotency_key does not match content.")
+
+
+def _validate_metrics_identity(payload: Mapping[str, Any]) -> None:
+    body = dict(payload)
+    observed_id = str(body.pop("metrics_id"))
+    observed_idempotency_key = str(body.pop("idempotency_key"))
+    expected_id, expected_idempotency_key = _artifact_identity(
+        body,
+        artifact_type=METRICS_ARTIFACT_TYPE,
+        upstream_ids=(str(payload["bridge_id"]), str(payload["candidate_id"])),
+    )
+    if observed_id != expected_id:
+        raise CreativeHypothesisSpecBridgeError("metrics_id does not match content.")
+    if observed_idempotency_key != expected_idempotency_key:
+        raise CreativeHypothesisSpecBridgeError("idempotency_key does not match content.")
+
+
+def _require_exact_keys(
+    payload: Mapping[str, Any], expected: frozenset[str], *, label: str
+) -> None:
+    actual = set(payload)
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing:
+        raise CreativeHypothesisSpecBridgeError(
+            f"{label} is missing required fields: {', '.join(missing)}"
+        )
+    if extra:
+        raise CreativeHypothesisSpecBridgeError(
+            f"{label} has unsupported fields: {', '.join(extra)}"
+        )
+
+
+def _require_const(payload: Mapping[str, Any], key: str, expected: Any, *, label: str) -> Any:
+    value = payload.get(key)
+    if value != expected:
+        raise CreativeHypothesisSpecBridgeError(f"{label}.{key} must equal {expected!r}.")
+    return value
+
+
+def _require_bool(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    expected: bool | None,
+    label: str,
+) -> bool:
+    value = payload.get(key)
+    if not isinstance(value, bool):
+        raise CreativeHypothesisSpecBridgeError(f"{label}.{key} must be a boolean.")
+    if expected is not None and value is not expected:
+        raise CreativeHypothesisSpecBridgeError(f"{label}.{key} must be {expected}.")
+    return value
+
+
+def _require_int(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    min_value: int,
+    max_value: int,
+    label: str,
+) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CreativeHypothesisSpecBridgeError(f"{label}.{key} must be an integer.")
+    if not min_value <= value <= max_value:
+        raise CreativeHypothesisSpecBridgeError(
+            f"{label}.{key} must be between {min_value} and {max_value}."
+        )
+    return value
+
+
+def _require_id(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise CreativeHypothesisSpecBridgeError(f"{label}.{key} must be a string.")
+    normalized = value.strip()
+    if not normalized or not ID_RE.fullmatch(normalized):
+        raise CreativeHypothesisSpecBridgeError(f"{label}.{key} must be a safe id.")
+    reject_bridge_payload_safety(normalized, label=f"{label}.{key}")
+    return normalized
+
+
+def _require_token(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise CreativeHypothesisSpecBridgeError(f"{label}.{key} must be a string.")
+    normalized = value.strip()
+    if not normalized or not re.fullmatch(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$", normalized):
+        raise CreativeHypothesisSpecBridgeError(f"{label}.{key} must be a safe token.")
+    reject_bridge_payload_safety(normalized, label=f"{label}.{key}")
+    return normalized
+
+
+def _require_optional_token(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    return _require_token({"value": value}, "value", label=label)
+
+
+def _require_sha256(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a sha256 digest.")
+    return value
+
+
+def _require_string_list(
+    raw_items: Any,
+    *,
+    label: str,
+    allow_empty: bool,
+) -> list[str]:
+    if not isinstance(raw_items, list):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a list.")
+    if not raw_items and not allow_empty:
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be non-empty.")
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw_items):
+        if not isinstance(item, str):
+            raise CreativeHypothesisSpecBridgeError(f"{label}[{index}] must be a string.")
+        cleaned = item.strip()
+        if not cleaned:
+            raise CreativeHypothesisSpecBridgeError(f"{label}[{index}] must be non-empty.")
+        reject_bridge_payload_safety(cleaned, label=f"{label}[{index}]")
+        if cleaned in seen:
+            raise CreativeHypothesisSpecBridgeError(f"{label} must not contain duplicates.")
+        seen.add(cleaned)
+        normalized.append(cleaned)
+    return normalized
+
+
+def _normalize_source_block(raw_source: Any, *, label: str) -> dict[str, str]:
+    if not isinstance(raw_source, Mapping):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_source, SOURCE_KEYS, label=label)
+    return {
+        "context_map_id": _require_id(raw_source, "context_map_id", label=label),
+        "context_map_fingerprint": _require_sha256(
+            raw_source["context_map_fingerprint"],
+            label=f"{label}.context_map_fingerprint",
+        ),
+        "hypothesis_packet_id": _require_id(raw_source, "hypothesis_packet_id", label=label),
+        "hypothesis_packet_fingerprint": _require_sha256(
+            raw_source["hypothesis_packet_fingerprint"],
+            label=f"{label}.hypothesis_packet_fingerprint",
+        ),
+        "coordinator_dispatch_id": _require_id(
+            raw_source,
+            "coordinator_dispatch_id",
+            label=label,
+        ),
+        "coordinator_dispatch_fingerprint": _require_sha256(
+            raw_source["coordinator_dispatch_fingerprint"],
+            label=f"{label}.coordinator_dispatch_fingerprint",
+        ),
+        "approval_id": _require_id(raw_source, "approval_id", label=label),
+        "approval_fingerprint": _require_sha256(
+            raw_source["approval_fingerprint"],
+            label=f"{label}.approval_fingerprint",
+        ),
+    }
+
+
+def _normalize_metrics_source(raw_source: Any, *, label: str) -> dict[str, str]:
+    if not isinstance(raw_source, Mapping):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_source, METRICS_SOURCE_KEYS, label=label)
+    source = _normalize_source_block(
+        {key: raw_source[key] for key in SOURCE_KEYS},
+        label=label,
+    )
+    source["candidate_fingerprint"] = _require_sha256(
+        raw_source["candidate_fingerprint"],
+        label=f"{label}.candidate_fingerprint",
+    )
+    return source
+
+
+def _normalize_selected_hypothesis(raw_value: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(raw_value, Mapping):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_value, SELECTED_HYPOTHESIS_KEYS, label=label)
+    variant_count = _require_int(
+        raw_value,
+        "variant_count",
+        min_value=3,
+        max_value=5,
+        label=label,
+    )
+    return {
+        "hypothesis_id": _require_id(raw_value, "hypothesis_id", label=label),
+        "hypothesis_fingerprint": _require_sha256(
+            raw_value["hypothesis_fingerprint"],
+            label=f"{label}.hypothesis_fingerprint",
+        ),
+        "approved_target_surfaces": _normalize_repo_path_list(
+            raw_value["approved_target_surfaces"],
+            label=f"{label}.approved_target_surfaces",
+            allow_empty=False,
+            allow_artifact_ref=False,
+        ),
+        "candidate_target_surface": _normalize_repo_path_list(
+            raw_value["candidate_target_surface"],
+            label=f"{label}.candidate_target_surface",
+            allow_empty=False,
+            allow_artifact_ref=False,
+        ),
+        "immutable_oracles": _normalize_repo_path_list(
+            raw_value["immutable_oracles"],
+            label=f"{label}.immutable_oracles",
+            allow_empty=False,
+            allow_artifact_ref=False,
+        ),
+        "approved_agents": _require_string_list(
+            raw_value["approved_agents"],
+            label=f"{label}.approved_agents",
+            allow_empty=True,
+        ),
+        "dispatch_agents": _require_string_list(
+            raw_value["dispatch_agents"],
+            label=f"{label}.dispatch_agents",
+            allow_empty=False,
+        ),
+        "variant_count": variant_count,
+    }
+
+
+def _normalize_candidate_ref(raw_value: Any, *, label: str) -> dict[str, str]:
+    if not isinstance(raw_value, Mapping):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_value, CANDIDATE_REF_KEYS, label=label)
+    return {
+        "candidate_id": _require_id(raw_value, "candidate_id", label=label),
+        "candidate_fingerprint": _require_sha256(
+            raw_value["candidate_fingerprint"],
+            label=f"{label}.candidate_fingerprint",
+        ),
+        "candidate_packet_ref": _normalize_repo_path(
+            raw_value["candidate_packet_ref"],
+            label=f"{label}.candidate_packet_ref",
+            allow_artifact_ref=True,
+        ),
+    }
+
+
+def _normalize_spec_prepare(raw_value: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(raw_value, Mapping):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_value, SPEC_PREPARE_KEYS, label=label)
+    expected_files = _require_string_list(
+        raw_value["expected_files"],
+        label=f"{label}.expected_files",
+        allow_empty=False,
+    )
+    if expected_files != list(PREPARE_FILENAMES):
+        raise CreativeHypothesisSpecBridgeError(f"{label}.expected_files must match PR-1 prepare.")
+    return {
+        "run_dir_ref": _normalize_repo_path(
+            raw_value["run_dir_ref"],
+            label=f"{label}.run_dir_ref",
+            allow_artifact_ref=True,
+        ),
+        "expected_files": expected_files,
+        "prepared": _require_bool(raw_value, "prepared", expected=None, label=label),
+        "finalized": _require_bool(raw_value, "finalized", expected=False, label=label),
+        "next_allowed_action": _require_const(
+            raw_value,
+            "next_allowed_action",
+            "agent_skeptic_review",
+            label=label,
+        ),
+    }
+
+
+def _normalize_metrics_counts(raw_value: Any, *, label: str) -> dict[str, int]:
+    if not isinstance(raw_value, Mapping):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_value, METRICS_COUNTS_KEYS, label=label)
+    return {
+        "hypothesis_count": _require_int(
+            raw_value, "hypothesis_count", min_value=0, max_value=5, label=label
+        ),
+        "approved_target_count": _require_int(
+            raw_value, "approved_target_count", min_value=0, max_value=100, label=label
+        ),
+        "candidate_target_count": _require_int(
+            raw_value, "candidate_target_count", min_value=0, max_value=100, label=label
+        ),
+        "immutable_oracle_count": _require_int(
+            raw_value, "immutable_oracle_count", min_value=0, max_value=100, label=label
+        ),
+        "variant_count": _require_int(
+            raw_value, "variant_count", min_value=3, max_value=5, label=label
+        ),
+        "prepare_files_written": _require_int(
+            raw_value, "prepare_files_written", min_value=0, max_value=4, label=label
+        ),
+        "pending_skeptic_review_count": _require_int(
+            raw_value, "pending_skeptic_review_count", min_value=0, max_value=15, label=label
+        ),
+    }
+
+
+def _normalize_cost_metadata(raw_value: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(raw_value, Mapping):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_value, COST_METADATA_KEYS, label=label)
+    return {
+        "provider_cost_available": _require_bool(
+            raw_value,
+            "provider_cost_available",
+            expected=False,
+            label=label,
+        ),
+        "provider_call_count": _require_int(
+            raw_value,
+            "provider_call_count",
+            min_value=0,
+            max_value=0,
+            label=label,
+        ),
+        "provider_cost_basis": _require_const(
+            raw_value,
+            "provider_cost_basis",
+            "not_available_local_no_provider_calls",
+            label=label,
+        ),
+    }
+
+
+def _normalize_bridge_authority(raw_authority: Any, *, label: str) -> dict[str, bool]:
+    if not isinstance(raw_authority, Mapping):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_authority, BRIDGE_AUTHORITY_KEYS, label=label)
+    normalized: dict[str, bool] = {}
+    for key in sorted(BRIDGE_AUTHORITY_KEYS):
+        expected = key in BRIDGE_AUTHORITY_TRUE_KEYS
+        normalized[key] = _require_bool(raw_authority, key, expected=expected, label=label)
+    return normalized
+
+
+def _normalize_repo_path_list(
+    raw_paths: Any,
+    *,
+    label: str,
+    allow_empty: bool,
+    allow_artifact_ref: bool,
+) -> list[str]:
+    if not isinstance(raw_paths, list):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a list.")
+    if not raw_paths and not allow_empty:
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be non-empty.")
+    normalized = [
+        _normalize_repo_path(
+            item,
+            label=f"{label}[{index}]",
+            allow_artifact_ref=allow_artifact_ref,
+        )
+        for index, item in enumerate(raw_paths)
+    ]
+    if len(normalized) != len(set(normalized)):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must not contain duplicates.")
+    return sorted(normalized)
+
+
+def _normalize_repo_path(raw_path: Any, *, label: str, allow_artifact_ref: bool) -> str:
+    if not isinstance(raw_path, str):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be a string.")
+    value = raw_path.strip()
+    if not value:
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be non-empty.")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must not contain control characters.")
+    if "\\" in value:
+        raise CreativeHypothesisSpecBridgeError(f"{label} must use POSIX separators.")
+    if value.startswith(("/", "~")) or Path(value).is_absolute():
+        raise CreativeHypothesisSpecBridgeError(f"{label} must be repo-relative.")
+    if SCHEME_RE.match(value):
+        raise CreativeHypothesisSpecBridgeError(f"{label} must not be a URL or scheme path.")
+    path = PurePosixPath(value)
+    if "." in path.parts or ".." in path.parts:
+        raise CreativeHypothesisSpecBridgeError(f"{label} must not contain traversal segments.")
+    normalized = path.as_posix()
+    if normalized in {".git", ".venv", "worktrees"} or normalized.startswith(
+        (".git/", ".venv/", "worktrees/")
+    ):
+        raise CreativeHypothesisSpecBridgeError(f"{label} points to a forbidden surface.")
+    if normalized == "artifacts" or normalized.startswith("artifacts/"):
+        if not allow_artifact_ref:
+            raise CreativeHypothesisSpecBridgeError(f"{label} points to a local artifact path.")
+        if not normalized.startswith("artifacts/orchestration/creative_code/spec_bridge/"):
+            raise CreativeHypothesisSpecBridgeError(
+                f"{label} must reference a spec_bridge local artifact."
+            )
+    reject_bridge_payload_safety(normalized, label=label)
+    return normalized

--- a/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
@@ -63,6 +63,7 @@ BRIDGE_FAILURE_REASONS = frozenset(
         "dispatch_row_missing",
         "fingerprint_mismatch",
         "hypothesis_not_found",
+        "hypothesis_packet_not_generated",
         "invalid_candidate_packet",
         NO_ALLOWED_MUTABLE_TARGET,
         "spec_prepare_failed",
@@ -240,6 +241,11 @@ def build_creative_hypothesis_spec_bridge_bundle(
     normalized_packet = sources["hypothesis_packet"]
     normalized_dispatch = sources["coordinator_dispatch"]
     normalized_approval = sources["approval"]
+    if normalized_packet["creative_status"] != "hypotheses_generated":
+        raise CreativeHypothesisSpecBridgeError(
+            "hypothesis_packet_not_generated: bridge requires a generated hypothesis packet.",
+            blocked_reason="hypothesis_packet_not_generated",
+        )
     if (
         normalized_approval["decision"] != "approve_for_pr1_specification"
         or normalized_approval["next_step"] != "create_pr1_specification"

--- a/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
@@ -454,6 +454,7 @@ def validate_creative_hypothesis_specification_bridge(
         "authority": _normalize_bridge_authority(payload["authority"], label=f"{label}.authority"),
         "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
     }
+    _validate_bridge_artifact_refs(normalized)
     _validate_bridge_identity(normalized)
     reject_bridge_payload_safety(normalized, label=label)
     return normalized
@@ -928,6 +929,31 @@ def _bridge_identity_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
         "authority": payload["authority"],
         "sanitized": payload["sanitized"],
     }
+
+
+def _expected_bridge_artifact_refs(bridge_id: str) -> tuple[str, str]:
+    artifact_root_ref = f"artifacts/orchestration/creative_code/spec_bridge/{bridge_id}"
+    return (
+        f"{artifact_root_ref}/creative_code_candidate_packet.json",
+        f"{artifact_root_ref}/spec_prepare",
+    )
+
+
+def _validate_bridge_artifact_refs(payload: Mapping[str, Any]) -> None:
+    bridge_id = str(payload["bridge_id"])
+    expected_candidate_ref, expected_run_dir_ref = _expected_bridge_artifact_refs(bridge_id)
+    candidate_ref = cast(Mapping[str, Any], payload["candidate_packet"])["candidate_packet_ref"]
+    if candidate_ref != expected_candidate_ref:
+        raise CreativeHypothesisSpecBridgeError(
+            "CreativeHypothesisSpecificationBridge.candidate_packet.candidate_packet_ref "
+            "must match the bridge id."
+        )
+    run_dir_ref = cast(Mapping[str, Any], payload["spec_prepare"])["run_dir_ref"]
+    if run_dir_ref != expected_run_dir_ref:
+        raise CreativeHypothesisSpecBridgeError(
+            "CreativeHypothesisSpecificationBridge.spec_prepare.run_dir_ref "
+            "must match the bridge id."
+        )
 
 
 def _artifact_identity(

--- a/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
+++ b/scripts/orchestration/creative_hypothesis_spec_bridge_contract.py
@@ -254,6 +254,7 @@ def build_creative_hypothesis_spec_bridge_bundle(
         normalized_packet,
         str(normalized_approval["hypothesis_id"]),
     )
+    _require_approval_binding(normalized_approval, normalized_packet, hypothesis)
     approved_targets = _require_approved_targets_subset(normalized_approval, hypothesis)
     dispatch_row = _find_dispatch_row(
         normalized_dispatch,
@@ -324,6 +325,7 @@ def mark_bridge_prepared(bridge: Mapping[str, Any]) -> dict[str, Any]:
     spec_prepare = dict(cast(Mapping[str, Any], prepared["spec_prepare"]))
     spec_prepare["prepared"] = True
     spec_prepare["finalized"] = False
+    spec_prepare["next_allowed_action"] = "agent_skeptic_review"
     prepared["spec_prepare"] = spec_prepare
     _validate_bridge_identity(prepared)
     reject_bridge_payload_safety(prepared, label="CreativeHypothesisSpecificationBridge")
@@ -454,6 +456,7 @@ def validate_creative_hypothesis_specification_bridge(
         "authority": _normalize_bridge_authority(payload["authority"], label=f"{label}.authority"),
         "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
     }
+    _validate_selected_hypothesis_invariants(normalized)
     _validate_bridge_artifact_refs(normalized)
     _validate_bridge_identity(normalized)
     reject_bridge_payload_safety(normalized, label=label)
@@ -618,6 +621,25 @@ def _dispatch_agents(dispatch_row: Mapping[str, Any]) -> list[str]:
         *(str(agent) for agent in dispatch_row["cross_domain_agents"]),
     }
     return sorted(agents)
+
+
+def _require_approval_binding(
+    approval: Mapping[str, Any],
+    packet: Mapping[str, Any],
+    hypothesis: Mapping[str, Any],
+) -> None:
+    packet_fingerprint = fingerprint_payload(cast(dict[str, Any], dict(packet)))
+    hypothesis_fingerprint = fingerprint_payload(cast(dict[str, Any], dict(hypothesis)))
+    if (
+        approval["source_hypothesis_packet_id"] != packet["packet_id"]
+        or approval["source_hypothesis_packet_fingerprint"] != packet_fingerprint
+        or approval["hypothesis_fingerprint"] != hypothesis_fingerprint
+    ):
+        raise CreativeHypothesisSpecBridgeError(
+            "fingerprint_mismatch: approval must bind to the current hypothesis "
+            "packet and selected hypothesis fingerprint.",
+            blocked_reason="fingerprint_mismatch",
+        )
 
 
 def _candidate_targets_from_approval(
@@ -833,7 +855,9 @@ def _build_bridge_artifact(
             "expected_files": list(PREPARE_FILENAMES),
             "prepared": prepared,
             "finalized": False,
-            "next_allowed_action": "agent_skeptic_review",
+            "next_allowed_action": (
+                "agent_skeptic_review" if prepared else "prepare_specification"
+            ),
         },
         "authority": default_bridge_authority(),
         "sanitized": True,
@@ -924,7 +948,6 @@ def _bridge_identity_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
         },
         "spec_prepare": {
             "expected_files": spec_prepare["expected_files"],
-            "next_allowed_action": spec_prepare["next_allowed_action"],
         },
         "authority": payload["authority"],
         "sanitized": payload["sanitized"],
@@ -953,6 +976,26 @@ def _validate_bridge_artifact_refs(payload: Mapping[str, Any]) -> None:
         raise CreativeHypothesisSpecBridgeError(
             "CreativeHypothesisSpecificationBridge.spec_prepare.run_dir_ref "
             "must match the bridge id."
+        )
+
+
+def _validate_selected_hypothesis_invariants(payload: Mapping[str, Any]) -> None:
+    selected = cast(Mapping[str, Any], payload["selected_hypothesis"])
+    approved_targets = set(cast(Sequence[str], selected["approved_target_surfaces"]))
+    candidate_targets = set(cast(Sequence[str], selected["candidate_target_surface"]))
+    immutable_oracles = set(cast(Sequence[str], selected["immutable_oracles"]))
+    if not candidate_targets.issubset(approved_targets):
+        raise CreativeHypothesisSpecBridgeError(
+            "CreativeHypothesisSpecificationBridge.selected_hypothesis."
+            "candidate_target_surface must be a subset of approved_target_surfaces."
+        )
+    _reject_target_oracle_overlap(sorted(candidate_targets), sorted(immutable_oracles))
+    approved_agents = set(cast(Sequence[str], selected["approved_agents"]))
+    dispatch_agents = set(cast(Sequence[str], selected["dispatch_agents"]))
+    if not approved_agents.issubset(dispatch_agents):
+        raise CreativeHypothesisSpecBridgeError(
+            "CreativeHypothesisSpecificationBridge.selected_hypothesis.approved_agents "
+            "must be a subset of dispatch_agents."
         )
 
 
@@ -1256,6 +1299,13 @@ def _normalize_spec_prepare(raw_value: Any, *, label: str) -> dict[str, Any]:
     )
     if expected_files != list(PREPARE_FILENAMES):
         raise CreativeHypothesisSpecBridgeError(f"{label}.expected_files must match PR-1 prepare.")
+    prepared = _require_bool(raw_value, "prepared", expected=None, label=label)
+    next_allowed_action = _require_token(raw_value, "next_allowed_action", label=label)
+    expected_next_action = "agent_skeptic_review" if prepared else "prepare_specification"
+    if next_allowed_action != expected_next_action:
+        raise CreativeHypothesisSpecBridgeError(
+            f"{label}.next_allowed_action must be {expected_next_action}."
+        )
     return {
         "run_dir_ref": _normalize_repo_path(
             raw_value["run_dir_ref"],
@@ -1263,14 +1313,9 @@ def _normalize_spec_prepare(raw_value: Any, *, label: str) -> dict[str, Any]:
             allow_artifact_ref=True,
         ),
         "expected_files": expected_files,
-        "prepared": _require_bool(raw_value, "prepared", expected=None, label=label),
+        "prepared": prepared,
         "finalized": _require_bool(raw_value, "finalized", expected=False, label=label),
-        "next_allowed_action": _require_const(
-            raw_value,
-            "next_allowed_action",
-            "agent_skeptic_review",
-            label=label,
-        ),
+        "next_allowed_action": next_allowed_action,
     }
 
 

--- a/scripts/orchestration/experiment_runner_pr_creative_context_contract.py
+++ b/scripts/orchestration/experiment_runner_pr_creative_context_contract.py
@@ -445,7 +445,10 @@ APPROVAL_KEYS = frozenset(
         "policy_version",
         "approval_id",
         "idempotency_key",
+        "source_hypothesis_packet_id",
+        "source_hypothesis_packet_fingerprint",
         "hypothesis_id",
+        "hypothesis_fingerprint",
         "decision",
         "approved_target_surfaces",
         "approved_agents",
@@ -629,6 +632,12 @@ def _require_id(payload: Mapping[str, Any], key: str, *, label: str) -> str:
         raise ExperimentRunnerCreativeContextContractError(f"{label}.{key} must be a safe id.")
     reject_unsafe_creative_context_value(normalized, label=f"{label}.{key}")
     return normalized
+
+
+def _require_optional_id(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    return _require_id({"value": value}, "value", label=label)
 
 
 def _require_token(payload: Mapping[str, Any], key: str, *, label: str) -> str:
@@ -2694,11 +2703,27 @@ def build_creative_hypothesis_approval(
     *,
     hypothesis_id: str,
     decision: str,
+    hypothesis_packet: Mapping[str, Any] | None = None,
     approved_target_surfaces: Sequence[str] = (),
     approved_agents: Sequence[str] = (),
     approved_by: str = "human_operator",
     next_step: str = "no_action",
 ) -> dict[str, Any]:
+    source_packet_id: str | None = None
+    source_packet_fingerprint: str | None = None
+    hypothesis_fingerprint: str | None = None
+    if hypothesis_packet is not None:
+        packet = validate_creative_hypothesis_packet(hypothesis_packet)
+        source_packet_id = str(packet["packet_id"])
+        source_packet_fingerprint = cast(str, fingerprint_payload(packet))
+        for row in packet["hypotheses"]:
+            if row["hypothesis_id"] == hypothesis_id:
+                hypothesis_fingerprint = cast(str, fingerprint_payload(cast(dict[str, Any], row)))
+                break
+        if hypothesis_fingerprint is None:
+            raise ExperimentRunnerCreativeContextContractError(
+                "approval hypothesis_id must exist in the supplied hypothesis packet."
+            )
     normalized_targets = _normalize_path_list(
         list(approved_target_surfaces),
         label="approved_target_surfaces",
@@ -2708,7 +2733,10 @@ def build_creative_hypothesis_approval(
         "schema_version": SCHEMA_VERSION,
         "artifact_type": APPROVAL_TYPE,
         "policy_version": POLICY_VERSION,
+        "source_hypothesis_packet_id": source_packet_id,
+        "source_hypothesis_packet_fingerprint": source_packet_fingerprint,
         "hypothesis_id": hypothesis_id,
+        "hypothesis_fingerprint": hypothesis_fingerprint,
         "decision": decision,
         "approved_target_surfaces": normalized_targets,
         "approved_agents": _normalize_text_list(
@@ -2725,7 +2753,15 @@ def build_creative_hypothesis_approval(
     approval_id, idempotency_key = _artifact_identity(
         body,
         artifact_type=APPROVAL_TYPE,
-        upstream_ids=(hypothesis_id,),
+        upstream_ids=tuple(
+            value
+            for value in (
+                hypothesis_id,
+                source_packet_id,
+                hypothesis_fingerprint,
+            )
+            if value
+        ),
     )
     return validate_creative_hypothesis_approval(
         {
@@ -2751,7 +2787,19 @@ def validate_creative_hypothesis_approval(payload: Mapping[str, Any]) -> dict[st
         "policy_version": _require_const(payload, "policy_version", POLICY_VERSION, label=label),
         "approval_id": _require_id(payload, "approval_id", label=label),
         "idempotency_key": _require_id(payload, "idempotency_key", label=label),
+        "source_hypothesis_packet_id": _require_optional_id(
+            payload["source_hypothesis_packet_id"],
+            label="source_hypothesis_packet_id",
+        ),
+        "source_hypothesis_packet_fingerprint": _require_optional_sha256(
+            payload["source_hypothesis_packet_fingerprint"],
+            label="source_hypothesis_packet_fingerprint",
+        ),
         "hypothesis_id": _require_id(payload, "hypothesis_id", label=label),
+        "hypothesis_fingerprint": _require_optional_sha256(
+            payload["hypothesis_fingerprint"],
+            label="hypothesis_fingerprint",
+        ),
         "decision": decision,
         "approved_target_surfaces": _normalize_path_list(
             payload["approved_target_surfaces"],
@@ -2786,6 +2834,14 @@ def validate_creative_hypothesis_approval(payload: Mapping[str, Any]) -> dict[st
     if normalized["decision"] == "defer" and normalized["next_step"] != "defer":
         raise ExperimentRunnerCreativeContextContractError("deferred approvals must set defer.")
     if normalized["decision"] == "approve_for_pr1_specification":
+        if (
+            not normalized["source_hypothesis_packet_id"]
+            or not normalized["source_hypothesis_packet_fingerprint"]
+            or not normalized["hypothesis_fingerprint"]
+        ):
+            raise ExperimentRunnerCreativeContextContractError(
+                "PR-1 approval requires source hypothesis packet and hypothesis fingerprint binding."
+            )
         if not normalized["approved_target_surfaces"]:
             raise ExperimentRunnerCreativeContextContractError(
                 "PR-1 approval requires at least one approved target surface."
@@ -2810,7 +2866,15 @@ def validate_creative_hypothesis_approval(payload: Mapping[str, Any]) -> dict[st
         id_key="approval_id",
         idempotency_key="idempotency_key",
         artifact_type=APPROVAL_TYPE,
-        upstream_ids=(normalized["hypothesis_id"],),
+        upstream_ids=tuple(
+            value
+            for value in (
+                normalized["hypothesis_id"],
+                normalized["source_hypothesis_packet_id"],
+                normalized["hypothesis_fingerprint"],
+            )
+            if value
+        ),
     )
     reject_unsafe_creative_context_value(normalized, label=label)
     return normalized

--- a/tests/test_creative_hypothesis_spec_bridge.py
+++ b/tests/test_creative_hypothesis_spec_bridge.py
@@ -19,9 +19,12 @@ from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
     PREPARE_FILENAMES,
     POLICY_VERSION,
     CreativeHypothesisSpecBridgeError,
+    build_bridge_metrics,
     build_creative_hypothesis_spec_bridge_bundle,
     validate_bridge_metrics,
     validate_creative_hypothesis_specification_bridge,
+    _artifact_identity as _bridge_artifact_identity,
+    _bridge_identity_payload,
 )
 from scripts.orchestration.experiment_runner_pr_creative_context_contract import (
     COORDINATOR_DISPATCH_POLICY_VERSION,
@@ -149,6 +152,7 @@ def _chain(
     approval = build_creative_hypothesis_approval(
         hypothesis_id=hypothesis["hypothesis_id"],
         decision=decision,
+        hypothesis_packet=packet if decision == "approve_for_pr1_specification" else None,
         approved_target_surfaces=selected_targets,
         approved_agents=[dispatch["dispatch"][0]["primary_agent"]] if selected_targets else [],
         next_step=next_step,
@@ -165,6 +169,28 @@ def _bundle() -> dict[str, dict[str, Any]]:
         approval=approval,
         variant_count=3,
     )
+
+
+def _refresh_bridge_identity(bridge: dict[str, Any]) -> dict[str, Any]:
+    source = bridge["source"]
+    candidate_ref = bridge["candidate_packet"]
+    bridge_id, idempotency_key = _bridge_artifact_identity(
+        _bridge_identity_payload(bridge),
+        artifact_type=BRIDGE_ARTIFACT_TYPE,
+        upstream_ids=(
+            str(source["hypothesis_packet_id"]),
+            str(source["approval_id"]),
+            str(candidate_ref["candidate_id"]),
+        ),
+    )
+    artifact_root_ref = f"artifacts/orchestration/creative_code/spec_bridge/{bridge_id}"
+    bridge["bridge_id"] = bridge_id
+    bridge["idempotency_key"] = idempotency_key
+    bridge["candidate_packet"][
+        "candidate_packet_ref"
+    ] = f"{artifact_root_ref}/creative_code_candidate_packet.json"
+    bridge["spec_prepare"]["run_dir_ref"] = f"{artifact_root_ref}/spec_prepare"
+    return bridge
 
 
 def _write_creative_context_inputs(
@@ -234,6 +260,31 @@ def test_dispatch_fingerprint_mismatch_rejects_before_candidate_output() -> None
         build_creative_hypothesis_spec_bridge_bundle(
             context_map=context,
             hypothesis_packet=packet,
+            coordinator_dispatch=dispatch,
+            approval=approval,
+            variant_count=3,
+        )
+
+
+def test_stale_approval_rejects_changed_hypothesis_fingerprint() -> None:
+    context, packet, _dispatch, approval = _chain(hypothesis_suffix="stale-approval")
+    mutated_packet = deepcopy(packet)
+    mutated_hypothesis = dict(mutated_packet["hypotheses"][0])
+    mutated_hypothesis["expected_behavior"] = (
+        "Changed hypothesis content must require a fresh human approval binding."
+    )
+    mutated_packet["hypotheses"][0] = mutated_hypothesis
+    mutated_packet = _refresh_packet_identity(mutated_packet)
+    routing = build_creative_hypothesis_agent_routing(mutated_packet)
+    dispatch = build_creative_hypothesis_coordinator_dispatch(
+        hypothesis_packet=mutated_packet,
+        routing=routing,
+    )
+
+    with pytest.raises(CreativeHypothesisSpecBridgeError, match="approval must bind"):
+        build_creative_hypothesis_spec_bridge_bundle(
+            context_map=context,
+            hypothesis_packet=mutated_packet,
             coordinator_dispatch=dispatch,
             approval=approval,
             variant_count=3,
@@ -352,6 +403,9 @@ def test_cli_build_and_prepare_writes_four_prepare_artifacts(
         variant_count=3,
     )
     bridge_id = str(expected_bundle["bridge"]["bridge_id"])
+    assert (
+        expected_bundle["bridge"]["spec_prepare"]["next_allowed_action"] == "prepare_specification"
+    )
     output_dir = cli.SPEC_BRIDGE_ROOT / bridge_id
     shutil.rmtree(output_dir, ignore_errors=True)
     input_dir, context_path, packet_path, dispatch_path, approval_path = (
@@ -393,6 +447,8 @@ def test_cli_build_and_prepare_writes_four_prepare_artifacts(
         )
         assert not (spec_prepare_dir / "bundle.json").exists()
         metrics = json.loads((output_dir / cli.METRICS_FILENAME).read_text(encoding="utf-8"))
+        bridge = json.loads((output_dir / cli.BRIDGE_FILENAME).read_text(encoding="utf-8"))
+        assert bridge["spec_prepare"]["next_allowed_action"] == "agent_skeptic_review"
         assert metrics["status"] == "prepared"
         assert metrics["counts"]["prepare_files_written"] == 4
         assert metrics["counts"]["pending_skeptic_review_count"] == 9
@@ -470,6 +526,66 @@ def test_prepare_specification_rejects_candidate_tampering(
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_validate_and_prepare_reject_bridge_candidate_parity_mismatch(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="parity")
+    bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    bridge = deepcopy(bundle["bridge"])
+    bridge["selected_hypothesis"]["immutable_oracles"] = bridge["selected_hypothesis"][
+        "immutable_oracles"
+    ][:1]
+    bridge = _refresh_bridge_identity(bridge)
+    metrics = build_bridge_metrics(
+        bridge=bridge,
+        candidate=bundle["candidate"],
+        hypothesis_packet=packet,
+        approval=approval,
+        status=BRIDGE_SUCCESS_STATUS,
+        prepare_files_written=0,
+        pending_skeptic_review_count=0,
+    )
+    output_dir = cli.SPEC_BRIDGE_ROOT / str(bridge["bridge_id"])
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        (output_dir / cli.BRIDGE_FILENAME).write_text(
+            json.dumps(bridge, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        (output_dir / cli.CANDIDATE_FILENAME).write_text(
+            json.dumps(bundle["candidate"], indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        (output_dir / cli.METRICS_FILENAME).write_text(
+            json.dumps(metrics, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        exit_code = cli.main(["validate", "--bridge", str(output_dir / cli.BRIDGE_FILENAME)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "candidate immutable_oracles" in captured.err
+
+        exit_code = cli.main(
+            ["prepare-specification", "--bridge", str(output_dir / cli.BRIDGE_FILENAME)]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "candidate immutable_oracles" in captured.err
+        blocked_metrics = json.loads((output_dir / cli.METRICS_FILENAME).read_text("utf-8"))
+        assert blocked_metrics["status"] == "blocked"
+        assert blocked_metrics["blocked_reason"] == "fingerprint_mismatch"
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
 
 
 def test_prepare_recomputes_stale_metrics_counts(
@@ -860,6 +976,56 @@ def test_cli_rejects_outside_repo_and_symlink_inputs(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_cli_rejects_noncanonical_output_dir(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="output-dir")
+    expected_bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    bridge_id = str(expected_bundle["bridge"]["bridge_id"])
+    custom_dir = cli.SPEC_BRIDGE_ROOT / "custom-review" / bridge_id
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-output-dir",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    shutil.rmtree(custom_dir.parent, ignore_errors=True)
+    try:
+        exit_code = cli.main(
+            [
+                "build-candidate",
+                "--context-map",
+                str(context_path),
+                "--hypothesis-packet",
+                str(packet_path),
+                "--coordinator-dispatch",
+                str(dispatch_path),
+                "--approval",
+                str(approval_path),
+                "--variant-count",
+                "3",
+                "--output-dir",
+                str(custom_dir),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "canonical spec_bridge/<bridge-id>" in captured.err
+        assert not custom_dir.exists()
+    finally:
+        shutil.rmtree(custom_dir.parent, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 def test_validate_rejects_symlinked_bridge_path(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -970,6 +1136,24 @@ def test_new_schemas_are_closed() -> None:
         assert schema["additionalProperties"] is False
         assert schema["properties"]["authority"]["$ref"] == "#/$defs/bridge_authority"
         assert schema["$defs"]["bridge_authority"]["additionalProperties"] is False
+        if filename == "creative_hypothesis_specification_bridge.v1.schema.json":
+            repo_path_pattern = schema["$defs"]["repo_path"]["not"]["pattern"]
+            assert "(?:^|/)\\.\\.?(?:/|$)" in repo_path_pattern
+            assert "artifacts" in repo_path_pattern
+            spec_prepare = schema["$defs"]["spec_prepare"]
+            assert spec_prepare["properties"]["next_allowed_action"]["enum"] == [
+                "prepare_specification",
+                "agent_skeptic_review",
+            ]
+            prepared_guards = spec_prepare["allOf"]
+            assert (
+                prepared_guards[0]["then"]["properties"]["next_allowed_action"]["const"]
+                == "prepare_specification"
+            )
+            assert (
+                prepared_guards[1]["then"]["properties"]["next_allowed_action"]["const"]
+                == "agent_skeptic_review"
+            )
 
 
 def test_bridge_modules_do_not_import_downstream_mutation_surfaces() -> None:

--- a/tests/test_creative_hypothesis_spec_bridge.py
+++ b/tests/test_creative_hypothesis_spec_bridge.py
@@ -447,6 +447,120 @@ def test_prepare_specification_rejects_candidate_tampering(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_validate_rejects_candidate_and_metrics_mismatch(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain()
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-validate",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    first = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    second = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=4,
+    )
+    first_dir = cli.SPEC_BRIDGE_ROOT / str(first["bridge"]["bridge_id"])
+    second_dir = cli.SPEC_BRIDGE_ROOT / str(second["bridge"]["bridge_id"])
+    shutil.rmtree(first_dir, ignore_errors=True)
+    shutil.rmtree(second_dir, ignore_errors=True)
+    try:
+        assert (
+            cli.main(
+                [
+                    "build-candidate",
+                    "--context-map",
+                    str(context_path),
+                    "--hypothesis-packet",
+                    str(packet_path),
+                    "--coordinator-dispatch",
+                    str(dispatch_path),
+                    "--approval",
+                    str(approval_path),
+                    "--variant-count",
+                    "3",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        assert (
+            cli.main(
+                [
+                    "build-candidate",
+                    "--context-map",
+                    str(context_path),
+                    "--hypothesis-packet",
+                    str(packet_path),
+                    "--coordinator-dispatch",
+                    str(dispatch_path),
+                    "--approval",
+                    str(approval_path),
+                    "--variant-count",
+                    "4",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+        assert cli.main(["validate", "--bridge", str(first_dir / cli.BRIDGE_FILENAME)]) == 0
+        capsys.readouterr()
+
+        first_candidate = json.loads(
+            (first_dir / cli.CANDIDATE_FILENAME).read_text(encoding="utf-8")
+        )
+        first_candidate["candidate_id"] = "tampered-candidate-id"
+        tampered_candidate = first_dir / "tampered_candidate.json"
+        tampered_candidate.write_text(
+            json.dumps(first_candidate, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        exit_code = cli.main(
+            [
+                "validate",
+                "--bridge",
+                str(first_dir / cli.BRIDGE_FILENAME),
+                "--candidate",
+                str(tampered_candidate),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "fingerprint_mismatch" in captured.err
+
+        exit_code = cli.main(
+            [
+                "validate",
+                "--bridge",
+                str(first_dir / cli.BRIDGE_FILENAME),
+                "--metrics",
+                str(second_dir / cli.METRICS_FILENAME),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "fingerprint_mismatch" in captured.err
+    finally:
+        shutil.rmtree(first_dir, ignore_errors=True)
+        shutil.rmtree(second_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 def test_cli_failure_prints_single_fail_line(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -551,6 +665,37 @@ def test_cli_rejects_outside_repo_and_symlink_inputs(
         assert "must not traverse symlinks" in captured.err
     finally:
         shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_validate_rejects_symlinked_bridge_path(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain()
+    bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    output_dir = cli.SPEC_BRIDGE_ROOT / str(bundle["bridge"]["bridge_id"])
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    bridge_path = output_dir / cli.BRIDGE_FILENAME
+    bridge_path.write_text(
+        json.dumps(bundle["bridge"], indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    symlink_path = output_dir / "bridge_link.json"
+    symlink_path.symlink_to(bridge_path)
+    try:
+        exit_code = cli.main(["validate", "--bridge", str(symlink_path)])
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert "must not traverse symlinks" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
 
 
 def test_new_schemas_are_closed() -> None:

--- a/tests/test_creative_hypothesis_spec_bridge.py
+++ b/tests/test_creative_hypothesis_spec_bridge.py
@@ -447,6 +447,87 @@ def test_prepare_specification_rejects_candidate_tampering(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_prepare_recomputes_stale_metrics_counts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain()
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-stale-metrics",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    first = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    second = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=4,
+    )
+    first_dir = cli.SPEC_BRIDGE_ROOT / str(first["bridge"]["bridge_id"])
+    second_dir = cli.SPEC_BRIDGE_ROOT / str(second["bridge"]["bridge_id"])
+    shutil.rmtree(first_dir, ignore_errors=True)
+    shutil.rmtree(second_dir, ignore_errors=True)
+    try:
+        for variant_count in ("3", "4"):
+            assert (
+                cli.main(
+                    [
+                        "build-candidate",
+                        "--context-map",
+                        str(context_path),
+                        "--hypothesis-packet",
+                        str(packet_path),
+                        "--coordinator-dispatch",
+                        str(dispatch_path),
+                        "--approval",
+                        str(approval_path),
+                        "--variant-count",
+                        variant_count,
+                    ]
+                )
+                == 0
+            )
+            capsys.readouterr()
+
+        shutil.copyfile(second_dir / cli.METRICS_FILENAME, first_dir / cli.METRICS_FILENAME)
+        assert (
+            cli.main(["prepare-specification", "--bridge", str(first_dir / cli.BRIDGE_FILENAME)])
+            == 0
+        )
+        capsys.readouterr()
+
+        metrics = json.loads((first_dir / cli.METRICS_FILENAME).read_text(encoding="utf-8"))
+        candidate = json.loads((first_dir / cli.CANDIDATE_FILENAME).read_text(encoding="utf-8"))
+        bridge = json.loads((first_dir / cli.BRIDGE_FILENAME).read_text(encoding="utf-8"))
+        selected = bridge["selected_hypothesis"]
+        assert metrics["status"] == "prepared"
+        assert metrics["bridge_id"] == bridge["bridge_id"]
+        assert metrics["candidate_id"] == candidate["candidate_id"]
+        assert metrics["selected_hypothesis_id"] == selected["hypothesis_id"]
+        assert metrics["counts"]["approved_target_count"] == len(
+            selected["approved_target_surfaces"]
+        )
+        assert metrics["counts"]["candidate_target_count"] == len(candidate["target_surface"])
+        assert metrics["counts"]["immutable_oracle_count"] == len(candidate["immutable_oracles"])
+        assert metrics["counts"]["variant_count"] == candidate["variant_count"] == 3
+        assert cli.main(["validate", "--bridge", str(first_dir / cli.BRIDGE_FILENAME)]) == 0
+    finally:
+        shutil.rmtree(first_dir, ignore_errors=True)
+        shutil.rmtree(second_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 def test_validate_rejects_candidate_and_metrics_mismatch(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -696,6 +777,74 @@ def test_validate_rejects_symlinked_bridge_path(
         assert "must not traverse symlinks" in captured.err
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def test_validate_and_prepare_reject_default_metrics_symlink(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    context, packet, dispatch, approval = _chain()
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-metrics-link",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    output_dir = cli.SPEC_BRIDGE_ROOT / str(bundle["bridge"]["bridge_id"])
+    shutil.rmtree(output_dir, ignore_errors=True)
+    outside_metrics = tmp_path / cli.METRICS_FILENAME
+    outside_metrics.write_text(
+        json.dumps(bundle["metrics"], indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    try:
+        assert (
+            cli.main(
+                [
+                    "build-candidate",
+                    "--context-map",
+                    str(context_path),
+                    "--hypothesis-packet",
+                    str(packet_path),
+                    "--coordinator-dispatch",
+                    str(dispatch_path),
+                    "--approval",
+                    str(approval_path),
+                    "--variant-count",
+                    "3",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        metrics_path = output_dir / cli.METRICS_FILENAME
+        metrics_path.unlink()
+        metrics_path.symlink_to(outside_metrics)
+
+        for command in ("validate", "prepare-specification"):
+            exit_code = cli.main(
+                [
+                    command,
+                    "--bridge",
+                    str(output_dir / cli.BRIDGE_FILENAME),
+                ]
+            )
+            captured = capsys.readouterr()
+            assert exit_code == 1
+            assert "must not traverse symlinks" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
 
 
 def test_new_schemas_are_closed() -> None:

--- a/tests/test_creative_hypothesis_spec_bridge.py
+++ b/tests/test_creative_hypothesis_spec_bridge.py
@@ -21,6 +21,7 @@ from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
     CreativeHypothesisSpecBridgeError,
     build_bridge_metrics,
     build_creative_hypothesis_spec_bridge_bundle,
+    mark_bridge_prepared,
     validate_bridge_metrics,
     validate_creative_hypothesis_specification_bridge,
     _artifact_identity as _bridge_artifact_identity,
@@ -588,13 +589,13 @@ def test_validate_and_prepare_reject_bridge_candidate_parity_mismatch(
         shutil.rmtree(output_dir, ignore_errors=True)
 
 
-def test_prepare_recomputes_stale_metrics_counts(
+def test_prepare_rejects_swapped_metrics_before_prepare(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    context, packet, dispatch, approval = _chain(hypothesis_suffix="stale-metrics")
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="swapped-metrics")
     input_dir, context_path, packet_path, dispatch_path, approval_path = (
         _write_creative_context_inputs(
-            leaf="pytest-spec-bridge-stale-metrics",
+            leaf="pytest-spec-bridge-swapped-metrics",
             context=context,
             packet=packet,
             dispatch=dispatch,
@@ -642,30 +643,82 @@ def test_prepare_recomputes_stale_metrics_counts(
             capsys.readouterr()
 
         shutil.copyfile(second_dir / cli.METRICS_FILENAME, first_dir / cli.METRICS_FILENAME)
-        assert (
-            cli.main(["prepare-specification", "--bridge", str(first_dir / cli.BRIDGE_FILENAME)])
-            == 0
+        exit_code = cli.main(
+            ["prepare-specification", "--bridge", str(first_dir / cli.BRIDGE_FILENAME)]
         )
-        capsys.readouterr()
-
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "fingerprint_mismatch" in captured.err
+        assert not (first_dir / "spec_prepare" / "source_packet.json").exists()
         metrics = json.loads((first_dir / cli.METRICS_FILENAME).read_text(encoding="utf-8"))
-        candidate = json.loads((first_dir / cli.CANDIDATE_FILENAME).read_text(encoding="utf-8"))
-        bridge = json.loads((first_dir / cli.BRIDGE_FILENAME).read_text(encoding="utf-8"))
-        selected = bridge["selected_hypothesis"]
-        assert metrics["status"] == "prepared"
-        assert metrics["bridge_id"] == bridge["bridge_id"]
-        assert metrics["candidate_id"] == candidate["candidate_id"]
-        assert metrics["selected_hypothesis_id"] == selected["hypothesis_id"]
-        assert metrics["counts"]["approved_target_count"] == len(
-            selected["approved_target_surfaces"]
-        )
-        assert metrics["counts"]["candidate_target_count"] == len(candidate["target_surface"])
-        assert metrics["counts"]["immutable_oracle_count"] == len(candidate["immutable_oracles"])
-        assert metrics["counts"]["variant_count"] == candidate["variant_count"] == 3
-        assert cli.main(["validate", "--bridge", str(first_dir / cli.BRIDGE_FILENAME)]) == 0
+        assert metrics["status"] == "blocked"
+        assert metrics["blocked_reason"] == "fingerprint_mismatch"
+        assert metrics["bridge_id"] == first["bridge"]["bridge_id"]
+        assert metrics["candidate_id"] == first["candidate"]["candidate_id"]
     finally:
         shutil.rmtree(first_dir, ignore_errors=True)
         shutil.rmtree(second_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_prepare_rejects_stale_spec_prepare_artifacts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="stale-prepare-file")
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-stale-prepare-file",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    output_dir = cli.SPEC_BRIDGE_ROOT / str(bundle["bridge"]["bridge_id"])
+    shutil.rmtree(output_dir, ignore_errors=True)
+    try:
+        assert (
+            cli.main(
+                [
+                    "build-candidate",
+                    "--context-map",
+                    str(context_path),
+                    "--hypothesis-packet",
+                    str(packet_path),
+                    "--coordinator-dispatch",
+                    str(dispatch_path),
+                    "--approval",
+                    str(approval_path),
+                    "--variant-count",
+                    "3",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        spec_prepare_dir = output_dir / "spec_prepare"
+        spec_prepare_dir.mkdir(parents=True, exist_ok=True)
+        (spec_prepare_dir / "bundle.json").write_text("{}\n", encoding="utf-8")
+
+        exit_code = cli.main(
+            ["prepare-specification", "--bridge", str(output_dir / cli.BRIDGE_FILENAME)]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "unexpected spec_prepare artifact" in captured.err
+        metrics = json.loads((output_dir / cli.METRICS_FILENAME).read_text(encoding="utf-8"))
+        assert metrics["status"] == "blocked"
+        assert metrics["blocked_reason"] == "spec_prepare_failed"
+        assert not (spec_prepare_dir / "source_packet.json").exists()
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
@@ -781,6 +834,43 @@ def test_validate_rejects_candidate_and_metrics_mismatch(
         shutil.rmtree(first_dir, ignore_errors=True)
         shutil.rmtree(second_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_validate_rejects_prepared_bridge_with_unprepared_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="prepared-metrics")
+    bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    bridge = mark_bridge_prepared(bundle["bridge"])
+    output_dir = cli.SPEC_BRIDGE_ROOT / str(bridge["bridge_id"])
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        (output_dir / cli.BRIDGE_FILENAME).write_text(
+            json.dumps(bridge, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        (output_dir / cli.CANDIDATE_FILENAME).write_text(
+            json.dumps(bundle["candidate"], indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        (output_dir / cli.METRICS_FILENAME).write_text(
+            json.dumps(bundle["metrics"], indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        exit_code = cli.main(["validate", "--bridge", str(output_dir / cli.BRIDGE_FILENAME)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "prepared bridge requires prepared metrics" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_creative_hypothesis_spec_bridge.py
+++ b/tests/test_creative_hypothesis_spec_bridge.py
@@ -21,6 +21,7 @@ from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
     CreativeHypothesisSpecBridgeError,
     build_creative_hypothesis_spec_bridge_bundle,
     validate_bridge_metrics,
+    validate_creative_hypothesis_specification_bridge,
 )
 from scripts.orchestration.experiment_runner_pr_creative_context_contract import (
     COORDINATOR_DISPATCH_POLICY_VERSION,
@@ -114,10 +115,13 @@ def _chain(
     approved_targets: list[str] | None = None,
     decision: str = "approve_for_pr1_specification",
     next_step: str = "create_pr1_specification",
+    hypothesis_suffix: str = "",
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
     context = _context()
     packet = build_creative_hypothesis_packet(context, hypothesis_count=3)
     hypothesis = dict(packet["hypotheses"][0])
+    if hypothesis_suffix:
+        hypothesis["hypothesis_id"] = f"{hypothesis['hypothesis_id']}-{hypothesis_suffix}"
     hypothesis["target_surfaces"] = sorted(
         [
             "docs/prompts/cv/program.md",
@@ -314,11 +318,32 @@ def test_metrics_sidecar_is_redacted_and_rejects_unsafe_claims() -> None:
     with pytest.raises(ValueError):
         validate_bridge_metrics(metrics)
 
+    metrics = deepcopy(_bundle()["metrics"])
+    metrics["counts"]["candidate_target_count"] = 101
+    with pytest.raises(ValueError):
+        validate_bridge_metrics(metrics)
+
+
+def test_bridge_validator_rejects_loose_spec_bridge_artifact_refs() -> None:
+    bridge = deepcopy(_bundle()["bridge"])
+    bridge["candidate_packet"][
+        "candidate_packet_ref"
+    ] = "artifacts/orchestration/creative_code/spec_bridge/-unsafe/candidate.json"
+    with pytest.raises(CreativeHypothesisSpecBridgeError, match="spec_bridge local artifact"):
+        validate_creative_hypothesis_specification_bridge(bridge)
+
+    bridge = deepcopy(_bundle()["bridge"])
+    bridge["spec_prepare"][
+        "run_dir_ref"
+    ] = "artifacts/orchestration/creative_code/spec_bridge/-unsafe/spec_prepare"
+    with pytest.raises(CreativeHypothesisSpecBridgeError, match="spec_bridge local artifact"):
+        validate_creative_hypothesis_specification_bridge(bridge)
+
 
 def test_cli_build_and_prepare_writes_four_prepare_artifacts(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    context, packet, dispatch, approval = _chain()
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="happy")
     expected_bundle = build_creative_hypothesis_spec_bridge_bundle(
         context_map=context,
         hypothesis_packet=packet,
@@ -379,7 +404,7 @@ def test_cli_build_and_prepare_writes_four_prepare_artifacts(
 def test_prepare_specification_rejects_candidate_tampering(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    context, packet, dispatch, approval = _chain()
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="tamper")
     expected_bundle = build_creative_hypothesis_spec_bridge_bundle(
         context_map=context,
         hypothesis_packet=packet,
@@ -450,7 +475,7 @@ def test_prepare_specification_rejects_candidate_tampering(
 def test_prepare_recomputes_stale_metrics_counts(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    context, packet, dispatch, approval = _chain()
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="stale-metrics")
     input_dir, context_path, packet_path, dispatch_path, approval_path = (
         _write_creative_context_inputs(
             leaf="pytest-spec-bridge-stale-metrics",
@@ -531,7 +556,7 @@ def test_prepare_recomputes_stale_metrics_counts(
 def test_validate_rejects_candidate_and_metrics_mismatch(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    context, packet, dispatch, approval = _chain()
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="validate-mismatch")
     input_dir, context_path, packet_path, dispatch_path, approval_path = (
         _write_creative_context_inputs(
             leaf="pytest-spec-bridge-validate",
@@ -659,7 +684,7 @@ def test_validate_and_prepare_reject_cross_bridge_refs(
     bridge_key: str,
     expected_error: str,
 ) -> None:
-    context, packet, dispatch, approval = _chain()
+    context, packet, dispatch, approval = _chain(hypothesis_suffix=f"cross-ref-{bridge_key}")
     input_dir, context_path, packet_path, dispatch_path, approval_path = (
         _write_creative_context_inputs(
             leaf=f"pytest-spec-bridge-cross-ref-{bridge_key}",
@@ -778,7 +803,7 @@ def test_cli_rejects_outside_repo_and_symlink_inputs(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    context, packet, dispatch, approval = _chain()
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="input-guard")
     input_dir, _context_path, packet_path, dispatch_path, approval_path = (
         _write_creative_context_inputs(
             leaf="pytest-spec-bridge-input-guard",
@@ -838,7 +863,7 @@ def test_cli_rejects_outside_repo_and_symlink_inputs(
 def test_validate_rejects_symlinked_bridge_path(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    context, packet, dispatch, approval = _chain()
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="bridge-link")
     bundle = build_creative_hypothesis_spec_bridge_bundle(
         context_map=context,
         hypothesis_packet=packet,
@@ -870,7 +895,7 @@ def test_validate_and_prepare_reject_default_metrics_symlink(
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
-    context, packet, dispatch, approval = _chain()
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="metrics-link")
     input_dir, context_path, packet_path, dispatch_path, approval_path = (
         _write_creative_context_inputs(
             leaf="pytest-spec-bridge-metrics-link",

--- a/tests/test_creative_hypothesis_spec_bridge.py
+++ b/tests/test_creative_hypothesis_spec_bridge.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+import json
+from pathlib import Path
+import shutil
+from typing import Any
+
+import pytest
+
+from scripts.orchestration import creative_hypothesis_spec_bridge as cli
+from scripts.orchestration.creative_code_contract import validate_creative_code_candidate_packet
+from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
+    BRIDGE_ARTIFACT_TYPE,
+    BRIDGE_SUCCESS_STATUS,
+    METRICS_ARTIFACT_TYPE,
+    NO_ALLOWED_MUTABLE_TARGET,
+    PREPARE_FILENAMES,
+    POLICY_VERSION,
+    CreativeHypothesisSpecBridgeError,
+    build_creative_hypothesis_spec_bridge_bundle,
+    validate_bridge_metrics,
+)
+from scripts.orchestration.experiment_runner_pr_creative_context_contract import (
+    COORDINATOR_DISPATCH_POLICY_VERSION,
+    COORDINATOR_DISPATCH_TYPE,
+    HYPOTHESIS_PACKET_TYPE,
+    _artifact_identity,
+    build_creative_hypothesis_agent_routing,
+    build_creative_hypothesis_approval,
+    build_creative_hypothesis_coordinator_dispatch,
+    build_creative_hypothesis_packet,
+    build_creative_protocol_context_map,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
+SHA256_D = "sha256:" + ("d" * 64)
+
+
+def _context() -> dict[str, Any]:
+    return build_creative_protocol_context_map(
+        changed_paths=[
+            "scripts/orchestration/creative_hypothesis_spec_bridge.py",
+            "docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json",
+        ],
+        repository="Katsiarynakavaleuskaya/PulsePlate",
+        pr_number=2068,
+        base_ref="main",
+        base_sha=BASE_SHA,
+        head_sha=HEAD_SHA,
+        task_packet_id="task:spec-bridge",
+        generated_at_utc="2026-07-03T00:00:00Z",
+        nearby_repo_refs=["scripts/orchestration/creative_code_spec_pipeline.py"],
+        test_refs=["tests/test_creative_hypothesis_spec_bridge.py"],
+        contract_refs=[
+            "docs/orchestration/contracts/EXPERIMENT_RUNNER_PR_CREATIVE_CONTEXT_CONTRACT.md"
+        ],
+        backlog_refs=["docs/roadmap/BACKLOG_LEDGER.md"],
+        review_source_refs=["artifacts/orchestration/experiments/results/oracle-result.json"],
+        capability_state_ref=(
+            "artifacts/orchestration/experiments/creative_context/capability_state.json"
+        ),
+        philosophical_context_refs=["docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md"],
+        cross_domain_candidate_refs=[
+            "docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md"
+        ],
+        label_enabled=False,
+        marker_enabled=False,
+        manual_enabled=False,
+        sealed_codex_security_scan_ref=(
+            "artifacts/orchestration/experiments/creative_context/codex-security.json"
+        ),
+        sealed_codex_security_scan_fingerprint=SHA256_D,
+        security_relevant_diff_changed=False,
+    )
+
+
+def _refresh_packet_identity(packet: dict[str, Any]) -> dict[str, Any]:
+    body = {
+        key: value for key, value in packet.items() if key not in {"packet_id", "idempotency_key"}
+    }
+    packet_id, idempotency_key = _artifact_identity(
+        body,
+        artifact_type=HYPOTHESIS_PACKET_TYPE,
+        upstream_ids=(str(packet["context_map_id"]),),
+    )
+    packet["packet_id"] = packet_id
+    packet["idempotency_key"] = idempotency_key
+    return packet
+
+
+def _refresh_dispatch_identity(dispatch: dict[str, Any]) -> dict[str, Any]:
+    body = {
+        key: value
+        for key, value in dispatch.items()
+        if key not in {"dispatch_id", "idempotency_key"}
+    }
+    dispatch_id, idempotency_key = _artifact_identity(
+        body,
+        artifact_type=COORDINATOR_DISPATCH_TYPE,
+        upstream_ids=(str(dispatch["source_hypothesis_packet_id"]),),
+        policy_version=COORDINATOR_DISPATCH_POLICY_VERSION,
+    )
+    dispatch["dispatch_id"] = dispatch_id
+    dispatch["idempotency_key"] = idempotency_key
+    return dispatch
+
+
+def _chain(
+    *,
+    approved_targets: list[str] | None = None,
+    decision: str = "approve_for_pr1_specification",
+    next_step: str = "create_pr1_specification",
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    context = _context()
+    packet = build_creative_hypothesis_packet(context, hypothesis_count=3)
+    hypothesis = dict(packet["hypotheses"][0])
+    hypothesis["target_surfaces"] = sorted(
+        [
+            "docs/prompts/cv/program.md",
+            "scripts/orchestration/creative_hypothesis_spec_bridge.py",
+            "tests/test_creative_hypothesis_spec_bridge.py",
+            "docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json",
+        ]
+    )
+    hypothesis["tests_or_oracles"] = sorted(
+        [
+            "tests/test_creative_hypothesis_spec_bridge.py",
+            "docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json",
+        ]
+    )
+    packet["hypotheses"][0] = hypothesis
+    packet = _refresh_packet_identity(packet)
+    routing = build_creative_hypothesis_agent_routing(packet)
+    dispatch = build_creative_hypothesis_coordinator_dispatch(
+        hypothesis_packet=packet,
+        routing=routing,
+    )
+    selected_targets = (
+        approved_targets if approved_targets is not None else list(hypothesis["target_surfaces"])
+    )
+    approval = build_creative_hypothesis_approval(
+        hypothesis_id=hypothesis["hypothesis_id"],
+        decision=decision,
+        approved_target_surfaces=selected_targets,
+        approved_agents=[dispatch["dispatch"][0]["primary_agent"]] if selected_targets else [],
+        next_step=next_step,
+    )
+    return context, packet, dispatch, approval
+
+
+def _bundle() -> dict[str, dict[str, Any]]:
+    context, packet, dispatch, approval = _chain()
+    return build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+
+
+def _write_creative_context_inputs(
+    *,
+    leaf: str,
+    context: dict[str, Any],
+    packet: dict[str, Any],
+    dispatch: dict[str, Any],
+    approval: dict[str, Any],
+) -> tuple[Path, Path, Path, Path, Path]:
+    input_dir = cli.CREATIVE_CONTEXT_ROOT / leaf
+    shutil.rmtree(input_dir, ignore_errors=True)
+    input_dir.mkdir(parents=True, exist_ok=True)
+    paths = (
+        input_dir / "context_map.json",
+        input_dir / "hypothesis_packet.json",
+        input_dir / "coordinator_dispatch.json",
+        input_dir / "approval.json",
+    )
+    for path, payload in zip(paths, (context, packet, dispatch, approval), strict=True):
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return input_dir, *paths
+
+
+def test_valid_approval_builds_valid_candidate_and_metrics() -> None:
+    bundle = _bundle()
+    candidate = validate_creative_code_candidate_packet(bundle["candidate"])
+    bridge = bundle["bridge"]
+    metrics = validate_bridge_metrics(bundle["metrics"])
+
+    assert bridge["artifact_type"] == BRIDGE_ARTIFACT_TYPE
+    assert bridge["policy_version"] == POLICY_VERSION
+    assert candidate["target_surface"] == ["docs/prompts/cv/program.md"]
+    assert "tests/test_creative_hypothesis_spec_bridge.py" in candidate["immutable_oracles"]
+    assert (
+        "docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json"
+        in candidate["immutable_oracles"]
+    )
+    assert metrics["artifact_type"] == METRICS_ARTIFACT_TYPE
+    assert metrics["status"] == BRIDGE_SUCCESS_STATUS
+    assert metrics["blocked_reason"] is None
+    assert metrics["counts"]["candidate_target_count"] == 1
+    assert metrics["counts"]["immutable_oracle_count"] >= 2
+    assert metrics["cost_metadata"] == {
+        "provider_cost_available": False,
+        "provider_call_count": 0,
+        "provider_cost_basis": "not_available_local_no_provider_calls",
+    }
+    assert all(
+        value is False for key, value in metrics["authority"].items() if key.startswith("open_")
+    )
+
+
+def test_same_inputs_are_deterministic() -> None:
+    first = _bundle()
+    second = _bundle()
+
+    assert first == second
+
+
+def test_dispatch_fingerprint_mismatch_rejects_before_candidate_output() -> None:
+    context, packet, dispatch, approval = _chain()
+    dispatch["source_hypothesis_packet_fingerprint"] = SHA256_D
+    dispatch = _refresh_dispatch_identity(dispatch)
+
+    with pytest.raises(CreativeHypothesisSpecBridgeError, match="fingerprint_mismatch"):
+        build_creative_hypothesis_spec_bridge_bundle(
+            context_map=context,
+            hypothesis_packet=packet,
+            coordinator_dispatch=dispatch,
+            approval=approval,
+            variant_count=3,
+        )
+
+
+@pytest.mark.parametrize(
+    ("decision", "next_step"),
+    [
+        ("reject", "no_action"),
+        ("defer", "defer"),
+    ],
+)
+def test_reject_or_defer_approval_cannot_build_candidate(
+    decision: str,
+    next_step: str,
+) -> None:
+    context, packet, dispatch, approval = _chain(
+        approved_targets=[],
+        decision=decision,
+        next_step=next_step,
+    )
+
+    with pytest.raises(CreativeHypothesisSpecBridgeError, match="approval_not_pr1"):
+        build_creative_hypothesis_spec_bridge_bundle(
+            context_map=context,
+            hypothesis_packet=packet,
+            coordinator_dispatch=dispatch,
+            approval=approval,
+            variant_count=3,
+        )
+
+
+def test_approved_scripts_tests_and_docs_targets_become_immutable_oracles() -> None:
+    bundle = _bundle()
+    candidate = bundle["candidate"]
+
+    assert candidate["target_surface"] == ["docs/prompts/cv/program.md"]
+    assert (
+        "scripts/orchestration/creative_hypothesis_spec_bridge.py" in candidate["immutable_oracles"]
+    )
+    assert "tests/test_creative_hypothesis_spec_bridge.py" in candidate["immutable_oracles"]
+
+
+def test_no_allowed_mutable_target_fails_closed() -> None:
+    context, packet, dispatch, approval = _chain(
+        approved_targets=[
+            "scripts/orchestration/creative_hypothesis_spec_bridge.py",
+            "tests/test_creative_hypothesis_spec_bridge.py",
+            "docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json",
+        ],
+    )
+
+    with pytest.raises(CreativeHypothesisSpecBridgeError, match=NO_ALLOWED_MUTABLE_TARGET):
+        build_creative_hypothesis_spec_bridge_bundle(
+            context_map=context,
+            hypothesis_packet=packet,
+            coordinator_dispatch=dispatch,
+            approval=approval,
+            variant_count=3,
+        )
+
+
+def test_metrics_sidecar_is_redacted_and_rejects_unsafe_claims() -> None:
+    metrics = deepcopy(_bundle()["metrics"])
+    serialized = json.dumps(metrics, sort_keys=True)
+
+    for forbidden in (
+        "raw_prompt",
+        "provider_payload",
+        "candidate.patch",
+        "diff --git",
+        "/Users/",
+        "sk-proj-",
+        "semantic-cache",
+        "graph truth",
+        "mergeable",
+    ):
+        assert forbidden not in serialized
+
+    metrics["source"]["approval_id"] = "raw_prompt"
+    with pytest.raises(ValueError):
+        validate_bridge_metrics(metrics)
+
+
+def test_cli_build_and_prepare_writes_four_prepare_artifacts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain()
+    expected_bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    bridge_id = str(expected_bundle["bridge"]["bridge_id"])
+    output_dir = cli.SPEC_BRIDGE_ROOT / bridge_id
+    shutil.rmtree(output_dir, ignore_errors=True)
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-happy",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    try:
+        exit_code = cli.main(
+            [
+                "build-and-prepare",
+                "--context-map",
+                str(context_path),
+                "--hypothesis-packet",
+                str(packet_path),
+                "--coordinator-dispatch",
+                str(dispatch_path),
+                "--approval",
+                str(approval_path),
+                "--variant-count",
+                "3",
+            ]
+        )
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert captured.out.strip() == cli.SUCCESS_BUILD_PREPARE_OUTPUT
+        assert captured.err == ""
+        assert (output_dir / cli.BRIDGE_FILENAME).is_file()
+        assert (output_dir / cli.CANDIDATE_FILENAME).is_file()
+        assert (output_dir / cli.METRICS_FILENAME).is_file()
+        spec_prepare_dir = output_dir / "spec_prepare"
+        assert sorted(path.name for path in spec_prepare_dir.iterdir()) == sorted(
+            list(PREPARE_FILENAMES)
+        )
+        assert not (spec_prepare_dir / "bundle.json").exists()
+        metrics = json.loads((output_dir / cli.METRICS_FILENAME).read_text(encoding="utf-8"))
+        assert metrics["status"] == "prepared"
+        assert metrics["counts"]["prepare_files_written"] == 4
+        assert metrics["counts"]["pending_skeptic_review_count"] == 9
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_prepare_specification_rejects_candidate_tampering(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain()
+    expected_bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    bridge_id = str(expected_bundle["bridge"]["bridge_id"])
+    output_dir = cli.SPEC_BRIDGE_ROOT / bridge_id
+    shutil.rmtree(output_dir, ignore_errors=True)
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-tamper",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    try:
+        assert (
+            cli.main(
+                [
+                    "build-candidate",
+                    "--context-map",
+                    str(context_path),
+                    "--hypothesis-packet",
+                    str(packet_path),
+                    "--coordinator-dispatch",
+                    str(dispatch_path),
+                    "--approval",
+                    str(approval_path),
+                    "--variant-count",
+                    "3",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        candidate_path = output_dir / cli.CANDIDATE_FILENAME
+        candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+        candidate["candidate_id"] = "tampered-candidate-id"
+        candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n")
+
+        exit_code = cli.main(
+            [
+                "prepare-specification",
+                "--bridge",
+                str(output_dir / cli.BRIDGE_FILENAME),
+            ]
+        )
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert captured.out == ""
+        assert "fingerprint_mismatch" in captured.err
+        bridge = json.loads((output_dir / cli.BRIDGE_FILENAME).read_text(encoding="utf-8"))
+        metrics = json.loads((output_dir / cli.METRICS_FILENAME).read_text(encoding="utf-8"))
+        assert bridge["spec_prepare"]["prepared"] is False
+        assert metrics["status"] == "blocked"
+        assert metrics["blocked_reason"] == "fingerprint_mismatch"
+        assert not (output_dir / "spec_prepare" / "source_packet.json").exists()
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_cli_failure_prints_single_fail_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain(
+        approved_targets=[
+            "scripts/orchestration/creative_hypothesis_spec_bridge.py",
+            "tests/test_creative_hypothesis_spec_bridge.py",
+        ],
+    )
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-failure",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+
+    try:
+        exit_code = cli.main(
+            [
+                "build-candidate",
+                "--context-map",
+                str(context_path),
+                "--hypothesis-packet",
+                str(packet_path),
+                "--coordinator-dispatch",
+                str(dispatch_path),
+                "--approval",
+                str(approval_path),
+                "--variant-count",
+                "3",
+            ]
+        )
+        captured = capsys.readouterr()
+    finally:
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert captured.err.startswith(f"FAIL: {NO_ALLOWED_MUTABLE_TARGET}")
+    assert captured.err.count("\n") == 1
+
+
+def test_cli_rejects_outside_repo_and_symlink_inputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain()
+    input_dir, _context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-input-guard",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    outside_context = tmp_path / "context_map.json"
+    outside_context.write_text(json.dumps(context), encoding="utf-8")
+    try:
+        exit_code = cli.main(
+            [
+                "build-candidate",
+                "--context-map",
+                str(outside_context),
+                "--hypothesis-packet",
+                str(packet_path),
+                "--coordinator-dispatch",
+                str(dispatch_path),
+                "--approval",
+                str(approval_path),
+                "--variant-count",
+                "3",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "must stay inside the repository" in captured.err
+
+        capsys.readouterr()
+        symlink_context = input_dir / "context_map_link.json"
+        symlink_context.symlink_to(input_dir / "context_map.json")
+        exit_code = cli.main(
+            [
+                "build-candidate",
+                "--context-map",
+                str(symlink_context),
+                "--hypothesis-packet",
+                str(packet_path),
+                "--coordinator-dispatch",
+                str(dispatch_path),
+                "--approval",
+                str(approval_path),
+                "--variant-count",
+                "3",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "must not traverse symlinks" in captured.err
+    finally:
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_new_schemas_are_closed() -> None:
+    for filename in (
+        "creative_hypothesis_specification_bridge.v1.schema.json",
+        "creative_hypothesis_spec_bridge_metrics.v1.schema.json",
+    ):
+        schema = json.loads(
+            (REPO_ROOT / "docs/orchestration/contracts" / filename).read_text(encoding="utf-8")
+        )
+        assert schema["additionalProperties"] is False
+        assert schema["properties"]["authority"]["$ref"] == "#/$defs/bridge_authority"
+        assert schema["$defs"]["bridge_authority"]["additionalProperties"] is False
+
+
+def test_bridge_modules_do_not_import_downstream_mutation_surfaces() -> None:
+    banned_prefixes = (
+        "app",
+        "httpx",
+        "requests",
+        "slack",
+        "github",
+        "scripts.orchestration.creative_code_patch",
+        "scripts.orchestration.creative_code_pr_promotion",
+    )
+    banned_exact = {
+        "scripts.orchestration.experiment_runner",
+        "scripts.orchestration.experiment_pipeline",
+    }
+    for module_path in (
+        REPO_ROOT / "scripts/orchestration/creative_hypothesis_spec_bridge.py",
+        REPO_ROOT / "scripts/orchestration/creative_hypothesis_spec_bridge_contract.py",
+    ):
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        imports: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.append(node.module)
+        assert not [
+            imported
+            for imported in imports
+            if imported in banned_exact or imported.startswith(banned_prefixes)
+        ]

--- a/tests/test_creative_hypothesis_spec_bridge.py
+++ b/tests/test_creative_hypothesis_spec_bridge.py
@@ -642,6 +642,93 @@ def test_validate_rejects_candidate_and_metrics_mismatch(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+@pytest.mark.parametrize(
+    ("bridge_section", "bridge_key", "expected_error"),
+    (
+        (
+            "candidate_packet",
+            "candidate_packet_ref",
+            "candidate_packet_ref must match the bridge id",
+        ),
+        ("spec_prepare", "run_dir_ref", "run_dir_ref must match the bridge id"),
+    ),
+)
+def test_validate_and_prepare_reject_cross_bridge_refs(
+    capsys: pytest.CaptureFixture[str],
+    bridge_section: str,
+    bridge_key: str,
+    expected_error: str,
+) -> None:
+    context, packet, dispatch, approval = _chain()
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf=f"pytest-spec-bridge-cross-ref-{bridge_key}",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    first = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    second = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=4,
+    )
+    first_dir = cli.SPEC_BRIDGE_ROOT / str(first["bridge"]["bridge_id"])
+    second_dir = cli.SPEC_BRIDGE_ROOT / str(second["bridge"]["bridge_id"])
+    shutil.rmtree(first_dir, ignore_errors=True)
+    shutil.rmtree(second_dir, ignore_errors=True)
+    try:
+        for variant_count in ("3", "4"):
+            assert (
+                cli.main(
+                    [
+                        "build-candidate",
+                        "--context-map",
+                        str(context_path),
+                        "--hypothesis-packet",
+                        str(packet_path),
+                        "--coordinator-dispatch",
+                        str(dispatch_path),
+                        "--approval",
+                        str(approval_path),
+                        "--variant-count",
+                        variant_count,
+                    ]
+                )
+                == 0
+            )
+            capsys.readouterr()
+
+        bridge_path = first_dir / cli.BRIDGE_FILENAME
+        bridge = json.loads(bridge_path.read_text(encoding="utf-8"))
+        bridge[bridge_section][bridge_key] = second["bridge"][bridge_section][bridge_key]
+        bridge_path.write_text(
+            json.dumps(bridge, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        for command in ("validate", "prepare-specification"):
+            exit_code = cli.main([command, "--bridge", str(bridge_path)])
+            captured = capsys.readouterr()
+            assert exit_code == 1
+            assert expected_error in captured.err
+        assert not (second_dir / "spec_prepare" / "source_packet.json").exists()
+    finally:
+        shutil.rmtree(first_dir, ignore_errors=True)
+        shutil.rmtree(second_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 def test_cli_failure_prints_single_fail_line(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_creative_hypothesis_spec_bridge.py
+++ b/tests/test_creative_hypothesis_spec_bridge.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+from core.evidence.fingerprints import fingerprint_payload
 from scripts.orchestration import creative_hypothesis_spec_bridge as cli
 from scripts.orchestration.creative_code_contract import validate_creative_code_candidate_packet
 from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
@@ -286,6 +287,38 @@ def test_stale_approval_rejects_changed_hypothesis_fingerprint() -> None:
         build_creative_hypothesis_spec_bridge_bundle(
             context_map=context,
             hypothesis_packet=mutated_packet,
+            coordinator_dispatch=dispatch,
+            approval=approval,
+            variant_count=3,
+        )
+
+
+def test_blocked_hypothesis_packet_cannot_build_candidate() -> None:
+    context, packet, _dispatch, _approval = _chain(hypothesis_suffix="blocked-packet")
+    blocked_packet = deepcopy(packet)
+    blocked_packet["creative_status"] = "blocked"
+    blocked_packet = _refresh_packet_identity(blocked_packet)
+    routing = build_creative_hypothesis_agent_routing(blocked_packet)
+    dispatch = build_creative_hypothesis_coordinator_dispatch(
+        hypothesis_packet=blocked_packet,
+        routing=routing,
+    )
+    approval = build_creative_hypothesis_approval(
+        hypothesis_id=blocked_packet["hypotheses"][0]["hypothesis_id"],
+        decision="approve_for_pr1_specification",
+        hypothesis_packet=blocked_packet,
+        approved_target_surfaces=blocked_packet["hypotheses"][0]["target_surfaces"],
+        approved_agents=[dispatch["dispatch"][0]["primary_agent"]],
+        next_step="create_pr1_specification",
+    )
+
+    with pytest.raises(
+        CreativeHypothesisSpecBridgeError,
+        match="bridge requires a generated hypothesis packet",
+    ):
+        build_creative_hypothesis_spec_bridge_bundle(
+            context_map=context,
+            hypothesis_packet=blocked_packet,
             coordinator_dispatch=dispatch,
             approval=approval,
             variant_count=3,
@@ -717,6 +750,69 @@ def test_prepare_rejects_stale_spec_prepare_artifacts(
         assert metrics["status"] == "blocked"
         assert metrics["blocked_reason"] == "spec_prepare_failed"
         assert not (spec_prepare_dir / "source_packet.json").exists()
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_prepare_rejects_already_prepared_bridge_without_rewriting_reviews(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context, packet, dispatch, approval = _chain(hypothesis_suffix="already-prepared")
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf="pytest-spec-bridge-already-prepared",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    output_dir = cli.SPEC_BRIDGE_ROOT / str(bundle["bridge"]["bridge_id"])
+    shutil.rmtree(output_dir, ignore_errors=True)
+    try:
+        assert (
+            cli.main(
+                [
+                    "build-and-prepare",
+                    "--context-map",
+                    str(context_path),
+                    "--hypothesis-packet",
+                    str(packet_path),
+                    "--coordinator-dispatch",
+                    str(dispatch_path),
+                    "--approval",
+                    str(approval_path),
+                    "--variant-count",
+                    "3",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        reviews_path = output_dir / "spec_prepare" / "skeptic_reviews.json"
+        reviews = json.loads(reviews_path.read_text(encoding="utf-8"))
+        reviews[0]["decision"] = "pass"
+        reviews[0]["blockers"] = []
+        reviews_path.write_text(json.dumps(reviews, indent=2, sort_keys=True) + "\n")
+        expected_fingerprint = fingerprint_payload(reviews)
+
+        exit_code = cli.main(
+            ["prepare-specification", "--bridge", str(output_dir / cli.BRIDGE_FILENAME)]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "spec_prepare_already_prepared" in captured.err
+        assert (
+            fingerprint_payload(json.loads(reviews_path.read_text("utf-8"))) == expected_fingerprint
+        )
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)

--- a/tests/test_experiment_runner_pr_creative_context.py
+++ b/tests/test_experiment_runner_pr_creative_context.py
@@ -238,6 +238,7 @@ def test_valid_artifact_chain_enforces_creative_authority_boundary() -> None:
     approval = build_creative_hypothesis_approval(
         hypothesis_id=packet["hypotheses"][0]["hypothesis_id"],
         decision="approve_for_pr1_specification",
+        hypothesis_packet=packet,
         approved_target_surfaces=packet["hypotheses"][0]["target_surfaces"],
         approved_agents=[routing["routing"][0]["primary_agent"]],
         next_step="create_pr1_specification",
@@ -1098,6 +1099,21 @@ def test_approval_rejects_rejected_or_deferred_pr1_handoff() -> None:
         )
 
 
+def test_approval_requires_packet_binding_for_pr1_handoff() -> None:
+    packet = _packet()
+    with pytest.raises(
+        ExperimentRunnerCreativeContextContractError,
+        match="PR-1 approval requires source hypothesis packet and hypothesis fingerprint binding",
+    ):
+        build_creative_hypothesis_approval(
+            hypothesis_id=packet["hypotheses"][0]["hypothesis_id"],
+            decision="approve_for_pr1_specification",
+            approved_target_surfaces=packet["hypotheses"][0]["target_surfaces"],
+            approved_agents=["orchestration-architect"],
+            next_step="create_pr1_specification",
+        )
+
+
 def test_approval_rejects_product_runtime_pr1_targets() -> None:
     with pytest.raises(
         ExperimentRunnerCreativeContextContractError,
@@ -1106,6 +1122,7 @@ def test_approval_rejects_product_runtime_pr1_targets() -> None:
         build_creative_hypothesis_approval(
             hypothesis_id="hyp-001",
             decision="approve_for_pr1_specification",
+            hypothesis_packet=_packet(),
             approved_target_surfaces=["app/main.py"],
             next_step="create_pr1_specification",
         )
@@ -1545,6 +1562,9 @@ def test_approval_schema_encodes_decision_state_machine() -> None:
 
     approve_then = approve_guard["then"]["properties"]
     assert approve_then["next_step"]["const"] == "create_pr1_specification"
+    assert approve_then["source_hypothesis_packet_id"]["$ref"] == "#/$defs/safe_id"
+    assert approve_then["source_hypothesis_packet_fingerprint"]["$ref"] == "#/$defs/sha256"
+    assert approve_then["hypothesis_fingerprint"]["$ref"] == "#/$defs/sha256"
     assert approve_then["approved_target_surfaces"]["minItems"] == 1
     assert (
         approve_then["approved_target_surfaces"]["items"]["$ref"]


### PR DESCRIPTION
## Goal
Bridge human-approved Experiment Runner creative hypotheses into validated PR-1 creative-code specification candidates.

## Business reason
This closes the next local handoff in the creative line: coordinator-approved hypotheses can become deterministic specification inputs without granting patch, provider, GitHub/Slack, product runtime, semantic-cache, graph, or merge authority.

## Scope
- Add `creative_hypothesis_spec_bridge_contract.py` as the pure contract/builder layer.
- Add `creative_hypothesis_spec_bridge.py` CLI with:
  - `build-candidate`
  - `prepare-specification`
  - `build-and-prepare`
  - `validate`
- Add closed schemas:
  - `creative_hypothesis_specification_bridge.v1.schema.json`
  - `creative_hypothesis_spec_bridge_metrics.v1.schema.json`
- Emit local artifacts only under `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/`.
- Reuse existing `CreativeHypothesisApproval`, `CreativeCodeCandidatePacket`, and `creative_code_spec_pipeline.prepare`.
- Update creative-code / creative-context contracts, `scripts/AGENTS.md`, and backlog follow-ups.

## Out of scope
- Provider/model calls.
- Workflow dispatch or workflow mutation.
- GitHub/Slack writes.
- Patch generation.
- PR creation/promotion tooling.
- Product runtime, OpenAPI/client runtime, semantic cache, graph truth.
- Agent auto-execution, PR-1 `finalize`, review-thread resolution, fixed mapping, merge/readiness automation.

## Key decisions
- `CreativeCodeCandidatePacket.target_surface` remains limited by the existing `validate_mutable_candidate_surface(...)` allowlist.
- Approved scripts/tests/orchestration docs are converted to `immutable_oracles`, not mutable targets.
- If no allowed mutable target remains, the bridge fails closed with `no_allowed_mutable_target`.
- `variant_count` is required and restricted to `3|4|5`.
- `prepare-specification` verifies the candidate file still matches the bridge-recorded candidate id/fingerprint before calling PR-1 `prepare`.
- Build inputs must be repo-local, non-symlink JSON under the creative-context artifact root with expected filenames.

## Tests / validation
Local gates run on branch head `2f70ec85d`:

- `python3 scripts/orchestration/check_preflight.py` PASS
  - Warning only: local `PULSEPLATE_PYTHON_INDEX_URL` shape warning.
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `pytest -q tests/test_creative_hypothesis_spec_bridge.py tests/test_experiment_runner_pr_creative_context.py` PASS
- `pytest -q tests/test_creative_code_contract.py tests/test_creative_code_specification.py tests/test_agent_learning_loop.py` PASS
- `make validate-changed` PASS
- `pre-commit run --all-files` PASS
- Pre-push hooks PASS during `git push`, including changed-file mypy, pip-audit, backend pre-push tests, full-repo Bandit, and docker build test.

Pre-open role / oracle evidence:

- `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent` completed in order via dispatch packet `artifacts/orchestration/task_packets/1ecc9fd44a92.json`.
- Premortem found two issues and both were fixed before PR open:
  - candidate id/fingerprint mismatch before prepare now fails closed and leaves bridge unprepared;
  - build input paths are restricted to repo-local non-symlink creative-context artifacts.
- Experiment Runner oracle-only reviewer accepted final evidence:
  - packet: `artifacts/orchestration/experiments/approved-hypothesis-spec-bridge-oracle-packet-network1.json`
  - result: `artifacts/orchestration/experiments/results/approved-hypothesis-spec-bridge-oracle-result-final2.json`
  - status: `accepted`, oracle returncode `0`, `shared_tree_untouched=true`, `mutated_paths=[]`
  - note: `network_budget=1` was used because the default network-disabled sandbox hit the local host `unshare` PATH blocker before oracle execution.


Post-open role review evidence:

- `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> architecture-specialist` completed in order via dispatch packet `artifacts/orchestration/task_packets/6a1a89324bab.json`.
- QA, bug-hunter, security, cursor, architecture, and review-bot findings were fixed in follow-up commits through `2f70ec85d` and recorded in `docs/review/PR_2070_FIXED_MAPPING.md`.

## Security notes
- No provider, product runtime, Slack/GitHub write, workflow, patch, PR, semantic-cache, graph, or agent execution imports are added.
- Bridge outputs reject unsafe raw prompt/provider/patch/oracle/local-path/secret-like content through existing creative-context safety guards plus bridge checks.
- Metrics sidecar is deterministic and local-only; provider cost metadata is explicitly unavailable. Validate/prepare now rejects swapped metrics, stale prepare artifacts, blocked hypothesis packets, already-prepared reruns, and prepared-state/count mismatches before emitting PR-1 handoff evidence.

## Risks / rollback
- Rollback is removal of the two new bridge modules, schemas, tests, and docs/backlog references.
- The bridge writes only gitignored local artifacts under `artifacts/orchestration/creative_code/spec_bridge/`.
- CI and post-open review remain required before merge readiness can be claimed.

## Deferred / follow-ups
- Attach agent skeptic-review evidence and run explicit PR-1 `finalize` in a later reviewed PR.
- Ingest bridge metrics into the existing telemetry / learning-loop rollup in a later reviewed PR.
- Explore graph/multimodal lineage only after repo-reviewed evidence contracts define asset lineage, fingerprints, idempotency, replay/admission behavior, and rollback boundaries.

## AGENTS.md or agent-instruction updates
- Updated `scripts/AGENTS.md` with the local-only bridge boundary and forbidden authority list.

## Next best step
Wait for current-head CI/bot review on `2f70ec85d`, resolve mapped review threads only with disposition proof, and run strict merge-readiness gates. Merge readiness is not claimed yet.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2070_FIXED_MAPPING.md`

Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local bridge that turns human‑approved Experiment Runner creative hypotheses into validated PR‑1 creative‑code specification candidates. Tightens approval binding, enforces approval↔candidate parity, validates bridge metrics before prepare, hardens artifact identity, and blocks invalid prepare reruns.

- New Features
  - Bridge contract and CLI `creative_hypothesis_spec_bridge.py` with build-candidate, prepare-specification, build-and-prepare, validate.
  - Closed schemas for bridge bundle and metrics; emits local-only artifacts under `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/`.
  - Reuses existing approvals, candidate packet, and PR‑1 prepare; no provider/model calls, PR/branch writes, GitHub/Slack writes, or agent execution.

- Bug Fixes
  - PR‑1 approval now requires binding to `source_hypothesis_packet_id`/`source_hypothesis_packet_fingerprint` and `hypothesis_fingerprint`; parity with the candidate is checked before prepare.
  - Hardened validation: bridge metrics validated before prepare, strict metrics schema, safe bridge‑id shape, artifact‑identity checks with fail‑closed behavior, path/input sanitization, enforced target-surface and `variant_count` gates, and prepare rerun guards that block invalid reruns.

<sup>Written for commit 2f70ec85d292688703a292b7fdba146c686f82fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “approved-hypothesis specification bridge” stage generating a validated creative-code candidate packet, deterministic bridge metrics, and PR-1 spec-preparation artifacts.
  * Added a CLI workflow (build candidate, prepare spec, build-and-prepare, validate) plus new v1 JSON schemas for bridge and metrics.
* **Bug Fixes**
  * Enforced fail-closed authority boundaries, improved mismatch handling (fingerprints/IDs), and tightened approval-to-packet binding.
* **Documentation**
  * Updated orchestration/agents/roadmap/ledger contracts with lane behavior, artifacts, and constraints.
* **Tests**
  * Added end-to-end tests for determinism, schema strictness, validation failures, metrics redaction, and CLI path hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


