### PR TITLE
Move food/catalog registration to canonical bootstrap

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -59,10 +59,16 @@ from app.routers.business import BUSINESS_ROUTE_SPECS, router as business_router
 from app.routers.bmi_compat import BMI_COMPAT_ROUTE_SPECS, router as bmi_compat_router
 from app.routers.bmi_registration import BmiRouteRegistration, register_bmi_routes
 from app.routers.billing import register_billing_routes
+from app.routers.catalog import (
+    CATALOG_ROUTE_SPECS,
+    get_catalog_service,
+    router as catalog_router,
+)
 from app.routers.cbt_insight import router as cbt_insight_router
 from app.routers.feedback import router as feedback_router
 from app.routers.fitchef_structured import router as fitchef_structured_router
 from app.routers.favicon import FAVICON_ROUTE_PATH, router as favicon_router
+from app.routers.foods import FOODS_ROUTE_SPECS, get_food_store, router as foods_router
 from app.routers.health import router as health_router
 from app.routers.legal import router as legal_router
 from app.routers import legacy_export_aliases as legacy_export_aliases_module
@@ -158,6 +164,14 @@ _BUSINESS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in BUSINESS_ROUTE_SPECS
 )
+_CATALOG_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in CATALOG_ROUTE_SPECS
+)
+_FOODS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in FOODS_ROUTE_SPECS
+)
 _TEST_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in TEST_ROUTE_SPECS
@@ -197,6 +211,8 @@ _RESTAURANT_MODERATION_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
 _EXPORT_ROUTE_REQUIRED_STATUS_CODES = frozenset({429})
 _RESTAURANT_MODERATION_REQUIRED_STATUS_CODES = frozenset({404, 422})
 _PLAN_SIGNED_EXPORT_PATHS = frozenset({WEEK_EXPORT_CSV_PATH, WEEK_EXPORT_PDF_PATH})
+_NO_REQUIRED_STATUS_CODES: frozenset[int] = frozenset()
+_FOODS_BARCODE_REQUIRED_STATUS_CODES = frozenset({404, 422})
 
 
 def _build_legacy_export_aliases_router() -> APIRouter:
@@ -382,6 +398,34 @@ def _business_route_members() -> tuple[RouteMemberContract, ...]:
         )
         for path, method, include_in_schema in _BUSINESS_ROUTE_SPECS
     )
+
+
+def _food_catalog_route_members() -> tuple[RouteMemberContract, ...]:
+    members: list[RouteMemberContract] = []
+    for path, method, include_in_schema in _FOODS_ROUTE_SPECS:
+        members.append(
+            RouteMemberContract(
+                path=path,
+                method=method,
+                include_in_schema=include_in_schema,
+                required_status_codes=(
+                    _FOODS_BARCODE_REQUIRED_STATUS_CODES
+                    if path.endswith("/{barcode}")
+                    else _NO_REQUIRED_STATUS_CODES
+                ),
+                required_dependencies=(get_food_store,),
+            )
+        )
+    for path, method, include_in_schema in _CATALOG_ROUTE_SPECS:
+        members.append(
+            RouteMemberContract(
+                path=path,
+                method=method,
+                include_in_schema=include_in_schema,
+                required_dependencies=(get_catalog_service,),
+            )
+        )
+    return tuple(members)
 
 
 def _test_route_members() -> tuple[RouteMemberContract, ...]:
@@ -939,6 +983,17 @@ def _include_business_router_if_enabled(target_app: FastAPI) -> None:
     )
 
 
+def _include_food_catalog_routers_if_needed(target_app: FastAPI) -> None:
+    """Register foods/catalog routes as one canonical static family."""
+
+    ensure_route_family_registered(
+        target_app,
+        family_name="Food catalog",
+        routers=(foods_router, catalog_router),
+        members=_food_catalog_route_members(),
+    )
+
+
 def _include_test_router_if_enabled(target_app: FastAPI) -> None:
     """Register non-production test routes as one hidden canonical family."""
 
@@ -1131,6 +1186,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _include_bmi_compat_router_if_needed(app)
     _include_bodyfat_router_if_needed(app)
     _include_business_router_if_enabled(app)
+    _include_food_catalog_routers_if_needed(app)
     _include_test_router_if_enabled(app)
     _include_plan_export_routers_if_needed(app)
     _include_shoplist_export_router_if_needed(app)

--- a/app/routers/catalog.py
+++ b/app/routers/catalog.py
@@ -7,6 +7,12 @@ from fastapi import APIRouter, Depends, Query
 from app.schemas.catalog import CatalogRegion, CatalogSKU, CatalogStore
 from core.catalog.service import CatalogService, default_catalog_service
 
+CATALOG_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/catalog/regions", "GET", True),
+    ("/api/v1/catalog/stores", "GET", True),
+    ("/api/v1/catalog/search", "GET", True),
+)
+
 router = APIRouter(prefix="/api/v1/catalog", tags=["catalog"])
 
 

--- a/app/routers/foods.py
+++ b/app/routers/foods.py
@@ -10,7 +10,14 @@ from app.http_error_details import MALFORMED_BARCODE_DETAIL
 from app.schemas.food import FoodHit, FoodItem
 from app.services import food_store
 
-router = APIRouter(tags=["foods"])
+FOODS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/foods", "GET", False),
+    ("/api/v1/foods/search", "GET", False),
+    ("/api/v1/foods/{food_id}", "GET", False),
+    ("/api/v1/foods/barcode/{barcode}", "GET", False),
+)
+
+router = APIRouter(tags=["foods"], include_in_schema=False)
 
 
 class FoodStore(Protocol):
@@ -65,7 +72,7 @@ def get_food_store() -> FoodStore:
     return _FOOD_STORE_COMPAT
 
 
-@router.get("/api/v1/foods", response_model=list[FoodHit])
+@router.get("/api/v1/foods", response_model=list[FoodHit], include_in_schema=False)
 def list_foods(
     query: str = Query("", max_length=64),
     limit: int = 20,
@@ -90,7 +97,7 @@ def list_foods(
 
 
 # Backward-compatible alias for tests expecting /api/v1/foods/search
-@router.get("/api/v1/foods/search", response_model=list[FoodHit])
+@router.get("/api/v1/foods/search", response_model=list[FoodHit], include_in_schema=False)
 def list_foods_search(
     query: str = Query("", max_length=64),
     limit: int = 20,
@@ -103,7 +110,7 @@ def list_foods_search(
     return delegate(query=query, limit=limit, offset=offset, store=store)
 
 
-@router.get("/api/v1/foods/{food_id}", response_model=FoodItem)
+@router.get("/api/v1/foods/{food_id}", response_model=FoodItem, include_in_schema=False)
 def get_food(food_id: str, store: FoodStore = Depends(get_food_store)) -> FoodItem:
     row = store.get_food(food_id)
     if not row:
@@ -118,6 +125,7 @@ def get_food(food_id: str, store: FoodStore = Depends(get_food_store)) -> FoodIt
         status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Malformed barcode"},
         status.HTTP_404_NOT_FOUND: {"description": "Food not found"},
     },
+    include_in_schema=False,
 )
 def get_food_by_barcode(barcode: str, store: FoodStore = Depends(get_food_store)) -> FoodItem:
     try:

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -30,10 +30,38 @@ Anchor (stable): `legacy_app.py -> include_router(...) for core API routers`
 
 Evidence: `legacy_app.py:922-932`
 
-- `foods_router` (`app/routers/foods.py`)
 - `recipes_router` (`app/routers/recipes.py`)
 - `users_router` (`app/routers/users.py`)
-- `catalog_router` (`app/routers/catalog.py`)
+
+### Canonical food/catalog routers (canonical bootstrap-owned)
+
+Anchor (stable): `app/main.py -> _include_food_catalog_routers_if_needed(app)`
+
+Evidence:
+- `app/bootstrap/route_family.py` — shared `RouteMemberContract` /
+  `ensure_route_family_registered(...)` guard for exact static route families.
+- `app/main.py` — registers `foods_router` and `catalog_router` as one canonical
+  static route family and validates dependency, visibility, duplicate, partial,
+  foreign-handler, and response-metadata drift.
+- `app/routers/foods.py` — owns food endpoint handlers, `get_food_store`, hidden
+  `FOODS_ROUTE_SPECS`, and barcode `404`/`422` response metadata.
+- `app/routers/catalog.py` — owns catalog endpoint handlers, `get_catalog_service`,
+  and visible source-route `CATALOG_ROUTE_SPECS`.
+
+Runtime effect:
+- `GET /api/v1/foods`
+- `GET /api/v1/foods/search`
+- `GET /api/v1/foods/{food_id}`
+- `GET /api/v1/foods/barcode/{barcode}`
+- `GET /api/v1/catalog/regions`
+- `GET /api/v1/catalog/stores`
+- `GET /api/v1/catalog/search`
+
+OpenAPI effect:
+- Food source routes stay hidden from OpenAPI at route metadata level.
+- Catalog source routes remain schema-visible in route metadata, but final public
+  `app.openapi()` continues to filter `/api/v1/catalog/*` through the canonical
+  OpenAPI builder.
 
 ### Canonical plan export routers (canonical bootstrap-owned)
 

--- a/docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md
+++ b/docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md
@@ -32,12 +32,18 @@ command.
 - Shared tree untouched: `true`
 - Contribution kind: `oracle_review`
 - Co-author required: `true`
+- Evidence commit: `e91828e2e607727ca7e85d133ea6ef77ad91d0f1`
+- Evidence commit trailer:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
 
 The accepted fallback used the same oracle-only governance intent and an
 explicit nonzero network budget to avoid the local `unshare` blocker. It is
 review-required evidence and does not replace local gates, current-head CI,
 post-open role passes, Codex Security, `pulseplate-pr-review`, or
 merge-readiness checks.
+
+Any squash or landing commit that carries this oracle-shaped evidence must
+preserve the same co-author trailer.
 
 ## Oracle Commands
 

--- a/docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md
+++ b/docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md
@@ -1,0 +1,52 @@
+# Food/Catalog Canonical Bootstrap Experiment Runner Evidence
+
+Branch: `codex/move-food-catalog-registration-to-canonical-bootstrap`
+
+Mode: `oracle_only_governance_reviewer`
+
+## Zero-Network Attempt
+
+- Experiment ID: `exp-7b394904754b`
+- Result artifact:
+  `artifacts/orchestration/experiments/results/exp-7b394904754b-rerun.json`
+- Status: `rejected`
+- Failure class: `infra_flake`
+- Runner error: `Network-disabled sandbox requires unshare on PATH`
+- Oracle commands executed: `0`
+
+Disposition: local infrastructure blocker. This macOS host does not provide
+Linux `unshare`, so the zero-network sandbox could not execute any oracle
+command.
+
+## Review-Required Fallback
+
+- Experiment ID: `exp-e539da8b2f47`
+- Packet:
+  `artifacts/orchestration/experiments/exp-food-catalog-registration-macos-oracle.json`
+- Result artifact:
+  `artifacts/orchestration/experiments/results/exp-food-catalog-registration-oracle-review-result.json`
+- Status: `accepted`
+- Failure class: `null`
+- Runner mode: `oracle_only_governance_reviewer`
+- Network budget: `1`
+- Shared tree untouched: `true`
+- Contribution kind: `oracle_review`
+- Co-author required: `true`
+
+The accepted fallback used the same oracle-only governance intent and an
+explicit nonzero network budget to avoid the local `unshare` blocker. It is
+review-required evidence and does not replace local gates, current-head CI,
+post-open role passes, Codex Security, `pulseplate-pr-review`, or
+merge-readiness checks.
+
+## Oracle Commands
+
+All fallback oracle commands returned `0`:
+
+- `python -m pytest -q tests/test_food_catalog_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_metrics.py::test_metrics_include_food_catalog_route_templates`
+- `python scripts/ci/check_legacy_growth_guard.py`
+
+## Decision
+
+Use `exp-e539da8b2f47` as the pre-open Experiment Runner oracle-only evidence
+for this PR, with the local zero-network infrastructure limitation disclosed.

--- a/docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_PREMORTEM.md
+++ b/docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_PREMORTEM.md
@@ -72,6 +72,34 @@ Evidence:
 - `tests/test_metrics.py` proves existing Prometheus labels use route templates
   for foods/catalog routes, not raw IDs or query strings.
 
+## Post-Open Premortem Addendum
+
+The first guard hardening closed direct, alias, module-qualified, literal
+dynamic, destructured, walrus, and nested include regrowth. Post-open security
+review found one remaining production-risk story: a later change could rebuild
+`app.routers.foods` or `app.routers.catalog` through a computed string, assign
+the imported router to an old allowlisted name such as `recipes_router`, and
+pass `app.include_router(recipes_router)` without tripping the legacy-growth
+guard.
+
+Production impact: route ownership would silently split back into
+`legacy_app.py`, so future migration evidence, OpenAPI proof, and route-template
+metrics could look healthy while canonical ownership had regressed.
+
+Closure: FIXED in the guard-hardening follow-up for this PR.
+
+Evidence:
+
+- `scripts/ci/check_legacy_growth_guard.py` now resolves static dynamic-import
+  strings across constants, names, concatenation, f-strings, and
+  `".".join(...)`.
+- The same guard tracks unresolved `app.routers` string hints and fails closed
+  when an unresolved dynamic import is used as a router registration source.
+- `tests/test_legacy_growth_guard.py` rejects computed foods/catalog dynamic
+  imports hidden behind old allowlisted router aliases.
+- `python -m pytest tests/test_legacy_growth_guard.py -q` passes.
+- `python scripts/ci/check_legacy_growth_guard.py` passes.
+
 ## Revised Plan
 
 1. Keep the diff registration-only: no FoodDB, Meili/provider, recipes, users,

--- a/docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_PREMORTEM.md
+++ b/docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_PREMORTEM.md
@@ -1,0 +1,102 @@
+# Food/Catalog Canonical Bootstrap Premortem
+
+Mode: `pr-premortem`
+
+Skill: `pulseplate-premortem-risk-review`
+
+Task packet: `artifacts/orchestration/task_packets/f130c83cd0bd.json`
+
+Implementation commit reviewed: `687f77e97b`
+
+## Summary
+
+Plan: move only foods/catalog route registration ownership from `legacy_app.py`
+to canonical `app/main.py` bootstrap while preserving runtime behavior,
+OpenAPI visibility, dependencies, response metadata, and existing metrics labels.
+
+Failure frame: six months from now this PR failed because route ownership looked
+migrated, but runtime/API evidence drifted in a way local smoke tests missed.
+
+## Most Likely Failure
+
+Foods/catalog are reintroduced into `legacy_app.py` later through an alias,
+dynamic import, or wrapper router because the legacy guard still allows the old
+facts. The product continues to run, but ownership silently splits again and
+future route-family migrations inherit contradictory registration truth.
+
+Closure: FIXED in `687f77e97b`.
+
+Evidence:
+
+- `scripts/ci/check_legacy_growth_guard.py` removes foods/catalog router imports
+  and registration facts from the allowlist.
+- `tests/test_legacy_growth_guard.py` rejects direct, aliased, module-qualified,
+  dynamic, destructured, walrus, and nested include reintroduction patterns.
+
+## Most Dangerous Failure
+
+Foods become visible in public OpenAPI, or catalog public OpenAPI exposure
+changes, because the old hiding behavior was include-level in `legacy_app.py`
+while the canonical registrar validates source route metadata. That would
+change public contract visibility without an explicit API-contract PR.
+
+Closure: FIXED in `687f77e97b`.
+
+Evidence:
+
+- `app/routers/foods.py` makes foods source route metadata hidden and publishes
+  hidden `FOODS_ROUTE_SPECS`.
+- `app/routers/catalog.py` keeps visible source-route `CATALOG_ROUTE_SPECS`.
+- `tests/test_food_catalog_registration_bootstrap.py` validates source
+  visibility and registered route visibility.
+- `tests/test_openapi_namespace_guards.py` rejects `/api/v1/foods*` and
+  `/api/v1/catalog*` public OpenAPI leaks.
+
+## Hidden Assumption
+
+The migration assumes route behavior is unchanged if paths and methods still
+work. That is not enough for this repo: dependency provider identity, response
+metadata, duplicate/partial registration behavior, and metrics labels are part
+of the production contract.
+
+Closure: FIXED in `687f77e97b`.
+
+Evidence:
+
+- `app/main.py` registers foods/catalog through `ensure_route_family_registered`
+  with `get_food_store`, `get_catalog_service`, and barcode `404`/`422`
+  response metadata contracts.
+- `tests/test_food_catalog_registration_bootstrap.py` covers idempotency,
+  duplicate route rejection, partial registration rejection, foreign handlers,
+  wrong methods, dependency drift, visibility drift, and response metadata drift.
+- `tests/test_metrics.py` proves existing Prometheus labels use route templates
+  for foods/catalog routes, not raw IDs or query strings.
+
+## Revised Plan
+
+1. Keep the diff registration-only: no FoodDB, Meili/provider, recipes, users,
+   restaurants, nutrition recommendation, frontend, iOS, or macOS changes.
+2. Use the established canonical static-family pattern in `app/main.py` and
+   leave business logic in the source routers/services.
+3. Treat OpenAPI and observability as proof surfaces only: no new runtime
+   metrics, dashboards, or public contract expansion.
+4. Keep rollback bounded to the canonical bootstrap helper/imports/call, route
+   specs/visibility, legacy include removal, guard shrink, tests, and this
+   routing evidence.
+
+## Pre-Merge Checklist
+
+- Focused foods/catalog bootstrap tests pass.
+- Legacy-growth guard rejects foods/catalog regrowth.
+- Public OpenAPI still excludes `/api/v1/foods*` and `/api/v1/catalog*`.
+- Existing metrics labels remain route templates, with no raw path/query labels.
+- `make validate-changed` and `pre-commit run --all-files` pass on the committed
+  branch diff.
+- Post-open review chain runs before readiness claims.
+
+## Decision
+
+`proceed with changes`
+
+All premortem findings identified for this PR scope are closed by code,
+deterministic tests, guard narrowing, and routing evidence in `687f77e97b`.

--- a/docs/review/PR_2071_FIXED_MAPPING.md
+++ b/docs/review/PR_2071_FIXED_MAPPING.md
@@ -28,6 +28,16 @@ Commit: b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
 Evidence: scripts/ci/check_legacy_growth_guard.py:308 collects unresolved dynamic import targets, line 367 taints router registration calls from those targets, and tests/test_legacy_growth_guard.py:1155 proves an unresolved dynamic import cannot be routed through an allowlisted wrapper router.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522146316 -> b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
 
+Disposition: FIXED
+Commit: 31c8b103e44e09a27231c203e710730cdcb10c3c
+Evidence: scripts/ci/check_legacy_growth_guard.py:609 propagates unresolved dynamic router-import taint through assignment aliases, and tests/test_legacy_growth_guard.py:1170 covers the one-hop `.router` alias wrapper-router bypass.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522218893 -> 31c8b103e44e09a27231c203e710730cdcb10c3c
+
+Disposition: FIXED
+Commit: 31c8b103e44e09a27231c203e710730cdcb10c3c
+Evidence: scripts/ci/check_legacy_growth_guard.py:802 reads keyword-form dynamic import module names, and tests/test_legacy_growth_guard.py:1185 covers `import_module(name="app.routers.foods")`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522218896 -> 31c8b103e44e09a27231c203e710730cdcb10c3c
+
 ## Review Comment Dispositions
 
 ### Codex: Preserve Runner Co-Author Trailer
@@ -53,6 +63,28 @@ Evidence:
 - `scripts/ci/check_legacy_growth_guard.py` now tracks unresolved dynamic-import targets and taints router registration calls that route those targets through wrapper routers.
 - `tests/test_legacy_growth_guard.py` rejects `module = import_module(os.getenv(...)); recipes_router.include_router(module.router); app.include_router(recipes_router)`.
 - `tests/test_legacy_growth_guard.py` also proves an unresolved dynamic import remains allowed when it is not used as a router registration source.
+
+### Codex: Propagate Unresolved Router-Import Taint Through Aliases
+
+Disposition: FIXED
+Comment:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522218893
+Commit: 31c8b103e44e09a27231c203e710730cdcb10c3c
+Evidence:
+
+- `scripts/ci/check_legacy_growth_guard.py` now propagates unresolved dynamic router-import taint through assignment aliases.
+- `tests/test_legacy_growth_guard.py` rejects `module = import_module(os.getenv(...)); router = module.router; recipes_router.include_router(router); app.include_router(recipes_router)`.
+
+### Codex: Handle Keyword-Form Dynamic Imports In The Guard
+
+Disposition: FIXED
+Comment:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522218896
+Commit: 31c8b103e44e09a27231c203e710730cdcb10c3c
+Evidence:
+
+- `scripts/ci/check_legacy_growth_guard.py` now reads the `name=` keyword when resolving dynamic import module names.
+- `tests/test_legacy_growth_guard.py` rejects `importlib.import_module(name="app.routers.foods").router` hidden behind an allowlisted router name.
 
 ### Advisory Bot Comments
 

--- a/docs/review/PR_2071_FIXED_MAPPING.md
+++ b/docs/review/PR_2071_FIXED_MAPPING.md
@@ -1,0 +1,73 @@
+# PR 2071 - Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071
+
+Branch: `codex/move-food-catalog-registration-to-canonical-bootstrap`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Fixed in commit mapping artifact created after GitHub assigned PR number `#2071`.
+- [x] Post-open `qa-engineer-agent` pass completed.
+- [x] Post-open `bug-hunter` pass completed.
+- [x] Post-open `security-auditor` pass completed.
+- [x] Codex Security diff scan / finding discovery completed for current head.
+- [x] Codex review actionable comments checked and dispositioned below.
+- [x] CodeRabbit actionable review comments checked; walkthrough and finishing-touch checkboxes are advisory/non-actionable.
+- [x] Sourcery actionable review comments checked; only a rate-limit status review was present.
+- [x] Cubic actionable review comments checked; generated summary only.
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
+Evidence: docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md:35 records the evidence commit, line 37 records the required trailer, and commit b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521 itself carries the same `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>` trailer.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522146313 -> b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
+
+Disposition: FIXED
+Commit: b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
+Evidence: scripts/ci/check_legacy_growth_guard.py:308 collects unresolved dynamic import targets, line 367 taints router registration calls from those targets, and tests/test_legacy_growth_guard.py:1155 proves an unresolved dynamic import cannot be routed through an allowlisted wrapper router.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522146316 -> b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
+
+## Review Comment Dispositions
+
+### Codex: Preserve Runner Co-Author Trailer
+
+Disposition: FIXED
+Comment:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522146313
+Commit: b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
+Evidence:
+
+- `docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md` now records the evidence commit that carries the Experiment Runner trailer.
+- The same evidence document states that any squash or landing commit carrying this oracle-shaped evidence must preserve the trailer.
+- The fix commit itself includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+
+### Codex: Track Unresolved Imports Through Wrapper Routers
+
+Disposition: FIXED
+Comment:
+https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522146316
+Commit: b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
+Evidence:
+
+- `scripts/ci/check_legacy_growth_guard.py` now tracks unresolved dynamic-import targets and taints router registration calls that route those targets through wrapper routers.
+- `tests/test_legacy_growth_guard.py` rejects `module = import_module(os.getenv(...)); recipes_router.include_router(module.router); app.include_router(recipes_router)`.
+- `tests/test_legacy_growth_guard.py` also proves an unresolved dynamic import remains allowed when it is not used as a router registration source.
+
+### Advisory Bot Comments
+
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit posted a walkthrough plus optional finishing-touch UI controls, Codecov reported all modified coverable lines covered, Cursor reported Bugbot disabled, Sourcery reported rate limiting only, and Cubic generated a PR summary.
+Reason: These comments did not include actionable code, test, docs, security, or governance findings requiring branch changes beyond the fixed Codex review threads above.
+
+## Experiment Runner Evidence
+- Artifact: `artifacts/orchestration/experiments/results/exp-food-catalog-registration-oracle-review-result.json`
+- Commit carrying required trailer: `e91828e2e607727ca7e85d133ea6ef77ad91d0f1`
+- Follow-up fix commit preserving trailer: `b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521`
+
+## Lane Start Provenance
+- Packet: `artifacts/orchestration/task_packets/f130c83cd0bd.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+
+## Merge Readiness
+- Not claimed here. Requires current-head CI after the latest mapping/body commit, strict merge-readiness gate, and resolved review threads.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -49,8 +49,6 @@ from app.http_error_details import (
     INVALID_PREMIUM_PLATE_INPUT_DETAIL,
 )
 from app.routers.api_key import api_key_header
-from app.routers.catalog import router as catalog_router
-from app.routers.foods import router as foods_router
 from app.routers.nutrition_recommendations import router as nutrition_recommendations_router
 from app.routers.recipes import router as recipes_router
 from app.routers.restaurants import router as restaurants_router
@@ -909,12 +907,10 @@ async def admin_status() -> Dict[str, str]:
 
 
 # Include API routers
-app.include_router(foods_router, include_in_schema=False)
 app.include_router(nutrition_recommendations_router)
 app.include_router(restaurants_router, include_in_schema=False)
 app.include_router(recipes_router)
 app.include_router(users_router)
-app.include_router(catalog_router)
 
 # PRO/VIP route registration is owned by app.main canonical bootstrap.
 # Compatibility attrs above are populated there after successful registration.

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -98,12 +98,10 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("decorator", "post", "/api/v1/premium/targets", "api_who_targets"),
         LegacyFact("decorator", "post", "/api/v1/premium/plan/week", "api_weekly_menu"),
         LegacyFact("decorator", "post", "/api/v1/premium/gaps", "api_nutrient_gaps"),
-        LegacyFact("registration", "include_router", "foods_router", ""),
         LegacyFact("registration", "include_router", "nutrition_recommendations_router", ""),
         LegacyFact("registration", "include_router", "restaurants_router", ""),
         LegacyFact("registration", "include_router", "recipes_router", ""),
         LegacyFact("registration", "include_router", "users_router", ""),
-        LegacyFact("registration", "include_router", "catalog_router", ""),
     }
 )
 
@@ -112,8 +110,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
         LegacyFact("router_import", "app.routers", "vip", "_vip_mod"),
         LegacyFact("router_import", "app.routers.api_key", "api_key_header", ""),
         LegacyFact("router_import", "app.routers.bmi", "bmi_calculate_handler", ""),
-        LegacyFact("router_import", "app.routers.catalog", "router", "catalog_router"),
-        LegacyFact("router_import", "app.routers.foods", "router", "foods_router"),
         LegacyFact(
             "router_import",
             "app.routers.nutrition_recommendations",

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -305,6 +305,11 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
         tree,
         static_string_bindings,
     )
+    dynamic_import_target_modules = _collect_unresolved_dynamic_import_target_modules(
+        tree,
+        import_func_names=dynamic_import_names,
+        static_string_bindings=static_string_bindings,
+    )
     registered_router_targets = _collect_registered_router_targets(tree)
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module is not None:
@@ -350,6 +355,18 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
                 static_string_bindings=static_string_bindings,
                 static_app_router_hint_bindings=static_app_router_hint_bindings,
                 unresolved_router_registration=True,
+            ):
+                facts.add(
+                    LegacyFact(
+                        "router_import",
+                        "dynamic",
+                        module_name,
+                        _safe_unparse(node.func),
+                    )
+                )
+            for module_name in _tainted_dynamic_router_modules_in_registration_call(
+                node,
+                dynamic_import_target_modules,
             ):
                 facts.add(
                     LegacyFact(
@@ -554,6 +571,39 @@ def _collect_dynamic_import_function_names(tree: ast.Module) -> frozenset[str]:
     return frozenset(names)
 
 
+def _collect_unresolved_dynamic_import_target_modules(
+    tree: ast.Module,
+    *,
+    import_func_names: frozenset[str],
+    static_string_bindings: Mapping[str, str],
+) -> Mapping[str, frozenset[str]]:
+    """Return unresolved dynamic-import targets for fail-closed router registration checks."""
+
+    targets: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        value: ast.AST | None = None
+        assignment_targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            value = node.value
+            assignment_targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            value = node.value
+            assignment_targets = [node.target]
+        elif isinstance(node, ast.NamedExpr):
+            value = node.value
+            assignment_targets = [node.target]
+        if value is None or not _contains_unresolved_dynamic_import(
+            value,
+            import_func_names=import_func_names,
+            static_string_bindings=static_string_bindings,
+        ):
+            continue
+        for target in assignment_targets:
+            for target_name in _assignment_target_names(target):
+                targets.setdefault(target_name, set()).add(UNRESOLVED_DYNAMIC_ROUTER_IMPORT)
+    return {name: frozenset(module_names) for name, module_names in targets.items()}
+
+
 def _is_dynamic_import_function_reference(
     node: ast.AST,
     *,
@@ -629,6 +679,27 @@ def _dynamic_app_router_import_assignments(
     return tuple(pairs)
 
 
+def _tainted_dynamic_router_modules_in_registration_call(
+    call: ast.Call,
+    dynamic_import_target_modules: Mapping[str, frozenset[str]],
+) -> frozenset[str]:
+    """Return unresolved dynamic imports routed through wrapper-router registration args."""
+
+    if not call.args:
+        return frozenset()
+    if isinstance(call.args[0], ast.Name):
+        return frozenset()
+    modules: set[str] = set()
+    for child in ast.walk(call.args[0]):
+        if isinstance(child, ast.Name):
+            modules.update(dynamic_import_target_modules.get(child.id, ()))
+        elif isinstance(child, ast.Attribute):
+            root_name = _attribute_root_name(child)
+            if root_name is not None:
+                modules.update(dynamic_import_target_modules.get(root_name, ()))
+    return frozenset(modules)
+
+
 def _dynamic_app_router_import_modules(
     node: ast.AST,
     *,
@@ -660,6 +731,15 @@ def _dynamic_app_router_import_modules(
         ):
             modules.add(module_name)
     return frozenset(modules)
+
+
+def _attribute_root_name(node: ast.Attribute) -> str | None:
+    value: ast.AST = node
+    while isinstance(value, ast.Attribute):
+        value = value.value
+    if isinstance(value, ast.Name):
+        return value.id
+    return None
 
 
 def _dynamic_import_module_name(
@@ -699,7 +779,9 @@ def _contains_unresolved_dynamic_import(
     node: ast.AST,
     *,
     import_func_names: frozenset[str],
+    static_string_bindings: Mapping[str, str] | None = None,
 ) -> bool:
+    static_string_bindings = static_string_bindings or {}
     for child in ast.walk(node):
         if not isinstance(child, ast.Call) or not child.args:
             continue
@@ -707,7 +789,9 @@ def _contains_unresolved_dynamic_import(
         if (isinstance(func, ast.Name) and func.id in import_func_names) or (
             isinstance(func, ast.Attribute) and func.attr == "import_module"
         ):
-            return True
+            resolved = _resolve_static_string(child.args[0], static_string_bindings)
+            if resolved is None:
+                return True
     return False
 
 

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -84,6 +84,8 @@ SENSITIVE_APP_SURFACE_LIMITS: Mapping[str, int] = {
     "receipt": 0,
     "subscription": 0,
 }
+UNRESOLVED_APP_ROUTER_IMPORT = "<unresolved app.routers import>"
+UNRESOLVED_DYNAMIC_ROUTER_IMPORT = "<unresolved dynamic router import>"
 
 ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
     {
@@ -298,6 +300,12 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
 
     facts: set[LegacyFact] = set()
     dynamic_import_names = _collect_dynamic_import_function_names(tree)
+    static_string_bindings = _collect_static_string_bindings(tree)
+    static_app_router_hint_bindings = _collect_static_app_router_hint_bindings(
+        tree,
+        static_string_bindings,
+    )
+    registered_router_targets = _collect_registered_router_targets(tree)
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module is not None:
             if node.module != "app.routers" and not node.module.startswith("app.routers."):
@@ -318,6 +326,9 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
                     value,
                     target,
                     import_func_names=dynamic_import_names,
+                    static_string_bindings=static_string_bindings,
+                    static_app_router_hint_bindings=static_app_router_hint_bindings,
+                    registered_router_targets=registered_router_targets,
                 ):
                     facts.add(LegacyFact("router_import", "dynamic", module_name, target_name))
         elif isinstance(node, ast.NamedExpr):
@@ -325,6 +336,9 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
                 node.value,
                 node.target,
                 import_func_names=dynamic_import_names,
+                static_string_bindings=static_string_bindings,
+                static_app_router_hint_bindings=static_app_router_hint_bindings,
+                registered_router_targets=registered_router_targets,
             ):
                 facts.add(LegacyFact("router_import", "dynamic", module_name, target_name))
         elif isinstance(node, ast.Call):
@@ -333,6 +347,9 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
             for module_name in _dynamic_app_router_import_modules(
                 node,
                 import_func_names=dynamic_import_names,
+                static_string_bindings=static_string_bindings,
+                static_app_router_hint_bindings=static_app_router_hint_bindings,
+                unresolved_router_registration=True,
             ):
                 facts.add(
                     LegacyFact(
@@ -343,6 +360,152 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
                     )
                 )
     return facts
+
+
+def _collect_static_string_bindings(tree: ast.Module) -> Mapping[str, str]:
+    """Return statically resolvable string assignments used by dynamic imports."""
+
+    bindings: dict[str, str] = {}
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            value: ast.AST | None = None
+            targets: list[ast.expr] = []
+            if isinstance(node, ast.Assign):
+                value = node.value
+                targets = list(node.targets)
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                value = node.value
+                targets = [node.target]
+            elif isinstance(node, ast.NamedExpr):
+                value = node.value
+                targets = [node.target]
+            if value is None:
+                continue
+            resolved = _resolve_static_string(value, bindings)
+            if resolved is None:
+                continue
+            for target in targets:
+                for target_name in _assignment_target_names(target):
+                    if target_name not in bindings:
+                        bindings[target_name] = resolved
+                        changed = True
+    return bindings
+
+
+def _resolve_static_string(node: ast.AST, bindings: Mapping[str, str]) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return bindings.get(node.id)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _resolve_static_string(node.left, bindings)
+        right = _resolve_static_string(node.right, bindings)
+        if left is not None and right is not None:
+            return left + right
+        return None
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue):
+                formatted_value = _resolve_static_string(value.value, bindings)
+                if formatted_value is None:
+                    return None
+                parts.append(formatted_value)
+            else:
+                return None
+        return "".join(parts)
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "join"
+        and len(node.args) == 1
+        and isinstance(node.args[0], (ast.List, ast.Tuple))
+    ):
+        separator = _resolve_static_string(node.func.value, bindings)
+        if separator is None:
+            return None
+        items: list[str] = []
+        for item in node.args[0].elts:
+            item_value = _resolve_static_string(item, bindings)
+            if item_value is None:
+                return None
+            items.append(item_value)
+        return separator.join(items)
+    return None
+
+
+def _collect_static_app_router_hint_bindings(
+    tree: ast.Module,
+    static_string_bindings: Mapping[str, str],
+) -> frozenset[str]:
+    hints: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            value: ast.AST | None = None
+            targets: list[ast.expr] = []
+            if isinstance(node, ast.Assign):
+                value = node.value
+                targets = list(node.targets)
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                value = node.value
+                targets = [node.target]
+            elif isinstance(node, ast.NamedExpr):
+                value = node.value
+                targets = [node.target]
+            if value is None or not _static_app_router_hint(
+                value,
+                static_string_bindings,
+                frozenset(hints),
+            ):
+                continue
+            for target in targets:
+                for target_name in _assignment_target_names(target):
+                    if target_name not in hints:
+                        hints.add(target_name)
+                        changed = True
+    return frozenset(hints)
+
+
+def _static_app_router_hint(
+    node: ast.AST,
+    bindings: Mapping[str, str],
+    hint_bindings: frozenset[str],
+) -> bool:
+    resolved = _resolve_static_string(node, bindings)
+    if resolved is not None:
+        return resolved == "app.routers" or resolved.startswith("app.routers.")
+    if isinstance(node, ast.Name) and node.id in hint_bindings:
+        return True
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            if "app.routers" in child.value:
+                return True
+        elif isinstance(child, ast.Name):
+            if child.id in hint_bindings:
+                return True
+            bound = bindings.get(child.id)
+            if bound is not None and (bound == "app.routers" or bound.startswith("app.routers.")):
+                return True
+    return False
+
+
+def _collect_registered_router_targets(tree: ast.Module) -> frozenset[str]:
+    targets: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_router_registration_call(node):
+            continue
+        if not node.args:
+            continue
+        first_arg = node.args[0]
+        if isinstance(first_arg, ast.Name):
+            targets.add(first_arg.id)
+    return frozenset(targets)
 
 
 def _collect_dynamic_import_function_names(tree: ast.Module) -> frozenset[str]:
@@ -421,6 +584,9 @@ def _dynamic_app_router_import_assignments(
     target: ast.AST,
     *,
     import_func_names: frozenset[str],
+    static_string_bindings: Mapping[str, str],
+    static_app_router_hint_bindings: frozenset[str],
+    registered_router_targets: frozenset[str],
 ) -> tuple[tuple[str, str], ...]:
     """Return dynamic app.routers imports paired with the assigned target name."""
 
@@ -432,6 +598,9 @@ def _dynamic_app_router_import_assignments(
                     value_item,
                     target_item,
                     import_func_names=import_func_names,
+                    static_string_bindings=static_string_bindings,
+                    static_app_router_hint_bindings=static_app_router_hint_bindings,
+                    registered_router_targets=registered_router_targets,
                 )
             )
         return tuple(destructured_pairs)
@@ -442,10 +611,21 @@ def _dynamic_app_router_import_assignments(
 
     pairs: list[tuple[str, str]] = []
     for module_name in _dynamic_app_router_import_modules(
-        value, import_func_names=import_func_names
+        value,
+        import_func_names=import_func_names,
+        static_string_bindings=static_string_bindings,
+        static_app_router_hint_bindings=static_app_router_hint_bindings,
+        unresolved_router_registration=False,
     ):
         for target_name in target_names:
             pairs.append((module_name, target_name))
+    for target_name in target_names:
+        if target_name not in registered_router_targets:
+            continue
+        if pairs:
+            continue
+        if _contains_unresolved_dynamic_import(value, import_func_names=import_func_names):
+            pairs.append((UNRESOLVED_DYNAMIC_ROUTER_IMPORT, target_name))
     return tuple(pairs)
 
 
@@ -453,6 +633,9 @@ def _dynamic_app_router_import_modules(
     node: ast.AST,
     *,
     import_func_names: frozenset[str],
+    static_string_bindings: Mapping[str, str],
+    static_app_router_hint_bindings: frozenset[str],
+    unresolved_router_registration: bool,
 ) -> frozenset[str]:
     """Return dynamic app.routers module imports embedded in an AST node."""
 
@@ -460,10 +643,21 @@ def _dynamic_app_router_import_modules(
     for child in ast.walk(node):
         if not isinstance(child, ast.Call):
             continue
-        module_name = _dynamic_import_module_name(child, import_func_names=import_func_names)
+        module_name = _dynamic_import_module_name(
+            child,
+            import_func_names=import_func_names,
+            static_string_bindings=static_string_bindings,
+            static_app_router_hint_bindings=static_app_router_hint_bindings,
+            unresolved_router_registration=unresolved_router_registration,
+        )
         if module_name is None:
             continue
-        if module_name == "app.routers" or module_name.startswith("app.routers."):
+        if (
+            module_name == UNRESOLVED_APP_ROUTER_IMPORT
+            or module_name == UNRESOLVED_DYNAMIC_ROUTER_IMPORT
+            or module_name == "app.routers"
+            or module_name.startswith("app.routers.")
+        ):
             modules.add(module_name)
     return frozenset(modules)
 
@@ -472,19 +666,49 @@ def _dynamic_import_module_name(
     call: ast.Call,
     *,
     import_func_names: frozenset[str],
+    static_string_bindings: Mapping[str, str],
+    static_app_router_hint_bindings: frozenset[str],
+    unresolved_router_registration: bool,
 ) -> str | None:
     if not call.args:
         return None
     first_arg = call.args[0]
-    if not isinstance(first_arg, ast.Constant) or not isinstance(first_arg.value, str):
-        return None
 
     func = call.func
-    if isinstance(func, ast.Name) and func.id in import_func_names:
-        return first_arg.value
-    if isinstance(func, ast.Attribute) and func.attr == "import_module":
-        return first_arg.value
+    if not (
+        (isinstance(func, ast.Name) and func.id in import_func_names)
+        or (isinstance(func, ast.Attribute) and func.attr == "import_module")
+    ):
+        return None
+
+    resolved = _resolve_static_string(first_arg, static_string_bindings)
+    if resolved is not None:
+        return resolved
+    if _static_app_router_hint(
+        first_arg,
+        static_string_bindings,
+        static_app_router_hint_bindings,
+    ):
+        return UNRESOLVED_APP_ROUTER_IMPORT
+    if unresolved_router_registration:
+        return UNRESOLVED_DYNAMIC_ROUTER_IMPORT
     return None
+
+
+def _contains_unresolved_dynamic_import(
+    node: ast.AST,
+    *,
+    import_func_names: frozenset[str],
+) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call) or not child.args:
+            continue
+        func = child.func
+        if (isinstance(func, ast.Name) and func.id in import_func_names) or (
+            isinstance(func, ast.Attribute) and func.attr == "import_module"
+        ):
+            return True
+    return False
 
 
 def collect_sensitive_call_counts(

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import re
 import sys
+from typing import AbstractSet
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_APP = "legacy_app.py"
@@ -580,27 +581,41 @@ def _collect_unresolved_dynamic_import_target_modules(
     """Return unresolved dynamic-import targets for fail-closed router registration checks."""
 
     targets: dict[str, set[str]] = {}
-    for node in ast.walk(tree):
-        value: ast.AST | None = None
-        assignment_targets: list[ast.expr] = []
-        if isinstance(node, ast.Assign):
-            value = node.value
-            assignment_targets = list(node.targets)
-        elif isinstance(node, ast.AnnAssign) and node.value is not None:
-            value = node.value
-            assignment_targets = [node.target]
-        elif isinstance(node, ast.NamedExpr):
-            value = node.value
-            assignment_targets = [node.target]
-        if value is None or not _contains_unresolved_dynamic_import(
-            value,
-            import_func_names=import_func_names,
-            static_string_bindings=static_string_bindings,
-        ):
-            continue
-        for target in assignment_targets:
-            for target_name in _assignment_target_names(target):
-                targets.setdefault(target_name, set()).add(UNRESOLVED_DYNAMIC_ROUTER_IMPORT)
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            value: ast.AST | None = None
+            assignment_targets: list[ast.expr] = []
+            if isinstance(node, ast.Assign):
+                value = node.value
+                assignment_targets = list(node.targets)
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                value = node.value
+                assignment_targets = [node.target]
+            elif isinstance(node, ast.NamedExpr):
+                value = node.value
+                assignment_targets = [node.target]
+            if value is None:
+                continue
+
+            module_names: set[str] = set()
+            if _contains_unresolved_dynamic_import(
+                value,
+                import_func_names=import_func_names,
+                static_string_bindings=static_string_bindings,
+            ):
+                module_names.add(UNRESOLVED_DYNAMIC_ROUTER_IMPORT)
+            module_names.update(_tainted_dynamic_router_modules_in_node(value, targets))
+            if not module_names:
+                continue
+
+            for target in assignment_targets:
+                for target_name in _assignment_target_names(target):
+                    target_modules = targets.setdefault(target_name, set())
+                    before = len(target_modules)
+                    target_modules.update(module_names)
+                    changed = changed or len(target_modules) != before
     return {name: frozenset(module_names) for name, module_names in targets.items()}
 
 
@@ -681,16 +696,25 @@ def _dynamic_app_router_import_assignments(
 
 def _tainted_dynamic_router_modules_in_registration_call(
     call: ast.Call,
-    dynamic_import_target_modules: Mapping[str, frozenset[str]],
+    dynamic_import_target_modules: Mapping[str, AbstractSet[str]],
 ) -> frozenset[str]:
     """Return unresolved dynamic imports routed through wrapper-router registration args."""
 
     if not call.args:
         return frozenset()
-    if isinstance(call.args[0], ast.Name):
+    if isinstance(call.args[0], ast.Name) and _safe_unparse(call.func) == "app.include_router":
         return frozenset()
+    return _tainted_dynamic_router_modules_in_node(call.args[0], dynamic_import_target_modules)
+
+
+def _tainted_dynamic_router_modules_in_node(
+    node: ast.AST,
+    dynamic_import_target_modules: Mapping[str, AbstractSet[str]],
+) -> frozenset[str]:
+    """Return unresolved dynamic imports referenced by names or attributes in node."""
+
     modules: set[str] = set()
-    for child in ast.walk(call.args[0]):
+    for child in ast.walk(node):
         if isinstance(child, ast.Name):
             modules.update(dynamic_import_target_modules.get(child.id, ()))
         elif isinstance(child, ast.Attribute):
@@ -750,10 +774,6 @@ def _dynamic_import_module_name(
     static_app_router_hint_bindings: frozenset[str],
     unresolved_router_registration: bool,
 ) -> str | None:
-    if not call.args:
-        return None
-    first_arg = call.args[0]
-
     func = call.func
     if not (
         (isinstance(func, ast.Name) and func.id in import_func_names)
@@ -761,17 +781,30 @@ def _dynamic_import_module_name(
     ):
         return None
 
-    resolved = _resolve_static_string(first_arg, static_string_bindings)
+    module_arg = _dynamic_import_module_arg(call)
+    if module_arg is None:
+        return None
+
+    resolved = _resolve_static_string(module_arg, static_string_bindings)
     if resolved is not None:
         return resolved
     if _static_app_router_hint(
-        first_arg,
+        module_arg,
         static_string_bindings,
         static_app_router_hint_bindings,
     ):
         return UNRESOLVED_APP_ROUTER_IMPORT
     if unresolved_router_registration:
         return UNRESOLVED_DYNAMIC_ROUTER_IMPORT
+    return None
+
+
+def _dynamic_import_module_arg(call: ast.Call) -> ast.AST | None:
+    if call.args:
+        return call.args[0]
+    for keyword in call.keywords:
+        if keyword.arg == "name":
+            return keyword.value
     return None
 
 
@@ -783,13 +816,16 @@ def _contains_unresolved_dynamic_import(
 ) -> bool:
     static_string_bindings = static_string_bindings or {}
     for child in ast.walk(node):
-        if not isinstance(child, ast.Call) or not child.args:
+        if not isinstance(child, ast.Call):
             continue
         func = child.func
         if (isinstance(func, ast.Name) and func.id in import_func_names) or (
             isinstance(func, ast.Attribute) and func.attr == "import_module"
         ):
-            resolved = _resolve_static_string(child.args[0], static_string_bindings)
+            module_arg = _dynamic_import_module_arg(child)
+            if module_arg is None:
+                continue
+            resolved = _resolve_static_string(module_arg, static_string_bindings)
             if resolved is None:
                 return True
     return False

--- a/tests/test_food_catalog_registration_bootstrap.py
+++ b/tests/test_food_catalog_registration_bootstrap.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.routing import APIRoute
+
+import app.main as app_main
+from app.bootstrap.route_family import route_has_dependency_call
+from app.effective_routes import (
+    is_api_route_candidate,
+    iter_effective_route_candidates,
+    route_endpoint,
+    route_include_in_schema,
+    route_methods,
+    route_path,
+    route_responses,
+)
+
+_EXPECTED_ROUTE_SPECS = (
+    *app_main._FOODS_ROUTE_SPECS,
+    *app_main._CATALOG_ROUTE_SPECS,
+)
+_EXPECTED_ROUTE_KEYS = {
+    (path, method) for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS
+}
+_EXPECTED_ROUTE_PATHS = {path for path, _method in _EXPECTED_ROUTE_KEYS}
+_FOODS_ROUTE_KEYS = {
+    (path, method) for path, method, _include_in_schema in app_main._FOODS_ROUTE_SPECS
+}
+_CATALOG_ROUTE_KEYS = {
+    (path, method) for path, method, _include_in_schema in app_main._CATALOG_ROUTE_SPECS
+}
+_BARCODE_ROUTE_KEY = ("/api/v1/foods/barcode/{barcode}", "GET")
+_EXPECTED_DEPENDENCIES: dict[tuple[str, str], Callable[..., object]] = {
+    **{key: app_main.get_food_store for key in _FOODS_ROUTE_KEYS},
+    **{key: app_main.get_catalog_service for key in _CATALOG_ROUTE_KEYS},
+}
+_EXPECTED_ENDPOINT_MODULES = {
+    ("/api/v1/foods", "GET"): "app.routers.foods",
+    ("/api/v1/foods/search", "GET"): "app.routers.foods",
+    ("/api/v1/foods/{food_id}", "GET"): "app.routers.foods",
+    ("/api/v1/foods/barcode/{barcode}", "GET"): "app.routers.foods",
+    ("/api/v1/catalog/regions", "GET"): "app.routers.catalog",
+    ("/api/v1/catalog/stores", "GET"): "app.routers.catalog",
+    ("/api/v1/catalog/search", "GET"): "app.routers.catalog",
+}
+
+
+def _food_catalog_routes(target_app: FastAPI) -> list[object]:
+    return [
+        route
+        for route in iter_effective_route_candidates(target_app.routes)
+        if is_api_route_candidate(route) and route_path(route) in _EXPECTED_ROUTE_PATHS
+    ]
+
+
+def _registered_route_counts(target_app: FastAPI) -> Counter[tuple[str, str]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for route in _food_catalog_routes(target_app):
+        for method in route_methods(route):
+            key = (route_path(route), method)
+            if key in _EXPECTED_ROUTE_KEYS:
+                counts[key] += 1
+    return counts
+
+
+def _food_catalog_route(target_app: FastAPI, path: str, method: str) -> object:
+    matches = [
+        route
+        for route in _food_catalog_routes(target_app)
+        if route_path(route) == path and method in route_methods(route)
+    ]
+    route_summaries = [
+        f"{route_path(route)}:{sorted(route_methods(route))}:{route_endpoint(route).__module__}"
+        for route in matches
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one food/catalog route for {method} {path}; "
+        f"found {len(matches)}: {route_summaries}"
+    )
+    return matches[0]
+
+
+def _source_route(path: str, method: str) -> APIRoute:
+    for router in (app_main.foods_router, app_main.catalog_router):
+        for route in router.routes:
+            if not isinstance(route, APIRoute):
+                continue
+            if str(route.path) == path and method in (route.methods or set()):
+                return route
+    raise AssertionError(f"missing source route: {method} {path}")
+
+
+def _clone_endpoint_with_matching_identity(
+    source_endpoint: Callable[..., object],
+    dependency: Callable[..., object] | None,
+) -> Callable[..., object]:
+    if dependency is None:
+
+        async def _endpoint_without_dependency() -> dict[str, str]:
+            return {"status": "stub"}
+
+        endpoint = _endpoint_without_dependency
+    else:
+
+        async def _endpoint_with_dependency(
+            _dependency_result: object = Depends(dependency),
+        ) -> dict[str, str]:
+            return {"status": "stub"}
+
+        endpoint = _endpoint_with_dependency
+
+    endpoint.__module__ = source_endpoint.__module__
+    endpoint.__qualname__ = source_endpoint.__qualname__
+    return endpoint
+
+
+def _assert_food_catalog_routes_registered_once(target_app: FastAPI) -> None:
+    counts = _registered_route_counts(target_app)
+    assert set(counts) == _EXPECTED_ROUTE_KEYS
+    assert all(count == 1 for count in counts.values())
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _food_catalog_route(target_app, path, method)
+        assert route_include_in_schema(route) is include_in_schema
+        endpoint = route_endpoint(route)
+        assert getattr(endpoint, "__module__", None) == _EXPECTED_ENDPOINT_MODULES[(path, method)]
+        assert route_has_dependency_call(route, _EXPECTED_DEPENDENCIES[(path, method)])
+
+    barcode_route = _food_catalog_route(target_app, *_BARCODE_ROUTE_KEY)
+    assert {404, 422}.issubset(route_responses(barcode_route))
+
+
+def test_empty_app_registers_all_food_catalog_routes_once() -> None:
+    target_app = FastAPI()
+
+    app_main._include_food_catalog_routers_if_needed(target_app)
+
+    _assert_food_catalog_routes_registered_once(target_app)
+
+
+def test_bootstrapped_app_registers_all_food_catalog_routes_once() -> None:
+    _assert_food_catalog_routes_registered_once(app_main.app)
+
+
+def test_food_catalog_registration_is_idempotent() -> None:
+    target_app = FastAPI()
+
+    app_main._include_food_catalog_routers_if_needed(target_app)
+    app_main._include_food_catalog_routers_if_needed(target_app)
+
+    _assert_food_catalog_routes_registered_once(target_app)
+
+
+def test_food_catalog_members_assert_dependency_and_status_contracts() -> None:
+    members = {
+        (member.path, member.method): member for member in app_main._food_catalog_route_members()
+    }
+
+    assert set(members) == _EXPECTED_ROUTE_KEYS
+    for key in _FOODS_ROUTE_KEYS:
+        assert members[key].required_dependencies == (app_main.get_food_store,)
+    for key in _CATALOG_ROUTE_KEYS:
+        assert members[key].required_dependencies == (app_main.get_catalog_service,)
+    assert members[_BARCODE_ROUTE_KEY].required_status_codes == frozenset({404, 422})
+
+
+def test_food_catalog_source_routers_keep_dependency_contracts() -> None:
+    for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _source_route(path, method)
+
+        assert route_has_dependency_call(route, _EXPECTED_DEPENDENCIES[(path, method)])
+
+
+def test_food_catalog_router_source_specs_match_current_visibility() -> None:
+    route_specs: set[tuple[str, str, bool]] = set()
+    for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _source_route(path, method)
+        route_specs.add((str(route.path), method, route.include_in_schema))
+
+    assert route_specs == set(_EXPECTED_ROUTE_SPECS)
+
+
+def test_food_catalog_public_openapi_paths_remain_hidden() -> None:
+    schema = app_main.app.openapi()
+    paths = {str(path) for path in schema.get("paths", {})}
+
+    leaked_paths = sorted(
+        path for path in paths if path.startswith(("/api/v1/foods", "/api/v1/catalog"))
+    )
+    assert leaked_paths == []
+
+
+def test_food_catalog_registration_rejects_partial_existing_family() -> None:
+    target_app = FastAPI()
+    path, method, include_in_schema = _EXPECTED_ROUTE_SPECS[0]
+
+    async def _partial_food_catalog_route() -> dict[str, str]:
+        return {"status": "partial"}
+
+    target_app.add_api_route(
+        path,
+        _partial_food_catalog_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(RuntimeError, match="Partial food catalog route registration detected"):
+        app_main._include_food_catalog_routers_if_needed(target_app)
+
+
+def test_food_catalog_registration_rejects_duplicate_method_path() -> None:
+    target_app = FastAPI()
+    app_main._include_food_catalog_routers_if_needed(target_app)
+    path, method, include_in_schema = _EXPECTED_ROUTE_SPECS[0]
+
+    async def _duplicate_food_catalog_route() -> dict[str, str]:
+        return {"status": "duplicate"}
+
+    target_app.add_api_route(
+        path,
+        _duplicate_food_catalog_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different food catalog handler",
+    ):
+        app_main._include_food_catalog_routers_if_needed(target_app)
+
+
+def test_food_catalog_registration_rejects_foreign_handlers() -> None:
+    target_app = FastAPI()
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+
+        async def _foreign_food_catalog_route(
+            current_route_path: str = path,
+        ) -> dict[str, str]:
+            return {"path": current_route_path}
+
+        target_app.add_api_route(
+            path,
+            _foreign_food_catalog_route,
+            methods=[method],
+            include_in_schema=include_in_schema,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different food catalog handler",
+    ):
+        app_main._include_food_catalog_routers_if_needed(target_app)
+
+
+def test_food_catalog_registration_rejects_existing_wrong_method() -> None:
+    target_app = FastAPI()
+
+    async def _wrong_method_food_catalog_route() -> dict[str, str]:
+        return {"status": "wrong-method"}
+
+    target_app.add_api_route(
+        "/api/v1/foods",
+        _wrong_method_food_catalog_route,
+        methods=["POST"],
+    )
+
+    with pytest.raises(RuntimeError, match="Partial food catalog route registration detected"):
+        app_main._include_food_catalog_routers_if_needed(target_app)
+
+
+def test_food_catalog_registration_rejects_visibility_drift() -> None:
+    target_app = FastAPI()
+    app_main._include_food_catalog_routers_if_needed(target_app)
+    route = _food_catalog_route(target_app, "/api/v1/foods", "GET")
+    setattr(route, "include_in_schema", True)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve food catalog OpenAPI visibility",
+    ):
+        app_main._include_food_catalog_routers_if_needed(target_app)
+
+
+def test_food_catalog_registration_rejects_response_metadata_drift() -> None:
+    target_app = FastAPI()
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+        source_endpoint = _source_route(path, method).endpoint
+        route_kwargs: dict[str, object] = {}
+        if (path, method) != _BARCODE_ROUTE_KEY:
+            route_kwargs["responses"] = dict(_source_route(path, method).responses)
+        target_app.add_api_route(
+            path,
+            source_endpoint,
+            methods=[method],
+            include_in_schema=include_in_schema,
+            dependencies=[Depends(_EXPECTED_DEPENDENCIES[(path, method)])],
+            **route_kwargs,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve (404|422) response metadata",
+    ):
+        app_main._include_food_catalog_routers_if_needed(target_app)
+
+
+@pytest.mark.parametrize("missing_key", sorted(_EXPECTED_ROUTE_KEYS))
+def test_food_catalog_registration_rejects_missing_required_dependency(
+    missing_key: tuple[str, str],
+) -> None:
+    target_app = FastAPI()
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+        source_route = _source_route(path, method)
+        source_endpoint = source_route.endpoint
+        endpoint = (
+            _clone_endpoint_with_matching_identity(source_endpoint, None)
+            if (path, method) == missing_key
+            else source_endpoint
+        )
+        dependencies = (
+            []
+            if (path, method) == missing_key
+            else [Depends(_EXPECTED_DEPENDENCIES[(path, method)])]
+        )
+        target_app.add_api_route(
+            path,
+            endpoint,
+            methods=[method],
+            include_in_schema=include_in_schema,
+            responses=dict(source_route.responses),
+            dependencies=dependencies,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve food catalog required dependency",
+    ):
+        app_main._include_food_catalog_routers_if_needed(target_app)

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -1147,6 +1147,21 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
                 "router_import:dynamic:<unresolved dynamic router import> -> recipes_router"
             ],
         ),
+        (
+            textwrap.dedent("""
+                import os
+                from importlib import import_module
+
+                module = import_module(os.getenv("LEGACY_ROUTER_MODULE"))
+                recipes_router.include_router(module.router)
+                app.include_router(recipes_router)
+                """),
+            [
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:<unresolved dynamic router import> -> "
+                "recipes_router.include_router"
+            ],
+        ),
     ],
 )
 def test_legacy_growth_guard_rejects_computed_food_catalog_dynamic_import_alias_bypass(
@@ -1156,6 +1171,19 @@ def test_legacy_growth_guard_rejects_computed_food_catalog_dynamic_import_alias_
     errors = legacy_guard.validate_legacy_growth(source)
 
     assert errors == expected
+
+
+def test_legacy_growth_guard_allows_unregistered_dynamic_import_without_router_use() -> None:
+    source = textwrap.dedent("""
+        import os
+        from importlib import import_module
+
+        module = import_module(os.getenv("LEGACY_HELPER_MODULE"))
+        value = module.VALUE
+        app.include_router(recipes_router)
+        """)
+
+    assert legacy_guard.validate_legacy_growth(source) == []
 
 
 def test_legacy_growth_guard_rejects_module_qualified_bodyfat_router_registration() -> None:

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -946,6 +946,134 @@ def test_legacy_growth_guard_rejects_shopping_list_router_reintroduction(
     assert errors == expected
 
 
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            textwrap.dedent("""
+                from app.routers.foods import router as foods_router
+
+                app.include_router(foods_router, include_in_schema=False)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:foods_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.foods:router -> foods_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from app.routers.catalog import router as catalog_router
+
+                app.include_router(catalog_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:catalog_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.catalog:router -> catalog_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from app.routers.foods import router as canonical_foods_router
+
+                app.include_router(canonical_foods_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:canonical_foods_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.foods:router -> canonical_foods_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import app.routers.catalog as catalog_routes
+
+                app.include_router(catalog_routes.router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:catalog_routes.router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:import:app.routers.catalog -> catalog_routes",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                food_router = importlib.import_module("app.routers.foods").router
+                app.include_router(food_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:food_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.foods -> food_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                catalog_router, _ = (
+                    importlib.import_module("app.routers.catalog").router,
+                    None,
+                )
+                app.include_router(catalog_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:catalog_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.catalog -> catalog_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from importlib import import_module
+
+                if (food_router := import_module("app.routers.foods").router):
+                    app.include_router(food_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:food_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.foods -> food_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                wrapper_router = APIRouter()
+                wrapper_router.include_router(
+                    importlib.import_module("app.routers.catalog").router
+                )
+                app.include_router(wrapper_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:wrapper_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.catalog -> wrapper_router.include_router",
+            ],
+        ),
+    ],
+)
+def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
+    source: str,
+    expected: list[str],
+) -> None:
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == expected
+
+
 def test_legacy_growth_guard_rejects_module_qualified_bodyfat_router_registration() -> None:
     source = textwrap.dedent("""
         import app.routers.bodyfat as bodyfat_routes
@@ -1407,7 +1535,7 @@ def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_route() -> None:
 
 
 def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_router() -> None:
-    source = "app.include_router(foods_router, dependencies=[Depends(auth_guard)])\n"
+    source = "app.include_router(recipes_router, dependencies=[Depends(auth_guard)])\n"
 
     errors = legacy_guard.validate_legacy_growth(source)
 
@@ -1426,7 +1554,7 @@ def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_router() -> None
             """),
         textwrap.dedent("""
             deps = [Depends(auth_guard)]
-            app.include_router(foods_router, dependencies=deps)
+            app.include_router(recipes_router, dependencies=deps)
             """),
     ],
 )

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -1162,6 +1162,34 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
                 "recipes_router.include_router"
             ],
         ),
+        (
+            textwrap.dedent("""
+                import os
+                from importlib import import_module
+
+                module = import_module(os.getenv("LEGACY_ROUTER_MODULE"))
+                router = module.router
+                recipes_router.include_router(router)
+                app.include_router(recipes_router)
+                """),
+            [
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:<unresolved dynamic router import> -> "
+                "recipes_router.include_router"
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                recipes_router = importlib.import_module(name="app.routers.foods").router
+                app.include_router(recipes_router)
+                """),
+            [
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.foods -> recipes_router"
+            ],
+        ),
     ],
 )
 def test_legacy_growth_guard_rejects_computed_food_catalog_dynamic_import_alias_bypass(

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -1074,6 +1074,90 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
     assert errors == expected
 
 
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            textwrap.dedent("""
+                import importlib
+
+                module_name = "app.routers." + "foods"
+                recipes_router = importlib.import_module(module_name).router
+                app.include_router(recipes_router)
+                """),
+            [
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.foods -> recipes_router"
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                module_name = ".".join(["app", "routers", "catalog"])
+                users_router = importlib.import_module(module_name).router
+                app.include_router(users_router)
+                """),
+            [
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.catalog -> users_router"
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                family = "catalog"
+                module_name = f"app.routers.{family}"
+                restaurants_router = importlib.import_module(module_name).router
+                app.include_router(restaurants_router)
+                """),
+            [
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.catalog -> restaurants_router"
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+                import os
+
+                family = os.getenv("ROUTER_FAMILY", "foods")
+                module_name = f"app.routers.{family}"
+                nutrition_recommendations_router = importlib.import_module(module_name).router
+                app.include_router(nutrition_recommendations_router)
+                """),
+            [
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:<unresolved app.routers import> -> "
+                "nutrition_recommendations_router"
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+                import os
+
+                module_name = os.getenv("LEGACY_ROUTER_MODULE")
+                recipes_router = importlib.import_module(module_name).router
+                app.include_router(recipes_router)
+                """),
+            [
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:<unresolved dynamic router import> -> recipes_router"
+            ],
+        ),
+    ],
+)
+def test_legacy_growth_guard_rejects_computed_food_catalog_dynamic_import_alias_bypass(
+    source: str,
+    expected: list[str],
+) -> None:
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == expected
+
+
 def test_legacy_growth_guard_rejects_module_qualified_bodyfat_router_registration() -> None:
     source = textwrap.dedent("""
         import app.routers.bodyfat as bodyfat_routes

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -215,6 +215,45 @@ def test_metrics_includes_route_template(client: TestClient) -> None:
         assert "?" not in route_label, f"Route label should not contain query params: {route_label}"
 
 
+def test_metrics_include_food_catalog_route_templates(client: TestClient) -> None:
+    """Foods/catalog legacy-registration move must preserve route-template labels."""
+    missing_food_id = "missing-food-id-for-metrics"
+
+    food_response = client.get(f"/api/v1/foods/{missing_food_id}?debug_raw_path=true")
+    assert food_response.status_code == 404
+
+    catalog_response = client.get(
+        "/api/v1/catalog/search",
+        params={"q": "ban", "region_id": "ES", "limit": 1, "debug_raw_query": "true"},
+    )
+    assert catalog_response.status_code == 200
+
+    metrics_text = client.get("/metrics").text
+
+    assert (
+        _metric_value(
+            metrics_text,
+            method="GET",
+            route="/api/v1/foods/{food_id}",
+            status="404",
+        )
+        >= 1.0
+    )
+    assert (
+        _metric_value(
+            metrics_text,
+            method="GET",
+            route="/api/v1/catalog/search",
+            status="200",
+        )
+        >= 1.0
+    )
+    assert missing_food_id not in metrics_text
+    assert "debug_raw_path" not in metrics_text
+    assert "debug_raw_query" not in metrics_text
+    assert 'route="/api/v1/catalog/search?' not in metrics_text
+
+
 def test_metrics_content_type(client: TestClient) -> None:
     """Test /metrics returns correct Content-Type header.
 

--- a/tests/test_openapi_namespace_guards.py
+++ b/tests/test_openapi_namespace_guards.py
@@ -22,6 +22,7 @@ ALLOWED_EXACT: frozenset[str] = frozenset({"/api/v1/bmi", "/api/v1/insight"})
 # Legacy WS path is kept at runtime but should NOT appear in OpenAPI schema
 # (WebSocket endpoints are not included in OpenAPI by default)
 LEGACY_DENY_PREFIXES: tuple[str, ...] = (
+    "/api/v1/catalog",
     "/api/v1/foods",
     "/api/v1/restaurants",
     "/api/v1/users",
@@ -67,6 +68,7 @@ def test_runtime_keeps_legacy_routes_and_ws_for_transition_window() -> None:
     # Canonical PRO WS path
     assert "/api/v1/pro/ws" in runtime_paths
     # Legacy food/restaurant routes (hidden from schema, kept at runtime)
+    assert "/api/v1/catalog/search" in runtime_paths
     assert "/api/v1/foods" in runtime_paths
     assert "/api/v1/restaurants/search" in runtime_paths
     # Users CRUD remains registered for internal callers but is hidden from public schema


### PR DESCRIPTION
## Goal
Move the Food/Catalog legacy registration slice from `legacy_app.py` to canonical `app/main.py` bootstrap while preserving route behavior, OpenAPI visibility, dependency providers, and existing route-template metrics labels.

## Business Reason
This reduces legacy bootstrap ownership without changing public API behavior, keeping the migration narrow and measurable before adjacent route families move.

## Scope
- Added `FOODS_ROUTE_SPECS` and `CATALOG_ROUTE_SPECS` to the source routers.
- Added canonical food/catalog route-family registration in `app/main.py` via `ensure_route_family_registered(...)`.
- Preserved `get_food_store` and `get_catalog_service` dependency contracts.
- Removed only foods/catalog router registration/import ownership from `legacy_app.py`.
- Tightened legacy growth guard coverage for food/catalog reintroduction paths.
- Added route bootstrap, OpenAPI visibility, dependency, duplicate/partial registration, guard, and metrics regression coverage.

## Out Of Scope
- Recipes, users, restaurants, nutrition recommendations, FoodDB/Meili/provider logic.
- Frontend, iOS, macOS, new dashboards, new runtime counters, or production metrics changes.
- Full local `make verify` per root AGENTS.md local budget policy.

## Files Changed
- `app/main.py`
- `app/routers/foods.py`
- `app/routers/catalog.py`
- `legacy_app.py`
- `scripts/ci/check_legacy_growth_guard.py`
- `tests/test_food_catalog_registration_bootstrap.py`
- `tests/test_legacy_growth_guard.py`
- `tests/test_metrics.py`
- `tests/test_openapi_namespace_guards.py`
- `docs/architecture/backend_routing_map.md`
- `docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_PREMORTEM.md`
- `docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md`

## Key Decisions
- Foods remain hidden from OpenAPI (`include_in_schema=False`) at source/router/spec level.
- Catalog remains visible in OpenAPI.
- Observability scope is proof-only: existing Prometheus route labels are asserted for route templates, without adding new production metrics.
- Legacy growth guard now rejects foods/catalog registration returning through direct import, alias import, module import, dynamic import, destructuring, walrus assignment, or nested include patterns.

## Local Tests / Validation
- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_food_catalog_registration_bootstrap.py`
- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_metrics.py::test_metrics_include_food_catalog_route_templates`
- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_route_family_bootstrap.py tests/test_catalog_api.py tests/test_catalog_no_network.py tests/test_foods_router_additional.py tests/test_metrics.py`
- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/ci/check_legacy_growth_guard.py`
- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m mypy app/main.py app/routers/foods.py app/routers/catalog.py scripts/ci/check_legacy_growth_guard.py`
- PASS: `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make openapi-check`
- PASS: `git diff --exit-code -- frontend/src/api/openapi.json frontend/src/api/schema.ts`
- PASS: `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
- PASS: `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files`
- PASS during push hooks: backend pytest, full-repo bandit, docker build test.

## Governance / Role Evidence
Startup used `scripts/orchestration/start_pr_lane.sh` with packet `artifacts/orchestration/task_packets/f130c83cd0bd.json`.

Pre-open role passes were executed read-only in order:
`agent-coordinator -> backend-engineer -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`.

## Premortem Evidence
Artifact: `docs/review/FOOD_CATALOG_CANONICAL_BOOTSTRAP_PREMORTEM.md`

Decision: `proceed with changes`; findings closed by implementation/tests in this PR.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/exp-food-catalog-registration-oracle-review-result.json`

Status: accepted; runner mode `oracle_only_governance_reviewer`; 2/2 oracle commands executed; shared tree untouched; contribution kind `oracle_review`; co-author required and present on commit `e91828e2e`.

Zero-network attempt artifact `artifacts/orchestration/experiments/results/exp-7b394904754b-rerun.json` was rejected before oracle execution with `infra_flake` because this macOS host does not provide Linux `unshare` on PATH. The accepted fallback used `network_budget=1`, matching existing repo-documented local macOS fallback practice.

## Security Notes
- No auth, billing, entitlement, export, LLM, CI workflow, secret, deploy, or data migration surface changed.
- Existing route dependency contracts remain fail-closed through `ensure_route_family_registered(...)` validation.
- No `# type: ignore`, `# nosec`, skipped tests, or allowlist additions were introduced.

## Risks / Rollback
- Main risk: route ownership drift or duplicate FastAPI method/path registration. Covered by bootstrap and guard tests.
- Rollback: revert this PR to restore legacy-app ownership for foods/catalog registration; no schema/data migration is involved.

## Deferred / Follow-Ups
- New production metrics/dashboard surfaces are deferred to a separate observability PR.
- Adjacent legacy route families remain out of scope for this slice.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Current fixed mapping artifact: `docs/review/PR_2071_FIXED_MAPPING.md`.
- Post-open `qa-engineer-agent`, `bug-hunter`, `security-auditor`, Codex Security, and Codex review findings have been checked for this lane.
- Actionable Codex review threads are mapped in the canonical artifact.
- CodeRabbit, Sourcery, Cubic, Codecov, and Cursor comments were checked; no additional actionable code/test/docs/security findings remain beyond the mapped Codex threads.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2071_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522146313 -> b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522146316 -> b1a23a4efe8c6dc7dc5dcf1fd58ee31efa321521
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522218893 -> 31c8b103e44e09a27231c203e710730cdcb10c3c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2071#discussion_r3522218896 -> 31c8b103e44e09a27231c203e710730cdcb10c3c

## Merge Readiness
- Pending latest mapping/body commit current-head CI and strict merge-readiness gate.
- Full local `make verify` was intentionally not run under root AGENTS.md local budget policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved Food and Catalog router registration from `legacy_app.py` to canonical bootstrap in `app/main.py`, registering them as one guarded route family. Behavior is unchanged: foods stay out of OpenAPI; catalog endpoints remain filtered from the public schema; dependencies and route-template metrics are preserved.

- **Refactors**
  - Added `FOODS_ROUTE_SPECS` and `CATALOG_ROUTE_SPECS`; foods are hidden (`include_in_schema=False`), barcode keeps `404/422` responses.
  - Canonical registration via `_include_food_catalog_routers_if_needed()` and `ensure_route_family_registered(...)` with `get_food_store` and `get_catalog_service`.
  - Removed foods/catalog registration from `legacy_app.py`; hardened the legacy growth guard to block computed dynamic imports (concat, f-strings, `".".join(...)`), keyword-form `import_module`, and to propagate unresolved router-import taint through aliases and wrapper routers; rejects duplicate/partial/wrong-method/foreign-handler cases.
  - Added focused tests for idempotent bootstrap, dependency/response contracts, OpenAPI visibility (including `/api/v1/catalog*` filtering), and route-template metrics labels; updated routing docs and added Experiment Runner evidence and the fixed-mapping artifact.

<sup>Written for commit 0dd024b2933dfa49cd965da9e78ca72519c85a09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Food and catalog endpoints are now registered via the app’s canonical startup flow, ensuring consistent runtime availability.
  * Canonical coverage added for catalog regions, stores, and search.
* **Bug Fixes**
  * OpenAPI visibility is more strictly controlled: foods stay hidden where expected, while catalog schema exposure remains consistent.
  * Metrics now report route-template labels (cleaner series names) for key foods/catalog cases.
  * Route registration safeguards prevent duplicates and conflicting handlers.
* **Documentation**
  * Updated backend routing map plus added canonical bootstrap evidence and a pre-merge premortem.
* **Tests**
  * Added comprehensive bootstrap/visibility/metrics/guard coverage for foods/catalog registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

