### PR TITLE
feat(orchestration): add reviewed creative spec finalize handoff

### DIFF
--- a/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
+++ b/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
@@ -56,6 +56,7 @@ open the semantic-cache gate.
 | `private-pilot-lifecycle` | Reads sanitized lifecycle metadata and emits local next-action artifacts. | Allowed only through the private-pilot loop operator; no candidate generation or GitHub write authority. |
 | `pr-creative-context` | Expands eligible PR context into 3-5 hypotheses, validates operator-supplied local hypothesis JSON, assigns normalized hypothesis IDs, records cross-domain analogies, emits agent routing/coordinator dispatch, and prepares approval reservations. | Allowed only through local sanitized Experiment Runner creative-context artifacts; no repo-side provider/model call, patch generation, workflow mutation, semantic cache, or GitHub write authority. |
 | `approved-hypothesis-spec-bridge` | Converts a human-approved creative hypothesis into a validated PR-0 creative-code candidate and existing PR-1 prepare artifacts. | Allowed only through local `creative_hypothesis_spec_bridge.py`; no mutable-surface widening, provider calls, patch generation, PR writes, role execution, finalization, semantic cache, graph truth, or product runtime authority. |
+| `reviewed-spec-finalize` | Attaches sanitized local skeptic-review evidence to a prepared bridge run and delegates to existing PR-1 finalize in a sibling reviewed directory. | Allowed only through local `creative_specification_skeptic_review.py`; must preserve `spec_prepare/`; no agent execution, provider calls, patch generation, PR writes, workflow changes, semantic cache, graph truth, product runtime, fixed-mapping edits, review-thread actions, or readiness claims. |
 
 PR-0 sets:
 
@@ -184,6 +185,8 @@ The approved creative-hypothesis specification bridge artifacts are:
 - `docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json`
 - `scripts/orchestration/creative_hypothesis_spec_bridge_contract.py`
 - `scripts/orchestration/creative_hypothesis_spec_bridge.py`
+- `scripts/orchestration/creative_specification_skeptic_review_contract.py`
+- `scripts/orchestration/creative_specification_skeptic_review.py`
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/creative_hypothesis_specification_bridge.json`
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/creative_code_candidate_packet.json`
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/bridge_metrics.json`
@@ -191,6 +194,9 @@ The approved creative-hypothesis specification bridge artifacts are:
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_prepare/variants.json`
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_prepare/skeptic_reviews.json`
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_prepare/context_pack.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/skeptic_review_attachment.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/creative_code_specification_bundle.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/finalize_receipt.json`
 
 Bridge output directories must be exactly
 `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/`; bridge refs,
@@ -248,6 +254,12 @@ PR-0 is a contract-only start point.
   existing PR-1 prepare artifacts; no agent execution, finalize, candidate
   patches, provider calls, workflow changes, repository writes, product runtime
   truth, semantic cache, graph truth, or mutable-surface widening.
+- Reviewed bridge finalize evidence attachment: attach sanitized local
+  skeptic-review evidence in sibling `spec_finalize_reviewed/`, run the
+  existing PR-1 `finalize`, emit metadata-only attachment/receipt counts, and
+  preserve `spec_prepare/`; no agent execution, patches, branch/PR writes,
+  provider calls, workflows, product runtime truth, semantic cache, graph truth,
+  fixed-mapping edits, review-thread actions, or readiness claims.
 - PR-2: generate isolated candidate patches only in sandboxed evaluation
   workspaces with exact source-bundle fingerprint binding, exact `origin/main`
   base SHA, fixed Codex CLI argv/env, strict patch policy validation, direct
@@ -280,9 +292,9 @@ PR-0 is a contract-only start point.
   workflows, call providers, call product runtime, create branches, open PRs,
   post comments, resolve threads, edit fixed mappings, merge, or claim
   readiness.
-- Bridge follow-ups remain separate reviewed PRs: attach agent skeptic reviews
-  and `finalize`, ingest bridge metrics into the existing telemetry /
-  learning-loop rollup, and explore graph/multimodal lineage only after
+- Bridge follow-ups remain separate reviewed PRs: ingest bridge metrics into
+  the existing telemetry / learning-loop rollup and explore graph/multimodal
+  lineage only after
   repo-reviewed evidence contracts define asset lineage, fingerprints,
   idempotency, and replay/admission behavior.
 

--- a/docs/orchestration/contracts/CREATIVE_CODE_SPECIFICATION_CONTRACT.md
+++ b/docs/orchestration/contracts/CREATIVE_CODE_SPECIFICATION_CONTRACT.md
@@ -121,6 +121,28 @@ root, non-JSON inputs, duplicate JSON keys, and partial-write states. The pure
 validator module has no filesystem writes, subprocesses, provider imports,
 network imports, GitHub/Slack calls, or product-runtime imports.
 
+## Reviewed Bridge Finalize Handoff
+
+`creative_specification_skeptic_review.py` is the only bridge-finalize wrapper.
+It consumes a prepared `creative_hypothesis_spec_bridge.py` run plus an
+operator-supplied sanitized `CreativeSpecificationAgentSkepticReviews` artifact,
+validates bridge, candidate, metrics, source-packet, variant, and review
+fingerprints, and writes a sibling reviewed run:
+
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/source_packet.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/variants.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/skeptic_reviews.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/context_pack.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/skeptic_review_attachment.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/creative_code_specification_bundle.json`
+- `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/finalize_receipt.json`
+
+The wrapper must not mutate the original `spec_prepare/` directory. The
+attachment and receipt are metadata-only binding artifacts with bounded counts
+and closed authority flags; they do not grant patch, branch, PR, provider,
+runtime, semantic-cache, graph-truth, fixed-mapping, review-thread, or
+merge-readiness authority.
+
 ## Rejection Index
 
 Rejected variants are recorded in

--- a/docs/orchestration/contracts/EXPERIMENT_RUNNER_PR_CREATIVE_CONTEXT_CONTRACT.md
+++ b/docs/orchestration/contracts/EXPERIMENT_RUNNER_PR_CREATIVE_CONTEXT_CONTRACT.md
@@ -172,6 +172,15 @@ Build-only bridge artifacts keep `spec_prepare.prepared=false` and
 `prepare-specification` writes the four deterministic PR-1 artifacts may the
 bridge mark `prepared=true` and expose `next_allowed_action=agent_skeptic_review`.
 
+The reviewed finalize follow-up remains outside the bridge. It may only run
+through `creative_specification_skeptic_review.py`, which copies prepared
+artifacts into sibling `spec_finalize_reviewed/`, attaches sanitized local
+agent skeptic-review evidence, delegates to the existing PR-1
+`creative_code_spec_pipeline.finalize`, and emits metadata-only attachment and
+receipt artifacts. It must not rewrite `spec_prepare/` or add agent, provider,
+patch, branch, PR, workflow, product-runtime, semantic-cache, graph-truth,
+fixed-mapping, review-thread, or merge-readiness authority to the bridge.
+
 ## Operator Model Intake
 
 `CreativeHypothesisOperatorModelIntake` is an advisory, unverified local input

--- a/docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json
@@ -50,7 +50,7 @@
       "maxLength": 96,
       "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$",
       "not": {
-        "pattern": "(sk-[A-Za-z0-9_-]{12,}|gh[psoru]_[A-Za-z0-9_]{12,}|github_pat_|xox[abprs]-|authorization:\\s*bearer|private[_ -]?key)"
+        "pattern": "([Ss][Kk]-[A-Za-z0-9_-]{12,}|[Gg][Hh][PpSsOoRrUu]_[A-Za-z0-9_]{12,}|[Gg][Ii][Tt][Hh][Uu][Bb]_[Pp][Aa][Tt]_|[Xx][Oo][Xx][abprsABPRS]-|[Aa]uthorization:\\s*[Bb]earer|[Pp]rivate[_ -]?[Kk]ey)"
       }
     },
     "safe_text": {
@@ -60,7 +60,7 @@
       "allOf": [
         {
           "not": {
-            "pattern": "([Cc]andidate\\.patch|[Dd]iff --git|[Pp]rovider[_ -]?[Pp]ayload|[Rr]aw[_ -]?([Pp]rompt|[Rr]esponse|[Cc]ontext)|[Cc]hain[_ -]?[Oo]f[_ -]?[Tt]hought|https?://|api\\.openai\\.com|[Cc]all [Mm]odel|[Cc]all [Nn]etwork|[Rr]untime [Ss]ervice|[Pp]roduct [Rr]untime|[Aa]pply ([Aa] )?([Rr]epository )?[Pp]atch|[Rr]epository [Pp]atch|[Cc]ommit [Cc]hanges|[Gg]it [Cc]ommit|[Gg]it [Pp]ush|[Cc]reate ([Aa] )?([Pp]ull [Rr]equest|PR|[Bb]ranch)|[Oo]pen ([Aa] )?([Dd]raft )?([Pp]ull [Rr]equest|PR)|[Ww]rite ([Tt]o )?([Tt]he )?[Rr]epository|[Ww]rite [Rr]epository|[Rr]esolve [Rr]eview [Tt]hread|[Mm]ark [Rr]eady [Ff]or [Rr]eview|[Mm]erge [Rr]eadiness|[Ss]emantic [Cc]ache|[Gg]raph [Tt]ruth|[Ww]orkflow [Dd]ispatch|[Pp]rovider [Cc]all|[Dd]iagnose|[Tt]reat|[Cc]linical [Ee]fficacy|[Cc]risis [Ss]upport|[Ee]mergency [Cc]are)"
+            "pattern": "([Cc]andidate\\.patch|[Dd]iff --git|[Pp]rovider[_ -]?[Pp]ayload|[Rr]aw[_ -]?([Pp]rompt|[Rr]esponse|[Cc]ontext)|[Cc]hain[_ -]?[Oo]f[_ -]?[Tt]hought|https?://|api\\.openai\\.com|[Cc]all [Mm]odel|[Cc]all [Nn]etwork|[Rr]untime [Ss]ervice|[Pp]roduct [Rr]untime|[Aa]pply ([Aa] )?([Rr]epository )?[Pp]atch|[Rr]epository [Pp]atch|[Cc]ommit [Cc]hanges|[Gg]it [Cc]ommit|[Gg]it [Pp]ush|[Cc]reate ([Aa] )?([Pp]ull [Rr]equest|[Pp][Rr]|[Bb]ranch)|[Oo]pen ([Aa] )?([Dd]raft )?([Pp]ull [Rr]equest|[Pp][Rr])|[Ww]rite ([Tt]o )?([Tt]he )?[Rr]epository|[Ww]rite [Rr]epository|[Rr]esolve [Rr]eview [Tt]hread|[Mm]ark [Rr]eady [Ff]or [Rr]eview|[Mm]erge [Rr]eadiness|[Ss]emantic [Cc]ache|[Gg]raph [Tt]ruth|[Ww]orkflow [Dd]ispatch|[Pp]rovider [Cc]all|[Dd]iagnose|[Tt]reat|[Cc]linical [Ee]fficacy|[Cc]risis [Ss]upport|[Ee]mergency [Cc]are)"
           }
         },
         {
@@ -70,7 +70,7 @@
         },
         {
           "not": {
-            "pattern": "(sk-[A-Za-z0-9_-]{12,}|gh[psoru]_[A-Za-z0-9_]{12,}|github_pat_|xox[abprs]-|authorization:\\s*bearer|private[_ -]?key)"
+            "pattern": "([Ss][Kk]-[A-Za-z0-9_-]{12,}|[Gg][Hh][PpSsOoRrUu]_[A-Za-z0-9_]{12,}|[Gg][Ii][Tt][Hh][Uu][Bb]_[Pp][Aa][Tt]_|[Xx][Oo][Xx][abprsABPRS]-|[Aa]uthorization:\\s*[Bb]earer|[Pp]rivate[_ -]?[Kk]ey)"
           }
         }
       ]

--- a/docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json
@@ -65,7 +65,7 @@
         },
         {
           "not": {
-            "pattern": "(^|[\\s:=,(\\[{'\"`<])(/(users|home|etc|workspace|tmp|private/var|var/folders)(/|$)|~[/\\\\]|[A-Za-z]:[/\\\\](Users|Documents and Settings|Windows|Temp|tmp)|\\\\\\\\[^\\\\/\\s]+[/\\\\][^\\\\/\\s]+)"
+            "pattern": "(^|[\\s:=,(\\[{'\"`<])(/([Uu]sers|[Hh]ome|[Ee]tc|[Ww]orkspace|[Tt]mp|[Pp]rivate/[Vv]ar|[Vv]ar/[Ff]olders)(/|$)|~[/\\\\]|[A-Za-z]:[/\\\\]([Uu]sers|[Dd]ocuments and Settings|[Ww]indows|[Tt]emp|[Tt]mp)|\\\\\\\\[^\\\\/\\s]+[/\\\\][^\\\\/\\s]+)"
           }
         },
         {

--- a/docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json",
+  "title": "CreativeSpecificationAgentSkepticReviews",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "source_bridge_id",
+    "source_bridge_fingerprint",
+    "source_candidate_id",
+    "source_candidate_fingerprint",
+    "source_packet_fingerprint",
+    "variants_fingerprint",
+    "reviews",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_specification_agent_skeptic_reviews" },
+    "policy_version": { "const": "creative-specification-skeptic-review-finalize-v1" },
+    "source_bridge_id": { "$ref": "#/$defs/safe_id" },
+    "source_bridge_fingerprint": { "$ref": "#/$defs/sha256" },
+    "source_candidate_id": { "$ref": "#/$defs/safe_id" },
+    "source_candidate_fingerprint": { "$ref": "#/$defs/sha256" },
+    "source_packet_fingerprint": { "$ref": "#/$defs/sha256" },
+    "variants_fingerprint": { "$ref": "#/$defs/sha256" },
+    "reviews": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 15,
+      "items": { "$ref": "#/$defs/review_input" }
+    },
+    "authority": { "$ref": "#/$defs/input_authority" },
+    "sanitized": { "const": true }
+  },
+  "$defs": {
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "safe_token": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 96,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$",
+      "not": {
+        "pattern": "(sk-[A-Za-z0-9_-]{12,}|gh[psoru]_[A-Za-z0-9_]{12,}|github_pat_|xox[abprs]-|authorization:\\s*bearer|private[_ -]?key)"
+      }
+    },
+    "safe_text": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "allOf": [
+        {
+          "not": {
+            "pattern": "(candidate\\.patch|diff --git|provider[_ -]?payload|raw[_ -]?(prompt|response|context)|chain[_ -]?of[_ -]?thought|https?://|api\\.openai\\.com|call model|call network|runtime service|product runtime|repository patch|git commit|git push|pull request|write repository|resolve review thread|merge readiness|semantic cache|graph truth|workflow dispatch|diagnose|treat|clinical efficacy|crisis support|emergency care)"
+          }
+        },
+        {
+          "not": {
+            "pattern": "(^|[\\s:=,(\\[{'\"`<])(/(users|home|etc|workspace|tmp|private/var|var/folders)(/|$)|~[/\\\\]|[A-Za-z]:[/\\\\](Users|Documents and Settings|Windows|Temp|tmp)|\\\\\\\\[^\\\\/\\s]+[/\\\\][^\\\\/\\s]+)"
+          }
+        },
+        {
+          "not": {
+            "pattern": "(sk-[A-Za-z0-9_-]{12,}|gh[psoru]_[A-Za-z0-9_]{12,}|github_pat_|xox[abprs]-|authorization:\\s*bearer|private[_ -]?key)"
+          }
+        }
+      ]
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "review_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "variant_id",
+        "reviewer_role",
+        "decision",
+        "blockers",
+        "unsafe_authority_flags",
+        "duplicate_reason",
+        "required_revision"
+      ],
+      "properties": {
+        "variant_id": { "$ref": "#/$defs/safe_id" },
+        "reviewer_role": {
+          "enum": [
+            "architecture-specialist",
+            "security-auditor",
+            "qa-engineer-agent"
+          ]
+        },
+        "decision": { "enum": ["pass", "revise", "reject"] },
+        "blockers": {
+          "type": "array",
+          "maxItems": 10,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/safe_token" }
+        },
+        "unsafe_authority_flags": {
+          "type": "array",
+          "maxItems": 10,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/safe_token" }
+        },
+        "duplicate_reason": { "$ref": "#/$defs/safe_text" },
+        "required_revision": { "$ref": "#/$defs/safe_text" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "decision": { "const": "pass" } } },
+          "then": {
+            "properties": {
+              "blockers": { "maxItems": 0 },
+              "unsafe_authority_flags": { "maxItems": 0 },
+              "duplicate_reason": { "const": "none" },
+              "required_revision": { "const": "none" }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "decision": { "const": "reject" } } },
+          "then": { "properties": { "blockers": { "minItems": 1 } } }
+        },
+        {
+          "if": { "properties": { "decision": { "const": "revise" } } },
+          "then": {
+            "properties": {
+              "required_revision": { "not": { "const": "none" } }
+            }
+          }
+        }
+      ]
+    },
+    "input_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attach_skeptic_reviews",
+        "call_product_runtime",
+        "call_provider",
+        "change_client_runtime",
+        "change_openapi",
+        "claim_merge_readiness",
+        "create_branch",
+        "dispatch_to_agents",
+        "edit_fixed_mapping",
+        "emit_local_artifacts",
+        "execute_agent_tasks",
+        "execute_pr2_patch_builder",
+        "execute_pr3_promotion",
+        "finalize_specification_bundle",
+        "generate_candidate_patch",
+        "generate_patch",
+        "merge",
+        "modify_workflows",
+        "open_draft_pr",
+        "open_pr",
+        "operator_supplied_sanitized_reviews",
+        "post_github_comment",
+        "push",
+        "read_secrets",
+        "resolve_threads",
+        "use_semantic_cache",
+        "workflow_dispatch",
+        "write_branch",
+        "write_graph_truth",
+        "write_repository",
+        "write_shared_worktree"
+      ],
+      "properties": {
+        "operator_supplied_sanitized_reviews": { "const": true },
+        "attach_skeptic_reviews": { "const": false },
+        "emit_local_artifacts": { "const": false },
+        "finalize_specification_bundle": { "const": false },
+        "call_product_runtime": { "const": false },
+        "call_provider": { "const": false },
+        "change_client_runtime": { "const": false },
+        "change_openapi": { "const": false },
+        "claim_merge_readiness": { "const": false },
+        "create_branch": { "const": false },
+        "dispatch_to_agents": { "const": false },
+        "edit_fixed_mapping": { "const": false },
+        "execute_agent_tasks": { "const": false },
+        "execute_pr2_patch_builder": { "const": false },
+        "execute_pr3_promotion": { "const": false },
+        "generate_candidate_patch": { "const": false },
+        "generate_patch": { "const": false },
+        "merge": { "const": false },
+        "modify_workflows": { "const": false },
+        "open_draft_pr": { "const": false },
+        "open_pr": { "const": false },
+        "post_github_comment": { "const": false },
+        "push": { "const": false },
+        "read_secrets": { "const": false },
+        "resolve_threads": { "const": false },
+        "use_semantic_cache": { "const": false },
+        "workflow_dispatch": { "const": false },
+        "write_branch": { "const": false },
+        "write_graph_truth": { "const": false },
+        "write_repository": { "const": false },
+        "write_shared_worktree": { "const": false }
+      }
+    }
+  }
+}

--- a/docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json
@@ -60,7 +60,7 @@
       "allOf": [
         {
           "not": {
-            "pattern": "(candidate\\.patch|diff --git|provider[_ -]?payload|raw[_ -]?(prompt|response|context)|chain[_ -]?of[_ -]?thought|https?://|api\\.openai\\.com|call model|call network|runtime service|product runtime|repository patch|git commit|git push|pull request|write repository|resolve review thread|merge readiness|semantic cache|graph truth|workflow dispatch|diagnose|treat|clinical efficacy|crisis support|emergency care)"
+            "pattern": "([Cc]andidate\\.patch|[Dd]iff --git|[Pp]rovider[_ -]?[Pp]ayload|[Rr]aw[_ -]?([Pp]rompt|[Rr]esponse|[Cc]ontext)|[Cc]hain[_ -]?[Oo]f[_ -]?[Tt]hought|https?://|api\\.openai\\.com|[Cc]all [Mm]odel|[Cc]all [Nn]etwork|[Rr]untime [Ss]ervice|[Pp]roduct [Rr]untime|[Aa]pply ([Aa] )?([Rr]epository )?[Pp]atch|[Rr]epository [Pp]atch|[Cc]ommit [Cc]hanges|[Gg]it [Cc]ommit|[Gg]it [Pp]ush|[Cc]reate ([Aa] )?([Pp]ull [Rr]equest|PR|[Bb]ranch)|[Oo]pen ([Aa] )?([Dd]raft )?([Pp]ull [Rr]equest|PR)|[Ww]rite ([Tt]o )?([Tt]he )?[Rr]epository|[Ww]rite [Rr]epository|[Rr]esolve [Rr]eview [Tt]hread|[Mm]ark [Rr]eady [Ff]or [Rr]eview|[Mm]erge [Rr]eadiness|[Ss]emantic [Cc]ache|[Gg]raph [Tt]ruth|[Ww]orkflow [Dd]ispatch|[Pp]rovider [Cc]all|[Dd]iagnose|[Tt]reat|[Cc]linical [Ee]fficacy|[Cc]risis [Ss]upport|[Ee]mergency [Cc]are)"
           }
         },
         {

--- a/docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json
@@ -113,7 +113,7 @@
         "review_count": { "type": "integer", "minimum": 1, "maximum": 15 },
         "selected_variant_count": { "type": "integer", "minimum": 0, "maximum": 1 },
         "rejected_variant_count": { "type": "integer", "minimum": 0, "maximum": 5 },
-        "unresolved_blocker_count": { "type": "integer", "minimum": 0, "maximum": 30 },
+        "unresolved_blocker_count": { "type": "integer", "minimum": 0, "maximum": 150 },
         "rejection_record_count": { "type": "integer", "minimum": 0, "maximum": 5 }
       }
     },

--- a/docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_specification_finalize_receipt.v1.schema.json",
+  "title": "CreativeSpecificationFinalizeReceipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "finalize_id",
+    "idempotency_key",
+    "policy_version",
+    "source_attachment_id",
+    "source_attachment_fingerprint",
+    "source_attachment_ref",
+    "reviewed_run_dir_ref",
+    "bundle_ref",
+    "bundle_id",
+    "bundle_fingerprint",
+    "bundle_idempotency_key",
+    "selected_variant_id",
+    "synthesis_status",
+    "next_allowed_action",
+    "counts",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_specification_finalize_receipt" },
+    "finalize_id": { "$ref": "#/$defs/safe_id" },
+    "idempotency_key": { "$ref": "#/$defs/safe_id" },
+    "policy_version": { "const": "creative-specification-skeptic-review-finalize-v1" },
+    "source_attachment_id": { "$ref": "#/$defs/safe_id" },
+    "source_attachment_fingerprint": { "$ref": "#/$defs/sha256" },
+    "source_attachment_ref": { "$ref": "#/$defs/artifact_ref" },
+    "reviewed_run_dir_ref": { "$ref": "#/$defs/reviewed_run_ref" },
+    "bundle_ref": { "$ref": "#/$defs/artifact_ref" },
+    "bundle_id": { "$ref": "#/$defs/safe_id" },
+    "bundle_fingerprint": { "$ref": "#/$defs/sha256" },
+    "bundle_idempotency_key": { "$ref": "#/$defs/safe_id" },
+    "selected_variant_id": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/safe_id" }
+      ]
+    },
+    "synthesis_status": { "enum": ["selected", "all_rejected"] },
+    "next_allowed_action": {
+      "enum": [
+        "human_review_for_patch_builder",
+        "human_review_for_discard_or_defer"
+      ]
+    },
+    "counts": { "$ref": "#/$defs/counts" },
+    "authority": { "$ref": "#/$defs/finalize_authority" },
+    "sanitized": { "const": true }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "selected_variant_id": { "type": "null" } } },
+      "then": {
+        "properties": {
+          "synthesis_status": { "const": "all_rejected" },
+          "next_allowed_action": { "const": "human_review_for_discard_or_defer" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "selected_variant_id": { "type": "string" } } },
+      "then": {
+        "properties": {
+          "synthesis_status": { "const": "selected" },
+          "next_allowed_action": { "const": "human_review_for_patch_builder" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "artifact_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:\\.json)?)?$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" }
+    },
+    "reviewed_run_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "variant_count",
+        "review_count",
+        "selected_variant_count",
+        "rejected_variant_count",
+        "unresolved_blocker_count",
+        "rejection_record_count"
+      ],
+      "properties": {
+        "variant_count": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "review_count": { "type": "integer", "minimum": 1, "maximum": 15 },
+        "selected_variant_count": { "type": "integer", "minimum": 0, "maximum": 1 },
+        "rejected_variant_count": { "type": "integer", "minimum": 0, "maximum": 5 },
+        "unresolved_blocker_count": { "type": "integer", "minimum": 0, "maximum": 30 },
+        "rejection_record_count": { "type": "integer", "minimum": 0, "maximum": 5 }
+      }
+    },
+    "finalize_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "finalize_specification_bundle": { "const": true },
+        "emit_local_artifacts": { "const": true },
+        "attach_skeptic_reviews": { "const": false },
+        "operator_supplied_sanitized_reviews": { "const": false },
+        "call_product_runtime": { "const": false },
+        "call_provider": { "const": false },
+        "change_client_runtime": { "const": false },
+        "change_openapi": { "const": false },
+        "claim_merge_readiness": { "const": false },
+        "create_branch": { "const": false },
+        "dispatch_to_agents": { "const": false },
+        "edit_fixed_mapping": { "const": false },
+        "execute_agent_tasks": { "const": false },
+        "execute_pr2_patch_builder": { "const": false },
+        "execute_pr3_promotion": { "const": false },
+        "generate_candidate_patch": { "const": false },
+        "generate_patch": { "const": false },
+        "merge": { "const": false },
+        "modify_workflows": { "const": false },
+        "open_draft_pr": { "const": false },
+        "open_pr": { "const": false },
+        "post_github_comment": { "const": false },
+        "push": { "const": false },
+        "read_secrets": { "const": false },
+        "resolve_threads": { "const": false },
+        "use_semantic_cache": { "const": false },
+        "workflow_dispatch": { "const": false },
+        "write_branch": { "const": false },
+        "write_graph_truth": { "const": false },
+        "write_repository": { "const": false },
+        "write_shared_worktree": { "const": false }
+      },
+      "required": [
+        "attach_skeptic_reviews",
+        "call_product_runtime",
+        "call_provider",
+        "change_client_runtime",
+        "change_openapi",
+        "claim_merge_readiness",
+        "create_branch",
+        "dispatch_to_agents",
+        "edit_fixed_mapping",
+        "emit_local_artifacts",
+        "execute_agent_tasks",
+        "execute_pr2_patch_builder",
+        "execute_pr3_promotion",
+        "finalize_specification_bundle",
+        "generate_candidate_patch",
+        "generate_patch",
+        "merge",
+        "modify_workflows",
+        "open_draft_pr",
+        "open_pr",
+        "operator_supplied_sanitized_reviews",
+        "post_github_comment",
+        "push",
+        "read_secrets",
+        "resolve_threads",
+        "use_semantic_cache",
+        "workflow_dispatch",
+        "write_branch",
+        "write_graph_truth",
+        "write_repository",
+        "write_shared_worktree"
+      ]
+    }
+  }
+}

--- a/docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json
@@ -33,9 +33,9 @@
     "policy_version": { "const": "creative-specification-skeptic-review-finalize-v1" },
     "source_attachment_id": { "$ref": "#/$defs/safe_id" },
     "source_attachment_fingerprint": { "$ref": "#/$defs/sha256" },
-    "source_attachment_ref": { "$ref": "#/$defs/artifact_ref" },
+    "source_attachment_ref": { "$ref": "#/$defs/reviewed_attachment_ref" },
     "reviewed_run_dir_ref": { "$ref": "#/$defs/reviewed_run_ref" },
-    "bundle_ref": { "$ref": "#/$defs/artifact_ref" },
+    "bundle_ref": { "$ref": "#/$defs/reviewed_bundle_ref" },
     "bundle_id": { "$ref": "#/$defs/safe_id" },
     "bundle_fingerprint": { "$ref": "#/$defs/sha256" },
     "bundle_idempotency_key": { "$ref": "#/$defs/safe_id" },
@@ -62,7 +62,12 @@
       "then": {
         "properties": {
           "synthesis_status": { "const": "all_rejected" },
-          "next_allowed_action": { "const": "human_review_for_discard_or_defer" }
+          "next_allowed_action": { "const": "human_review_for_discard_or_defer" },
+          "counts": {
+            "properties": {
+              "selected_variant_count": { "const": 0 }
+            }
+          }
         }
       }
     },
@@ -71,7 +76,122 @@
       "then": {
         "properties": {
           "synthesis_status": { "const": "selected" },
-          "next_allowed_action": { "const": "human_review_for_patch_builder" }
+          "next_allowed_action": { "const": "human_review_for_patch_builder" },
+          "counts": {
+            "properties": {
+              "selected_variant_count": { "const": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "selected_variant_id": { "type": "null" },
+          "counts": {
+            "properties": {
+              "variant_count": { "const": 1 }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "counts": {
+            "properties": {
+              "rejected_variant_count": { "const": 1 },
+              "rejection_record_count": { "const": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "selected_variant_id": { "type": "null" },
+          "counts": {
+            "properties": {
+              "variant_count": { "const": 2 }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "counts": {
+            "properties": {
+              "rejected_variant_count": { "const": 2 },
+              "rejection_record_count": { "const": 2 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "selected_variant_id": { "type": "null" },
+          "counts": {
+            "properties": {
+              "variant_count": { "const": 3 }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "counts": {
+            "properties": {
+              "rejected_variant_count": { "const": 3 },
+              "rejection_record_count": { "const": 3 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "selected_variant_id": { "type": "null" },
+          "counts": {
+            "properties": {
+              "variant_count": { "const": 4 }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "counts": {
+            "properties": {
+              "rejected_variant_count": { "const": 4 },
+              "rejection_record_count": { "const": 4 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "selected_variant_id": { "type": "null" },
+          "counts": {
+            "properties": {
+              "variant_count": { "const": 5 }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "counts": {
+            "properties": {
+              "rejected_variant_count": { "const": 5 },
+              "rejection_record_count": { "const": 5 }
+            }
+          }
         }
       }
     }
@@ -96,6 +216,18 @@
       "type": "string",
       "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed$",
       "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" }
+    },
+    "reviewed_attachment_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed/skeptic_review_attachment\\.json$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" },
+      "$comment": "Same-run prefix equality with reviewed_run_dir_ref is enforced by the repository runtime validator."
+    },
+    "reviewed_bundle_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed/creative_code_specification_bundle\\.json$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" },
+      "$comment": "Same-run prefix equality with reviewed_run_dir_ref is enforced by the repository runtime validator."
     },
     "counts": {
       "type": "object",

--- a/docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json
@@ -89,7 +89,7 @@
     },
     "artifact_ref": {
       "type": "string",
-      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:\\.json)?)?$",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:\\.json)?)*$",
       "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" }
     },
     "reviewed_run_ref": {

--- a/docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json
@@ -41,7 +41,7 @@
     },
     "artifact_ref": {
       "type": "string",
-      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:\\.json)?)?$",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:\\.json)?)*$",
       "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" }
     },
     "reviewed_run_ref": {

--- a/docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json
@@ -133,8 +133,8 @@
         "pass_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
         "revise_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
         "reject_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
-        "unsafe_authority_flag_count": { "type": "integer", "minimum": 0, "maximum": 15 },
-        "blocker_count": { "type": "integer", "minimum": 0, "maximum": 30 }
+        "unsafe_authority_flag_count": { "type": "integer", "minimum": 0, "maximum": 150 },
+        "blocker_count": { "type": "integer", "minimum": 0, "maximum": 150 }
       }
     },
     "attachment_authority": {

--- a/docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_specification_skeptic_review_attachment.v1.schema.json",
+  "title": "CreativeSpecificationSkepticReviewAttachment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "attachment_id",
+    "idempotency_key",
+    "policy_version",
+    "source",
+    "reviewed_run",
+    "coverage",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_specification_skeptic_review_attachment" },
+    "attachment_id": { "$ref": "#/$defs/safe_id" },
+    "idempotency_key": { "$ref": "#/$defs/safe_id" },
+    "policy_version": { "const": "creative-specification-skeptic-review-finalize-v1" },
+    "source": { "$ref": "#/$defs/source" },
+    "reviewed_run": { "$ref": "#/$defs/reviewed_run" },
+    "coverage": { "$ref": "#/$defs/coverage" },
+    "authority": { "$ref": "#/$defs/attachment_authority" },
+    "sanitized": { "const": true }
+  },
+  "$defs": {
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "artifact_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}(?:\\.json)?)?$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" }
+    },
+    "reviewed_run_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bridge_id",
+        "bridge_fingerprint",
+        "bridge_ref",
+        "candidate_id",
+        "candidate_fingerprint",
+        "candidate_ref",
+        "metrics_id",
+        "metrics_fingerprint",
+        "metrics_ref",
+        "spec_prepare_ref",
+        "source_packet_ref",
+        "source_packet_fingerprint",
+        "variants_ref",
+        "variants_fingerprint",
+        "pending_reviews_ref",
+        "pending_reviews_fingerprint",
+        "context_pack_ref",
+        "context_pack_fingerprint"
+      ],
+      "properties": {
+        "bridge_id": { "$ref": "#/$defs/safe_id" },
+        "bridge_fingerprint": { "$ref": "#/$defs/sha256" },
+        "bridge_ref": { "$ref": "#/$defs/artifact_ref" },
+        "candidate_id": { "$ref": "#/$defs/safe_id" },
+        "candidate_fingerprint": { "$ref": "#/$defs/sha256" },
+        "candidate_ref": { "$ref": "#/$defs/artifact_ref" },
+        "metrics_id": { "$ref": "#/$defs/safe_id" },
+        "metrics_fingerprint": { "$ref": "#/$defs/sha256" },
+        "metrics_ref": { "$ref": "#/$defs/artifact_ref" },
+        "spec_prepare_ref": { "$ref": "#/$defs/artifact_ref" },
+        "source_packet_ref": { "$ref": "#/$defs/artifact_ref" },
+        "source_packet_fingerprint": { "$ref": "#/$defs/sha256" },
+        "variants_ref": { "$ref": "#/$defs/artifact_ref" },
+        "variants_fingerprint": { "$ref": "#/$defs/sha256" },
+        "pending_reviews_ref": { "$ref": "#/$defs/artifact_ref" },
+        "pending_reviews_fingerprint": { "$ref": "#/$defs/sha256" },
+        "context_pack_ref": { "$ref": "#/$defs/artifact_ref" },
+        "context_pack_fingerprint": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "reviewed_run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_dir_ref",
+        "source_packet_ref",
+        "variants_ref",
+        "skeptic_reviews_ref",
+        "context_pack_ref",
+        "normalized_reviews_fingerprint"
+      ],
+      "properties": {
+        "run_dir_ref": { "$ref": "#/$defs/reviewed_run_ref" },
+        "source_packet_ref": { "$ref": "#/$defs/artifact_ref" },
+        "variants_ref": { "$ref": "#/$defs/artifact_ref" },
+        "skeptic_reviews_ref": { "$ref": "#/$defs/artifact_ref" },
+        "context_pack_ref": { "$ref": "#/$defs/artifact_ref" },
+        "normalized_reviews_fingerprint": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "variant_count",
+        "required_reviewer_count",
+        "review_count",
+        "pass_review_count",
+        "revise_review_count",
+        "reject_review_count",
+        "unsafe_authority_flag_count",
+        "blocker_count"
+      ],
+      "properties": {
+        "variant_count": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "required_reviewer_count": { "const": 3 },
+        "review_count": { "type": "integer", "minimum": 1, "maximum": 15 },
+        "pass_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
+        "revise_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
+        "reject_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
+        "unsafe_authority_flag_count": { "type": "integer", "minimum": 0, "maximum": 15 },
+        "blocker_count": { "type": "integer", "minimum": 0, "maximum": 30 }
+      }
+    },
+    "attachment_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attach_skeptic_reviews": { "const": true },
+        "emit_local_artifacts": { "const": true },
+        "finalize_specification_bundle": { "const": false },
+        "operator_supplied_sanitized_reviews": { "const": false },
+        "call_product_runtime": { "const": false },
+        "call_provider": { "const": false },
+        "change_client_runtime": { "const": false },
+        "change_openapi": { "const": false },
+        "claim_merge_readiness": { "const": false },
+        "create_branch": { "const": false },
+        "dispatch_to_agents": { "const": false },
+        "edit_fixed_mapping": { "const": false },
+        "execute_agent_tasks": { "const": false },
+        "execute_pr2_patch_builder": { "const": false },
+        "execute_pr3_promotion": { "const": false },
+        "generate_candidate_patch": { "const": false },
+        "generate_patch": { "const": false },
+        "merge": { "const": false },
+        "modify_workflows": { "const": false },
+        "open_draft_pr": { "const": false },
+        "open_pr": { "const": false },
+        "post_github_comment": { "const": false },
+        "push": { "const": false },
+        "read_secrets": { "const": false },
+        "resolve_threads": { "const": false },
+        "use_semantic_cache": { "const": false },
+        "workflow_dispatch": { "const": false },
+        "write_branch": { "const": false },
+        "write_graph_truth": { "const": false },
+        "write_repository": { "const": false },
+        "write_shared_worktree": { "const": false }
+      },
+      "required": [
+        "attach_skeptic_reviews",
+        "call_product_runtime",
+        "call_provider",
+        "change_client_runtime",
+        "change_openapi",
+        "claim_merge_readiness",
+        "create_branch",
+        "dispatch_to_agents",
+        "edit_fixed_mapping",
+        "emit_local_artifacts",
+        "execute_agent_tasks",
+        "execute_pr2_patch_builder",
+        "execute_pr3_promotion",
+        "finalize_specification_bundle",
+        "generate_candidate_patch",
+        "generate_patch",
+        "merge",
+        "modify_workflows",
+        "open_draft_pr",
+        "open_pr",
+        "operator_supplied_sanitized_reviews",
+        "post_github_comment",
+        "push",
+        "read_secrets",
+        "resolve_threads",
+        "use_semantic_cache",
+        "workflow_dispatch",
+        "write_branch",
+        "write_graph_truth",
+        "write_repository",
+        "write_shared_worktree"
+      ]
+    }
+  }
+}

--- a/docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json
+++ b/docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json
@@ -49,6 +49,30 @@
       "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed$",
       "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" }
     },
+    "reviewed_source_packet_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed/source_packet\\.json$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" },
+      "$comment": "Same-run prefix equality with run_dir_ref is enforced by the repository runtime validator."
+    },
+    "reviewed_variants_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed/variants\\.json$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" },
+      "$comment": "Same-run prefix equality with run_dir_ref is enforced by the repository runtime validator."
+    },
+    "reviewed_reviews_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed/skeptic_reviews\\.json$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" },
+      "$comment": "Same-run prefix equality with run_dir_ref is enforced by the repository runtime validator."
+    },
+    "reviewed_context_pack_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/spec_bridge/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}/spec_finalize_reviewed/context_pack\\.json$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" },
+      "$comment": "Same-run prefix equality with run_dir_ref is enforced by the repository runtime validator."
+    },
     "source": {
       "type": "object",
       "additionalProperties": false,
@@ -106,10 +130,10 @@
       ],
       "properties": {
         "run_dir_ref": { "$ref": "#/$defs/reviewed_run_ref" },
-        "source_packet_ref": { "$ref": "#/$defs/artifact_ref" },
-        "variants_ref": { "$ref": "#/$defs/artifact_ref" },
-        "skeptic_reviews_ref": { "$ref": "#/$defs/artifact_ref" },
-        "context_pack_ref": { "$ref": "#/$defs/artifact_ref" },
+        "source_packet_ref": { "$ref": "#/$defs/reviewed_source_packet_ref" },
+        "variants_ref": { "$ref": "#/$defs/reviewed_variants_ref" },
+        "skeptic_reviews_ref": { "$ref": "#/$defs/reviewed_reviews_ref" },
+        "context_pack_ref": { "$ref": "#/$defs/reviewed_context_pack_ref" },
         "normalized_reviews_fingerprint": { "$ref": "#/$defs/sha256" }
       }
     },
@@ -135,7 +159,29 @@
         "reject_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
         "unsafe_authority_flag_count": { "type": "integer", "minimum": 0, "maximum": 150 },
         "blocker_count": { "type": "integer", "minimum": 0, "maximum": 150 }
-      }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "variant_count": { "const": 1 } } },
+          "then": { "properties": { "review_count": { "const": 3 } } }
+        },
+        {
+          "if": { "properties": { "variant_count": { "const": 2 } } },
+          "then": { "properties": { "review_count": { "const": 6 } } }
+        },
+        {
+          "if": { "properties": { "variant_count": { "const": 3 } } },
+          "then": { "properties": { "review_count": { "const": 9 } } }
+        },
+        {
+          "if": { "properties": { "variant_count": { "const": 4 } } },
+          "then": { "properties": { "review_count": { "const": 12 } } }
+        },
+        {
+          "if": { "properties": { "variant_count": { "const": 5 } } },
+          "then": { "properties": { "review_count": { "const": 15 } } }
+        }
+      ]
     },
     "attachment_authority": {
       "type": "object",

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -64,6 +64,16 @@ Evidence: `scripts/orchestration/creative_specification_skeptic_review_contract.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523498149 -> 134d726e806b0734f2ef7d23d6669166fe279054
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629921037 -> 134d726e806b0734f2ef7d23d6669166fe279054
 
+Disposition: FIXED
+Commit: c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3
+Evidence: `docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json` now uses canonical reviewed attachment/bundle refs and conditional selected/all-rejected count constraints; `docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json` now uses canonical reviewed-run child refs and conditional reviewer-total constraints. `scripts/orchestration/creative_specification_skeptic_review.py` now reapplies prepared bridge state checks when validating recovered attachments. Covered by `tests/test_creative_specification_skeptic_review.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534574 -> c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534577 -> c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534578 -> c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534579 -> c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534581 -> c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629954169 -> c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3
+
 ## Experiment Runner Evidence
 Artifact: `artifacts/orchestration/experiments/results/oracle-spec-skeptic-review-finalize-network1-result.json`
 

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -19,6 +19,11 @@ Role: bug-hunter
 Commit: f2ff78212
 Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` now requires the canonical `skeptic_review_attachment.json` artifact during validate/finalize, rejects symlink JSON artifacts before reads, rejects symlink children under prepared `spec_prepare/`, and rejects symlink output targets. `docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json` aligns unsafe authority phrases with the Python validator. Covered by `tests/test_creative_specification_skeptic_review.py`.
 
+Disposition: FIXED
+Role: security-auditor
+Commit: dd84b4bf3
+Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` now rejects unexpected files in `spec_finalize_reviewed/`, requires `reviewed_run_dir_ref` to be the sibling of the source bridge artifact, and requires `spec_prepare_ref` to be a sibling of the source bridge artifact. Covered by `tests/test_creative_specification_skeptic_review.py`.
+
 ## Lane Start Provenance
 Packet: `artifacts/orchestration/task_packets/c7a115b7e8b5.json`
 

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -34,6 +34,13 @@ Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` now u
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384324 -> f724a25b55ef1513f2c160b760aca8b62eef228f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384327 -> f724a25b55ef1513f2c160b760aca8b62eef228f
 
+Disposition: FIXED
+Commit: d450c73e275963286d39f93049d3e02173e1b027
+Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` now rejects noncanonical bridge filenames during `attach`, `docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json` aligns deny patterns with runtime case-insensitive safety checks for lower-case PR authority phrases and upper-case secret-shaped tokens, and `scripts/orchestration/creative_specification_skeptic_review_contract.py` rejects finalize receipts whose selected counts contradict `selected_variant_id`. Covered by `tests/test_creative_specification_skeptic_review.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523432892 -> d450c73e275963286d39f93049d3e02173e1b027
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523432893 -> d450c73e275963286d39f93049d3e02173e1b027
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523432897 -> d450c73e275963286d39f93049d3e02173e1b027
+
 ## Experiment Runner Evidence
 Artifact: `artifacts/orchestration/experiments/results/oracle-spec-skeptic-review-finalize-network1-result.json`
 

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -12,6 +12,13 @@ Artifact: `artifacts/orchestration/experiments/results/oracle-spec-skeptic-revie
 
 Summary: accepted oracle-only governance review, source diff applied in isolated checkout, `shared_tree_untouched=true`, and local oracle pytest commands passed. The implementation commit includes the canonical Experiment Runner co-author trailer.
 
+## Post-Open Role Finding Disposition Evidence
+
+Disposition: FIXED
+Role: bug-hunter
+Commit: f2ff78212
+Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` now requires the canonical `skeptic_review_attachment.json` artifact during validate/finalize, rejects symlink JSON artifacts before reads, rejects symlink children under prepared `spec_prepare/`, and rejects symlink output targets. `docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json` aligns unsafe authority phrases with the Python validator. Covered by `tests/test_creative_specification_skeptic_review.py`.
+
 ## Lane Start Provenance
 Packet: `artifacts/orchestration/task_packets/c7a115b7e8b5.json`
 

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -20,15 +20,11 @@ Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` rejec
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523325121 -> f2ff78212abea1d863355c43130a22e04b382928
 
 Disposition: FIXED
-Commit: dd84b4bf300dace4fc010e9d503efed23dd88df4
-Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` requires `reviewed_run_dir_ref` to be the sibling of the source bridge artifact. Covered by `tests/test_creative_specification_skeptic_review.py`.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367669 -> dd84b4bf300dace4fc010e9d503efed23dd88df4
-
-Disposition: FIXED
 Commit: f724a25b55ef1513f2c160b760aca8b62eef228f
 Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` now uses the canonical bridge filename import, cleans partial finalize outputs on receipt/build validation failures, requires canonical source bridge/spec_prepare refs tied to bridge contents, rejects source `spec_prepare/` sidecars, recomputes attachment coverage from reviewed files, and validates source refs against reviewed layout. `scripts/orchestration/creative_specification_skeptic_review_contract.py` enforces safe artifact path components, exact reviewer-count coverage, exact reviewed-run sibling shape, and aggregate bounded counts aligned with the JSON schemas. Covered by `tests/test_creative_specification_skeptic_review.py`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323651 -> f724a25b55ef1513f2c160b760aca8b62eef228f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323656 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367669 -> f724a25b55ef1513f2c160b760aca8b62eef228f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367670 -> f724a25b55ef1513f2c160b760aca8b62eef228f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367671 -> f724a25b55ef1513f2c160b760aca8b62eef228f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367673 -> f724a25b55ef1513f2c160b760aca8b62eef228f

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -56,6 +56,14 @@ Evidence: This CodeRabbit review object is a rollup/status review for the inline
 Reason: The review-level URL has no additional actionable finding beyond its inline comments, and each inline actionable has commit proof and test coverage in this artifact.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629721700
 
+Disposition: FIXED
+Commit: 134d726e806b0734f2ef7d23d6669166fe279054
+Evidence: `scripts/orchestration/creative_specification_skeptic_review_contract.py` now rejects all-rejected receipts whose rejection counts contradict variant coverage, binds `source_attachment_ref` and `bundle_ref` to the canonical files under `reviewed_run_dir_ref`, and enforces nonzero Python-side attachment/receipt variant and review counts to match the published schemas. Covered by `tests/test_creative_specification_skeptic_review.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523498147 -> 134d726e806b0734f2ef7d23d6669166fe279054
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523498148 -> 134d726e806b0734f2ef7d23d6669166fe279054
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523498149 -> 134d726e806b0734f2ef7d23d6669166fe279054
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629921037 -> 134d726e806b0734f2ef7d23d6669166fe279054
+
 ## Experiment Runner Evidence
 Artifact: `artifacts/orchestration/experiments/results/oracle-spec-skeptic-review-finalize-network1-result.json`
 

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+# PR 2072 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/oracle-spec-skeptic-review-finalize-network1-result.json`
+
+Summary: accepted oracle-only governance review, source diff applied in isolated checkout, `shared_tree_untouched=true`, and local oracle pytest commands passed. The implementation commit includes the canonical Experiment Runner co-author trailer.
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/c7a115b7e8b5.json`
+
+Starter: `scripts/orchestration/start_pr_lane.sh`
+
+## Merge Readiness
+Not claimed. Requires current-head CI, completed post-open review chain, bot review status, and strict merge-readiness governance after the latest mapping/body update.

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -10,6 +10,7 @@ Disposition: FIXED
 Commit: c89f19fa08d862bb817739b0470367027ce5afd8
 Evidence: `docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json` and `docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json` accept nested `spec_prepare/*` and `spec_finalize_reviewed/*` artifact refs; `scripts/orchestration/creative_specification_skeptic_review_contract.py` enforces review list caps. Covered by `tests/test_creative_specification_skeptic_review.py`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323647 -> c89f19fa08d862bb817739b0470367027ce5afd8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323649 -> c89f19fa08d862bb817739b0470367027ce5afd8
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523325117 -> c89f19fa08d862bb817739b0470367027ce5afd8
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523325119 -> c89f19fa08d862bb817739b0470367027ce5afd8
 

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -5,7 +5,37 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+
+Disposition: FIXED
+Commit: c89f19fa08d862bb817739b0470367027ce5afd8
+Evidence: `docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json` and `docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json` accept nested `spec_prepare/*` and `spec_finalize_reviewed/*` artifact refs; `scripts/orchestration/creative_specification_skeptic_review_contract.py` enforces review list caps. Covered by `tests/test_creative_specification_skeptic_review.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323647 -> c89f19fa08d862bb817739b0470367027ce5afd8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523325117 -> c89f19fa08d862bb817739b0470367027ce5afd8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523325119 -> c89f19fa08d862bb817739b0470367027ce5afd8
+
+Disposition: FIXED
+Commit: f2ff78212abea1d863355c43130a22e04b382928
+Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` rejects unexpected artifacts and child symlinks in `spec_finalize_reviewed/` before validate/finalize blesses a reviewed run. Covered by `tests/test_creative_specification_skeptic_review.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523325121 -> f2ff78212abea1d863355c43130a22e04b382928
+
+Disposition: FIXED
+Commit: dd84b4bf300dace4fc010e9d503efed23dd88df4
+Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` requires `reviewed_run_dir_ref` to be the sibling of the source bridge artifact. Covered by `tests/test_creative_specification_skeptic_review.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367669 -> dd84b4bf300dace4fc010e9d503efed23dd88df4
+
+Disposition: FIXED
+Commit: f724a25b55ef1513f2c160b760aca8b62eef228f
+Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` now uses the canonical bridge filename import, cleans partial finalize outputs on receipt/build validation failures, requires canonical source bridge/spec_prepare refs tied to bridge contents, rejects source `spec_prepare/` sidecars, recomputes attachment coverage from reviewed files, and validates source refs against reviewed layout. `scripts/orchestration/creative_specification_skeptic_review_contract.py` enforces safe artifact path components, exact reviewer-count coverage, exact reviewed-run sibling shape, and aggregate bounded counts aligned with the JSON schemas. Covered by `tests/test_creative_specification_skeptic_review.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323651 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323656 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367670 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367671 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367673 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367675 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384319 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384321 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384324 -> f724a25b55ef1513f2c160b760aca8b62eef228f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384327 -> f724a25b55ef1513f2c160b760aca8b62eef228f
 
 ## Experiment Runner Evidence
 Artifact: `artifacts/orchestration/experiments/results/oracle-spec-skeptic-review-finalize-network1-result.json`
@@ -30,4 +60,4 @@ Packet: `artifacts/orchestration/task_packets/c7a115b7e8b5.json`
 Starter: `scripts/orchestration/start_pr_lane.sh`
 
 ## Merge Readiness
-Not claimed. Requires current-head CI, completed post-open review chain, bot review status, and strict merge-readiness governance after the latest mapping/body update.
+Pending after latest review-fix commit. Requires current-head CI, resolved review threads, bot review status, and strict merge-readiness governance after this mapping/body update.

--- a/docs/review/PR_2072_FIXED_MAPPING.md
+++ b/docs/review/PR_2072_FIXED_MAPPING.md
@@ -41,6 +41,21 @@ Evidence: `scripts/orchestration/creative_specification_skeptic_review.py` now r
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523432893 -> d450c73e275963286d39f93049d3e02173e1b027
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523432897 -> d450c73e275963286d39f93049d3e02173e1b027
 
+Disposition: FIXED
+Commit: f745750185410345c5c1ba820dc3b1b3d83ffb4e
+Evidence: `tests/test_creative_specification_skeptic_review.py` now types the review-input mutator parameters as callables instead of `Any`. Covered by `pytest -q tests/test_creative_specification_skeptic_review.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629734570 -> f745750185410345c5c1ba820dc3b1b3d83ffb4e
+
+Disposition: NOT-A-BUG
+Evidence: The Sourcery review is a high-level maintainability suggestion to split the new local contract/CLI helpers. Current v1 intentionally keeps the reviewed-finalize safety logic local to the new orchestration lane to avoid widening shared helpers before a second consumer exists; the boundary is documented in `scripts/AGENTS.md` and covered by `tests/test_creative_specification_skeptic_review.py`.
+Reason: No production/runtime defect or current-PR governance bypass remains after the concrete path/symlink/artifact-ref findings were fixed and tested.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629713409
+
+Disposition: NOT-A-BUG
+Evidence: This CodeRabbit review object is a rollup/status review for the inline comments already mapped above as FIXED: schema artifact refs, unused import/canonical bridge handling, and finalize cleanup/recovery validation.
+Reason: The review-level URL has no additional actionable finding beyond its inline comments, and each inline actionable has commit proof and test coverage in this artifact.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629721700
+
 ## Experiment Runner Evidence
 Artifact: `artifacts/orchestration/experiments/results/oracle-spec-skeptic-review-finalize-network1-result.json`
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -11030,9 +11030,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Follow-up bridge finalize evidence attachment:
       - Priority: P1 automation leverage.
       - Owner: orchestration.
-      - Target PR: separate reviewed PR after the approved-hypothesis bridge.
-      - Reason: bridge output emits pending `skeptic_reviews.json`; downstream reviewer evidence attachment and explicit `finalize` remain outside this slice under coordinator-owned governance.
-      - DoD: reviewer evidence is attached before explicit `finalize`, and no patch, branch, PR, provider, runtime, or review-thread authority is added.
+      - Target PR: `codex/experiment-runner-agent-skeptic-review-finalize`.
+      - Reason: bridge output emits pending `skeptic_reviews.json`; downstream reviewer evidence attachment and explicit `finalize` must happen in a sibling reviewed run so original bridge validation and metrics stay immutable.
+      - DoD: `creative_specification_skeptic_review.py` validates operator-supplied sanitized local skeptic-review evidence, writes only `spec_finalize_reviewed/`, calls existing PR-1 `finalize`, emits a valid `CreativeCodeSpecificationBundle` plus metadata-only receipt, preserves `spec_prepare/`, and adds no patch, branch, PR, provider, workflow, runtime, semantic-cache, graph-truth, fixed-mapping, review-thread, or readiness authority.
+      - Evidence: `scripts/orchestration/creative_specification_skeptic_review.py`; `scripts/orchestration/creative_specification_skeptic_review_contract.py`; `docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json`; `docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json`; `docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json`; `tests/test_creative_specification_skeptic_review.py`.
     - Follow-up bridge metrics ingestion:
       - Priority: P1 learning-loop leverage.
       - Owner: orchestration.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -60,6 +60,18 @@
   readiness, merge, release, call providers, call product runtime, change
   workflows, use semantic cache, write graph truth, or mutate GitHub App /
   Slack settings.
+- Reviewed creative-code specification finalization artifacts stay local under
+  `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/`.
+  The `creative_specification_skeptic_review.py` CLI may only read a prepared
+  bridge run, read operator-supplied sanitized local skeptic-review evidence,
+  copy immutable `spec_prepare/` inputs into the sibling reviewed run,
+  normalize `skeptic_reviews.json`, call the existing PR-1
+  `creative_code_spec_pipeline.finalize`, and emit
+  `skeptic_review_attachment.json` plus `finalize_receipt.json`. It must not
+  rewrite `spec_prepare/`, execute agents, call providers, generate patches,
+  create/write branches, push/open PRs, edit fixed mappings, resolve review
+  threads, modify workflows, call product runtime, use semantic cache, write
+  graph truth, or claim readiness.
 - The runner must apply patches only inside an isolated temporary checkout and must leave the shared working tree untouched.
 - Mutable surfaces, immutable oracles, budgets, and promotion boundaries are defined by `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or relax them here.
 - Runner mutation of `scripts/ci/**`, `docs/review/**`, `AGENTS.md`, merge

--- a/scripts/orchestration/creative_specification_skeptic_review.py
+++ b/scripts/orchestration/creative_specification_skeptic_review.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+"""Attach reviewed skeptic evidence and explicitly finalize PR-1 specifications."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from typing import Any, Mapping, Sequence, cast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.evidence.fingerprints import fingerprint_payload
+from scripts.orchestration import creative_code_spec_pipeline
+from scripts.orchestration.creative_code_specification import (
+    CreativeCodeSpecificationError,
+    build_creative_code_specification_bundle,
+    read_creative_code_specification_bundle,
+    validate_creative_code_specification_bundle,
+    validate_source_candidate_packet,
+)
+from scripts.orchestration.creative_hypothesis_spec_bridge import (
+    BRIDGE_FILENAME,
+    CANDIDATE_FILENAME,
+    METRICS_FILENAME,
+)
+from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
+    PREPARED_STATUS,
+    PREPARE_FILENAMES,
+    CreativeHypothesisSpecBridgeError,
+    validate_bridge_metrics,
+    validate_creative_hypothesis_specification_bridge,
+)
+from scripts.orchestration.creative_specification_skeptic_review_contract import (
+    ATTACHMENT_ARTIFACT_TYPE,
+    FINALIZE_RECEIPT_ARTIFACT_TYPE,
+    REVIEWED_RUN_DIRNAME,
+    CreativeSpecificationSkepticReviewError,
+    build_finalize_receipt,
+    build_skeptic_review_attachment,
+    normalize_skeptic_reviews_for_pr1,
+    validate_agent_skeptic_reviews_input,
+    validate_finalize_receipt,
+    validate_skeptic_review_attachment,
+)
+
+SPEC_BRIDGE_ROOT: Path = creative_code_spec_pipeline.ARTIFACT_ROOT / "spec_bridge"
+ATTACHMENT_FILENAME = "skeptic_review_attachment.json"
+BUNDLE_FILENAME = "creative_code_specification_bundle.json"
+FINALIZE_RECEIPT_FILENAME = "finalize_receipt.json"
+ATTACH_SUCCESS_OUTPUT = "PASS: creative specification skeptic reviews attached"
+VALIDATE_SUCCESS_OUTPUT = "PASS: creative specification skeptic review attachment valid"
+FINALIZE_SUCCESS_OUTPUT = "PASS: creative specification finalize receipt written"
+
+
+class CreativeSpecificationSkepticReviewCliError(ValueError):
+    """Raised when reviewed finalize CLI file I/O cannot safely complete."""
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _existing_components(path: Path) -> list[Path]:
+    components: list[Path] = []
+    current_path = Path(path.anchor) if path.anchor else Path(".")
+    parts = path.parts[1:] if path.anchor else path.parts
+    for part in parts:
+        current_path = current_path / part
+        if current_path.exists() or current_path.is_symlink():
+            components.append(current_path)
+    return components
+
+
+def _reject_symlink_components(path: Path, *, label: str) -> None:
+    for component in _existing_components(path):
+        if component.is_symlink():
+            raise CreativeSpecificationSkepticReviewCliError(f"{label} must not traverse symlinks.")
+
+
+def _ensure_spec_bridge_root() -> Path:
+    _reject_symlink_components(SPEC_BRIDGE_ROOT, label="spec bridge root")
+    SPEC_BRIDGE_ROOT.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_components(SPEC_BRIDGE_ROOT, label="spec bridge root")
+    root: Path = SPEC_BRIDGE_ROOT.resolve(strict=True)
+    if not root.is_dir():
+        raise CreativeSpecificationSkepticReviewCliError("spec bridge root must be a directory.")
+    return root
+
+
+def _resolve_repo_json_file(raw_path: Path, *, label: str) -> Path:
+    candidate = raw_path if raw_path.is_absolute() else REPO_ROOT / raw_path
+    _reject_symlink_components(candidate, label=label)
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise CreativeSpecificationSkepticReviewCliError(f"{label} must exist.") from exc
+    if not _is_relative_to(resolved, REPO_ROOT.resolve()):
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"{label} must stay inside the repository."
+        )
+    if not resolved.is_file() or resolved.suffix != ".json":
+        raise CreativeSpecificationSkepticReviewCliError(f"{label} must be a JSON file.")
+    return resolved
+
+
+def _resolve_repo_artifact_ref(ref: str, *, label: str, expect_dir: bool = False) -> Path:
+    candidate = REPO_ROOT / ref
+    _reject_symlink_components(candidate, label=label)
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise CreativeSpecificationSkepticReviewCliError(f"{label} must exist.") from exc
+    repo_root = REPO_ROOT.resolve()
+    artifact_root = creative_code_spec_pipeline.ARTIFACT_ROOT.resolve(strict=False)
+    if not _is_relative_to(resolved, repo_root) or not _is_relative_to(resolved, artifact_root):
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"{label} must stay under creative-code artifacts."
+        )
+    if expect_dir:
+        if not resolved.is_dir():
+            raise CreativeSpecificationSkepticReviewCliError(f"{label} must be a directory.")
+    elif not resolved.is_file() or resolved.suffix != ".json":
+        raise CreativeSpecificationSkepticReviewCliError(f"{label} must be a JSON file.")
+    return resolved
+
+
+def _artifact_ref(path: Path) -> str:
+    return path.resolve(strict=False).relative_to(REPO_ROOT.resolve()).as_posix()
+
+
+def _read_json_file(path: Path) -> Any:
+    try:
+        return json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_object_keys,
+        )
+    except CreativeSpecificationSkepticReviewCliError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CreativeSpecificationSkepticReviewCliError("Unable to read JSON artifact.") from exc
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    payload = _read_json_file(path)
+    if not isinstance(payload, dict):
+        raise CreativeSpecificationSkepticReviewCliError(f"{label} must be a JSON object.")
+    return payload
+
+
+def _read_json_array(path: Path, *, label: str) -> list[Any]:
+    payload = _read_json_file(path)
+    if not isinstance(payload, list):
+        raise CreativeSpecificationSkepticReviewCliError(f"{label} must be a JSON array.")
+    return payload
+
+
+def _reject_duplicate_json_object_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: set[str] = set()
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise CreativeSpecificationSkepticReviewCliError(
+                f"creative specification skeptic review JSON has duplicate key: {key}"
+            )
+        seen.add(key)
+        payload[key] = value
+    return payload
+
+
+def _write_json_atomic(path: Path, payload: Any) -> None:
+    if path.suffix != ".json":
+        raise CreativeSpecificationSkepticReviewCliError("output artifact must be JSON.")
+    _reject_symlink_components(path.parent, label="output artifact parent")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_components(path.parent, label="output artifact parent")
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_name = temp_file.name
+            json.dump(payload, temp_file, indent=2, sort_keys=True)
+            temp_file.write("\n")
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_name, path)
+        temp_name = None
+    finally:
+        if temp_name is not None:
+            try:
+                Path(temp_name).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _read_prepared_bridge(bridge_path: Path) -> dict[str, Any]:
+    bridge_file = _resolve_repo_json_file(bridge_path, label="bridge input")
+    bridge = validate_creative_hypothesis_specification_bridge(
+        _read_json_object(bridge_file, label="bridge input")
+    )
+    bridge_dir = _prepared_bridge_dir(bridge, bridge_file)
+    candidate = _read_json_object(bridge_dir / CANDIDATE_FILENAME, label="candidate packet")
+    metrics = validate_bridge_metrics(
+        _read_json_object(bridge_dir / METRICS_FILENAME, label="bridge metrics")
+    )
+    _assert_prepared_bridge_state(bridge=bridge, candidate=candidate, metrics=metrics)
+    source_run_dir = _resolve_repo_artifact_ref(
+        str(cast(Mapping[str, Any], bridge["spec_prepare"])["run_dir_ref"]),
+        label="spec_prepare ref",
+        expect_dir=True,
+    )
+    _reject_unexpected_entries(source_run_dir, allowed=set(PREPARE_FILENAMES), label="spec_prepare")
+    source_packet = _read_json_object(source_run_dir / "source_packet.json", label="source packet")
+    variants = _read_json_array(source_run_dir / "variants.json", label="variants")
+    pending_reviews = _read_json_array(
+        source_run_dir / "skeptic_reviews.json",
+        label="pending skeptic reviews",
+    )
+    context_pack = _read_json_object(source_run_dir / "context_pack.json", label="context pack")
+    _assert_prepared_artifacts(
+        bridge=bridge,
+        candidate=candidate,
+        metrics=metrics,
+        source_packet=source_packet,
+        variants=variants,
+        pending_reviews=pending_reviews,
+    )
+    return {
+        "bridge": bridge,
+        "bridge_dir": bridge_dir,
+        "bridge_path": bridge_file,
+        "candidate": candidate,
+        "candidate_path": bridge_dir / CANDIDATE_FILENAME,
+        "metrics": metrics,
+        "metrics_path": bridge_dir / METRICS_FILENAME,
+        "source_run_dir": source_run_dir,
+        "source_packet": source_packet,
+        "variants": variants,
+        "pending_reviews": pending_reviews,
+        "context_pack": context_pack,
+    }
+
+
+def _prepared_bridge_dir(bridge: Mapping[str, Any], bridge_file: Path) -> Path:
+    root = _ensure_spec_bridge_root()
+    expected_dir = root / str(bridge["bridge_id"])
+    try:
+        expected_resolved = expected_dir.resolve(strict=True)
+        bridge_parent = bridge_file.parent.resolve(strict=True)
+    except OSError as exc:
+        raise CreativeSpecificationSkepticReviewCliError("bridge directory must exist.") from exc
+    if expected_resolved != bridge_parent:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "bridge path must be the canonical spec_bridge/<bridge-id> artifact."
+        )
+    return bridge_parent
+
+
+def _assert_prepared_bridge_state(
+    *,
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+) -> None:
+    spec_prepare = cast(Mapping[str, Any], bridge["spec_prepare"])
+    if (
+        spec_prepare["prepared"] is not True
+        or spec_prepare["finalized"] is not False
+        or spec_prepare["next_allowed_action"] != "agent_skeptic_review"
+    ):
+        raise CreativeSpecificationSkepticReviewCliError(
+            "bridge must be prepared and waiting for agent_skeptic_review."
+        )
+    normalized_packet = validate_source_candidate_packet(candidate)
+    candidate_ref = cast(Mapping[str, Any], bridge["candidate_packet"])
+    if normalized_packet["candidate_id"] != candidate_ref["candidate_id"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: candidate id does not match bridge."
+        )
+    if fingerprint_payload(dict(normalized_packet)) != candidate_ref["candidate_fingerprint"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: candidate fingerprint does not match bridge."
+        )
+    if metrics["status"] != PREPARED_STATUS or metrics["blocked_reason"] is not None:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "bridge metrics must be prepared with no blocked reason."
+        )
+    if metrics["bridge_id"] != bridge["bridge_id"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: metrics bridge id does not match bridge."
+        )
+    if metrics["candidate_id"] != normalized_packet["candidate_id"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: metrics candidate id does not match candidate."
+        )
+    metric_source = cast(Mapping[str, Any], metrics["source"])
+    if metric_source["candidate_fingerprint"] != fingerprint_payload(dict(normalized_packet)):
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: metrics candidate fingerprint does not match candidate."
+        )
+
+
+def _assert_prepared_artifacts(
+    *,
+    bridge: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+    source_packet: Mapping[str, Any],
+    variants: Sequence[Any],
+    pending_reviews: Sequence[Any],
+) -> None:
+    normalized_candidate = validate_source_candidate_packet(candidate)
+    normalized_source_packet = validate_source_candidate_packet(source_packet)
+    if normalized_source_packet != normalized_candidate:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: source_packet.json must match the bridge candidate packet."
+        )
+    expected_variant_count = int(normalized_candidate["variant_count"])
+    if len(variants) != expected_variant_count:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: variants must match candidate variant_count."
+        )
+    counts = cast(Mapping[str, Any], metrics["counts"])
+    if counts["prepare_files_written"] != len(PREPARE_FILENAMES):
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: metrics prepare_files_written does not match spec_prepare."
+        )
+    if counts["pending_skeptic_review_count"] != _pending_skeptic_review_count(pending_reviews):
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: metrics pending_skeptic_review_count does not match spec_prepare."
+        )
+    try:
+        build_creative_code_specification_bundle(
+            source_packet=source_packet,
+            variants=cast(Sequence[Mapping[str, Any]], variants),
+            skeptic_reviews=cast(Sequence[Mapping[str, Any]], pending_reviews),
+        )
+    except CreativeCodeSpecificationError as exc:
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"prepared spec_prepare artifacts are not valid PR-1 inputs: {exc}"
+        ) from exc
+    if (
+        fingerprint_payload(dict(normalized_source_packet))
+        != cast(Mapping[str, Any], bridge["candidate_packet"])["candidate_fingerprint"]
+    ):
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: prepared source packet fingerprint does not match bridge."
+        )
+
+
+def _pending_skeptic_review_count(reviews: Sequence[Any]) -> int:
+    return sum(
+        1
+        for row in reviews
+        if isinstance(row, dict)
+        and row.get("decision") != "pass"
+        and "skeptic_review_required" in row.get("blockers", [])
+    )
+
+
+def _reject_unexpected_entries(path: Path, *, allowed: set[str], label: str) -> None:
+    if path.exists() and not path.is_dir():
+        raise CreativeSpecificationSkepticReviewCliError(f"{label} must be a directory.")
+    if not path.exists():
+        return
+    unexpected = sorted(child.name for child in path.iterdir() if child.name not in allowed)
+    if unexpected:
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"{label} contains unexpected artifact(s): {', '.join(unexpected)}."
+        )
+
+
+def _reviewed_run_dir(bridge_dir: Path) -> Path:
+    candidate = bridge_dir / REVIEWED_RUN_DIRNAME
+    _reject_symlink_components(candidate, label="reviewed finalize run")
+    resolved_candidate = candidate.resolve(strict=False)
+    if not _is_relative_to(resolved_candidate, SPEC_BRIDGE_ROOT.resolve(strict=False)):
+        raise CreativeSpecificationSkepticReviewCliError(
+            "reviewed finalize run must stay under creative-code spec_bridge artifacts."
+        )
+    return Path(candidate)
+
+
+def _attach_from_bridge(bridge_path: Path, reviews_path: Path) -> dict[str, Any]:
+    prepared = _read_prepared_bridge(bridge_path)
+    review_input_path = _resolve_repo_json_file(reviews_path, label="skeptic review input")
+    review_input = validate_agent_skeptic_reviews_input(
+        _read_json_object(review_input_path, label="skeptic review input")
+    )
+    bridge = cast(dict[str, Any], prepared["bridge"])
+    candidate = cast(dict[str, Any], prepared["candidate"])
+    source_packet = cast(dict[str, Any], prepared["source_packet"])
+    variants = cast(list[Mapping[str, Any]], prepared["variants"])
+    expected = {
+        "source_bridge_id": bridge["bridge_id"],
+        "source_bridge_fingerprint": fingerprint_payload(bridge),
+        "source_candidate_id": candidate["candidate_id"],
+        "source_candidate_fingerprint": fingerprint_payload(candidate),
+        "source_packet_fingerprint": fingerprint_payload(source_packet),
+        "variants_fingerprint": fingerprint_payload(variants),
+    }
+    for key, value in expected.items():
+        if review_input[key] != value:
+            raise CreativeSpecificationSkepticReviewCliError(
+                f"fingerprint_mismatch: review input {key} does not match prepared artifacts."
+            )
+    normalized_reviews = normalize_skeptic_reviews_for_pr1(
+        review_input=review_input,
+        source_packet=source_packet,
+        variants=variants,
+    )
+    reviewed_dir = _reviewed_run_dir(cast(Path, prepared["bridge_dir"]))
+    if reviewed_dir.exists() or reviewed_dir.is_symlink():
+        raise CreativeSpecificationSkepticReviewCliError(
+            "reviewed finalize run already exists; remove the local sibling artifact to rerun."
+        )
+    reviewed_dir.mkdir(parents=True, exist_ok=False)
+    try:
+        reviewed_source_packet = reviewed_dir / "source_packet.json"
+        reviewed_variants = reviewed_dir / "variants.json"
+        reviewed_reviews = reviewed_dir / "skeptic_reviews.json"
+        reviewed_context_pack = reviewed_dir / "context_pack.json"
+        attachment_path = reviewed_dir / ATTACHMENT_FILENAME
+        attachment = cast(
+            dict[str, Any],
+            build_skeptic_review_attachment(
+                bridge_id=str(bridge["bridge_id"]),
+                bridge_fingerprint=fingerprint_payload(bridge),
+                bridge_ref=_artifact_ref(cast(Path, prepared["bridge_path"])),
+                candidate_id=str(candidate["candidate_id"]),
+                candidate_fingerprint=fingerprint_payload(candidate),
+                candidate_ref=_artifact_ref(cast(Path, prepared["candidate_path"])),
+                metrics_id=str(cast(Mapping[str, Any], prepared["metrics"])["metrics_id"]),
+                metrics_fingerprint=fingerprint_payload(cast(dict[str, Any], prepared["metrics"])),
+                metrics_ref=_artifact_ref(cast(Path, prepared["metrics_path"])),
+                spec_prepare_ref=_artifact_ref(cast(Path, prepared["source_run_dir"])),
+                source_packet_ref=_artifact_ref(
+                    cast(Path, prepared["source_run_dir"]) / "source_packet.json"
+                ),
+                source_packet_fingerprint=fingerprint_payload(source_packet),
+                variants_ref=_artifact_ref(
+                    cast(Path, prepared["source_run_dir"]) / "variants.json"
+                ),
+                variants_fingerprint=fingerprint_payload(variants),
+                pending_reviews_ref=_artifact_ref(
+                    cast(Path, prepared["source_run_dir"]) / "skeptic_reviews.json"
+                ),
+                pending_reviews_fingerprint=fingerprint_payload(
+                    cast(Sequence[Any], prepared["pending_reviews"])
+                ),
+                context_pack_ref=_artifact_ref(
+                    cast(Path, prepared["source_run_dir"]) / "context_pack.json"
+                ),
+                context_pack_fingerprint=fingerprint_payload(
+                    cast(dict[str, Any], prepared["context_pack"])
+                ),
+                reviewed_run_dir_ref=_artifact_ref(reviewed_dir),
+                reviewed_source_packet_ref=_artifact_ref(reviewed_source_packet),
+                reviewed_variants_ref=_artifact_ref(reviewed_variants),
+                reviewed_reviews_ref=_artifact_ref(reviewed_reviews),
+                reviewed_context_pack_ref=_artifact_ref(reviewed_context_pack),
+                normalized_reviews=normalized_reviews,
+                variant_count=len(variants),
+            ),
+        )
+        _write_json_atomic(reviewed_source_packet, source_packet)
+        _write_json_atomic(reviewed_variants, variants)
+        _write_json_atomic(reviewed_reviews, normalized_reviews)
+        _write_json_atomic(reviewed_context_pack, cast(dict[str, Any], prepared["context_pack"]))
+        _write_json_atomic(attachment_path, attachment)
+    except Exception:
+        shutil.rmtree(reviewed_dir, ignore_errors=True)
+        raise
+    return attachment
+
+
+def _validate_attachment_artifacts(attachment_path: Path) -> tuple[dict[str, Any], Path]:
+    attachment_file = _resolve_repo_json_file(attachment_path, label="attachment input")
+    attachment = validate_skeptic_review_attachment(
+        _read_json_object(attachment_file, label="attachment input")
+    )
+    reviewed_run = cast(Mapping[str, Any], attachment["reviewed_run"])
+    reviewed_dir = _resolve_repo_artifact_ref(
+        str(reviewed_run["run_dir_ref"]),
+        label="reviewed run dir",
+        expect_dir=True,
+    )
+    if attachment_file.parent.resolve(strict=True) != reviewed_dir.resolve(strict=True):
+        raise CreativeSpecificationSkepticReviewCliError(
+            "attachment must be stored inside its reviewed_run_dir_ref."
+        )
+    source_packet = _read_json_object(reviewed_dir / "source_packet.json", label="source packet")
+    variants = _read_json_array(reviewed_dir / "variants.json", label="variants")
+    reviews = _read_json_array(reviewed_dir / "skeptic_reviews.json", label="skeptic reviews")
+    context_pack = _read_json_object(reviewed_dir / "context_pack.json", label="context pack")
+    source = cast(Mapping[str, Any], attachment["source"])
+    _assert_reviewed_ref(
+        str(reviewed_run["source_packet_ref"]),
+        reviewed_dir / "source_packet.json",
+        "reviewed source_packet",
+    )
+    _assert_reviewed_ref(
+        str(reviewed_run["variants_ref"]),
+        reviewed_dir / "variants.json",
+        "reviewed variants",
+    )
+    _assert_reviewed_ref(
+        str(reviewed_run["skeptic_reviews_ref"]),
+        reviewed_dir / "skeptic_reviews.json",
+        "reviewed skeptic_reviews",
+    )
+    _assert_reviewed_ref(
+        str(reviewed_run["context_pack_ref"]),
+        reviewed_dir / "context_pack.json",
+        "reviewed context_pack",
+    )
+    _assert_artifact_ref(
+        str(source["bridge_ref"]),
+        expected_payload=None,
+        expected_fingerprint=str(source["bridge_fingerprint"]),
+        label="bridge",
+    )
+    _assert_artifact_ref(
+        str(source["candidate_ref"]),
+        expected_payload=None,
+        expected_fingerprint=str(source["candidate_fingerprint"]),
+        label="candidate",
+    )
+    _assert_artifact_ref(
+        str(source["metrics_ref"]),
+        expected_payload=None,
+        expected_fingerprint=str(source["metrics_fingerprint"]),
+        label="metrics",
+    )
+    _assert_artifact_ref(
+        str(source["source_packet_ref"]),
+        expected_payload=source_packet,
+        expected_fingerprint=str(source["source_packet_fingerprint"]),
+        label="source_packet",
+    )
+    _assert_artifact_ref(
+        str(source["variants_ref"]),
+        expected_payload=variants,
+        expected_fingerprint=str(source["variants_fingerprint"]),
+        label="variants",
+    )
+    _assert_artifact_ref(
+        str(source["pending_reviews_ref"]),
+        expected_payload=None,
+        expected_fingerprint=str(source["pending_reviews_fingerprint"]),
+        label="pending_reviews",
+    )
+    _assert_artifact_ref(
+        str(source["context_pack_ref"]),
+        expected_payload=context_pack,
+        expected_fingerprint=str(source["context_pack_fingerprint"]),
+        label="context_pack",
+    )
+    if fingerprint_payload(reviews) != reviewed_run["normalized_reviews_fingerprint"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: reviewed skeptic_reviews fingerprint does not match attachment."
+        )
+    try:
+        build_creative_code_specification_bundle(
+            source_packet=source_packet,
+            variants=cast(Sequence[Mapping[str, Any]], variants),
+            skeptic_reviews=cast(Sequence[Mapping[str, Any]], reviews),
+        )
+    except CreativeCodeSpecificationError as exc:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "reviewed finalize run cannot build a valid CreativeCodeSpecificationBundle."
+        ) from exc
+    if fingerprint_payload(source_packet) != source["source_packet_fingerprint"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: reviewed source packet does not match attachment."
+        )
+    if fingerprint_payload(variants) != source["variants_fingerprint"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: reviewed variants do not match attachment."
+        )
+    return attachment, reviewed_dir
+
+
+def _assert_reviewed_ref(ref: str, expected_path: Path, label: str) -> None:
+    path = _resolve_repo_artifact_ref(ref, label=f"{label} ref")
+    if path.resolve(strict=True) != expected_path.resolve(strict=True):
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"fingerprint_mismatch: {label} ref does not match reviewed run layout."
+        )
+
+
+def _assert_artifact_ref(
+    ref: str,
+    *,
+    expected_payload: Any | None,
+    expected_fingerprint: str,
+    label: str,
+) -> None:
+    path = _resolve_repo_artifact_ref(ref, label=f"{label} ref")
+    payload = _read_json_file(path)
+    if expected_payload is not None and payload != expected_payload:
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"fingerprint_mismatch: reviewed {label} copy diverges from source ref."
+        )
+    if fingerprint_payload(payload) != expected_fingerprint:
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"fingerprint_mismatch: {label} fingerprint does not match attachment."
+        )
+
+
+def _finalize_from_attachment(attachment_path: Path) -> dict[str, Any]:
+    attachment, reviewed_dir = _validate_attachment_artifacts(attachment_path)
+    bundle_path = reviewed_dir / BUNDLE_FILENAME
+    receipt_path = reviewed_dir / FINALIZE_RECEIPT_FILENAME
+    if bundle_path.exists() or receipt_path.exists():
+        raise CreativeSpecificationSkepticReviewCliError(
+            "reviewed finalize outputs already exist; remove local artifacts to rerun."
+        )
+    try:
+        creative_code_spec_pipeline.finalize(reviewed_dir, bundle_path)
+    except creative_code_spec_pipeline.CreativeCodeSpecPipelineError as exc:
+        raise CreativeSpecificationSkepticReviewCliError(str(exc)) from exc
+    bundle = validate_creative_code_specification_bundle(
+        read_creative_code_specification_bundle(bundle_path)
+    )
+    receipt = cast(
+        dict[str, Any],
+        build_finalize_receipt(
+            attachment=attachment,
+            attachment_ref=_artifact_ref(reviewed_dir / ATTACHMENT_FILENAME),
+            bundle=bundle,
+            bundle_ref=_artifact_ref(bundle_path),
+        ),
+    )
+    _write_json_atomic(receipt_path, receipt)
+    validate_finalize_receipt(receipt)
+    return receipt
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    attach_parser = subparsers.add_parser("attach")
+    attach_parser.add_argument("--bridge", type=Path, required=True)
+    attach_parser.add_argument("--reviews", type=Path, required=True)
+
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("--attachment", type=Path, required=True)
+
+    finalize_parser = subparsers.add_parser("finalize")
+    finalize_parser.add_argument("--attachment", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "attach":
+            attachment = _attach_from_bridge(args.bridge, args.reviews)
+            if attachment["artifact_type"] != ATTACHMENT_ARTIFACT_TYPE:
+                raise CreativeSpecificationSkepticReviewCliError("unexpected attachment artifact.")
+            print(ATTACH_SUCCESS_OUTPUT)
+            return 0
+        if args.command == "validate":
+            _validate_attachment_artifacts(args.attachment)
+            print(VALIDATE_SUCCESS_OUTPUT)
+            return 0
+        if args.command == "finalize":
+            receipt = _finalize_from_attachment(args.attachment)
+            if receipt["artifact_type"] != FINALIZE_RECEIPT_ARTIFACT_TYPE:
+                raise CreativeSpecificationSkepticReviewCliError("unexpected finalize receipt.")
+            print(FINALIZE_SUCCESS_OUTPUT)
+            return 0
+    except (
+        CreativeSpecificationSkepticReviewCliError,
+        CreativeSpecificationSkepticReviewError,
+        CreativeCodeSpecificationError,
+        CreativeHypothesisSpecBridgeError,
+    ) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    parser.error("unsupported command")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestration/creative_specification_skeptic_review.py
+++ b/scripts/orchestration/creative_specification_skeptic_review.py
@@ -140,6 +140,7 @@ def _artifact_ref(path: Path) -> str:
 
 
 def _read_json_file(path: Path) -> Any:
+    _reject_symlink_components(path, label="JSON artifact")
     try:
         return json.loads(
             path.read_text(encoding="utf-8"),
@@ -184,6 +185,8 @@ def _write_json_atomic(path: Path, payload: Any) -> None:
     _reject_symlink_components(path.parent, label="output artifact parent")
     path.parent.mkdir(parents=True, exist_ok=True)
     _reject_symlink_components(path.parent, label="output artifact parent")
+    if path.is_symlink():
+        raise CreativeSpecificationSkepticReviewCliError("output artifact must not be a symlink.")
     temp_name: str | None = None
     try:
         with tempfile.NamedTemporaryFile(
@@ -379,6 +382,11 @@ def _reject_unexpected_entries(path: Path, *, allowed: set[str], label: str) -> 
         raise CreativeSpecificationSkepticReviewCliError(f"{label} must be a directory.")
     if not path.exists():
         return
+    symlink_children = sorted(child.name for child in path.iterdir() if child.is_symlink())
+    if symlink_children:
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"{label} contains symlink artifact(s): {', '.join(symlink_children)}."
+        )
     unexpected = sorted(child.name for child in path.iterdir() if child.name not in allowed)
     if unexpected:
         raise CreativeSpecificationSkepticReviewCliError(
@@ -504,6 +512,16 @@ def _validate_attachment_artifacts(attachment_path: Path) -> tuple[dict[str, Any
     if attachment_file.parent.resolve(strict=True) != reviewed_dir.resolve(strict=True):
         raise CreativeSpecificationSkepticReviewCliError(
             "attachment must be stored inside its reviewed_run_dir_ref."
+        )
+    canonical_attachment = reviewed_dir / ATTACHMENT_FILENAME
+    if attachment_file.name != ATTACHMENT_FILENAME:
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"attachment input must be the canonical {ATTACHMENT_FILENAME} artifact."
+        )
+    _reject_symlink_components(canonical_attachment, label="canonical attachment")
+    if attachment_file.resolve(strict=True) != canonical_attachment.resolve(strict=True):
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"attachment input must be the canonical {ATTACHMENT_FILENAME} artifact."
         )
     source_packet = _read_json_object(reviewed_dir / "source_packet.json", label="source packet")
     variants = _read_json_array(reviewed_dir / "variants.json", label="variants")

--- a/scripts/orchestration/creative_specification_skeptic_review.py
+++ b/scripts/orchestration/creative_specification_skeptic_review.py
@@ -57,6 +57,17 @@ FINALIZE_RECEIPT_FILENAME = "finalize_receipt.json"
 ATTACH_SUCCESS_OUTPUT = "PASS: creative specification skeptic reviews attached"
 VALIDATE_SUCCESS_OUTPUT = "PASS: creative specification skeptic review attachment valid"
 FINALIZE_SUCCESS_OUTPUT = "PASS: creative specification finalize receipt written"
+REVIEWED_RUN_FILENAMES = frozenset(
+    {
+        "source_packet.json",
+        "variants.json",
+        "skeptic_reviews.json",
+        "context_pack.json",
+        ATTACHMENT_FILENAME,
+        BUNDLE_FILENAME,
+        FINALIZE_RECEIPT_FILENAME,
+    }
+)
 
 
 class CreativeSpecificationSkepticReviewCliError(ValueError):
@@ -523,11 +534,36 @@ def _validate_attachment_artifacts(attachment_path: Path) -> tuple[dict[str, Any
         raise CreativeSpecificationSkepticReviewCliError(
             f"attachment input must be the canonical {ATTACHMENT_FILENAME} artifact."
         )
+    _reject_unexpected_entries(
+        reviewed_dir,
+        allowed=set(REVIEWED_RUN_FILENAMES),
+        label="reviewed finalize run",
+    )
+    source = cast(Mapping[str, Any], attachment["source"])
+    source_bridge_path = _resolve_repo_artifact_ref(
+        str(source["bridge_ref"]),
+        label="source bridge ref",
+    )
+    expected_reviewed_dir = source_bridge_path.parent / REVIEWED_RUN_DIRNAME
+    if reviewed_dir.resolve(strict=True) != expected_reviewed_dir.resolve(strict=False):
+        raise CreativeSpecificationSkepticReviewCliError(
+            "reviewed_run_dir_ref must be the sibling of the source bridge artifact."
+        )
+    source_spec_prepare_dir = _resolve_repo_artifact_ref(
+        str(source["spec_prepare_ref"]),
+        label="source spec_prepare ref",
+        expect_dir=True,
+    )
+    if source_spec_prepare_dir.parent.resolve(strict=True) != source_bridge_path.parent.resolve(
+        strict=True
+    ):
+        raise CreativeSpecificationSkepticReviewCliError(
+            "spec_prepare_ref must be a sibling of the source bridge artifact."
+        )
     source_packet = _read_json_object(reviewed_dir / "source_packet.json", label="source packet")
     variants = _read_json_array(reviewed_dir / "variants.json", label="variants")
     reviews = _read_json_array(reviewed_dir / "skeptic_reviews.json", label="skeptic reviews")
     context_pack = _read_json_object(reviewed_dir / "context_pack.json", label="context pack")
-    source = cast(Mapping[str, Any], attachment["source"])
     _assert_reviewed_ref(
         str(reviewed_run["source_packet_ref"]),
         reviewed_dir / "source_packet.json",

--- a/scripts/orchestration/creative_specification_skeptic_review.py
+++ b/scripts/orchestration/creative_specification_skeptic_review.py
@@ -553,10 +553,8 @@ def _validate_attachment_artifacts(attachment_path: Path) -> tuple[dict[str, Any
         raise CreativeSpecificationSkepticReviewCliError(
             f"source bridge ref must point to canonical {BRIDGE_FILENAME}."
         )
-    source_bridge = validate_creative_hypothesis_specification_bridge(
-        _read_json_object(source_bridge_path, label="source bridge")
-    )
-    _prepared_bridge_dir(source_bridge, source_bridge_path)
+    prepared_source = _read_prepared_bridge(source_bridge_path)
+    source_bridge = cast(Mapping[str, Any], prepared_source["bridge"])
     if source_bridge["bridge_id"] != source["bridge_id"]:
         raise CreativeSpecificationSkepticReviewCliError(
             "fingerprint_mismatch: source bridge id does not match attachment."

--- a/scripts/orchestration/creative_specification_skeptic_review.py
+++ b/scripts/orchestration/creative_specification_skeptic_review.py
@@ -44,6 +44,7 @@ from scripts.orchestration.creative_specification_skeptic_review_contract import
     CreativeSpecificationSkepticReviewError,
     build_finalize_receipt,
     build_skeptic_review_attachment,
+    build_skeptic_review_coverage,
     normalize_skeptic_reviews_for_pr1,
     validate_agent_skeptic_reviews_input,
     validate_finalize_receipt,
@@ -544,22 +545,78 @@ def _validate_attachment_artifacts(attachment_path: Path) -> tuple[dict[str, Any
         str(source["bridge_ref"]),
         label="source bridge ref",
     )
+    if source_bridge_path.name != BRIDGE_FILENAME:
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"source bridge ref must point to canonical {BRIDGE_FILENAME}."
+        )
+    source_bridge = validate_creative_hypothesis_specification_bridge(
+        _read_json_object(source_bridge_path, label="source bridge")
+    )
+    _prepared_bridge_dir(source_bridge, source_bridge_path)
+    if source_bridge["bridge_id"] != source["bridge_id"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: source bridge id does not match attachment."
+        )
+    if fingerprint_payload(source_bridge) != source["bridge_fingerprint"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: source bridge fingerprint does not match attachment."
+        )
+    source_bridge_candidate = cast(Mapping[str, Any], source_bridge["candidate_packet"])
+    if source_bridge_candidate["candidate_id"] != source["candidate_id"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: source candidate id does not match bridge."
+        )
+    if source_bridge_candidate["candidate_fingerprint"] != source["candidate_fingerprint"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: source candidate fingerprint does not match bridge."
+        )
+    if source_bridge_candidate["candidate_packet_ref"] != source["candidate_ref"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: source candidate ref does not match bridge."
+        )
     expected_reviewed_dir = source_bridge_path.parent / REVIEWED_RUN_DIRNAME
     if reviewed_dir.resolve(strict=True) != expected_reviewed_dir.resolve(strict=False):
         raise CreativeSpecificationSkepticReviewCliError(
             "reviewed_run_dir_ref must be the sibling of the source bridge artifact."
+        )
+    expected_metrics_ref = _artifact_ref(source_bridge_path.parent / METRICS_FILENAME)
+    if source["metrics_ref"] != expected_metrics_ref:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: source metrics ref does not match bridge layout."
+        )
+    source_bridge_prepare = cast(Mapping[str, Any], source_bridge["spec_prepare"])
+    if source_bridge_prepare["run_dir_ref"] != source["spec_prepare_ref"]:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: source spec_prepare ref does not match bridge."
         )
     source_spec_prepare_dir = _resolve_repo_artifact_ref(
         str(source["spec_prepare_ref"]),
         label="source spec_prepare ref",
         expect_dir=True,
     )
-    if source_spec_prepare_dir.parent.resolve(strict=True) != source_bridge_path.parent.resolve(
+    expected_spec_prepare_dir = source_bridge_path.parent / "spec_prepare"
+    if source_spec_prepare_dir.resolve(strict=True) != expected_spec_prepare_dir.resolve(
         strict=True
     ):
         raise CreativeSpecificationSkepticReviewCliError(
-            "spec_prepare_ref must be a sibling of the source bridge artifact."
+            "spec_prepare_ref must point to the canonical source spec_prepare artifact."
         )
+    _reject_unexpected_entries(
+        source_spec_prepare_dir,
+        allowed=set(PREPARE_FILENAMES),
+        label="source spec_prepare",
+    )
+    expected_source_refs = {
+        "source_packet_ref": source_spec_prepare_dir / "source_packet.json",
+        "variants_ref": source_spec_prepare_dir / "variants.json",
+        "pending_reviews_ref": source_spec_prepare_dir / "skeptic_reviews.json",
+        "context_pack_ref": source_spec_prepare_dir / "context_pack.json",
+    }
+    for key, expected_path in expected_source_refs.items():
+        if source[key] != _artifact_ref(expected_path):
+            raise CreativeSpecificationSkepticReviewCliError(
+                f"fingerprint_mismatch: source {key} does not match spec_prepare layout."
+            )
     source_packet = _read_json_object(reviewed_dir / "source_packet.json", label="source packet")
     variants = _read_json_array(reviewed_dir / "variants.json", label="variants")
     reviews = _read_json_array(reviewed_dir / "skeptic_reviews.json", label="skeptic reviews")
@@ -640,6 +697,14 @@ def _validate_attachment_artifacts(attachment_path: Path) -> tuple[dict[str, Any
         raise CreativeSpecificationSkepticReviewCliError(
             "reviewed finalize run cannot build a valid CreativeCodeSpecificationBundle."
         ) from exc
+    expected_coverage = build_skeptic_review_coverage(
+        normalized_reviews=cast(Sequence[Mapping[str, Any]], reviews),
+        variant_count=len(variants),
+    )
+    if attachment["coverage"] != expected_coverage:
+        raise CreativeSpecificationSkepticReviewCliError(
+            "fingerprint_mismatch: attachment coverage does not match reviewed artifacts."
+        )
     if fingerprint_payload(source_packet) != source["source_packet_fingerprint"]:
         raise CreativeSpecificationSkepticReviewCliError(
             "fingerprint_mismatch: reviewed source packet does not match attachment."
@@ -690,20 +755,25 @@ def _finalize_from_attachment(attachment_path: Path) -> dict[str, Any]:
         creative_code_spec_pipeline.finalize(reviewed_dir, bundle_path)
     except creative_code_spec_pipeline.CreativeCodeSpecPipelineError as exc:
         raise CreativeSpecificationSkepticReviewCliError(str(exc)) from exc
-    bundle = validate_creative_code_specification_bundle(
-        read_creative_code_specification_bundle(bundle_path)
-    )
-    receipt = cast(
-        dict[str, Any],
-        build_finalize_receipt(
-            attachment=attachment,
-            attachment_ref=_artifact_ref(reviewed_dir / ATTACHMENT_FILENAME),
-            bundle=bundle,
-            bundle_ref=_artifact_ref(bundle_path),
-        ),
-    )
-    _write_json_atomic(receipt_path, receipt)
-    validate_finalize_receipt(receipt)
+    try:
+        bundle = validate_creative_code_specification_bundle(
+            read_creative_code_specification_bundle(bundle_path)
+        )
+        receipt = cast(
+            dict[str, Any],
+            build_finalize_receipt(
+                attachment=attachment,
+                attachment_ref=_artifact_ref(reviewed_dir / ATTACHMENT_FILENAME),
+                bundle=bundle,
+                bundle_ref=_artifact_ref(bundle_path),
+            ),
+        )
+        _write_json_atomic(receipt_path, receipt)
+        validate_finalize_receipt(receipt)
+    except Exception:
+        bundle_path.unlink(missing_ok=True)
+        receipt_path.unlink(missing_ok=True)
+        raise
     return receipt
 
 

--- a/scripts/orchestration/creative_specification_skeptic_review.py
+++ b/scripts/orchestration/creative_specification_skeptic_review.py
@@ -226,6 +226,10 @@ def _write_json_atomic(path: Path, payload: Any) -> None:
 
 def _read_prepared_bridge(bridge_path: Path) -> dict[str, Any]:
     bridge_file = _resolve_repo_json_file(bridge_path, label="bridge input")
+    if bridge_file.name != BRIDGE_FILENAME:
+        raise CreativeSpecificationSkepticReviewCliError(
+            f"bridge input must point to canonical {BRIDGE_FILENAME}."
+        )
     bridge = validate_creative_hypothesis_specification_bridge(
         _read_json_object(bridge_file, label="bridge input")
     )

--- a/scripts/orchestration/creative_specification_skeptic_review_contract.py
+++ b/scripts/orchestration/creative_specification_skeptic_review_contract.py
@@ -32,6 +32,8 @@ ATTACHMENT_ARTIFACT_TYPE = "creative_specification_skeptic_review_attachment"
 FINALIZE_RECEIPT_ARTIFACT_TYPE = "creative_specification_finalize_receipt"
 POLICY_VERSION = "creative-specification-skeptic-review-finalize-v1"
 REVIEWED_RUN_DIRNAME = "spec_finalize_reviewed"
+ATTACHMENT_FILENAME = "skeptic_review_attachment.json"
+BUNDLE_FILENAME = "creative_code_specification_bundle.json"
 NEXT_ACTION_SELECTED = "human_review_for_patch_builder"
 NEXT_ACTION_ALL_REJECTED = "human_review_for_discard_or_defer"
 MAX_REVIEW_TEXT_LENGTH = 512
@@ -584,6 +586,40 @@ def validate_finalize_receipt(payload: Mapping[str, Any]) -> dict[str, Any]:
         raise CreativeSpecificationSkepticReviewError(
             f"{label}.counts.selected_variant_count does not match selected_variant_id."
         )
+    if selected_variant_id is None:
+        if counts["rejected_variant_count"] != counts["variant_count"]:
+            raise CreativeSpecificationSkepticReviewError(
+                f"{label}.counts.rejected_variant_count must match variant_count when all rejected."
+            )
+        if counts["rejection_record_count"] != counts["variant_count"]:
+            raise CreativeSpecificationSkepticReviewError(
+                f"{label}.counts.rejection_record_count must match variant_count when all rejected."
+            )
+    source_attachment_ref = _normalize_artifact_ref(
+        payload.get("source_attachment_ref"),
+        label=f"{label}.source_attachment_ref",
+    )
+    reviewed_run_dir_ref = _normalize_artifact_ref(
+        payload.get("reviewed_run_dir_ref"),
+        label=f"{label}.reviewed_run_dir_ref",
+        must_be_reviewed_run=True,
+    )
+    bundle_ref = _normalize_artifact_ref(
+        payload.get("bundle_ref"),
+        label=f"{label}.bundle_ref",
+    )
+    _require_reviewed_run_child_ref(
+        reviewed_run_dir_ref=reviewed_run_dir_ref,
+        child_ref=source_attachment_ref,
+        filename=ATTACHMENT_FILENAME,
+        label=f"{label}.source_attachment_ref",
+    )
+    _require_reviewed_run_child_ref(
+        reviewed_run_dir_ref=reviewed_run_dir_ref,
+        child_ref=bundle_ref,
+        filename=BUNDLE_FILENAME,
+        label=f"{label}.bundle_ref",
+    )
     normalized = {
         "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
         "artifact_type": _require_const(
@@ -606,19 +642,9 @@ def validate_finalize_receipt(payload: Mapping[str, Any]) -> dict[str, Any]:
             "source_attachment_fingerprint",
             label=label,
         ),
-        "source_attachment_ref": _normalize_artifact_ref(
-            payload.get("source_attachment_ref"),
-            label=f"{label}.source_attachment_ref",
-        ),
-        "reviewed_run_dir_ref": _normalize_artifact_ref(
-            payload.get("reviewed_run_dir_ref"),
-            label=f"{label}.reviewed_run_dir_ref",
-            must_be_reviewed_run=True,
-        ),
-        "bundle_ref": _normalize_artifact_ref(
-            payload.get("bundle_ref"),
-            label=f"{label}.bundle_ref",
-        ),
+        "source_attachment_ref": source_attachment_ref,
+        "reviewed_run_dir_ref": reviewed_run_dir_ref,
+        "bundle_ref": bundle_ref,
         "bundle_id": _require_id(payload, "bundle_id", label=label),
         "bundle_fingerprint": _require_fingerprint(payload, "bundle_fingerprint", label=label),
         "bundle_idempotency_key": _require_id(payload, "bundle_idempotency_key", label=label),
@@ -896,6 +922,10 @@ def _normalize_attachment_coverage(raw_counts: Any, *, label: str) -> dict[str, 
             "unsafe_authority_flag_count": MAX_TOTAL_REVIEW_TOKEN_COUNT,
             "blocker_count": MAX_TOTAL_REVIEW_TOKEN_COUNT,
         },
+        minima={
+            "variant_count": 1,
+            "review_count": 1,
+        },
     )
     if counts["required_reviewer_count"] != len(REQUIRED_SKEPTIC_REVIEWERS):
         raise CreativeSpecificationSkepticReviewError(
@@ -917,6 +947,10 @@ def _normalize_receipt_counts(raw_counts: Any, *, label: str) -> dict[str, int]:
             "unresolved_blocker_count": MAX_TOTAL_REVIEW_TOKEN_COUNT,
             "rejection_record_count": 5,
         },
+        minima={
+            "variant_count": 1,
+            "review_count": 1,
+        },
     )
 
 
@@ -926,14 +960,35 @@ def _normalize_counts(
     expected_keys: frozenset[str],
     label: str,
     maxima: Mapping[str, int],
+    minima: Mapping[str, int] | None = None,
 ) -> dict[str, int]:
     if not isinstance(raw_counts, dict):
         raise CreativeSpecificationSkepticReviewError(f"{label} must be a JSON object.")
     _require_exact_keys(raw_counts, expected_keys, label=label)
+    minimum_by_key = minima or {}
     return {
-        key: _bounded_count(raw_counts[key], f"{label}.{key}", minimum=0, maximum=maxima[key])
+        key: _bounded_count(
+            raw_counts[key],
+            f"{label}.{key}",
+            minimum=minimum_by_key.get(key, 0),
+            maximum=maxima[key],
+        )
         for key in sorted(expected_keys)
     }
+
+
+def _require_reviewed_run_child_ref(
+    *,
+    reviewed_run_dir_ref: str,
+    child_ref: str,
+    filename: str,
+    label: str,
+) -> None:
+    child_path = PurePosixPath(child_ref)
+    if child_path.parent != PurePosixPath(reviewed_run_dir_ref) or child_path.name != filename:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label} must point to canonical {filename} under reviewed_run_dir_ref."
+        )
 
 
 def _normalize_authority(

--- a/scripts/orchestration/creative_specification_skeptic_review_contract.py
+++ b/scripts/orchestration/creative_specification_skeptic_review_contract.py
@@ -1,0 +1,1130 @@
+"""Contracts for reviewed creative-code specification finalization.
+
+This module is a local control-plane contract. It validates operator-supplied,
+sanitized skeptic-review evidence, normalizes it into the PR-1
+``skeptic_reviews.json`` row shape, and describes the attachment/finalize
+receipts. It has no filesystem writes, subprocesses, provider calls, GitHub
+writes, product-runtime authority, semantic-cache authority, or graph-truth
+authority.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import PurePosixPath
+import re
+from typing import Any, cast
+
+from core.evidence.fingerprints import build_asset_id, build_idempotency_key, fingerprint_payload
+from scripts.orchestration.creative_code_specification import (
+    REQUIRED_SKEPTIC_REVIEWERS,
+    REVIEW_DECISIONS,
+    REVIEW_KEYS,
+    CreativeCodeSpecificationError,
+    build_creative_code_specification_bundle,
+    contains_unsafe_local_absolute_path,
+    validate_source_candidate_packet,
+)
+
+SCHEMA_VERSION = "1.0"
+REVIEW_INPUT_ARTIFACT_TYPE = "creative_specification_agent_skeptic_reviews"
+ATTACHMENT_ARTIFACT_TYPE = "creative_specification_skeptic_review_attachment"
+FINALIZE_RECEIPT_ARTIFACT_TYPE = "creative_specification_finalize_receipt"
+POLICY_VERSION = "creative-specification-skeptic-review-finalize-v1"
+REVIEWED_RUN_DIRNAME = "spec_finalize_reviewed"
+NEXT_ACTION_SELECTED = "human_review_for_patch_builder"
+NEXT_ACTION_ALL_REJECTED = "human_review_for_discard_or_defer"
+
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
+SHA256_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+SECRET_RE = re.compile(
+    r"(sk-[A-Za-z0-9_-]{12,}|gh[psoru]_[A-Za-z0-9_]{12,}|github_pat_|"
+    r"xox[abprs]-|authorization:\s*bearer|private[_ -]?key)",
+    re.IGNORECASE,
+)
+UNSAFE_TEXT_RE = re.compile(
+    r"(candidate\.patch|diff --git|provider[_ -]?payload|raw[_ -]?(prompt|response|context)|"
+    r"chain[_ -]?of[_ -]?thought|https?://|api\.openai\.com|call model|call network|"
+    r"runtime service|product runtime|apply (a )?(repository )?patch|repository patch|"
+    r"commit changes|git commit|git push|create (a )?(pull request|PR|branch)|"
+    r"open (a )?(draft )?(pull request|PR)|write (to )?(the )?repository|"
+    r"resolve review thread|mark ready for review|merge readiness|semantic cache|graph truth|"
+    r"workflow dispatch|provider call|\bdiagnose\b|\btreat\b|clinical efficacy|"
+    r"crisis support|emergency care)",
+    re.IGNORECASE,
+)
+
+REVIEW_INPUT_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "source_bridge_id",
+        "source_bridge_fingerprint",
+        "source_candidate_id",
+        "source_candidate_fingerprint",
+        "source_packet_fingerprint",
+        "variants_fingerprint",
+        "reviews",
+        "authority",
+        "sanitized",
+    }
+)
+REVIEW_INPUT_ROW_KEYS = frozenset(
+    {
+        "variant_id",
+        "reviewer_role",
+        "decision",
+        "blockers",
+        "unsafe_authority_flags",
+        "duplicate_reason",
+        "required_revision",
+    }
+)
+ATTACHMENT_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "attachment_id",
+        "idempotency_key",
+        "policy_version",
+        "source",
+        "reviewed_run",
+        "coverage",
+        "authority",
+        "sanitized",
+    }
+)
+ATTACHMENT_SOURCE_KEYS = frozenset(
+    {
+        "bridge_id",
+        "bridge_fingerprint",
+        "bridge_ref",
+        "candidate_id",
+        "candidate_fingerprint",
+        "candidate_ref",
+        "metrics_id",
+        "metrics_fingerprint",
+        "metrics_ref",
+        "spec_prepare_ref",
+        "source_packet_ref",
+        "source_packet_fingerprint",
+        "variants_ref",
+        "variants_fingerprint",
+        "pending_reviews_ref",
+        "pending_reviews_fingerprint",
+        "context_pack_ref",
+        "context_pack_fingerprint",
+    }
+)
+REVIEWED_RUN_KEYS = frozenset(
+    {
+        "run_dir_ref",
+        "source_packet_ref",
+        "variants_ref",
+        "skeptic_reviews_ref",
+        "context_pack_ref",
+        "normalized_reviews_fingerprint",
+    }
+)
+ATTACHMENT_COVERAGE_KEYS = frozenset(
+    {
+        "variant_count",
+        "required_reviewer_count",
+        "review_count",
+        "pass_review_count",
+        "revise_review_count",
+        "reject_review_count",
+        "unsafe_authority_flag_count",
+        "blocker_count",
+    }
+)
+RECEIPT_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "finalize_id",
+        "idempotency_key",
+        "policy_version",
+        "source_attachment_id",
+        "source_attachment_fingerprint",
+        "source_attachment_ref",
+        "reviewed_run_dir_ref",
+        "bundle_ref",
+        "bundle_id",
+        "bundle_fingerprint",
+        "bundle_idempotency_key",
+        "selected_variant_id",
+        "synthesis_status",
+        "next_allowed_action",
+        "counts",
+        "authority",
+        "sanitized",
+    }
+)
+RECEIPT_COUNTS_KEYS = frozenset(
+    {
+        "variant_count",
+        "review_count",
+        "selected_variant_count",
+        "rejected_variant_count",
+        "unresolved_blocker_count",
+        "rejection_record_count",
+    }
+)
+TRUE_AUTHORITY_KEYS = frozenset(
+    {
+        "attach_skeptic_reviews",
+        "emit_local_artifacts",
+        "finalize_specification_bundle",
+        "operator_supplied_sanitized_reviews",
+    }
+)
+FALSE_AUTHORITY_KEYS = frozenset(
+    {
+        "call_product_runtime",
+        "call_provider",
+        "change_client_runtime",
+        "change_openapi",
+        "claim_merge_readiness",
+        "create_branch",
+        "dispatch_to_agents",
+        "edit_fixed_mapping",
+        "execute_agent_tasks",
+        "execute_pr2_patch_builder",
+        "execute_pr3_promotion",
+        "generate_candidate_patch",
+        "generate_patch",
+        "merge",
+        "modify_workflows",
+        "open_draft_pr",
+        "open_pr",
+        "post_github_comment",
+        "push",
+        "read_secrets",
+        "resolve_threads",
+        "use_semantic_cache",
+        "workflow_dispatch",
+        "write_branch",
+        "write_graph_truth",
+        "write_repository",
+        "write_shared_worktree",
+    }
+)
+AUTHORITY_KEYS = TRUE_AUTHORITY_KEYS | FALSE_AUTHORITY_KEYS
+
+
+class CreativeSpecificationSkepticReviewError(ValueError):
+    """Raised when reviewed finalize evidence violates the local contract."""
+
+
+def default_review_input_authority() -> dict[str, bool]:
+    """Return the only authority allowed for operator-supplied review input."""
+
+    return _authority(
+        true_keys={"operator_supplied_sanitized_reviews"},
+        false_true_keys={
+            "attach_skeptic_reviews",
+            "emit_local_artifacts",
+            "finalize_specification_bundle",
+        },
+    )
+
+
+def default_attachment_authority() -> dict[str, bool]:
+    """Return the only authority allowed for skeptic-review attachment."""
+
+    return _authority(
+        true_keys={"attach_skeptic_reviews", "emit_local_artifacts"},
+        false_true_keys={"operator_supplied_sanitized_reviews", "finalize_specification_bundle"},
+    )
+
+
+def default_finalize_receipt_authority() -> dict[str, bool]:
+    """Return the only authority allowed for reviewed finalize receipts."""
+
+    return _authority(
+        true_keys={"emit_local_artifacts", "finalize_specification_bundle"},
+        false_true_keys={"attach_skeptic_reviews", "operator_supplied_sanitized_reviews"},
+    )
+
+
+def validate_agent_skeptic_reviews_input(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate operator-supplied sanitized skeptic-review input."""
+
+    label = "CreativeSpecificationAgentSkepticReviews"
+    _require_exact_keys(payload, REVIEW_INPUT_KEYS, label=label)
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(
+            payload,
+            "artifact_type",
+            REVIEW_INPUT_ARTIFACT_TYPE,
+            label=label,
+        ),
+        "policy_version": _require_const(
+            payload,
+            "policy_version",
+            POLICY_VERSION,
+            label=label,
+        ),
+        "source_bridge_id": _require_id(payload, "source_bridge_id", label=label),
+        "source_bridge_fingerprint": _require_fingerprint(
+            payload,
+            "source_bridge_fingerprint",
+            label=label,
+        ),
+        "source_candidate_id": _require_id(payload, "source_candidate_id", label=label),
+        "source_candidate_fingerprint": _require_fingerprint(
+            payload,
+            "source_candidate_fingerprint",
+            label=label,
+        ),
+        "source_packet_fingerprint": _require_fingerprint(
+            payload,
+            "source_packet_fingerprint",
+            label=label,
+        ),
+        "variants_fingerprint": _require_fingerprint(
+            payload,
+            "variants_fingerprint",
+            label=label,
+        ),
+        "reviews": _normalize_input_reviews(payload["reviews"], label=f"{label}.reviews"),
+        "authority": _normalize_authority(
+            payload["authority"],
+            expected=default_review_input_authority(),
+            label=f"{label}.authority",
+        ),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    _reject_payload_safety(normalized, label=label)
+    return normalized
+
+
+def normalize_skeptic_reviews_for_pr1(
+    *,
+    review_input: Mapping[str, Any],
+    source_packet: Mapping[str, Any],
+    variants: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Normalize operator review input into PR-1 skeptic review rows."""
+
+    normalized_input = validate_agent_skeptic_reviews_input(review_input)
+    normalized_packet = validate_source_candidate_packet(source_packet)
+    source_packet_id = str(normalized_packet["candidate_id"])
+    source_candidate_id = str(normalized_packet["source_creative_research"]["candidate_id"])
+    variant_ids = {str(variant["variant_id"]) for variant in variants}
+    review_keys: set[tuple[str, str]] = set()
+    reviews: list[dict[str, Any]] = []
+    for index, raw_review in enumerate(normalized_input["reviews"]):
+        review = cast(dict[str, Any], dict(raw_review))
+        variant_id = str(review["variant_id"])
+        reviewer_role = str(review["reviewer_role"])
+        if variant_id not in variant_ids:
+            raise CreativeSpecificationSkepticReviewError(
+                f"review[{index}].variant_id must reference a prepared variant."
+            )
+        key = (variant_id, reviewer_role)
+        if key in review_keys:
+            raise CreativeSpecificationSkepticReviewError(
+                "reviews must not repeat a reviewer for a variant."
+            )
+        review_keys.add(key)
+        normalized_review: dict[str, Any] = {
+            "review_id": f"{variant_id}:{reviewer_role}",
+            "source_packet_id": source_packet_id,
+            "source_candidate_id": source_candidate_id,
+            "variant_id": variant_id,
+            "reviewer_role": reviewer_role,
+            "decision": review["decision"],
+            "blockers": list(review["blockers"]),
+            "unsafe_authority_flags": list(review["unsafe_authority_flags"]),
+            "duplicate_reason": review["duplicate_reason"],
+            "required_revision": review["required_revision"],
+            "review_fingerprint": "pending",
+        }
+        normalized_review["review_fingerprint"] = fingerprint_payload(
+            _review_fingerprint_payload(normalized_review)
+        )
+        reviews.append(normalized_review)
+    expected_keys = {
+        (str(variant["variant_id"]), reviewer)
+        for variant in variants
+        for reviewer in REQUIRED_SKEPTIC_REVIEWERS
+    }
+    missing = sorted(expected_keys - review_keys)
+    if missing:
+        raise CreativeSpecificationSkepticReviewError(
+            "reviews must cover every required reviewer for every variant."
+        )
+    extra = sorted(review_keys - expected_keys)
+    if extra:
+        raise CreativeSpecificationSkepticReviewError(
+            "reviews include reviewer coverage outside the prepared PR-1 requirement."
+        )
+    try:
+        build_creative_code_specification_bundle(
+            source_packet=normalized_packet,
+            variants=list(variants),
+            skeptic_reviews=reviews,
+        )
+    except CreativeCodeSpecificationError as exc:
+        raise CreativeSpecificationSkepticReviewError(str(exc)) from exc
+    return reviews
+
+
+def build_skeptic_review_attachment(
+    *,
+    bridge_id: str,
+    bridge_fingerprint: str,
+    bridge_ref: str,
+    candidate_id: str,
+    candidate_fingerprint: str,
+    candidate_ref: str,
+    metrics_id: str,
+    metrics_fingerprint: str,
+    metrics_ref: str,
+    spec_prepare_ref: str,
+    source_packet_ref: str,
+    source_packet_fingerprint: str,
+    variants_ref: str,
+    variants_fingerprint: str,
+    pending_reviews_ref: str,
+    pending_reviews_fingerprint: str,
+    context_pack_ref: str,
+    context_pack_fingerprint: str,
+    reviewed_run_dir_ref: str,
+    reviewed_source_packet_ref: str,
+    reviewed_variants_ref: str,
+    reviewed_reviews_ref: str,
+    reviewed_context_pack_ref: str,
+    normalized_reviews: Sequence[Mapping[str, Any]],
+    variant_count: int,
+) -> dict[str, Any]:
+    """Build a metadata-only skeptic-review attachment artifact."""
+
+    counts = _review_counts(normalized_reviews=normalized_reviews, variant_count=variant_count)
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": ATTACHMENT_ARTIFACT_TYPE,
+        "attachment_id": "pending",
+        "idempotency_key": "pending",
+        "policy_version": POLICY_VERSION,
+        "source": {
+            "bridge_id": bridge_id,
+            "bridge_fingerprint": bridge_fingerprint,
+            "bridge_ref": bridge_ref,
+            "candidate_id": candidate_id,
+            "candidate_fingerprint": candidate_fingerprint,
+            "candidate_ref": candidate_ref,
+            "metrics_id": metrics_id,
+            "metrics_fingerprint": metrics_fingerprint,
+            "metrics_ref": metrics_ref,
+            "spec_prepare_ref": spec_prepare_ref,
+            "source_packet_ref": source_packet_ref,
+            "source_packet_fingerprint": source_packet_fingerprint,
+            "variants_ref": variants_ref,
+            "variants_fingerprint": variants_fingerprint,
+            "pending_reviews_ref": pending_reviews_ref,
+            "pending_reviews_fingerprint": pending_reviews_fingerprint,
+            "context_pack_ref": context_pack_ref,
+            "context_pack_fingerprint": context_pack_fingerprint,
+        },
+        "reviewed_run": {
+            "run_dir_ref": reviewed_run_dir_ref,
+            "source_packet_ref": reviewed_source_packet_ref,
+            "variants_ref": reviewed_variants_ref,
+            "skeptic_reviews_ref": reviewed_reviews_ref,
+            "context_pack_ref": reviewed_context_pack_ref,
+            "normalized_reviews_fingerprint": fingerprint_payload(list(normalized_reviews)),
+        },
+        "coverage": counts,
+        "authority": default_attachment_authority(),
+        "sanitized": True,
+    }
+    _set_identity(body, id_key="attachment_id", asset_type=ATTACHMENT_ARTIFACT_TYPE)
+    return validate_skeptic_review_attachment(body)
+
+
+def validate_skeptic_review_attachment(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize a skeptic-review attachment artifact."""
+
+    label = "CreativeSpecificationSkepticReviewAttachment"
+    _require_exact_keys(payload, ATTACHMENT_KEYS, label=label)
+    source = _normalize_attachment_source(payload["source"], label=f"{label}.source")
+    reviewed_run = _normalize_reviewed_run(payload["reviewed_run"], label=f"{label}.reviewed_run")
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(
+            payload,
+            "artifact_type",
+            ATTACHMENT_ARTIFACT_TYPE,
+            label=label,
+        ),
+        "attachment_id": _require_id(payload, "attachment_id", label=label),
+        "idempotency_key": _require_id(payload, "idempotency_key", label=label),
+        "policy_version": _require_const(
+            payload,
+            "policy_version",
+            POLICY_VERSION,
+            label=label,
+        ),
+        "source": source,
+        "reviewed_run": reviewed_run,
+        "coverage": _normalize_attachment_coverage(payload["coverage"], label=f"{label}.coverage"),
+        "authority": _normalize_authority(
+            payload["authority"],
+            expected=default_attachment_authority(),
+            label=f"{label}.authority",
+        ),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    _validate_identity(normalized, id_key="attachment_id", asset_type=ATTACHMENT_ARTIFACT_TYPE)
+    _reject_payload_safety(normalized, label=label)
+    return normalized
+
+
+def build_finalize_receipt(
+    *,
+    attachment: Mapping[str, Any],
+    attachment_ref: str,
+    bundle: Mapping[str, Any],
+    bundle_ref: str,
+) -> dict[str, Any]:
+    """Build a metadata-only receipt for an explicit reviewed finalize step."""
+
+    normalized_attachment = validate_skeptic_review_attachment(attachment)
+    synthesis = cast(Mapping[str, Any], bundle["synthesis"])
+    selected_variant_id = synthesis["selected_variant_id"]
+    selected_count = 1 if selected_variant_id is not None else 0
+    rejected_records = cast(Sequence[Mapping[str, Any]], bundle["rejection_index"]["records"])
+    unresolved_blockers = cast(Sequence[Any], synthesis["unresolved_blockers"])
+    variant_count = len(cast(Sequence[Any], bundle["variants"]))
+    review_count = len(cast(Sequence[Any], bundle["skeptic_reviews"]))
+    rejected_variant_count = len({str(record["variant_id"]) for record in rejected_records})
+    synthesis_status = "selected" if selected_variant_id is not None else "all_rejected"
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": FINALIZE_RECEIPT_ARTIFACT_TYPE,
+        "finalize_id": "pending",
+        "idempotency_key": "pending",
+        "policy_version": POLICY_VERSION,
+        "source_attachment_id": normalized_attachment["attachment_id"],
+        "source_attachment_fingerprint": fingerprint_payload(dict(normalized_attachment)),
+        "source_attachment_ref": attachment_ref,
+        "reviewed_run_dir_ref": normalized_attachment["reviewed_run"]["run_dir_ref"],
+        "bundle_ref": bundle_ref,
+        "bundle_id": bundle["bundle_id"],
+        "bundle_fingerprint": fingerprint_payload(cast(dict[str, Any], dict(bundle))),
+        "bundle_idempotency_key": bundle["idempotency_key"],
+        "selected_variant_id": selected_variant_id,
+        "synthesis_status": synthesis_status,
+        "next_allowed_action": (
+            NEXT_ACTION_SELECTED if selected_variant_id is not None else NEXT_ACTION_ALL_REJECTED
+        ),
+        "counts": {
+            "variant_count": variant_count,
+            "review_count": review_count,
+            "selected_variant_count": selected_count,
+            "rejected_variant_count": rejected_variant_count,
+            "unresolved_blocker_count": len(unresolved_blockers),
+            "rejection_record_count": len(rejected_records),
+        },
+        "authority": default_finalize_receipt_authority(),
+        "sanitized": True,
+    }
+    _set_identity(body, id_key="finalize_id", asset_type=FINALIZE_RECEIPT_ARTIFACT_TYPE)
+    return validate_finalize_receipt(body)
+
+
+def validate_finalize_receipt(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize a reviewed finalize receipt."""
+
+    label = "CreativeSpecificationFinalizeReceipt"
+    _require_exact_keys(payload, RECEIPT_KEYS, label=label)
+    selected_variant_id = _require_optional_id(
+        payload.get("selected_variant_id"), label=f"{label}.selected_variant_id"
+    )
+    synthesis_status = _require_token(payload, "synthesis_status", label=label)
+    if synthesis_status not in {"selected", "all_rejected"}:
+        raise CreativeSpecificationSkepticReviewError(f"{label}.synthesis_status is unsupported.")
+    next_allowed_action = _require_token(payload, "next_allowed_action", label=label)
+    expected_next = (
+        NEXT_ACTION_SELECTED if selected_variant_id is not None else NEXT_ACTION_ALL_REJECTED
+    )
+    if next_allowed_action != expected_next:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label}.next_allowed_action does not match selected status."
+        )
+    if (selected_variant_id is None and synthesis_status != "all_rejected") or (
+        selected_variant_id is not None and synthesis_status != "selected"
+    ):
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label}.synthesis_status does not match selected_variant_id."
+        )
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(
+            payload,
+            "artifact_type",
+            FINALIZE_RECEIPT_ARTIFACT_TYPE,
+            label=label,
+        ),
+        "finalize_id": _require_id(payload, "finalize_id", label=label),
+        "idempotency_key": _require_id(payload, "idempotency_key", label=label),
+        "policy_version": _require_const(
+            payload,
+            "policy_version",
+            POLICY_VERSION,
+            label=label,
+        ),
+        "source_attachment_id": _require_id(payload, "source_attachment_id", label=label),
+        "source_attachment_fingerprint": _require_fingerprint(
+            payload,
+            "source_attachment_fingerprint",
+            label=label,
+        ),
+        "source_attachment_ref": _normalize_artifact_ref(
+            payload.get("source_attachment_ref"),
+            label=f"{label}.source_attachment_ref",
+        ),
+        "reviewed_run_dir_ref": _normalize_artifact_ref(
+            payload.get("reviewed_run_dir_ref"),
+            label=f"{label}.reviewed_run_dir_ref",
+            must_be_reviewed_run=True,
+        ),
+        "bundle_ref": _normalize_artifact_ref(
+            payload.get("bundle_ref"),
+            label=f"{label}.bundle_ref",
+        ),
+        "bundle_id": _require_id(payload, "bundle_id", label=label),
+        "bundle_fingerprint": _require_fingerprint(payload, "bundle_fingerprint", label=label),
+        "bundle_idempotency_key": _require_id(payload, "bundle_idempotency_key", label=label),
+        "selected_variant_id": selected_variant_id,
+        "synthesis_status": synthesis_status,
+        "next_allowed_action": next_allowed_action,
+        "counts": _normalize_receipt_counts(payload["counts"], label=f"{label}.counts"),
+        "authority": _normalize_authority(
+            payload["authority"],
+            expected=default_finalize_receipt_authority(),
+            label=f"{label}.authority",
+        ),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    _validate_identity(normalized, id_key="finalize_id", asset_type=FINALIZE_RECEIPT_ARTIFACT_TYPE)
+    _reject_payload_safety(normalized, label=label)
+    return normalized
+
+
+def _authority(*, true_keys: set[str], false_true_keys: set[str]) -> dict[str, bool]:
+    if (true_keys | false_true_keys) - TRUE_AUTHORITY_KEYS:
+        raise AssertionError("authority configuration references unknown true key")
+    values = {key: False for key in AUTHORITY_KEYS}
+    for key in true_keys:
+        values[key] = True
+    for key in false_true_keys:
+        values[key] = False
+    return dict(sorted(values.items()))
+
+
+def _review_counts(
+    *,
+    normalized_reviews: Sequence[Mapping[str, Any]],
+    variant_count: int,
+) -> dict[str, int]:
+    decision_counts = {decision: 0 for decision in REVIEW_DECISIONS}
+    blocker_count = 0
+    unsafe_count = 0
+    for review in normalized_reviews:
+        decision_counts[str(review["decision"])] += 1
+        blocker_count += len(cast(Sequence[Any], review["blockers"]))
+        unsafe_count += len(cast(Sequence[Any], review["unsafe_authority_flags"]))
+    return {
+        "variant_count": _bounded_count(
+            variant_count, "coverage.variant_count", minimum=1, maximum=5
+        ),
+        "required_reviewer_count": len(REQUIRED_SKEPTIC_REVIEWERS),
+        "review_count": _bounded_count(
+            len(normalized_reviews), "coverage.review_count", minimum=1, maximum=15
+        ),
+        "pass_review_count": decision_counts["pass"],
+        "revise_review_count": decision_counts["revise"],
+        "reject_review_count": decision_counts["reject"],
+        "unsafe_authority_flag_count": unsafe_count,
+        "blocker_count": blocker_count,
+    }
+
+
+def _set_identity(body: dict[str, Any], *, id_key: str, asset_type: str) -> None:
+    fingerprint = fingerprint_payload(
+        {key: body[key] for key in sorted(body) if key not in {id_key, "idempotency_key"}}
+    )
+    upstream_ids = _identity_upstream_ids(body)
+    body[id_key] = build_asset_id(
+        asset_type=asset_type,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=upstream_ids,
+    )
+    body["idempotency_key"] = build_idempotency_key(
+        asset_type=asset_type,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=upstream_ids,
+    )
+
+
+def _validate_identity(body: Mapping[str, Any], *, id_key: str, asset_type: str) -> None:
+    expected = dict(body)
+    expected[id_key] = "pending"
+    expected["idempotency_key"] = "pending"
+    _set_identity(expected, id_key=id_key, asset_type=asset_type)
+    if body[id_key] != expected[id_key] or body["idempotency_key"] != expected["idempotency_key"]:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{asset_type} identity does not match artifact content."
+        )
+
+
+def _identity_upstream_ids(body: Mapping[str, Any]) -> tuple[str, ...]:
+    if body.get("artifact_type") == ATTACHMENT_ARTIFACT_TYPE:
+        source = cast(Mapping[str, Any], body["source"])
+        reviewed = cast(Mapping[str, Any], body["reviewed_run"])
+        return (
+            str(source["bridge_id"]),
+            str(source["candidate_id"]),
+            str(reviewed["normalized_reviews_fingerprint"]),
+        )
+    if body.get("artifact_type") == FINALIZE_RECEIPT_ARTIFACT_TYPE:
+        return (
+            str(body["source_attachment_id"]),
+            str(body["bundle_id"]),
+            str(body["bundle_fingerprint"]),
+        )
+    return ()
+
+
+def _review_fingerprint_payload(review: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: review[key] for key in sorted(REVIEW_KEYS - {"review_id", "review_fingerprint"})}
+
+
+def _normalize_input_reviews(raw_reviews: Any, *, label: str) -> list[dict[str, Any]]:
+    if not isinstance(raw_reviews, list):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be an array.")
+    if not raw_reviews:
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be non-empty.")
+    if len(raw_reviews) > 15:
+        raise CreativeSpecificationSkepticReviewError(f"{label} must contain at most 15 rows.")
+    return [
+        _normalize_input_review(raw_review, index=index, label=label)
+        for index, raw_review in enumerate(raw_reviews)
+    ]
+
+
+def _normalize_input_review(raw_review: Any, *, index: int, label: str) -> dict[str, Any]:
+    row_label = f"{label}[{index}]"
+    if not isinstance(raw_review, dict):
+        raise CreativeSpecificationSkepticReviewError(f"{row_label} must be a JSON object.")
+    _require_exact_keys(raw_review, REVIEW_INPUT_ROW_KEYS, label=row_label)
+    review = {
+        "variant_id": _require_id(raw_review, "variant_id", label=row_label),
+        "reviewer_role": _require_token(raw_review, "reviewer_role", label=row_label),
+        "decision": _require_token(raw_review, "decision", label=row_label),
+        "blockers": _normalize_token_list(
+            raw_review,
+            "blockers",
+            label=row_label,
+            allow_empty=True,
+        ),
+        "unsafe_authority_flags": _normalize_token_list(
+            raw_review,
+            "unsafe_authority_flags",
+            label=row_label,
+            allow_empty=True,
+        ),
+        "duplicate_reason": _require_text(raw_review, "duplicate_reason", label=row_label),
+        "required_revision": _require_text(raw_review, "required_revision", label=row_label),
+    }
+    if review["reviewer_role"] not in REQUIRED_SKEPTIC_REVIEWERS:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{row_label}.reviewer_role is not required for PR-1."
+        )
+    if review["decision"] not in REVIEW_DECISIONS:
+        raise CreativeSpecificationSkepticReviewError(f"{row_label}.decision is unsupported.")
+    if review["decision"] == "pass":
+        if (
+            review["blockers"]
+            or review["unsafe_authority_flags"]
+            or review["duplicate_reason"] != "none"
+            or review["required_revision"] != "none"
+        ):
+            raise CreativeSpecificationSkepticReviewError(
+                f"{row_label} pass reviews must be clean."
+            )
+    if review["decision"] == "reject" and not review["blockers"]:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{row_label} reject reviews require blockers."
+        )
+    if review["decision"] == "revise" and review["required_revision"] == "none":
+        raise CreativeSpecificationSkepticReviewError(
+            f"{row_label} revise reviews require revision notes."
+        )
+    return review
+
+
+def _normalize_attachment_source(raw_source: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(raw_source, dict):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_source, ATTACHMENT_SOURCE_KEYS, label=label)
+    return {
+        "bridge_id": _require_id(raw_source, "bridge_id", label=label),
+        "bridge_fingerprint": _require_fingerprint(raw_source, "bridge_fingerprint", label=label),
+        "bridge_ref": _normalize_artifact_ref(
+            raw_source.get("bridge_ref"), label=f"{label}.bridge_ref"
+        ),
+        "candidate_id": _require_id(raw_source, "candidate_id", label=label),
+        "candidate_fingerprint": _require_fingerprint(
+            raw_source, "candidate_fingerprint", label=label
+        ),
+        "candidate_ref": _normalize_artifact_ref(
+            raw_source.get("candidate_ref"), label=f"{label}.candidate_ref"
+        ),
+        "metrics_id": _require_id(raw_source, "metrics_id", label=label),
+        "metrics_fingerprint": _require_fingerprint(raw_source, "metrics_fingerprint", label=label),
+        "metrics_ref": _normalize_artifact_ref(
+            raw_source.get("metrics_ref"), label=f"{label}.metrics_ref"
+        ),
+        "spec_prepare_ref": _normalize_artifact_ref(
+            raw_source.get("spec_prepare_ref"),
+            label=f"{label}.spec_prepare_ref",
+        ),
+        "source_packet_ref": _normalize_artifact_ref(
+            raw_source.get("source_packet_ref"),
+            label=f"{label}.source_packet_ref",
+        ),
+        "source_packet_fingerprint": _require_fingerprint(
+            raw_source, "source_packet_fingerprint", label=label
+        ),
+        "variants_ref": _normalize_artifact_ref(
+            raw_source.get("variants_ref"), label=f"{label}.variants_ref"
+        ),
+        "variants_fingerprint": _require_fingerprint(
+            raw_source, "variants_fingerprint", label=label
+        ),
+        "pending_reviews_ref": _normalize_artifact_ref(
+            raw_source.get("pending_reviews_ref"),
+            label=f"{label}.pending_reviews_ref",
+        ),
+        "pending_reviews_fingerprint": _require_fingerprint(
+            raw_source, "pending_reviews_fingerprint", label=label
+        ),
+        "context_pack_ref": _normalize_artifact_ref(
+            raw_source.get("context_pack_ref"),
+            label=f"{label}.context_pack_ref",
+        ),
+        "context_pack_fingerprint": _require_fingerprint(
+            raw_source, "context_pack_fingerprint", label=label
+        ),
+    }
+
+
+def _normalize_reviewed_run(raw_run: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(raw_run, dict):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_run, REVIEWED_RUN_KEYS, label=label)
+    return {
+        "run_dir_ref": _normalize_artifact_ref(
+            raw_run.get("run_dir_ref"),
+            label=f"{label}.run_dir_ref",
+            must_be_reviewed_run=True,
+        ),
+        "source_packet_ref": _normalize_artifact_ref(
+            raw_run.get("source_packet_ref"), label=f"{label}.source_packet_ref"
+        ),
+        "variants_ref": _normalize_artifact_ref(
+            raw_run.get("variants_ref"), label=f"{label}.variants_ref"
+        ),
+        "skeptic_reviews_ref": _normalize_artifact_ref(
+            raw_run.get("skeptic_reviews_ref"), label=f"{label}.skeptic_reviews_ref"
+        ),
+        "context_pack_ref": _normalize_artifact_ref(
+            raw_run.get("context_pack_ref"), label=f"{label}.context_pack_ref"
+        ),
+        "normalized_reviews_fingerprint": _require_fingerprint(
+            raw_run, "normalized_reviews_fingerprint", label=label
+        ),
+    }
+
+
+def _normalize_attachment_coverage(raw_counts: Any, *, label: str) -> dict[str, int]:
+    return _normalize_counts(
+        raw_counts,
+        expected_keys=ATTACHMENT_COVERAGE_KEYS,
+        label=label,
+        maxima={
+            "variant_count": 5,
+            "required_reviewer_count": len(REQUIRED_SKEPTIC_REVIEWERS),
+            "review_count": 15,
+            "pass_review_count": 15,
+            "revise_review_count": 15,
+            "reject_review_count": 15,
+            "unsafe_authority_flag_count": 15,
+            "blocker_count": 30,
+        },
+    )
+
+
+def _normalize_receipt_counts(raw_counts: Any, *, label: str) -> dict[str, int]:
+    return _normalize_counts(
+        raw_counts,
+        expected_keys=RECEIPT_COUNTS_KEYS,
+        label=label,
+        maxima={
+            "variant_count": 5,
+            "review_count": 15,
+            "selected_variant_count": 1,
+            "rejected_variant_count": 5,
+            "unresolved_blocker_count": 30,
+            "rejection_record_count": 5,
+        },
+    )
+
+
+def _normalize_counts(
+    raw_counts: Any,
+    *,
+    expected_keys: frozenset[str],
+    label: str,
+    maxima: Mapping[str, int],
+) -> dict[str, int]:
+    if not isinstance(raw_counts, dict):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_counts, expected_keys, label=label)
+    return {
+        key: _bounded_count(raw_counts[key], f"{label}.{key}", minimum=0, maximum=maxima[key])
+        for key in sorted(expected_keys)
+    }
+
+
+def _normalize_authority(
+    raw_authority: Any,
+    *,
+    expected: Mapping[str, bool],
+    label: str,
+) -> dict[str, bool]:
+    if not isinstance(raw_authority, dict):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_authority, frozenset(expected), label=label)
+    for key, expected_value in expected.items():
+        if raw_authority[key] is not expected_value:
+            raise CreativeSpecificationSkepticReviewError(
+                f"{label}.{key} must be {expected_value!r}."
+            )
+    return dict(sorted((key, bool(raw_authority[key])) for key in expected))
+
+
+def _normalize_artifact_ref(
+    raw_ref: Any,
+    *,
+    label: str,
+    must_be_reviewed_run: bool = False,
+) -> str:
+    if not isinstance(raw_ref, str):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be a string.")
+    value = raw_ref.strip()
+    if not value:
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be non-empty.")
+    if "\\" in value:
+        raise CreativeSpecificationSkepticReviewError(f"{label} must use POSIX separators.")
+    if value.startswith(("/", "~")) or SCHEME_RE.match(value):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be a repo artifact ref.")
+    path = PurePosixPath(value)
+    if "." in path.parts or ".." in path.parts:
+        raise CreativeSpecificationSkepticReviewError(f"{label} must not contain traversal.")
+    prefix = ("artifacts", "orchestration", "creative_code", "spec_bridge")
+    if path.parts[:4] != prefix or len(path.parts) < 5:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label} must stay under creative-code spec_bridge artifacts."
+        )
+    if must_be_reviewed_run and path.name != REVIEWED_RUN_DIRNAME:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label} must point to {REVIEWED_RUN_DIRNAME}."
+        )
+    return path.as_posix()
+
+
+def _require_exact_keys(
+    payload: Mapping[str, Any],
+    expected_keys: frozenset[str],
+    *,
+    label: str,
+) -> None:
+    actual_keys = set(payload)
+    missing = sorted(expected_keys - actual_keys)
+    extra = sorted(actual_keys - expected_keys)
+    if missing:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label} is missing required fields: {', '.join(missing)}"
+        )
+    if extra:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label} has unsupported fields: {', '.join(extra)}"
+        )
+
+
+def _require_const(payload: Mapping[str, Any], key: str, expected: Any, *, label: str) -> Any:
+    value = payload.get(key)
+    if value != expected:
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must equal {expected!r}.")
+    return value
+
+
+def _require_bool(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    expected: bool,
+    label: str,
+) -> bool:
+    value = payload.get(key)
+    if value is not expected:
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be {expected!r}.")
+    return expected
+
+
+def _require_id(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be a string.")
+    normalized = value.strip()
+    if not normalized or not ID_RE.fullmatch(normalized):
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be a safe identifier.")
+    return normalized
+
+
+def _require_optional_id(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be null or string.")
+    normalized = value.strip()
+    if not normalized or not ID_RE.fullmatch(normalized):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be a safe identifier.")
+    return normalized
+
+
+def _require_token(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be a string.")
+    normalized = value.strip()
+    if not normalized or not SAFE_TOKEN_RE.fullmatch(normalized):
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be a safe token.")
+    if SECRET_RE.search(normalized):
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label}.{key} must not contain secret-shaped values."
+        )
+    return normalized
+
+
+def _require_text(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be a string.")
+    normalized = value.strip()
+    if not normalized:
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be non-empty.")
+    _reject_unsafe_text(normalized, label=f"{label}.{key}")
+    return normalized
+
+
+def _require_fingerprint(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be a sha256 digest.")
+    return value
+
+
+def _bounded_count(value: Any, label: str, *, minimum: int, maximum: int) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CreativeSpecificationSkepticReviewError(f"{label} must be an integer.")
+    if not minimum <= value <= maximum:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label} must be between {minimum} and {maximum}."
+        )
+    return value
+
+
+def _normalize_token_list(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    label: str,
+    allow_empty: bool = False,
+) -> list[str]:
+    value = payload.get(key)
+    if not isinstance(value, list):
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be an array.")
+    if not value and not allow_empty:
+        raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be non-empty.")
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise CreativeSpecificationSkepticReviewError(
+                f"{label}.{key}[{index}] must be a string."
+            )
+        token = item.strip()
+        if not token or not SAFE_TOKEN_RE.fullmatch(token):
+            raise CreativeSpecificationSkepticReviewError(
+                f"{label}.{key}[{index}] must be a safe token."
+            )
+        if SECRET_RE.search(token):
+            raise CreativeSpecificationSkepticReviewError(
+                f"{label}.{key}[{index}] must not contain secret-shaped values."
+            )
+        if token in seen:
+            raise CreativeSpecificationSkepticReviewError(
+                f"{label}.{key} must not contain duplicates."
+            )
+        seen.add(token)
+        normalized.append(token)
+    return normalized
+
+
+def _reject_unsafe_text(value: str, *, label: str) -> None:
+    if "\x00" in value or any(
+        ord(character) < 32 and character not in "\n\r\t" for character in value
+    ):
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label} must not contain control characters."
+        )
+    if SECRET_RE.search(value) or UNSAFE_TEXT_RE.search(value):
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label} contains unsafe creative-code authority."
+        )
+    if contains_unsafe_local_absolute_path(value):
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label} must not contain local absolute paths."
+        )
+
+
+def _reject_payload_safety(value: Any, *, label: str) -> None:
+    if isinstance(value, str):
+        _reject_unsafe_text(value, label=label)
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_payload_safety(item, label=f"{label}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in FALSE_AUTHORITY_KEYS:
+                continue
+            _reject_payload_safety(item, label=f"{label}.{key}")

--- a/scripts/orchestration/creative_specification_skeptic_review_contract.py
+++ b/scripts/orchestration/creative_specification_skeptic_review_contract.py
@@ -34,6 +34,8 @@ POLICY_VERSION = "creative-specification-skeptic-review-finalize-v1"
 REVIEWED_RUN_DIRNAME = "spec_finalize_reviewed"
 NEXT_ACTION_SELECTED = "human_review_for_patch_builder"
 NEXT_ACTION_ALL_REJECTED = "human_review_for_discard_or_defer"
+MAX_REVIEW_TEXT_LENGTH = 512
+MAX_REVIEW_TOKEN_LIST_LENGTH = 10
 
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
@@ -1040,6 +1042,10 @@ def _require_text(payload: Mapping[str, Any], key: str, *, label: str) -> str:
     normalized = value.strip()
     if not normalized:
         raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be non-empty.")
+    if len(normalized) > MAX_REVIEW_TEXT_LENGTH:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label}.{key} must be at most {MAX_REVIEW_TEXT_LENGTH} characters."
+        )
     _reject_unsafe_text(normalized, label=f"{label}.{key}")
     return normalized
 
@@ -1073,6 +1079,10 @@ def _normalize_token_list(
         raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be an array.")
     if not value and not allow_empty:
         raise CreativeSpecificationSkepticReviewError(f"{label}.{key} must be non-empty.")
+    if len(value) > MAX_REVIEW_TOKEN_LIST_LENGTH:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label}.{key} must contain at most {MAX_REVIEW_TOKEN_LIST_LENGTH} items."
+        )
     normalized: list[str] = []
     seen: set[str] = set()
     for index, item in enumerate(value):

--- a/scripts/orchestration/creative_specification_skeptic_review_contract.py
+++ b/scripts/orchestration/creative_specification_skeptic_review_contract.py
@@ -36,6 +36,7 @@ NEXT_ACTION_SELECTED = "human_review_for_patch_builder"
 NEXT_ACTION_ALL_REJECTED = "human_review_for_discard_or_defer"
 MAX_REVIEW_TEXT_LENGTH = 512
 MAX_REVIEW_TOKEN_LIST_LENGTH = 10
+MAX_TOTAL_REVIEW_TOKEN_COUNT = 150
 
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
@@ -449,6 +450,16 @@ def build_skeptic_review_attachment(
     }
     _set_identity(body, id_key="attachment_id", asset_type=ATTACHMENT_ARTIFACT_TYPE)
     return validate_skeptic_review_attachment(body)
+
+
+def build_skeptic_review_coverage(
+    *,
+    normalized_reviews: Sequence[Mapping[str, Any]],
+    variant_count: int,
+) -> dict[str, int]:
+    """Return bounded attachment coverage counts for normalized PR-1 reviews."""
+
+    return _review_counts(normalized_reviews=normalized_reviews, variant_count=variant_count)
 
 
 def validate_skeptic_review_attachment(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -865,7 +876,7 @@ def _normalize_reviewed_run(raw_run: Any, *, label: str) -> dict[str, Any]:
 
 
 def _normalize_attachment_coverage(raw_counts: Any, *, label: str) -> dict[str, int]:
-    return _normalize_counts(
+    counts = _normalize_counts(
         raw_counts,
         expected_keys=ATTACHMENT_COVERAGE_KEYS,
         label=label,
@@ -876,10 +887,15 @@ def _normalize_attachment_coverage(raw_counts: Any, *, label: str) -> dict[str, 
             "pass_review_count": 15,
             "revise_review_count": 15,
             "reject_review_count": 15,
-            "unsafe_authority_flag_count": 15,
-            "blocker_count": 30,
+            "unsafe_authority_flag_count": MAX_TOTAL_REVIEW_TOKEN_COUNT,
+            "blocker_count": MAX_TOTAL_REVIEW_TOKEN_COUNT,
         },
     )
+    if counts["required_reviewer_count"] != len(REQUIRED_SKEPTIC_REVIEWERS):
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label}.required_reviewer_count must equal {len(REQUIRED_SKEPTIC_REVIEWERS)}."
+        )
+    return counts
 
 
 def _normalize_receipt_counts(raw_counts: Any, *, label: str) -> dict[str, int]:
@@ -892,7 +908,7 @@ def _normalize_receipt_counts(raw_counts: Any, *, label: str) -> dict[str, int]:
             "review_count": 15,
             "selected_variant_count": 1,
             "rejected_variant_count": 5,
-            "unresolved_blocker_count": 30,
+            "unresolved_blocker_count": MAX_TOTAL_REVIEW_TOKEN_COUNT,
             "rejection_record_count": 5,
         },
     )
@@ -954,10 +970,16 @@ def _normalize_artifact_ref(
         raise CreativeSpecificationSkepticReviewError(
             f"{label} must stay under creative-code spec_bridge artifacts."
         )
-    if must_be_reviewed_run and path.name != REVIEWED_RUN_DIRNAME:
-        raise CreativeSpecificationSkepticReviewError(
-            f"{label} must point to {REVIEWED_RUN_DIRNAME}."
-        )
+    for component in path.parts[4:]:
+        if not ID_RE.fullmatch(component):
+            raise CreativeSpecificationSkepticReviewError(
+                f"{label} must use safe artifact path components."
+            )
+    if must_be_reviewed_run:
+        if len(path.parts) != 6 or path.name != REVIEWED_RUN_DIRNAME:
+            raise CreativeSpecificationSkepticReviewError(
+                f"{label} must point to the canonical {REVIEWED_RUN_DIRNAME} sibling."
+            )
     return path.as_posix()
 
 

--- a/scripts/orchestration/creative_specification_skeptic_review_contract.py
+++ b/scripts/orchestration/creative_specification_skeptic_review_contract.py
@@ -578,6 +578,12 @@ def validate_finalize_receipt(payload: Mapping[str, Any]) -> dict[str, Any]:
         raise CreativeSpecificationSkepticReviewError(
             f"{label}.synthesis_status does not match selected_variant_id."
         )
+    counts = _normalize_receipt_counts(payload["counts"], label=f"{label}.counts")
+    expected_selected_count = 1 if selected_variant_id is not None else 0
+    if counts["selected_variant_count"] != expected_selected_count:
+        raise CreativeSpecificationSkepticReviewError(
+            f"{label}.counts.selected_variant_count does not match selected_variant_id."
+        )
     normalized = {
         "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
         "artifact_type": _require_const(
@@ -619,7 +625,7 @@ def validate_finalize_receipt(payload: Mapping[str, Any]) -> dict[str, Any]:
         "selected_variant_id": selected_variant_id,
         "synthesis_status": synthesis_status,
         "next_allowed_action": next_allowed_action,
-        "counts": _normalize_receipt_counts(payload["counts"], label=f"{label}.counts"),
+        "counts": counts,
         "authority": _normalize_authority(
             payload["authority"],
             expected=default_finalize_receipt_authority(),

--- a/tests/test_creative_code_specification.py
+++ b/tests/test_creative_code_specification.py
@@ -37,6 +37,12 @@ SCHEMA = REPO_ROOT / "docs/orchestration/contracts/creative_code_specification.v
 SPEC_MODULE = REPO_ROOT / "scripts/orchestration/creative_code_specification.py"
 PIPELINE_MODULE = REPO_ROOT / "scripts/orchestration/creative_code_spec_pipeline.py"
 REJECTION_MODULE = REPO_ROOT / "scripts/orchestration/creative_code_rejection_index.py"
+REVIEW_FINALIZE_MODULE = (
+    REPO_ROOT / "scripts/orchestration/creative_specification_skeptic_review.py"
+)
+REVIEW_FINALIZE_CONTRACT_MODULE = (
+    REPO_ROOT / "scripts/orchestration/creative_specification_skeptic_review_contract.py"
+)
 UNSAFE_LOCAL_PATH_TEXTS = (
     "See local path /Users/example/project/.env",
     "Read /home/runner/.ssh/id_rsa for credentials.",
@@ -622,7 +628,13 @@ def test_pipeline_duplicate_keys_in_artifacts_fail_closed() -> None:
 
 def test_pr1_modules_do_not_import_network_provider_or_runtime_modules() -> None:
     forbidden_roots = {"app", "requests", "httpx", "urllib", "slack_sdk", "github", "openai"}
-    for module_path in (SPEC_MODULE, PIPELINE_MODULE, REJECTION_MODULE):
+    for module_path in (
+        SPEC_MODULE,
+        PIPELINE_MODULE,
+        REJECTION_MODULE,
+        REVIEW_FINALIZE_MODULE,
+        REVIEW_FINALIZE_CONTRACT_MODULE,
+    ):
         tree = ast.parse(module_path.read_text(encoding="utf-8"))
         imported_roots: set[str] = set()
         for node in ast.walk(tree):

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -787,6 +787,41 @@ def test_validate_rejects_noncanonical_source_bridge_ref(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_validate_rejects_recovered_attachment_for_unprepared_bridge(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="recovered-unprepared-bridge")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        bridge_path = output_dir / bridge_cli.BRIDGE_FILENAME
+        bridge_payload = _read_json(bridge_path)
+        bridge_payload["spec_prepare"]["prepared"] = False
+        bridge_payload["spec_prepare"]["next_allowed_action"] = "prepare_specification"
+        _write_json(bridge_path, bridge_payload)
+
+        attachment_path = output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+        exit_code = review_cli.main(["validate", "--attachment", str(attachment_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "prepared and waiting for agent_skeptic_review" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 def test_validate_rejects_noncanonical_source_spec_prepare_ref(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -871,8 +906,8 @@ def test_validate_rejects_source_spec_prepare_sidecar(
         )
         captured = capsys.readouterr()
         assert exit_code == 1
-        assert "source spec_prepare contains unexpected artifact(s): raw_provider_output.json" in (
-            captured.err
+        assert (
+            "spec_prepare contains unexpected artifact(s): raw_provider_output.json" in captured.err
         )
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
@@ -1461,6 +1496,17 @@ def test_reviewed_finalize_schemas_are_strict() -> None:
             "spec_finalize_reviewed/source_packet.json"
         ),
     )
+    assert attachment_schema["$defs"]["reviewed_source_packet_ref"]["pattern"].endswith(
+        "/spec_finalize_reviewed/source_packet\\.json$"
+    )
+    assert attachment_schema["$defs"]["reviewed_variants_ref"]["pattern"].endswith(
+        "/spec_finalize_reviewed/variants\\.json$"
+    )
+    attachment_review_count_conditions = [
+        branch["then"]["properties"]["review_count"]["const"]
+        for branch in attachment_schema["$defs"]["coverage"]["allOf"]
+    ]
+    assert sorted(attachment_review_count_conditions) == [3, 6, 9, 12, 15]
     assert attachment_schema["$defs"]["coverage"]["properties"]["blocker_count"]["maximum"] == 150
     assert (
         attachment_schema["$defs"]["attachment_authority"]["properties"][
@@ -1474,6 +1520,32 @@ def test_reviewed_finalize_schemas_are_strict() -> None:
             / "docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json"
         ).read_text(encoding="utf-8")
     )
+    assert (
+        receipt_schema["properties"]["source_attachment_ref"]["$ref"]
+        == "#/$defs/reviewed_attachment_ref"
+    )
+    assert receipt_schema["properties"]["bundle_ref"]["$ref"] == "#/$defs/reviewed_bundle_ref"
+    assert (
+        "skeptic_review_attachment" in receipt_schema["$defs"]["reviewed_attachment_ref"]["pattern"]
+    )
+    assert (
+        "creative_code_specification_bundle"
+        in receipt_schema["$defs"]["reviewed_bundle_ref"]["pattern"]
+    )
+    selected_count_conditions = [
+        branch["then"]["properties"]["counts"]["properties"]["selected_variant_count"]["const"]
+        for branch in receipt_schema["allOf"]
+        if "selected_variant_count"
+        in branch["then"]["properties"].get("counts", {}).get("properties", {})
+    ]
+    assert sorted(selected_count_conditions) == [0, 1]
+    rejected_count_conditions = [
+        branch["then"]["properties"]["counts"]["properties"]["rejected_variant_count"]["const"]
+        for branch in receipt_schema["allOf"]
+        if "rejected_variant_count"
+        in branch["then"]["properties"].get("counts", {}).get("properties", {})
+    ]
+    assert sorted(rejected_count_conditions) == [1, 2, 3, 4, 5]
     assert (
         receipt_schema["$defs"]["finalize_authority"]["properties"][
             "finalize_specification_bundle"

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -4,6 +4,7 @@ import ast
 from copy import deepcopy
 import json
 from pathlib import Path
+import re
 import shutil
 from typing import Any
 
@@ -24,7 +25,9 @@ from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
     build_creative_hypothesis_spec_bridge_bundle,
 )
 from scripts.orchestration.creative_specification_skeptic_review_contract import (
+    CreativeSpecificationSkepticReviewError,
     default_review_input_authority,
+    validate_agent_skeptic_reviews_input,
     validate_finalize_receipt,
     validate_skeptic_review_attachment,
 )
@@ -322,6 +325,10 @@ def test_attach_validate_finalize_preserves_original_spec_prepare(
         assert receipt["synthesis_status"] == "selected"
         assert receipt["next_allowed_action"] == "human_review_for_patch_builder"
         assert receipt["counts"]["selected_variant_count"] == 1
+        _assert_schema_artifact_refs_accept_generated_attachment_and_receipt(
+            attachment=attachment,
+            receipt=receipt,
+        )
 
         exit_code = bridge_cli.main(
             ["validate", "--bridge", str(output_dir / bridge_cli.BRIDGE_FILENAME)]
@@ -332,6 +339,42 @@ def test_attach_validate_finalize_preserves_original_spec_prepare(
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def _assert_schema_artifact_refs_accept_generated_attachment_and_receipt(
+    *,
+    attachment: dict[str, Any],
+    receipt: dict[str, Any],
+) -> None:
+    attachment_schema = json.loads(
+        (
+            REPO_ROOT
+            / "docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+    receipt_schema = json.loads(
+        (
+            REPO_ROOT
+            / "docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+    attachment_artifact_ref = re.compile(attachment_schema["$defs"]["artifact_ref"]["pattern"])
+    attachment_reviewed_run_ref = re.compile(
+        attachment_schema["$defs"]["reviewed_run_ref"]["pattern"]
+    )
+    receipt_artifact_ref = re.compile(receipt_schema["$defs"]["artifact_ref"]["pattern"])
+    receipt_reviewed_run_ref = re.compile(receipt_schema["$defs"]["reviewed_run_ref"]["pattern"])
+
+    for key, value in attachment["source"].items():
+        if key.endswith("_ref"):
+            assert attachment_artifact_ref.fullmatch(value), key
+    assert attachment_reviewed_run_ref.fullmatch(attachment["reviewed_run"]["run_dir_ref"])
+    for key, value in attachment["reviewed_run"].items():
+        if key.endswith("_ref") and key != "run_dir_ref":
+            assert attachment_artifact_ref.fullmatch(value), key
+    assert receipt_artifact_ref.fullmatch(receipt["source_attachment_ref"])
+    assert receipt_artifact_ref.fullmatch(receipt["bundle_ref"])
+    assert receipt_reviewed_run_ref.fullmatch(receipt["reviewed_run_dir_ref"])
 
 
 def test_finalize_receipt_records_all_rejected_status(
@@ -364,6 +407,48 @@ def test_finalize_receipt_records_all_rejected_status(
         assert receipt["synthesis_status"] == "all_rejected"
         assert receipt["next_allowed_action"] == "human_review_for_discard_or_defer"
         assert receipt["counts"]["selected_variant_count"] == 0
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    ("case_slug", "mutator", "expected_error"),
+    [
+        (
+            "overlong-text",
+            lambda payload: payload["reviews"][0].update({"duplicate_reason": "x" * 513}),
+            "at most 512 characters",
+        ),
+        (
+            "too-many-blockers",
+            lambda payload: payload["reviews"][0].update(
+                {"blockers": [f"blocker_{index}" for index in range(11)]}
+            ),
+            "at most 10 items",
+        ),
+        (
+            "too-many-unsafe-flags",
+            lambda payload: payload["reviews"][0].update(
+                {"unsafe_authority_flags": [f"flag_{index}" for index in range(11)]}
+            ),
+            "at most 10 items",
+        ),
+    ],
+)
+def test_review_input_validator_matches_schema_caps(
+    capsys: pytest.CaptureFixture[str],
+    case_slug: str,
+    mutator: Any,
+    expected_error: str,
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix=f"schema-caps-{case_slug}")
+    try:
+        payload = _review_input(output_dir, all_rejected=True)
+        mutator(payload)
+
+        with pytest.raises(CreativeSpecificationSkepticReviewError, match=expected_error):
+            validate_agent_skeptic_reviews_input(payload)
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -412,6 +412,111 @@ def test_finalize_receipt_records_all_rejected_status(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_validate_rejects_noncanonical_attachment_path(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="noncanonical-attachment")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+        reviewed_dir = output_dir / "spec_finalize_reviewed"
+        attachment_path = reviewed_dir / review_cli.ATTACHMENT_FILENAME
+        alternate_path = reviewed_dir / "alternate_attachment.json"
+        alternate_path.write_text(attachment_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+        exit_code = review_cli.main(["validate", "--attachment", str(alternate_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert f"canonical {review_cli.ATTACHMENT_FILENAME}" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_attach_rejects_prepared_child_symlink_before_read(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="prepared-child-symlink")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        spec_prepare = output_dir / "spec_prepare"
+        source_packet_path = spec_prepare / "source_packet.json"
+        symlink_target = tmp_path / "source_packet.json"
+        symlink_target.write_text(source_packet_path.read_text(encoding="utf-8"), encoding="utf-8")
+        source_packet_path.unlink()
+        source_packet_path.symlink_to(symlink_target)
+
+        exit_code = review_cli.main(
+            [
+                "attach",
+                "--bridge",
+                str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                "--reviews",
+                str(reviews_path),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "spec_prepare contains symlink artifact(s): source_packet.json" in captured.err
+        assert not (output_dir / "spec_finalize_reviewed").exists()
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_validate_rejects_reviewed_child_symlink_before_read(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="reviewed-child-symlink")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+        reviewed_dir = output_dir / "spec_finalize_reviewed"
+        variants_path = reviewed_dir / "variants.json"
+        symlink_target = tmp_path / "variants.json"
+        symlink_target.write_text(variants_path.read_text(encoding="utf-8"), encoding="utf-8")
+        variants_path.unlink()
+        variants_path.symlink_to(symlink_target)
+
+        exit_code = review_cli.main(
+            ["validate", "--attachment", str(reviewed_dir / review_cli.ATTACHMENT_FILENAME)]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "JSON artifact must not traverse symlinks" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 @pytest.mark.parametrize(
     ("case_slug", "mutator", "expected_error"),
     [
@@ -624,6 +729,23 @@ def test_reviewed_finalize_schemas_are_strict() -> None:
         )
         assert schema["additionalProperties"] is False
         assert "attach-and-finalize" not in json.dumps(schema)
+    review_input_schema = json.loads(
+        (
+            REPO_ROOT
+            / "docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+    unsafe_text_pattern = review_input_schema["$defs"]["safe_text"]["allOf"][0]["not"]["pattern"]
+    for blocked_phrase in (
+        "Apply patch",
+        "create branch",
+        "open PR",
+        "mark ready for review",
+        "provider call",
+        "Write to repository",
+        "Commit changes",
+    ):
+        assert re.search(unsafe_text_pattern, blocked_phrase), blocked_phrase
     attachment_schema = json.loads(
         (
             REPO_ROOT

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -14,6 +14,7 @@ from core.evidence.fingerprints import fingerprint_payload
 from scripts.orchestration import (
     creative_hypothesis_spec_bridge as bridge_cli,
     creative_specification_skeptic_review as review_cli,
+    creative_specification_skeptic_review_contract as review_contract,
 )
 from scripts.orchestration.creative_code_specification import (
     REQUIRED_SKEPTIC_REVIEWERS,
@@ -25,6 +26,7 @@ from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
     build_creative_hypothesis_spec_bridge_bundle,
 )
 from scripts.orchestration.creative_specification_skeptic_review_contract import (
+    ATTACHMENT_ARTIFACT_TYPE,
     CreativeSpecificationSkepticReviewError,
     build_skeptic_review_attachment,
     default_review_input_authority,
@@ -269,6 +271,67 @@ def _write_json(path: Path, payload: Any) -> None:
 
 def _read_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _refresh_attachment_identity(attachment: dict[str, Any]) -> dict[str, Any]:
+    attachment["attachment_id"] = "pending"
+    attachment["idempotency_key"] = "pending"
+    review_contract._set_identity(
+        attachment,
+        id_key="attachment_id",
+        asset_type=ATTACHMENT_ARTIFACT_TYPE,
+    )
+    return attachment
+
+
+def _rebuild_attachment(
+    attachment: dict[str, Any],
+    *,
+    source_overrides: dict[str, Any] | None = None,
+    reviewed_overrides: dict[str, Any] | None = None,
+    normalized_reviews: list[dict[str, Any]] | None = None,
+    variant_count: int | None = None,
+) -> dict[str, Any]:
+    source = dict(attachment["source"])
+    reviewed = dict(attachment["reviewed_run"])
+    if source_overrides:
+        source.update(source_overrides)
+    if reviewed_overrides:
+        reviewed.update(reviewed_overrides)
+    reviews = (
+        normalized_reviews
+        if normalized_reviews is not None
+        else _read_json(REPO_ROOT / reviewed["skeptic_reviews_ref"])
+    )
+    return build_skeptic_review_attachment(
+        bridge_id=source["bridge_id"],
+        bridge_fingerprint=source["bridge_fingerprint"],
+        bridge_ref=source["bridge_ref"],
+        candidate_id=source["candidate_id"],
+        candidate_fingerprint=source["candidate_fingerprint"],
+        candidate_ref=source["candidate_ref"],
+        metrics_id=source["metrics_id"],
+        metrics_fingerprint=source["metrics_fingerprint"],
+        metrics_ref=source["metrics_ref"],
+        spec_prepare_ref=source["spec_prepare_ref"],
+        source_packet_ref=source["source_packet_ref"],
+        source_packet_fingerprint=source["source_packet_fingerprint"],
+        variants_ref=source["variants_ref"],
+        variants_fingerprint=source["variants_fingerprint"],
+        pending_reviews_ref=source["pending_reviews_ref"],
+        pending_reviews_fingerprint=source["pending_reviews_fingerprint"],
+        context_pack_ref=source["context_pack_ref"],
+        context_pack_fingerprint=source["context_pack_fingerprint"],
+        reviewed_run_dir_ref=reviewed["run_dir_ref"],
+        reviewed_source_packet_ref=reviewed["source_packet_ref"],
+        reviewed_variants_ref=reviewed["variants_ref"],
+        reviewed_reviews_ref=reviewed["skeptic_reviews_ref"],
+        reviewed_context_pack_ref=reviewed["context_pack_ref"],
+        normalized_reviews=reviews,
+        variant_count=(
+            variant_count if variant_count is not None else attachment["coverage"]["variant_count"]
+        ),
+    )
 
 
 def test_attach_validate_finalize_preserves_original_spec_prepare(
@@ -642,6 +705,217 @@ def test_validate_rejects_relocated_reviewed_run(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_validate_rejects_noncanonical_source_bridge_ref(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="fake-bridge-ref")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+        reviewed_dir = output_dir / "spec_finalize_reviewed"
+        attachment_path = reviewed_dir / review_cli.ATTACHMENT_FILENAME
+        attachment = validate_skeptic_review_attachment(_read_json(attachment_path))
+        fake_bridge = output_dir / "fake_bridge.json"
+        shutil.copyfile(output_dir / bridge_cli.BRIDGE_FILENAME, fake_bridge)
+        fake_attachment = _rebuild_attachment(
+            attachment,
+            source_overrides={"bridge_ref": fake_bridge.relative_to(REPO_ROOT).as_posix()},
+        )
+        _write_json(attachment_path, fake_attachment)
+
+        exit_code = review_cli.main(["validate", "--attachment", str(attachment_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert f"canonical {bridge_cli.BRIDGE_FILENAME}" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_validate_rejects_noncanonical_source_spec_prepare_ref(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="staging-spec-prepare")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+        reviewed_dir = output_dir / "spec_finalize_reviewed"
+        attachment_path = reviewed_dir / review_cli.ATTACHMENT_FILENAME
+        attachment = validate_skeptic_review_attachment(_read_json(attachment_path))
+        staging_prepare = output_dir / "staging"
+        shutil.copytree(output_dir / "spec_prepare", staging_prepare)
+        staging_attachment = _rebuild_attachment(
+            attachment,
+            source_overrides={
+                "spec_prepare_ref": staging_prepare.relative_to(REPO_ROOT).as_posix(),
+                "source_packet_ref": (staging_prepare / "source_packet.json")
+                .relative_to(REPO_ROOT)
+                .as_posix(),
+                "variants_ref": (staging_prepare / "variants.json")
+                .relative_to(REPO_ROOT)
+                .as_posix(),
+                "pending_reviews_ref": (staging_prepare / "skeptic_reviews.json")
+                .relative_to(REPO_ROOT)
+                .as_posix(),
+                "context_pack_ref": (staging_prepare / "context_pack.json")
+                .relative_to(REPO_ROOT)
+                .as_posix(),
+            },
+        )
+        _write_json(attachment_path, staging_attachment)
+
+        exit_code = review_cli.main(["validate", "--attachment", str(attachment_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "source spec_prepare ref does not match bridge" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_validate_rejects_source_spec_prepare_sidecar(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="source-prepare-sidecar")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        _write_json(output_dir / "spec_prepare" / "raw_provider_output.json", {"raw": True})
+
+        exit_code = review_cli.main(
+            [
+                "validate",
+                "--attachment",
+                str(output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "source spec_prepare contains unexpected artifact(s): raw_provider_output.json" in (
+            captured.err
+        )
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_validate_rejects_attachment_coverage_mismatch(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="coverage-mismatch")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+        attachment_path = output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+        attachment = validate_skeptic_review_attachment(_read_json(attachment_path))
+        tampered_attachment = deepcopy(attachment)
+        tampered_attachment["coverage"]["reject_review_count"] = 0
+        _write_json(attachment_path, _refresh_attachment_identity(tampered_attachment))
+
+        exit_code = review_cli.main(["validate", "--attachment", str(attachment_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "attachment coverage does not match reviewed artifacts" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_finalize_cleans_partial_outputs_on_receipt_failure(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="finalize-cleanup")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        attachment_path = output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+
+        def _fail_receipt(**_: Any) -> dict[str, Any]:
+            raise CreativeSpecificationSkepticReviewError("synthetic receipt failure")
+
+        monkeypatch.setattr(review_cli, "build_finalize_receipt", _fail_receipt)
+        exit_code = review_cli.main(["finalize", "--attachment", str(attachment_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "synthetic receipt failure" in captured.err
+        assert not (output_dir / "spec_finalize_reviewed" / review_cli.BUNDLE_FILENAME).exists()
+        assert not (
+            output_dir / "spec_finalize_reviewed" / review_cli.FINALIZE_RECEIPT_FILENAME
+        ).exists()
+
+        monkeypatch.undo()
+        exit_code = review_cli.main(["finalize", "--attachment", str(attachment_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0, captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 @pytest.mark.parametrize(
     ("case_slug", "mutator", "expected_error"),
     [
@@ -761,6 +1035,41 @@ def test_attach_rejects_bad_review_inputs(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_attach_accepts_bounded_aggregate_blocker_counts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="aggregate-blockers")
+    try:
+        payload = _review_input(output_dir, all_rejected=True)
+        for review in payload["reviews"]:
+            review["blockers"] = [
+                "skeptic_rejected_variant",
+                "unsafe_layout",
+                "missing_evidence",
+                "needs_contract_sync",
+            ]
+        reviews_path = _write_review_input(output_dir, payload)
+
+        exit_code = review_cli.main(
+            [
+                "attach",
+                "--bridge",
+                str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                "--reviews",
+                str(reviews_path),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 0, captured.err
+        attachment = validate_skeptic_review_attachment(
+            _read_json(output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME)
+        )
+        assert attachment["coverage"]["blocker_count"] == 36
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 def test_attach_rejects_duplicate_json_keys(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -841,6 +1150,71 @@ def test_attach_rejects_symlink_reviewed_run(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_attachment_contract_rejects_unsafe_artifact_ref_component(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="bad-artifact-ref-component")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        attachment = _read_json(
+            output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+        )
+        attachment["source"]["bridge_ref"] = (
+            "artifacts/orchestration/creative_code/spec_bridge/-bad/"
+            f"{bridge_cli.BRIDGE_FILENAME}"
+        )
+
+        with pytest.raises(CreativeSpecificationSkepticReviewError, match="safe artifact"):
+            validate_skeptic_review_attachment(attachment)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_attachment_contract_requires_exact_reviewer_count(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="bad-reviewer-count")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        attachment = _read_json(
+            output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+        )
+        attachment["coverage"]["required_reviewer_count"] = 2
+
+        with pytest.raises(CreativeSpecificationSkepticReviewError, match="must equal 3"):
+            validate_skeptic_review_attachment(attachment)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 def test_reviewed_finalize_parser_has_no_combined_command() -> None:
     parser = review_cli.build_arg_parser()
     with pytest.raises(SystemExit):
@@ -871,12 +1245,23 @@ def test_reviewed_finalize_schemas_are_strict() -> None:
         "Commit changes",
     ):
         assert re.search(unsafe_text_pattern, blocked_phrase), blocked_phrase
+    unsafe_path_pattern = review_input_schema["$defs"]["safe_text"]["allOf"][1]["not"]["pattern"]
+    assert re.search(unsafe_path_pattern, "Inspect /Users/example/.env")
     attachment_schema = json.loads(
         (
             REPO_ROOT
             / "docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json"
         ).read_text(encoding="utf-8")
     )
+    attachment_artifact_pattern = attachment_schema["$defs"]["artifact_ref"]["pattern"]
+    assert re.fullmatch(
+        attachment_artifact_pattern,
+        (
+            "artifacts/orchestration/creative_code/spec_bridge/bridge-1/"
+            "spec_finalize_reviewed/source_packet.json"
+        ),
+    )
+    assert attachment_schema["$defs"]["coverage"]["properties"]["blocker_count"]["maximum"] == 150
     assert (
         attachment_schema["$defs"]["attachment_authority"]["properties"][
             "finalize_specification_bundle"
@@ -894,6 +1279,10 @@ def test_reviewed_finalize_schemas_are_strict() -> None:
             "finalize_specification_bundle"
         ]["const"]
         is True
+    )
+    assert (
+        receipt_schema["$defs"]["counts"]["properties"]["unresolved_blocker_count"]["maximum"]
+        == 150
     )
 
 

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -27,6 +27,7 @@ from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
 )
 from scripts.orchestration.creative_specification_skeptic_review_contract import (
     ATTACHMENT_ARTIFACT_TYPE,
+    FINALIZE_RECEIPT_ARTIFACT_TYPE,
     CreativeSpecificationSkepticReviewError,
     build_skeptic_review_attachment,
     default_review_input_authority,
@@ -284,6 +285,17 @@ def _refresh_attachment_identity(attachment: dict[str, Any]) -> dict[str, Any]:
     return attachment
 
 
+def _refresh_receipt_identity(receipt: dict[str, Any]) -> dict[str, Any]:
+    receipt["finalize_id"] = "pending"
+    receipt["idempotency_key"] = "pending"
+    review_contract._set_identity(
+        receipt,
+        id_key="finalize_id",
+        asset_type=FINALIZE_RECEIPT_ARTIFACT_TYPE,
+    )
+    return receipt
+
+
 def _rebuild_attachment(
     attachment: dict[str, Any],
     *,
@@ -400,6 +412,33 @@ def test_attach_validate_finalize_preserves_original_spec_prepare(
         captured = capsys.readouterr()
         assert exit_code == 0, captured.err
         assert captured.out.strip() == bridge_cli.SUCCESS_VALIDATE_OUTPUT
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_attach_rejects_noncanonical_bridge_file(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="noncanonical-bridge-file")
+    try:
+        bridge_copy = output_dir / "copy.json"
+        shutil.copyfile(output_dir / bridge_cli.BRIDGE_FILENAME, bridge_copy)
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+
+        exit_code = review_cli.main(
+            [
+                "attach",
+                "--bridge",
+                str(bridge_copy),
+                "--reviews",
+                str(reviews_path),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert f"canonical {bridge_cli.BRIDGE_FILENAME}" in captured.err
+        assert not (output_dir / "spec_finalize_reviewed").exists()
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)
@@ -916,6 +955,40 @@ def test_finalize_cleans_partial_outputs_on_receipt_failure(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_finalize_receipt_rejects_inconsistent_selected_count(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="receipt-count-mismatch")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        attachment_path = output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+        assert review_cli.main(["finalize", "--attachment", str(attachment_path)]) == 0
+        capsys.readouterr()
+        receipt_path = output_dir / "spec_finalize_reviewed" / review_cli.FINALIZE_RECEIPT_FILENAME
+        receipt = validate_finalize_receipt(_read_json(receipt_path))
+        tampered_receipt = deepcopy(receipt)
+        tampered_receipt["counts"]["selected_variant_count"] = 0
+
+        with pytest.raises(CreativeSpecificationSkepticReviewError, match="selected_variant_id"):
+            validate_finalize_receipt(_refresh_receipt_identity(tampered_receipt))
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 @pytest.mark.parametrize(
     ("case_slug", "mutator", "expected_error"),
     [
@@ -1243,8 +1316,12 @@ def test_reviewed_finalize_schemas_are_strict() -> None:
         "provider call",
         "Write to repository",
         "Commit changes",
+        "open pr",
+        "create pr",
     ):
         assert re.search(unsafe_text_pattern, blocked_phrase), blocked_phrase
+    unsafe_token_pattern = review_input_schema["$defs"]["safe_token"]["not"]["pattern"]
+    assert re.search(unsafe_token_pattern, "GHP_12345678901234567890")
     unsafe_path_pattern = review_input_schema["$defs"]["safe_text"]["allOf"][1]["not"]["pattern"]
     assert re.search(unsafe_path_pattern, "Inspect /Users/example/.env")
     attachment_schema = json.loads(

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -1,0 +1,597 @@
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+import json
+from pathlib import Path
+import shutil
+from typing import Any
+
+import pytest
+
+from core.evidence.fingerprints import fingerprint_payload
+from scripts.orchestration import (
+    creative_hypothesis_spec_bridge as bridge_cli,
+    creative_specification_skeptic_review as review_cli,
+)
+from scripts.orchestration.creative_code_specification import (
+    REQUIRED_SKEPTIC_REVIEWERS,
+    read_creative_code_specification_bundle,
+    validate_creative_code_specification_bundle,
+)
+from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
+    PREPARE_FILENAMES,
+    build_creative_hypothesis_spec_bridge_bundle,
+)
+from scripts.orchestration.creative_specification_skeptic_review_contract import (
+    default_review_input_authority,
+    validate_finalize_receipt,
+    validate_skeptic_review_attachment,
+)
+from scripts.orchestration.experiment_runner_pr_creative_context_contract import (
+    COORDINATOR_DISPATCH_POLICY_VERSION,
+    COORDINATOR_DISPATCH_TYPE,
+    HYPOTHESIS_PACKET_TYPE,
+    _artifact_identity,
+    build_creative_hypothesis_agent_routing,
+    build_creative_hypothesis_approval,
+    build_creative_hypothesis_coordinator_dispatch,
+    build_creative_hypothesis_packet,
+    build_creative_protocol_context_map,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
+SHA256_D = "sha256:" + ("d" * 64)
+SCHEMA_FILES = (
+    "creative_specification_agent_skeptic_reviews.v1.schema.json",
+    "creative_specification_skeptic_review_attachment.v1.schema.json",
+    "creative_specification_finalize_receipt.v1.schema.json",
+)
+
+
+def _context() -> dict[str, Any]:
+    return build_creative_protocol_context_map(
+        changed_paths=[
+            "scripts/orchestration/creative_specification_skeptic_review.py",
+            "scripts/orchestration/creative_specification_skeptic_review_contract.py",
+            "tests/test_creative_specification_skeptic_review.py",
+        ],
+        repository="Katsiarynakavaleuskaya/PulsePlate",
+        pr_number=2072,
+        base_ref="main",
+        base_sha=BASE_SHA,
+        head_sha=HEAD_SHA,
+        task_packet_id="task:spec-skeptic-review-finalize",
+        generated_at_utc="2026-07-04T00:00:00Z",
+        nearby_repo_refs=["scripts/orchestration/creative_code_spec_pipeline.py"],
+        test_refs=["tests/test_creative_specification_skeptic_review.py"],
+        contract_refs=["docs/orchestration/contracts/CREATIVE_CODE_SPECIFICATION_CONTRACT.md"],
+        backlog_refs=["docs/roadmap/BACKLOG_LEDGER.md"],
+        review_source_refs=["artifacts/orchestration/experiments/results/oracle-result.json"],
+        capability_state_ref=(
+            "artifacts/orchestration/experiments/creative_context/capability_state.json"
+        ),
+        philosophical_context_refs=["docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md"],
+        cross_domain_candidate_refs=[
+            "docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md"
+        ],
+        label_enabled=False,
+        marker_enabled=False,
+        manual_enabled=False,
+        sealed_codex_security_scan_ref=(
+            "artifacts/orchestration/experiments/creative_context/codex-security.json"
+        ),
+        sealed_codex_security_scan_fingerprint=SHA256_D,
+        security_relevant_diff_changed=False,
+    )
+
+
+def _refresh_packet_identity(packet: dict[str, Any]) -> dict[str, Any]:
+    body = {
+        key: value for key, value in packet.items() if key not in {"packet_id", "idempotency_key"}
+    }
+    packet_id, idempotency_key = _artifact_identity(
+        body,
+        artifact_type=HYPOTHESIS_PACKET_TYPE,
+        upstream_ids=(str(packet["context_map_id"]),),
+    )
+    packet["packet_id"] = packet_id
+    packet["idempotency_key"] = idempotency_key
+    return packet
+
+
+def _chain(
+    hypothesis_suffix: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    context = _context()
+    packet = build_creative_hypothesis_packet(context, hypothesis_count=3)
+    hypothesis = dict(packet["hypotheses"][0])
+    hypothesis["hypothesis_id"] = f"{hypothesis['hypothesis_id']}-{hypothesis_suffix}"
+    hypothesis["target_surfaces"] = sorted(
+        [
+            "docs/prompts/cv/program.md",
+            "scripts/orchestration/creative_specification_skeptic_review.py",
+            "scripts/orchestration/creative_specification_skeptic_review_contract.py",
+            "tests/test_creative_specification_skeptic_review.py",
+        ]
+    )
+    hypothesis["tests_or_oracles"] = sorted(
+        [
+            "tests/test_creative_specification_skeptic_review.py",
+            "docs/orchestration/contracts/creative_specification_agent_skeptic_reviews.v1.schema.json",
+        ]
+    )
+    hypothesis["negative_controls"] = sorted(
+        [
+            "patch_authority_rejected",
+            "provider_call_rejected",
+            "runtime_truth_rejected",
+        ]
+    )
+    packet["hypotheses"][0] = hypothesis
+    packet = _refresh_packet_identity(packet)
+    routing = build_creative_hypothesis_agent_routing(packet)
+    dispatch = build_creative_hypothesis_coordinator_dispatch(
+        hypothesis_packet=packet,
+        routing=routing,
+    )
+    approval = build_creative_hypothesis_approval(
+        hypothesis_id=hypothesis["hypothesis_id"],
+        decision="approve_for_pr1_specification",
+        hypothesis_packet=packet,
+        approved_target_surfaces=list(hypothesis["target_surfaces"]),
+        approved_agents=[dispatch["dispatch"][0]["primary_agent"]],
+        next_step="create_pr1_specification",
+    )
+    return context, packet, dispatch, approval
+
+
+def _write_creative_context_inputs(
+    *,
+    leaf: str,
+    context: dict[str, Any],
+    packet: dict[str, Any],
+    dispatch: dict[str, Any],
+    approval: dict[str, Any],
+) -> tuple[Path, Path, Path, Path, Path]:
+    input_dir = bridge_cli.CREATIVE_CONTEXT_ROOT / leaf
+    shutil.rmtree(input_dir, ignore_errors=True)
+    input_dir.mkdir(parents=True, exist_ok=True)
+    paths = (
+        input_dir / "context_map.json",
+        input_dir / "hypothesis_packet.json",
+        input_dir / "coordinator_dispatch.json",
+        input_dir / "approval.json",
+    )
+    for path, payload in zip(paths, (context, packet, dispatch, approval), strict=True):
+        _write_json(path, payload)
+    return input_dir, *paths
+
+
+def _prepared_bridge(
+    capsys: pytest.CaptureFixture[str],
+    *,
+    suffix: str,
+) -> tuple[Path, Path]:
+    context, packet, dispatch, approval = _chain(hypothesis_suffix=suffix)
+    expected_bundle = build_creative_hypothesis_spec_bridge_bundle(
+        context_map=context,
+        hypothesis_packet=packet,
+        coordinator_dispatch=dispatch,
+        approval=approval,
+        variant_count=3,
+    )
+    output_dir = bridge_cli.SPEC_BRIDGE_ROOT / str(expected_bundle["bridge"]["bridge_id"])
+    shutil.rmtree(output_dir, ignore_errors=True)
+    input_dir, context_path, packet_path, dispatch_path, approval_path = (
+        _write_creative_context_inputs(
+            leaf=f"pytest-spec-review-{suffix}",
+            context=context,
+            packet=packet,
+            dispatch=dispatch,
+            approval=approval,
+        )
+    )
+    exit_code = bridge_cli.main(
+        [
+            "build-and-prepare",
+            "--context-map",
+            str(context_path),
+            "--hypothesis-packet",
+            str(packet_path),
+            "--coordinator-dispatch",
+            str(dispatch_path),
+            "--approval",
+            str(approval_path),
+            "--variant-count",
+            "3",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    assert captured.out.strip() == bridge_cli.SUCCESS_BUILD_PREPARE_OUTPUT
+    return output_dir, input_dir
+
+
+def _review_input(output_dir: Path, *, all_rejected: bool = False) -> dict[str, Any]:
+    bridge = _read_json(output_dir / bridge_cli.BRIDGE_FILENAME)
+    candidate = _read_json(output_dir / bridge_cli.CANDIDATE_FILENAME)
+    spec_prepare = output_dir / "spec_prepare"
+    source_packet = _read_json(spec_prepare / "source_packet.json")
+    variants = _read_json(spec_prepare / "variants.json")
+    reviews: list[dict[str, Any]] = []
+    for variant_index, variant in enumerate(variants):
+        for reviewer in REQUIRED_SKEPTIC_REVIEWERS:
+            decision = "reject" if all_rejected or variant_index != 0 else "pass"
+            reviews.append(
+                {
+                    "variant_id": variant["variant_id"],
+                    "reviewer_role": reviewer,
+                    "decision": decision,
+                    "blockers": [] if decision == "pass" else ["skeptic_rejected_variant"],
+                    "unsafe_authority_flags": [],
+                    "duplicate_reason": "none",
+                    "required_revision": "none",
+                }
+            )
+    return {
+        "schema_version": "1.0",
+        "artifact_type": "creative_specification_agent_skeptic_reviews",
+        "policy_version": "creative-specification-skeptic-review-finalize-v1",
+        "source_bridge_id": bridge["bridge_id"],
+        "source_bridge_fingerprint": fingerprint_payload(bridge),
+        "source_candidate_id": candidate["candidate_id"],
+        "source_candidate_fingerprint": fingerprint_payload(candidate),
+        "source_packet_fingerprint": fingerprint_payload(source_packet),
+        "variants_fingerprint": fingerprint_payload(variants),
+        "reviews": reviews,
+        "authority": default_review_input_authority(),
+        "sanitized": True,
+    }
+
+
+def _write_review_input(output_dir: Path, payload: dict[str, Any]) -> Path:
+    path = output_dir / "agent_skeptic_reviews.json"
+    _write_json(path, payload)
+    return path
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_attach_validate_finalize_preserves_original_spec_prepare(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="happy")
+    try:
+        spec_prepare = output_dir / "spec_prepare"
+        original_fingerprints = {
+            filename: fingerprint_payload(_read_json(spec_prepare / filename))
+            for filename in PREPARE_FILENAMES
+        }
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+
+        exit_code = review_cli.main(
+            [
+                "attach",
+                "--bridge",
+                str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                "--reviews",
+                str(reviews_path),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 0, captured.err
+        assert captured.out.strip() == review_cli.ATTACH_SUCCESS_OUTPUT
+
+        reviewed_dir = output_dir / "spec_finalize_reviewed"
+        attachment_path = reviewed_dir / review_cli.ATTACHMENT_FILENAME
+        attachment = validate_skeptic_review_attachment(_read_json(attachment_path))
+        assert attachment["reviewed_run"]["run_dir_ref"].endswith("/spec_finalize_reviewed")
+        assert not (reviewed_dir / review_cli.BUNDLE_FILENAME).exists()
+        assert {
+            filename: fingerprint_payload(_read_json(spec_prepare / filename))
+            for filename in PREPARE_FILENAMES
+        } == original_fingerprints
+
+        exit_code = review_cli.main(["validate", "--attachment", str(attachment_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0, captured.err
+        assert captured.out.strip() == review_cli.VALIDATE_SUCCESS_OUTPUT
+
+        exit_code = review_cli.main(["finalize", "--attachment", str(attachment_path)])
+        captured = capsys.readouterr()
+        assert exit_code == 0, captured.err
+        assert captured.out.strip() == review_cli.FINALIZE_SUCCESS_OUTPUT
+
+        bundle = validate_creative_code_specification_bundle(
+            read_creative_code_specification_bundle(reviewed_dir / review_cli.BUNDLE_FILENAME)
+        )
+        receipt = validate_finalize_receipt(
+            _read_json(reviewed_dir / review_cli.FINALIZE_RECEIPT_FILENAME)
+        )
+        assert bundle["synthesis"]["selected_variant_id"] is not None
+        assert receipt["synthesis_status"] == "selected"
+        assert receipt["next_allowed_action"] == "human_review_for_patch_builder"
+        assert receipt["counts"]["selected_variant_count"] == 1
+
+        exit_code = bridge_cli.main(
+            ["validate", "--bridge", str(output_dir / bridge_cli.BRIDGE_FILENAME)]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 0, captured.err
+        assert captured.out.strip() == bridge_cli.SUCCESS_VALIDATE_OUTPUT
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_finalize_receipt_records_all_rejected_status(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="all-rejected")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir, all_rejected=True))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        attachment_path = output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+        assert review_cli.main(["finalize", "--attachment", str(attachment_path)]) == 0
+        capsys.readouterr()
+
+        receipt = validate_finalize_receipt(
+            _read_json(output_dir / "spec_finalize_reviewed" / review_cli.FINALIZE_RECEIPT_FILENAME)
+        )
+        assert receipt["selected_variant_id"] is None
+        assert receipt["synthesis_status"] == "all_rejected"
+        assert receipt["next_allowed_action"] == "human_review_for_discard_or_defer"
+        assert receipt["counts"]["selected_variant_count"] == 0
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    ("case_slug", "mutator", "expected_error"),
+    [
+        (
+            "missing-role",
+            lambda payload: payload["reviews"].pop(),
+            "cover every required reviewer",
+        ),
+        (
+            "duplicate-role",
+            lambda payload: payload["reviews"].append(deepcopy(payload["reviews"][0])),
+            "must not repeat a reviewer",
+        ),
+        (
+            "bad-decision",
+            lambda payload: payload["reviews"][0].update({"decision": "maybe"}),
+            "decision is unsupported",
+        ),
+        (
+            "unsafe-path",
+            lambda payload: payload["reviews"][0].update(
+                {
+                    "decision": "revise",
+                    "required_revision": "Inspect /Users/example/.env before review.",
+                }
+            ),
+            "local absolute paths",
+        ),
+        (
+            "secret-token",
+            lambda payload: payload["reviews"][0].update(
+                {"blockers": ["ghp_12345678901234567890"]}
+            ),
+            "secret-shaped",
+        ),
+        (
+            "stale-variants",
+            lambda payload: payload.update({"variants_fingerprint": "sha256:" + "e" * 64}),
+            "fingerprint_mismatch",
+        ),
+        (
+            "wrong-role",
+            lambda payload: payload["reviews"][0].update({"reviewer_role": "bug-hunter"}),
+            "reviewer_role is not required",
+        ),
+    ],
+)
+def test_attach_rejects_bad_review_inputs(
+    capsys: pytest.CaptureFixture[str],
+    case_slug: str,
+    mutator: Any,
+    expected_error: str,
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix=f"bad-{case_slug}")
+    try:
+        payload = _review_input(output_dir)
+        mutator(payload)
+        reviews_path = _write_review_input(output_dir, payload)
+
+        exit_code = review_cli.main(
+            [
+                "attach",
+                "--bridge",
+                str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                "--reviews",
+                str(reviews_path),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert expected_error in captured.err
+        assert not (output_dir / "spec_finalize_reviewed").exists()
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_attach_rejects_duplicate_json_keys(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="duplicate-json")
+    try:
+        reviews_path = output_dir / "agent_skeptic_reviews.json"
+        reviews_path.write_text('{"schema_version":"1.0","schema_version":"1.0"}\n', "utf-8")
+
+        exit_code = review_cli.main(
+            [
+                "attach",
+                "--bridge",
+                str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                "--reviews",
+                str(reviews_path),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "duplicate key: schema_version" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_attach_rejects_tampered_candidate_before_writing_reviewed_run(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="candidate-tamper")
+    try:
+        candidate_path = output_dir / bridge_cli.CANDIDATE_FILENAME
+        candidate = _read_json(candidate_path)
+        candidate["fallback"] = "Tampered fallback without changing bridge fingerprint."
+        _write_json(candidate_path, candidate)
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+
+        exit_code = review_cli.main(
+            [
+                "attach",
+                "--bridge",
+                str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                "--reviews",
+                str(reviews_path),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "candidate fingerprint does not match bridge" in captured.err
+        assert not (output_dir / "spec_finalize_reviewed").exists()
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_attach_rejects_symlink_reviewed_run(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="symlink-run")
+    try:
+        (output_dir / "spec_finalize_reviewed").symlink_to(tmp_path, target_is_directory=True)
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+
+        exit_code = review_cli.main(
+            [
+                "attach",
+                "--bridge",
+                str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                "--reviews",
+                str(reviews_path),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "must not traverse symlinks" in captured.err
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_reviewed_finalize_parser_has_no_combined_command() -> None:
+    parser = review_cli.build_arg_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["attach-and-finalize"])
+
+
+def test_reviewed_finalize_schemas_are_strict() -> None:
+    for filename in SCHEMA_FILES:
+        schema = json.loads(
+            (REPO_ROOT / "docs/orchestration/contracts" / filename).read_text(encoding="utf-8")
+        )
+        assert schema["additionalProperties"] is False
+        assert "attach-and-finalize" not in json.dumps(schema)
+    attachment_schema = json.loads(
+        (
+            REPO_ROOT
+            / "docs/orchestration/contracts/creative_specification_skeptic_review_attachment.v1.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert (
+        attachment_schema["$defs"]["attachment_authority"]["properties"][
+            "finalize_specification_bundle"
+        ]["const"]
+        is False
+    )
+    receipt_schema = json.loads(
+        (
+            REPO_ROOT
+            / "docs/orchestration/contracts/creative_specification_finalize_receipt.v1.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert (
+        receipt_schema["$defs"]["finalize_authority"]["properties"][
+            "finalize_specification_bundle"
+        ]["const"]
+        is True
+    )
+
+
+def test_reviewed_finalize_modules_do_not_import_mutation_surfaces() -> None:
+    banned_prefixes = (
+        "app",
+        "httpx",
+        "requests",
+        "slack",
+        "github",
+        "scripts.orchestration.creative_code_patch",
+        "scripts.orchestration.creative_code_pr_promotion",
+    )
+    banned_exact = {
+        "scripts.orchestration.experiment_runner",
+        "scripts.orchestration.experiment_pipeline",
+    }
+    for module_path in (
+        REPO_ROOT / "scripts/orchestration/creative_specification_skeptic_review.py",
+        REPO_ROOT / "scripts/orchestration/creative_specification_skeptic_review_contract.py",
+    ):
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        imports: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.append(node.module)
+        assert not [
+            imported
+            for imported in imports
+            if imported in banned_exact or imported.startswith(banned_prefixes)
+        ]

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -511,6 +511,8 @@ def test_finalize_receipt_records_all_rejected_status(
         assert receipt["synthesis_status"] == "all_rejected"
         assert receipt["next_allowed_action"] == "human_review_for_discard_or_defer"
         assert receipt["counts"]["selected_variant_count"] == 0
+        assert receipt["counts"]["rejected_variant_count"] == receipt["counts"]["variant_count"]
+        assert receipt["counts"]["rejection_record_count"] == receipt["counts"]["variant_count"]
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)
@@ -990,6 +992,93 @@ def test_finalize_receipt_rejects_inconsistent_selected_count(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_finalize_receipt_rejects_all_rejected_without_rejection_counts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="all-rejected-count-mismatch")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir, all_rejected=True))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        attachment_path = output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+        assert review_cli.main(["finalize", "--attachment", str(attachment_path)]) == 0
+        capsys.readouterr()
+        receipt_path = output_dir / "spec_finalize_reviewed" / review_cli.FINALIZE_RECEIPT_FILENAME
+        receipt = validate_finalize_receipt(_read_json(receipt_path))
+        tampered_receipt = deepcopy(receipt)
+        tampered_receipt["counts"]["rejected_variant_count"] = 0
+        tampered_receipt["counts"]["rejection_record_count"] = 0
+
+        with pytest.raises(CreativeSpecificationSkepticReviewError, match="when all rejected"):
+            validate_finalize_receipt(_refresh_receipt_identity(tampered_receipt))
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "replacement_suffix"),
+    [
+        (
+            "source_attachment_ref",
+            "skeptic_review_attachment.json",
+        ),
+        (
+            "bundle_ref",
+            "creative_code_specification_bundle.json",
+        ),
+    ],
+)
+def test_finalize_receipt_refs_must_bind_to_reviewed_run(
+    capsys: pytest.CaptureFixture[str],
+    field_name: str,
+    replacement_suffix: str,
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix=f"receipt-ref-{field_name}")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        attachment_path = output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+        assert review_cli.main(["finalize", "--attachment", str(attachment_path)]) == 0
+        capsys.readouterr()
+        receipt_path = output_dir / "spec_finalize_reviewed" / review_cli.FINALIZE_RECEIPT_FILENAME
+        receipt = validate_finalize_receipt(_read_json(receipt_path))
+        tampered_receipt = deepcopy(receipt)
+        tampered_receipt[field_name] = (
+            "artifacts/orchestration/creative_code/spec_bridge/other-bridge/"
+            f"spec_finalize_reviewed/{replacement_suffix}"
+        )
+
+        with pytest.raises(CreativeSpecificationSkepticReviewError, match="reviewed_run_dir_ref"):
+            validate_finalize_receipt(_refresh_receipt_identity(tampered_receipt))
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 @pytest.mark.parametrize(
     ("case_slug", "mutator", "expected_error"),
     [
@@ -1284,6 +1373,39 @@ def test_attachment_contract_requires_exact_reviewer_count(
 
         with pytest.raises(CreativeSpecificationSkepticReviewError, match="must equal 3"):
             validate_skeptic_review_attachment(attachment)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+@pytest.mark.parametrize("count_key", ["variant_count", "review_count"])
+def test_attachment_contract_rejects_zero_coverage_counts(
+    capsys: pytest.CaptureFixture[str],
+    count_key: str,
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix=f"zero-{count_key}")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        attachment = _read_json(
+            output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME
+        )
+        attachment["coverage"][count_key] = 0
+
+        with pytest.raises(CreativeSpecificationSkepticReviewError, match="between 1"):
+            validate_skeptic_review_attachment(_refresh_attachment_identity(attachment))
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -26,6 +26,7 @@ from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
 )
 from scripts.orchestration.creative_specification_skeptic_review_contract import (
     CreativeSpecificationSkepticReviewError,
+    build_skeptic_review_attachment,
     default_review_input_authority,
     validate_agent_skeptic_reviews_input,
     validate_finalize_receipt,
@@ -511,9 +512,133 @@ def test_validate_rejects_reviewed_child_symlink_before_read(
         )
         captured = capsys.readouterr()
         assert exit_code == 1
-        assert "JSON artifact must not traverse symlinks" in captured.err
+        assert "reviewed finalize run contains symlink artifact(s): variants.json" in captured.err
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_validate_rejects_hidden_reviewed_run_sidecar(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="reviewed-sidecar")
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+        reviewed_dir = output_dir / "spec_finalize_reviewed"
+        _write_json(reviewed_dir / "unexpected.json", {"extra": True})
+
+        exit_code = review_cli.main(
+            ["validate", "--attachment", str(reviewed_dir / review_cli.ATTACHMENT_FILENAME)]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "reviewed finalize run contains unexpected artifact(s): unexpected.json" in (
+            captured.err
+        )
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_validate_rejects_relocated_reviewed_run(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix="relocated-reviewed")
+    relocated_parent = output_dir.parent / f"{output_dir.name}-relocated"
+    try:
+        reviews_path = _write_review_input(output_dir, _review_input(output_dir))
+        assert (
+            review_cli.main(
+                [
+                    "attach",
+                    "--bridge",
+                    str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                    "--reviews",
+                    str(reviews_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+        reviewed_dir = output_dir / "spec_finalize_reviewed"
+        attachment = validate_skeptic_review_attachment(
+            _read_json(reviewed_dir / review_cli.ATTACHMENT_FILENAME)
+        )
+        relocated_dir = relocated_parent / "spec_finalize_reviewed"
+        relocated_dir.mkdir(parents=True)
+        for filename in (
+            "source_packet.json",
+            "variants.json",
+            "skeptic_reviews.json",
+            "context_pack.json",
+        ):
+            shutil.copyfile(reviewed_dir / filename, relocated_dir / filename)
+
+        source = attachment["source"]
+        normalized_reviews = _read_json(reviewed_dir / "skeptic_reviews.json")
+        relocated_attachment = build_skeptic_review_attachment(
+            bridge_id=source["bridge_id"],
+            bridge_fingerprint=source["bridge_fingerprint"],
+            bridge_ref=source["bridge_ref"],
+            candidate_id=source["candidate_id"],
+            candidate_fingerprint=source["candidate_fingerprint"],
+            candidate_ref=source["candidate_ref"],
+            metrics_id=source["metrics_id"],
+            metrics_fingerprint=source["metrics_fingerprint"],
+            metrics_ref=source["metrics_ref"],
+            spec_prepare_ref=source["spec_prepare_ref"],
+            source_packet_ref=source["source_packet_ref"],
+            source_packet_fingerprint=source["source_packet_fingerprint"],
+            variants_ref=source["variants_ref"],
+            variants_fingerprint=source["variants_fingerprint"],
+            pending_reviews_ref=source["pending_reviews_ref"],
+            pending_reviews_fingerprint=source["pending_reviews_fingerprint"],
+            context_pack_ref=source["context_pack_ref"],
+            context_pack_fingerprint=source["context_pack_fingerprint"],
+            reviewed_run_dir_ref=relocated_dir.relative_to(REPO_ROOT).as_posix(),
+            reviewed_source_packet_ref=(relocated_dir / "source_packet.json")
+            .relative_to(REPO_ROOT)
+            .as_posix(),
+            reviewed_variants_ref=(relocated_dir / "variants.json")
+            .relative_to(REPO_ROOT)
+            .as_posix(),
+            reviewed_reviews_ref=(relocated_dir / "skeptic_reviews.json")
+            .relative_to(REPO_ROOT)
+            .as_posix(),
+            reviewed_context_pack_ref=(relocated_dir / "context_pack.json")
+            .relative_to(REPO_ROOT)
+            .as_posix(),
+            normalized_reviews=normalized_reviews,
+            variant_count=attachment["coverage"]["variant_count"],
+        )
+        _write_json(relocated_dir / review_cli.ATTACHMENT_FILENAME, relocated_attachment)
+
+        exit_code = review_cli.main(
+            ["validate", "--attachment", str(relocated_dir / review_cli.ATTACHMENT_FILENAME)]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "reviewed_run_dir_ref must be the sibling of the source bridge artifact" in (
+            captured.err
+        )
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(relocated_parent, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)
 
 

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
 from copy import deepcopy
 import json
 from pathlib import Path
@@ -1016,7 +1017,7 @@ def test_finalize_receipt_rejects_inconsistent_selected_count(
 def test_review_input_validator_matches_schema_caps(
     capsys: pytest.CaptureFixture[str],
     case_slug: str,
-    mutator: Any,
+    mutator: Callable[[dict[str, Any]], None],
     expected_error: str,
 ) -> None:
     output_dir, input_dir = _prepared_bridge(capsys, suffix=f"schema-caps-{case_slug}")
@@ -1081,7 +1082,7 @@ def test_review_input_validator_matches_schema_caps(
 def test_attach_rejects_bad_review_inputs(
     capsys: pytest.CaptureFixture[str],
     case_slug: str,
-    mutator: Any,
+    mutator: Callable[[dict[str, Any]], None],
     expected_error: str,
 ) -> None:
     output_dir, input_dir = _prepared_bridge(capsys, suffix=f"bad-{case_slug}")


### PR DESCRIPTION
## Summary
Adds a local orchestration handoff for reviewed creative-code specification finalization.

This PR adds three explicit commands: `attach`, `validate`, and `finalize`. They attach operator-supplied sanitized skeptic-review evidence to an already prepared creative spec bridge, write a sibling `spec_finalize_reviewed/` run, call the existing PR-1 `creative_code_spec_pipeline.finalize`, and emit a valid `CreativeCodeSpecificationBundle` plus a bounded metadata receipt.

It does **not** change product runtime, OpenAPI, workflows, provider/model calls, patch generation, branch/PR authority, semantic cache, graph truth, fixed mapping authority inside artifacts, or merge-readiness authority.

## Goal
Attach validated local agent skeptic-review evidence to #2070 prepared creative specification artifacts without rewriting the original bridge `spec_prepare/` outputs.

## Business reason
This closes the next automation handoff after #2070: prepared creative-code specs can now be finalized from reviewed local evidence while preserving production authority boundaries and immutable bridge validation evidence.

## Scope
- Add `scripts/orchestration/creative_specification_skeptic_review.py` with explicit `attach`, `validate`, and `finalize` commands only.
- Add `scripts/orchestration/creative_specification_skeptic_review_contract.py` for strict local control-plane validation.
- Add JSON schemas for skeptic-review input, attachment metadata, and finalize receipt.
- Normalize sanitized reviews into the existing PR-1 `skeptic_reviews.json` row shape with repo-derived review ids and fingerprints.
- Write reviewed artifacts only under sibling `spec_finalize_reviewed/`.
- Update orchestration contracts, `scripts/AGENTS.md`, backlog ledger, and PR #2072 mapping governance.

## Out of scope
No agent execution, provider/model calls, product runtime changes, workflow changes, patch generation, branch/PR writes from artifacts, fixed-mapping edits by artifacts, review-thread actions by artifacts, metrics ingestion sidecar, semantic cache, graph truth, or merge-readiness claims.

## Key decisions
- Preserve #2070 `spec_prepare/`; reviewed finalize writes a sibling `spec_finalize_reviewed/` run.
- Reject stale bridge/candidate/source/variant fingerprints before writing reviewed artifacts.
- Reject duplicate JSON keys, duplicate/missing role coverage, unsupported reviewers, bad decisions, unsafe text, secret-shaped values, local absolute paths, symlinks, traversal refs, noncanonical attachment paths, relocated reviewed runs, and hidden reviewed-run sidecars.
- Delegate bundle synthesis to existing `creative_code_spec_pipeline.finalize` instead of creating a second synthesis path.
- Receipt carries bounded counts and closed authority flags only.

## Post-open QA / Bug-hunter / Security follow-up
Commit `c89f19fa0` fixes the post-open QA findings:
- JSON Schema `artifact_ref` patterns now accept generated nested refs like `spec_prepare/source_packet.json` and `spec_finalize_reviewed/creative_code_specification_bundle.json` while still blocking traversal.
- Python input validation now enforces the same review text and token-list caps as the published schemas.
- Added regression tests proving generated attachment/receipt refs match the published schemas.

Commit `f2ff78212` fixes the post-open `bug-hunter` findings:
- `validate` / `finalize` require the canonical `skeptic_review_attachment.json`, so receipts cannot bind one attachment fingerprint while pointing at another ref.
- JSON artifact reads reject symlinks before reading prepared or reviewed child artifacts.
- Schema unsafe-text guards now cover the additional authority phrases called out by review.

Commit `dd84b4bf3` fixes the post-open `security-auditor` finding:
- `spec_finalize_reviewed/` is now allowlisted, so hidden sidecars fail validation.
- `reviewed_run_dir_ref` must be the sibling of the source bridge artifact.
- `spec_prepare_ref` must be a sibling of the source bridge artifact.

Commit `f724a25b5` fixes live review-thread findings from CodeRabbit/Codex:
- `finalize` now cleans partial bundle/receipt outputs if post-finalize validation or receipt writing fails, so retries are not blocked by stale local artifacts.
- Existing reviewed runs must bind to the canonical bridge filename, bridge candidate ref, metrics ref, canonical `spec_prepare/`, and expected source refs before validate/finalize can pass.
- Existing reviewed runs reject source `spec_prepare/` sidecars and recompute attachment coverage from reviewed files.
- Artifact refs now reject unsafe path components, reviewed-run refs must use the exact sibling layout, reviewer-count coverage is exact, and schema/runtime count bounds are aligned.

Commit `844bbe82` records review-thread dispositions in `docs/review/PR_2072_FIXED_MAPPING.md`.

Commit `d450c73e` fixes the latest live review-thread findings:
- `attach` rejects noncanonical copied bridge JSON files before writing reviewed artifacts.
- The skeptic-review input schema deny patterns now catch lower-case PR authority phrases and upper-case secret-shaped GitHub tokens in line with runtime safety checks.
- Finalize receipt validation rejects contradictory `selected_variant_id` / `selected_variant_count` metadata.

Commit `f74575018` fixes the latest CodeRabbit review nitpick:
- Review-input mutator parameters in `tests/test_creative_specification_skeptic_review.py` now use callable typing instead of `Any`.

Commit `134d726e` fixes the latest reviewed-finalize receipt validator findings:
- All-rejected receipts now require rejection counts that match variant coverage.
- Receipt attachment/bundle refs must be canonical files under `reviewed_run_dir_ref`.
- Python attachment/receipt count validators now enforce the same nonzero variant/review minima as the published schemas.

Commit `c62e37ce` fixes the latest schema/recovered-attachment findings:
- Finalize receipt schema now uses canonical reviewed attachment/bundle refs plus selected/all-rejected count constraints.
- Skeptic-review attachment schema now uses canonical reviewed-run child refs plus reviewer-total constraints.
- Recovered attachment validation now reapplies prepared bridge state checks before validate/finalize can pass.

## Tests / validation
Local evidence before review-thread follow-up on head `d5e140e7e`:
- `python3 scripts/orchestration/check_preflight.py` PASS; warnings only for existing private index shape and analyze-mode scoped AGENTS.
- `python3 scripts/orchestration/check_agent_consistency.py` PASS.
- `python3 scripts/ci/check_pr_body_phase2_gates.py --body "$(cat /tmp/pr2072_body.md)" --pr-number 2072 --commit-range origin/main..HEAD --experiment-runner-evidence-mode advisory` PASS.
- `python -m json.tool` PASS for new schemas.
- `pytest -q tests/test_creative_specification_skeptic_review.py` PASS: 23 tests.
- `pytest -q tests/test_creative_code_specification.py tests/test_creative_hypothesis_spec_bridge.py tests/test_experiment_runner_pr_creative_context.py tests/test_agent_learning_loop.py tests/test_skill_router.py` PASS.
- `pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py` PASS: 42 tests.
- `make validate-changed` PASS after commit; ran `tests/test_creative_code_specification.py tests/test_creative_specification_skeptic_review.py`.
- `pre-commit run --all-files` PASS after follow-up commits.
- Push pre-push hooks PASS, including mypy changed files, pip-audit, backend pre-push tests, full-repo Bandit, and docker build test.

Additional local evidence after review-thread fix commits `f724a25b5` / `844bbe82`:
- `python -m json.tool` PASS for the three reviewed-finalize schemas.
- `pytest -q tests/test_creative_specification_skeptic_review.py` PASS: 31 tests.
- `pytest -q tests/test_creative_code_specification.py tests/test_creative_hypothesis_spec_bridge.py tests/test_experiment_runner_pr_creative_context.py tests/test_agent_learning_loop.py tests/test_skill_router.py` PASS.
- `pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py` PASS: 42 tests.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/oracle-spec-skeptic-review-finalize-network1-result.json`

Runner mode: `oracle_only_governance_reviewer`. Source diff was applied in isolated checkout, `shared_tree_untouched=true`, and both oracle commands passed:
- `python3 -m pytest -q tests/test_creative_specification_skeptic_review.py`
- `python3 -m pytest -q tests/test_creative_code_specification.py tests/test_creative_hypothesis_spec_bridge.py tests/test_experiment_runner_pr_creative_context.py tests/test_agent_learning_loop.py tests/test_skill_router.py`

Note: an earlier local runner attempt with `network_budget=0` rejected as infra-only because this macOS sandbox lacks `unshare`; the accepted artifact uses bounded `network_budget=1` and local pytest commands only.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2072_FIXED_MAPPING.md`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323647` -> `c89f19fa08d862bb817739b0470367027ce5afd8`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323649` -> `c89f19fa08d862bb817739b0470367027ce5afd8`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523325117` -> `c89f19fa08d862bb817739b0470367027ce5afd8`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523325119` -> `c89f19fa08d862bb817739b0470367027ce5afd8`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523325121` -> `f2ff78212abea1d863355c43130a22e04b382928`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323651` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523323656` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367669` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367670` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367671` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367673` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523367675` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384319` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384321` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384324` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523384327` -> `f724a25b55ef1513f2c160b760aca8b62eef228f`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523432892` -> `d450c73e275963286d39f93049d3e02173e1b027`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523432893` -> `d450c73e275963286d39f93049d3e02173e1b027`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523432897` -> `d450c73e275963286d39f93049d3e02173e1b027`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629734570` -> `f745750185410345c5c1ba820dc3b1b3d83ffb4e`
- NOT-A-BUG: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629713409` (high-level refactor suggestion; current v1 intentionally keeps safety helpers local to this lane)
- NOT-A-BUG: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629721700` (review rollup only; inline actionables are mapped as FIXED above)
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523498147` -> `134d726e806b0734f2ef7d23d6669166fe279054`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523498148` -> `134d726e806b0734f2ef7d23d6669166fe279054`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523498149` -> `134d726e806b0734f2ef7d23d6669166fe279054`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629921037` -> `134d726e806b0734f2ef7d23d6669166fe279054`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534574` -> `c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534577` -> `c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534578` -> `c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534579` -> `c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#discussion_r3523534581` -> `c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3`
- FIXED: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2072#pullrequestreview-4629954169` -> `c62e37ce64f7901ee87ffb0f6fc53bfa09392ef3`

## Lane Start Provenance
Packet: `artifacts/orchestration/task_packets/c7a115b7e8b5.json`

Starter: `scripts/orchestration/start_pr_lane.sh`

## Security notes
The new code has no provider imports, network imports, subprocess calls, GitHub/Slack writes, runtime imports, nosec suppressions, type ignores, or workflow changes. The local control-plane rejects unsafe text, local absolute paths, secret-shaped values, duplicate JSON keys, symlink traversal, stale artifact fingerprints, noncanonical attachment refs, relocated reviewed runs, hidden reviewed-run sidecars, and unsupported authority flags.

## Codex Security / PR Self-review
Codex Security diff scan completed on current head `d5e140e7e` with 0 reportable findings. Report: `/private/var/folders/bw/12x002vn67v2bvjpbhbtm8480000gn/T/codex-security-scans/experiment-runner-agent-skeptic-review-finalize/d5e140e7e_20260704T145147Z/report.md`.

`pulseplate-pr-review` dry-run completed. It emitted one advisory large-diff-risk note because this PR adds a new CLI, contract module, three schemas, docs, and focused tests in one governed handoff. Disposition: NOT-A-BUG for this slice; the diff remains one bounded orchestration lane, and focused/local gates plus post-open role findings were handled before current-head review.

## Risks / rollback
Rollback is removing the new wrapper, schemas, tests, and docs. Runtime/user-facing behavior is unaffected because artifacts are local under gitignored orchestration artifact roots and the original bridge output remains unchanged.

## Deferred / follow-ups
- Bridge metrics ingestion remains the next separate PR.
- Review-thread/fixed-mapping governance remains manual and out of scope for this artifact wrapper.
- This PR is not merge-ready from local evidence alone; current-head CI, resolved review threads, bot review state, and strict merge-readiness governance still apply after the latest review-fix commits.

## AGENTS.md or agent-instruction updates
Updated `scripts/AGENTS.md` to add the reviewed finalize local-artifact boundary and forbidden authority surfaces.

## Merge Readiness
Pending after latest review-fix commits. Requires current-head CI, completed post-open review chain, bot review status, resolved review threads, and strict merge-readiness governance after the latest mapping/body update.

## Next best step
Complete Codex Security diff scan and `pulseplate-pr-review`, then evaluate current-head CI/review governance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reviewed-spec skeptic-review attach → validate → finalize flow for creative specification runs, producing a metadata-only skeptic-review attachment and a finalize receipt.
  * Introduced a dedicated reviewed-bridge finalize handoff with constrained, receipt-style outputs in the reviewed finalize area.
* **Bug Fixes**
  * Strengthened validation and hygiene: canonical-path enforcement, symlink hardening, duplicate-key rejection, atomic writes, and idempotent finalize behavior.
* **Tests**
  * Expanded end-to-end and failure-mode coverage for the CLI flow and strict artifact/schema conformance.
* **Documentation**
  * Updated orchestration governance contracts and added/extended JSON Schemas for the attachment and receipt artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
