### PR TITLE
refactor(api): move recipe nutrition reference bootstrap

### DIFF
--- a/app/bootstrap/route_family.py
+++ b/app/bootstrap/route_family.py
@@ -284,6 +284,7 @@ def _validate_existing_routes(
     endpoint_matcher: EndpointMatcher,
 ) -> None:
     present_keys: set[RouteKey] = set()
+    present_order: list[RouteKey] = []
 
     for route in family_routes:
         path = route_path(route)
@@ -294,7 +295,9 @@ def _validate_existing_routes(
         unexpected_methods = methods - matching_methods - _FRAMEWORK_METHODS
         if unexpected_methods:
             raise RuntimeError(f"Partial {family_name.lower()} route registration detected.")
-        present_keys.add((path, next(iter(matching_methods))))
+        key = (path, next(iter(matching_methods)))
+        present_keys.add(key)
+        present_order.append(key)
 
     expected_keys = set(members_by_key)
     if present_keys != expected_keys:
@@ -343,3 +346,8 @@ def _validate_existing_routes(
                     f"Existing {path} route does not preserve "
                     f"{family_name.lower()} required dependency."
                 )
+
+    if tuple(present_order) != tuple(members_by_key):
+        raise RuntimeError(
+            f"Existing {family_name.lower()} route order does not preserve " "source route order."
+        )

--- a/app/main.py
+++ b/app/main.py
@@ -1205,6 +1205,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     register_tracing(app)
     _register_paid_tier_routes(app)
     register_pro_contract_routes(app)
+    _include_recipe_nutrition_reference_routers_if_needed(app)
     _include_nutrition_state_routers_if_needed(app)
 
     ws_paths_present = {path for path in _WS_ROUTE_PATHS if _has_route(app, path)}
@@ -1225,7 +1226,6 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _include_bodyfat_router_if_needed(app)
     _include_business_router_if_enabled(app)
     _include_food_catalog_routers_if_needed(app)
-    _include_recipe_nutrition_reference_routers_if_needed(app)
     _include_test_router_if_enabled(app)
     _include_plan_export_routers_if_needed(app)
     _include_shoplist_export_router_if_needed(app)

--- a/app/main.py
+++ b/app/main.py
@@ -80,6 +80,10 @@ from app.routers.legacy_nutrition_alias import (
     LEGACY_NUTRITION_ALIAS_ROUTE_SPECS,
     router as legacy_nutrition_alias_router,
 )
+from app.routers.nutrition_recommendations import (
+    NUTRITION_RECOMMENDATIONS_ROUTE_SPECS,
+    router as nutrition_recommendations_router,
+)
 from app.routers.nutrition_log import NUTRITION_LOG_ROUTE_SPECS, router as nutrition_log_router
 from app.routers.plan_export import (
     PLAN_EXPORT_ROUTE_SPECS,
@@ -90,6 +94,7 @@ from app.routers.plan_export import (
     plan_router,
 )
 from app.routers.pro_registration import register_pro_routes
+from app.routers.recipes import RECIPES_ROUTE_SPECS, router as recipes_router
 from app.routers.restaurants import (
     RESTAURANT_MODERATION_ROUTE_SPECS,
     moderation_router as restaurant_moderation_router,
@@ -188,9 +193,17 @@ _NUTRITION_LOG_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in NUTRITION_LOG_ROUTE_SPECS
 )
+_NUTRITION_RECOMMENDATIONS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in NUTRITION_RECOMMENDATIONS_ROUTE_SPECS
+)
 _PLAN_EXPORT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in PLAN_EXPORT_ROUTE_SPECS
+)
+_RECIPES_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in RECIPES_ROUTE_SPECS
 )
 _SHOPLIST_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
@@ -426,6 +439,20 @@ def _food_catalog_route_members() -> tuple[RouteMemberContract, ...]:
             )
         )
     return tuple(members)
+
+
+def _recipe_nutrition_reference_route_members() -> tuple[RouteMemberContract, ...]:
+    return tuple(
+        RouteMemberContract(
+            path=path,
+            method=method,
+            include_in_schema=include_in_schema,
+        )
+        for path, method, include_in_schema in (
+            *_RECIPES_ROUTE_SPECS,
+            *_NUTRITION_RECOMMENDATIONS_ROUTE_SPECS,
+        )
+    )
 
 
 def _test_route_members() -> tuple[RouteMemberContract, ...]:
@@ -994,6 +1021,17 @@ def _include_food_catalog_routers_if_needed(target_app: FastAPI) -> None:
     )
 
 
+def _include_recipe_nutrition_reference_routers_if_needed(target_app: FastAPI) -> None:
+    """Register recipe and nutrition-reference routes as one canonical static family."""
+
+    ensure_route_family_registered(
+        target_app,
+        family_name="Recipe nutrition reference",
+        routers=(recipes_router, nutrition_recommendations_router),
+        members=_recipe_nutrition_reference_route_members(),
+    )
+
+
 def _include_test_router_if_enabled(target_app: FastAPI) -> None:
     """Register non-production test routes as one hidden canonical family."""
 
@@ -1187,6 +1225,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _include_bodyfat_router_if_needed(app)
     _include_business_router_if_enabled(app)
     _include_food_catalog_routers_if_needed(app)
+    _include_recipe_nutrition_reference_routers_if_needed(app)
     _include_test_router_if_enabled(app)
     _include_plan_export_routers_if_needed(app)
     _include_shoplist_export_router_if_needed(app)

--- a/app/routers/nutrition_recommendations.py
+++ b/app/routers/nutrition_recommendations.py
@@ -14,6 +14,10 @@ from fastapi import APIRouter, Query
 
 from app.schemas.nutrition_recommendations import NutrientRecommendationsResponse
 
+NUTRITION_RECOMMENDATIONS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/nutrition/recommendations", "GET", True),
+)
+
 router = APIRouter(tags=["nutrition"])
 
 

--- a/app/routers/recipes.py
+++ b/app/routers/recipes.py
@@ -8,6 +8,13 @@ from app.schemas.recipe import Recipe, RecipePreviewRequest, RecipePreviewRespon
 from app.services import recipe_store
 from app.services.food_store import nutrients_for
 
+RECIPES_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/recipes", "GET", True),
+    ("/api/v1/recipes/search", "GET", True),
+    ("/api/v1/recipes/{recipe_id}", "GET", True),
+    ("/api/v1/recipes/preview", "POST", True),
+)
+
 router = APIRouter(tags=["recipes"])
 
 

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -30,8 +30,35 @@ Anchor (stable): `legacy_app.py -> include_router(...) for core API routers`
 
 Evidence: `legacy_app.py:922-932`
 
-- `recipes_router` (`app/routers/recipes.py`)
+- `restaurants_router` (`app/routers/restaurants.py`, hidden from OpenAPI at registration)
 - `users_router` (`app/routers/users.py`)
+
+### Canonical recipe/nutrition-reference routers (canonical bootstrap-owned)
+
+Anchor (stable): `app/main.py -> _include_recipe_nutrition_reference_routers_if_needed(app)`
+
+Evidence:
+- `app/bootstrap/route_family.py` — shared `RouteMemberContract` /
+  `ensure_route_family_registered(...)` guard for exact static route families.
+- `app/main.py` — registers `recipes_router` and `nutrition_recommendations_router`
+  as one canonical static route family and validates visibility, duplicate,
+  partial, and foreign-handler drift.
+- `app/routers/recipes.py` — owns recipe lookup/search/preview handlers and
+  visible source-route `RECIPES_ROUTE_SPECS`.
+- `app/routers/nutrition_recommendations.py` — owns the FREE basic nutrition
+  recommendation handler and visible source-route `NUTRITION_RECOMMENDATIONS_ROUTE_SPECS`.
+
+Runtime effect:
+- `GET /api/v1/recipes`
+- `GET /api/v1/recipes/search`
+- `GET /api/v1/recipes/{recipe_id}`
+- `POST /api/v1/recipes/preview`
+- `GET /api/v1/nutrition/recommendations`
+
+OpenAPI effect:
+- Source routes remain schema-visible in route metadata.
+- Final public `app.openapi()` continues to filter `/api/v1/recipes*` and
+  `/api/v1/nutrition/recommendations` through the canonical OpenAPI builder.
 
 ### Canonical food/catalog routers (canonical bootstrap-owned)
 

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -49,7 +49,6 @@ local `make verify`.
 - [x] Post-open `qa-engineer-agent` pass completed.
 - [x] Post-open `bug-hunter` pass completed; three P2 findings fixed in
   `8d50f28c1`.
-- [ ] Post-open `security-auditor` pass completed.
 - [x] Post-open `security-auditor` pass completed.
 - [x] Codex Security diff scan / finding discovery completed for
   `191a2a317a42b6b7cc255e0011affedfe74e4435`.
@@ -59,7 +58,7 @@ local `make verify`.
 - [ ] CodeRabbit actionable review comments checked and dispositioned.
 - [ ] Sourcery actionable review comments checked and dispositioned.
 - [ ] Cubic actionable review comments checked and dispositioned.
-- [ ] Discussion-thread pass completed.
+- [x] Discussion-thread pass completed.
 
 ## Fixed in Commit Mapping
 

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -34,6 +34,7 @@ Commit: 8d50f28c1
 Evidence: docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md:46 records the rejected zero-network attempt without the duplicated artifact path, and tests/test_recipe_nutrition_reference_registration_bootstrap.py:183 asserts JSON Content-Type before response.json().
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523323769 -> 8d50f28c1
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523323772 -> 8d50f28c1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#pullrequestreview-4629721797 -> 8d50f28c1
 
 Disposition: FIXED
 Commit: 111cc0f77e2ee1b849c92555e85422bb74b39a2e
@@ -80,6 +81,11 @@ Disposition: FIXED
 Commit: f843dddd18b6a76ef5e08d73a0b7342512c24e10
 Evidence: scripts/ci/check_legacy_growth_guard.py:257 recognizes getattr(app, "include_router") call actions, scripts/ci/check_legacy_growth_guard.py:656 treats indirect include_router calls as router-registration calls, and tests/test_legacy_growth_guard.py:1199 covers the recipes router bypass.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523434326 -> f843dddd18b6a76ef5e08d73a0b7342512c24e10
+
+Disposition: FIXED
+Commit: 41c09ce035c63cde9eb0591af4efa5ddc64123ca
+Evidence: scripts/ci/check_legacy_growth_guard.py:697 resolves getattr method-name aliases through collected static string bindings, and tests/test_legacy_growth_guard.py:1215 covers the bound method-name recipes router bypass.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523515621 -> 41c09ce035c63cde9eb0591af4efa5ddc64123ca
 
 Disposition: NOT-A-BUG
 Evidence: git cat-file -e c036554829af5c11d4703d088647daa3964ba195^{commit} fails locally while git log origin/main..HEAD contains ac08b4b6f4e241c18b62e24dbc90db027e78d985 with Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>.
@@ -151,9 +157,11 @@ runtime, provider, client, or public API authority.
 - `python -m pytest -q tests/test_legacy_growth_guard.py::test_legacy_growth_guard_rejects_recipe_nutrition_reference_router_reintroduction` - PASS after the indirect include_router regression fix.
 - `python -m pytest -q tests/test_legacy_growth_guard.py` - PASS after the indirect include_router regression fix.
 - `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py` - PASS after the indirect include_router regression fix.
+- `python -m pytest -q tests/test_legacy_growth_guard.py::test_legacy_growth_guard_rejects_recipe_nutrition_reference_router_reintroduction tests/test_legacy_growth_guard.py` - PASS after the bound getattr method-name regression fix.
 - `python -m pytest -q tests/test_nutrition_recommendations_api.py::TestFreeRecommendationsSuccess::test_recommendations_success tests/test_recipe_nutrition_reference_registration_bootstrap.py::test_nutrition_recommendations_route_cannot_be_shadowed_by_dynamic_v1_alias` - PASS.
 - `python scripts/ci/check_legacy_growth_guard.py` - PASS.
 - `python -m mypy app/bootstrap/route_family.py app/main.py app/routers/recipes.py app/routers/nutrition_recommendations.py scripts/ci/check_legacy_growth_guard.py` - PASS.
+- `python -m mypy scripts/ci/check_legacy_growth_guard.py` - PASS after the bound getattr method-name regression fix.
 - `DEV_PYTHON=.venv/bin/python make openapi-check` - PASS.
 - `git diff --exit-code -- frontend/src/api/openapi.json frontend/src/api/schema.ts` - PASS.
 - `pre-commit run --all-files` - PASS after hook formatting was committed and affected tests rerun.

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -20,7 +20,7 @@ generated client artifacts.
 - [x] Pre-edit role order completed: `agent-coordinator -> backend-engineer -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`.
 - [x] Post-open role chain completed: `qa-engineer-agent -> bug-hunter -> security-auditor`.
 - [x] Post-open bug-hunter findings fixed and re-reviewed.
-- [x] Codex Security diff scan / finding discovery completed for the last security-relevant head.
+- [x] Initial Codex Security diff scan / finding discovery completed for 191a2a317a42b6b7cc255e0011affedfe74e4435; current-head rescan e82db3b8-d682-4072-b013-ac81071d0663 was started for 55b527d22325ca655e66e8507edea6c15b48bb56 and remains pending in preflight.
 - [x] `pulseplate-pr-review` completed; advisory large-diff note dispositioned below.
 - [x] Codex review actionable comments checked and dispositioned below.
 - [x] CodeRabbit actionable review comments checked and dispositioned below.
@@ -132,9 +132,11 @@ runtime, provider, client, or public API authority.
 - `make validate-changed` - PASS on latest implementation head; selected tests/test_legacy_growth_guard.py, tests/test_main_paywall_bootstrap.py, and tests/test_recipe_nutrition_reference_registration_bootstrap.py.
 - Pre-push hooks - PASS on pushed heads: mypy where applicable, pip-audit, backend pytest pre-push, full-repo Bandit, and docker build test where applicable.
 - Codex Security diff scan 08025660-053e-4a39-bb72-73277fe7c22f completed with 0 findings and 6/6 coverage rows closed for 8fdcd0ac1668f612de4dca90846fd994967e60df..191a2a317a42b6b7cc255e0011affedfe74e4435.
+- Current-head Codex Security scan e82db3b8-d682-4072-b013-ac81071d0663 was opened for 8fdcd0ac1668f612de4dca90846fd994967e60df..55b527d22325ca655e66e8507edea6c15b48bb56; it remained in preflight during this pass and is not counted as pass evidence.
 - `pulseplate-pr-review` completed; one advisory large-diff note dispositioned as NOT-A-BUG above.
 
 ## Merge Readiness
 
 Not claimed here. Requires current-head CI after the latest mapping/body commit,
-strict merge-readiness gate, and resolved review threads.
+current-head Codex Security completion, strict merge-readiness gate, and resolved
+review threads.

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -12,168 +12,113 @@ runtime behavior, source route visibility, final public OpenAPI filtering,
 auth/tier posture, nutrition formula behavior, recipe-store behavior, and
 generated client artifacts.
 
-## Scope
-
-- Add static route specs for `recipes_router` and
-  `nutrition_recommendations_router`.
-- Register both routers through canonical route-family bootstrap in
-  `app/main.py`.
-- Remove only those two router imports/includes from `legacy_app.py`.
-- Tighten legacy-growth guard allowlists and regression tests.
-- Update backend routing map and attach premortem / Experiment Runner evidence.
-
-## Out Of Scope
-
-BOLA/authz expansion, BMI/users/restaurants ownership, premium nutrition
-handlers, middleware/lifespan behavior, recipe-store changes, nutrition formula
-changes, OpenAPI/client contract changes, frontend/iOS/macOS changes, and full
-local `make verify`.
-
-## Lane Start Provenance
-
-- Base branch: `main`
-- Branch:
-  `codex/move-recipe-nutrition-reference-registration-to-canonical-bootstrap`
-- Pre-open packet: `artifacts/orchestration/task_packets/3467351ee456.json`
-- Post-open review packet:
-  `artifacts/orchestration/task_packets/f5cb9acbe485.json`
-- Pre-edit role order executed:
-  `agent-coordinator -> backend-engineer -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`
-- Packet creation was treated as routing/provenance only. Role passes were
-  executed explicitly before implementation.
-
 ## Discussion Thread Pass
 
-- [x] Fixed in commit mapping artifact created after GitHub assigned PR number
-  `#2073`.
-- [x] Post-open `qa-engineer-agent` pass completed.
-- [x] Post-open `bug-hunter` pass completed; three P2 findings fixed in
-  `8d50f28c1`.
-- [x] Post-open `security-auditor` pass completed.
-- [x] Codex Security diff scan / finding discovery completed for
-  `191a2a317a42b6b7cc255e0011affedfe74e4435`.
-- [x] `pulseplate-pr-review` completed for
-  `191a2a317a42b6b7cc255e0011affedfe74e4435`; one advisory large-diff planning
-  note dispositioned below.
-- [ ] CodeRabbit actionable review comments checked and dispositioned.
-- [ ] Sourcery actionable review comments checked and dispositioned.
-- [ ] Cubic actionable review comments checked and dispositioned.
-- [x] Discussion-thread pass completed.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Fixed mapping artifact created after GitHub assigned PR number `#2073`.
+- [x] Pre-edit role order completed: `agent-coordinator -> backend-engineer -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`.
+- [x] Post-open role chain completed: `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [x] Post-open bug-hunter findings fixed and re-reviewed.
+- [x] Codex Security diff scan / finding discovery completed for the last security-relevant head.
+- [x] `pulseplate-pr-review` completed; advisory large-diff note dispositioned below.
+- [x] Codex review actionable comments checked and dispositioned below.
+- [x] CodeRabbit actionable review comments checked and dispositioned below.
+- [x] Sourcery actionable review comments checked and dispositioned below.
+- [x] Cubic actionable review comments checked; generated summary only.
 
 ## Fixed in Commit Mapping
 
-No GitHub review threads or actionable bot comments existed when this artifact
-was created. The post-open `bug-hunter` role pass found three P2 actionables;
-they are dispositioned below.
-
 Disposition: FIXED
 Commit: 8d50f28c1
-Evidence: `app/bootstrap/route_family.py` now rejects existing static-family
-registrations whose FastAPI route order differs from source route order;
-`tests/test_main_paywall_bootstrap.py` covers generic order drift, and
-`tests/test_recipe_nutrition_reference_registration_bootstrap.py` covers
-`/api/v1/recipes/search` before `/api/v1/recipes/{recipe_id}`.
-Reason: Prevents a complete preexisting family from passing membership checks
-while shadowing `/api/v1/recipes/search` through `/{recipe_id}`.
+Evidence: docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md:46 records the rejected zero-network attempt without the duplicated artifact path, and tests/test_recipe_nutrition_reference_registration_bootstrap.py:183 asserts JSON Content-Type before response.json().
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523323769 -> 8d50f28c1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523323772 -> 8d50f28c1
 
 Disposition: FIXED
-Commit: 8d50f28c1
-Evidence:
-`docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md`
-now records the rejected zero-network attempt as an unpromoted infra caveat
-without presenting a duplicated artifact path as review evidence.
-Reason: Keeps Experiment Runner evidence locatable and avoids promoting a
-rejected local infra-flake artifact.
-
-Disposition: FIXED
-Commit: 8d50f28c1
-Evidence: `tests/test_recipe_nutrition_reference_registration_bootstrap.py`
-asserts the JSON `Content-Type` before parsing the recipe search response.
-Reason: Aligns the new bootstrap test with `tests/AGENTS.md` JSON response
-assertion policy.
+Commit: 111cc0f77e2ee1b849c92555e85422bb74b39a2e
+Evidence: docs/review/PR_2073_FIXED_MAPPING.md now checks the required Discussion-thread pass item and removed the duplicate unchecked security-auditor row.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#pullrequestreview-4629760831 -> 111cc0f77e2ee1b849c92555e85422bb74b39a2e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#pullrequestreview-4629802649 -> 111cc0f77e2ee1b849c92555e85422bb74b39a2e
 
 Disposition: NOT-A-BUG
-Evidence: `pulseplate-pr-review` dry-run report found one advisory
-large-diff planning note because the diff exceeded the 800-line review-risk
-threshold; scope remains a bounded route-registration migration plus the
-bug-hunter route-order guard fix, and focused gates covered the changed
-surfaces: recipes/nutrition behavior tests, bootstrap/guard/OpenAPI/auth-tier
-tests, `check_legacy_growth_guard.py`, targeted mypy, `make openapi-check`,
-`pre-commit run --all-files`, `make validate-changed`, and pre-push hooks.
-Reason: The threshold is review-planning evidence, not a code/security defect.
-The PR was intentionally kept to one legacy-removal family plus the directly
-required shared route-order guard.
+Evidence: git show -s --format=%B ac08b4b6f4e241c18b62e24dbc90db027e78d985 includes the canonical Experiment Runner co-author trailer, and the Phase2 gate inspects origin/main..HEAD for that trailer.
+Reason: The Codex review targeted superseded commit d412942d75db55ec3cbc6c1e296a54f95433f0da; current branch history carries the required trailer on the implementation commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523327703
+
+Disposition: NOT-A-BUG
+Evidence: tests/test_recipe_nutrition_reference_registration_bootstrap.py exercises app.main bootstrap ownership directly, and tests/test_legacy_growth_guard.py pins guard message output for intentional reintroduction regressions.
+Reason: Sourcery raised maintainability considerations, not a correctness/security defect; adding a public test helper or guard-message builder would widen this legacy-removal PR beyond route ownership migration.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#pullrequestreview-4629716524
 
 ## Review Comment Dispositions
 
-No GitHub review comments have been dispositioned yet.
+### Post-Open Bug-Hunter Route-Order Finding
 
-### Advisory PulsePlate PR Review Note
+Disposition: FIXED
+Commit: 8d50f28c1
+Evidence: app/bootstrap/route_family.py rejects existing static-family registrations whose FastAPI route order differs from source route order; tests/test_main_paywall_bootstrap.py covers generic order drift, and tests/test_recipe_nutrition_reference_registration_bootstrap.py covers `/api/v1/recipes/search` before `/api/v1/recipes/{recipe_id}`.
+Reason: Prevents a complete preexisting family from passing membership checks while shadowing `/api/v1/recipes/search` through `/{recipe_id}`.
+
+### Post-Open Bug-Hunter Experiment Evidence Finding
+
+Disposition: FIXED
+Commit: 8d50f28c1
+Evidence: docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md records the rejected zero-network attempt as an unpromoted infra caveat without presenting a duplicated artifact path as review evidence.
+Reason: Keeps Experiment Runner evidence locatable and avoids promoting a rejected local infra-flake artifact.
+
+### Post-Open Bug-Hunter JSON Assertion Finding
+
+Disposition: FIXED
+Commit: 8d50f28c1
+Evidence: tests/test_recipe_nutrition_reference_registration_bootstrap.py asserts the JSON Content-Type before parsing the recipe search response.
+Reason: Aligns the new bootstrap test with tests/AGENTS.md JSON response assertion policy.
+
+### PulsePlate PR Review Large-Diff Note
 
 Disposition: NOT-A-BUG
-Evidence: `pulseplate-pr-review` reported only the large-diff planning note
-described in `Fixed in Commit Mapping`; no deterministic correctness,
-security, architecture, QA, wellness, release, or governance code finding was
-reported.
-Reason: The PR owns one bounded legacy-removal slice and the targeted
-bug-hunter fix required to keep that slice fail-closed.
+Evidence: pulseplate-pr-review reported only a large-diff planning note; focused recipe/nutrition behavior tests, bootstrap/guard/OpenAPI/auth-tier tests, check_legacy_growth_guard.py, targeted mypy, make openapi-check, pre-commit run --all-files, make validate-changed, pre-push hooks, role passes, and Codex Security all covered the changed surfaces.
+Reason: The threshold is review-planning evidence, not a code/security defect. The PR owns one bounded legacy-removal slice plus the directly required shared route-order guard.
 
 ## Experiment Runner Evidence
 
-- Artifact:
-  `artifacts/orchestration/experiments/results/recipe-nutrition-reference-oracle-result-v2.json`
+- Artifact: `artifacts/orchestration/experiments/results/recipe-nutrition-reference-oracle-result-v2.json`
 - Experiment id: `exp-4fe6753a1339`
 - Mode: `oracle_only_governance_reviewer`
 - Result: `accepted`
 - Contribution kind: `oracle_review`
 - `coauthor_required=true`
-- Commit carrying required trailer:
-  `ac08b4b6f4e241c18b62e24dbc90db027e78d985`
+- Commit carrying required trailer: `ac08b4b6f4e241c18b62e24dbc90db027e78d985`
 
-Infra caveat: the first zero-network local attempt recorded
-`status=rejected`, `failure_class=infra_flake` because this development host
-does not provide `unshare` for the network-disabled sandbox. The accepted
-`network_budget=1` artifact kept the same local oracle commands and does not
-grant product runtime, provider, client, or public API authority.
+Infra caveat: the first zero-network local attempt recorded `status=rejected`,
+`failure_class=infra_flake` because this development host does not provide
+`unshare` for the network-disabled sandbox. The accepted `network_budget=1`
+artifact kept the same local oracle commands and does not grant product
+runtime, provider, client, or public API authority.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/3467351ee456.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Post-open packet: `artifacts/orchestration/task_packets/f5cb9acbe485.json`
 
 ## Validation Evidence
 
-- `python scripts/orchestration/check_preflight.py` - PASS, with existing
-  private-index env warning only.
+- `python scripts/orchestration/check_preflight.py` - PASS, with existing private-index env warning only.
 - `python scripts/orchestration/check_agent_consistency.py` - PASS.
 - `python -m pytest -q tests/test_recipes_api.py tests/test_recipe_preview.py tests/test_nutrition_recommendations_api.py` - PASS.
 - `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py` - PASS.
 - `python scripts/ci/check_legacy_growth_guard.py` - PASS.
-- `python -m mypy app/main.py app/routers/recipes.py app/routers/nutrition_recommendations.py scripts/ci/check_legacy_growth_guard.py` - PASS.
+- `python -m mypy app/bootstrap/route_family.py app/main.py app/routers/recipes.py app/routers/nutrition_recommendations.py scripts/ci/check_legacy_growth_guard.py` - PASS.
 - `DEV_PYTHON=.venv/bin/python make openapi-check` - PASS.
 - `git diff --exit-code -- frontend/src/api/openapi.json frontend/src/api/schema.ts` - PASS.
-- `pre-commit run --all-files` - PASS after Black formatted the new bootstrap
-  test and the affected tests were rerun.
-- `make validate-changed` - PASS after commit; selected
-  `tests/test_legacy_growth_guard.py` and
-  `tests/test_recipe_nutrition_reference_registration_bootstrap.py`.
-- Pre-push hooks - PASS: mypy changed files, pip-audit, backend pytest
-  pre-push, full-repo Bandit, docker build test.
-- Bug-hunter fix validation:
-  `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_main_paywall_bootstrap.py::test_route_family_rejects_existing_route_order_drift`
-  - PASS.
-- Bug-hunter focused bundle:
-  `python -m pytest -q tests/test_recipes_api.py tests/test_recipe_preview.py tests/test_nutrition_recommendations_api.py tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
-  - PASS.
-- Bug-hunter fix `python scripts/ci/check_legacy_growth_guard.py` - PASS.
-- Bug-hunter fix `DEV_PYTHON=.venv/bin/python make openapi-check` - PASS.
-- Bug-hunter fix `pre-commit run --all-files` - PASS after Black formatted
-  `app/bootstrap/route_family.py` and affected tests were rerun.
-- Codex Security diff scan:
-  scan `08025660-053e-4a39-bb72-73277fe7c22f` completed with 0 findings and
-  6/6 coverage rows closed for
-  `8fdcd0ac1668f612de4dca90846fd994967e60df..191a2a317a42b6b7cc255e0011affedfe74e4435`.
-- `pulseplate-pr-review`:
-  `/tmp/pr2073_pulseplate_pr_review.md` completed; one advisory large-diff note
-  dispositioned as NOT-A-BUG above.
+- `pre-commit run --all-files` - PASS after hook formatting was committed and affected tests rerun.
+- `make validate-changed` - PASS on latest implementation head; selected tests/test_legacy_growth_guard.py, tests/test_main_paywall_bootstrap.py, and tests/test_recipe_nutrition_reference_registration_bootstrap.py.
+- Pre-push hooks - PASS on pushed heads: mypy where applicable, pip-audit, backend pytest pre-push, full-repo Bandit, and docker build test where applicable.
+- Codex Security diff scan 08025660-053e-4a39-bb72-73277fe7c22f completed with 0 findings and 6/6 coverage rows closed for 8fdcd0ac1668f612de4dca90846fd994967e60df..191a2a317a42b6b7cc255e0011affedfe74e4435.
+- `pulseplate-pr-review` completed; one advisory large-diff note dispositioned as NOT-A-BUG above.
 
 ## Merge Readiness
 
 Not claimed here. Requires current-head CI after the latest mapping/body commit,
-post-open role chain, Codex Security / review-bot pass, discussion-thread
-disposition, strict merge-readiness gate, and resolved review threads.
+strict merge-readiness gate, and resolved review threads.

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -50,8 +50,12 @@ local `make verify`.
 - [x] Post-open `bug-hunter` pass completed; three P2 findings fixed in
   `8d50f28c1`.
 - [ ] Post-open `security-auditor` pass completed.
-- [ ] Codex Security diff scan / finding discovery completed for current head.
-- [ ] `pulseplate-pr-review` completed for current head.
+- [x] Post-open `security-auditor` pass completed.
+- [x] Codex Security diff scan / finding discovery completed for
+  `191a2a317a42b6b7cc255e0011affedfe74e4435`.
+- [x] `pulseplate-pr-review` completed for
+  `191a2a317a42b6b7cc255e0011affedfe74e4435`; one advisory large-diff planning
+  note dispositioned below.
 - [ ] CodeRabbit actionable review comments checked and dispositioned.
 - [ ] Sourcery actionable review comments checked and dispositioned.
 - [ ] Cubic actionable review comments checked and dispositioned.
@@ -89,9 +93,31 @@ asserts the JSON `Content-Type` before parsing the recipe search response.
 Reason: Aligns the new bootstrap test with `tests/AGENTS.md` JSON response
 assertion policy.
 
+Disposition: NOT-A-BUG
+Evidence: `pulseplate-pr-review` dry-run report found one advisory
+large-diff planning note because the diff exceeded the 800-line review-risk
+threshold; scope remains a bounded route-registration migration plus the
+bug-hunter route-order guard fix, and focused gates covered the changed
+surfaces: recipes/nutrition behavior tests, bootstrap/guard/OpenAPI/auth-tier
+tests, `check_legacy_growth_guard.py`, targeted mypy, `make openapi-check`,
+`pre-commit run --all-files`, `make validate-changed`, and pre-push hooks.
+Reason: The threshold is review-planning evidence, not a code/security defect.
+The PR was intentionally kept to one legacy-removal family plus the directly
+required shared route-order guard.
+
 ## Review Comment Dispositions
 
 No GitHub review comments have been dispositioned yet.
+
+### Advisory PulsePlate PR Review Note
+
+Disposition: NOT-A-BUG
+Evidence: `pulseplate-pr-review` reported only the large-diff planning note
+described in `Fixed in Commit Mapping`; no deterministic correctness,
+security, architecture, QA, wellness, release, or governance code finding was
+reported.
+Reason: The PR owns one bounded legacy-removal slice and the targeted
+bug-hunter fix required to keep that slice fail-closed.
 
 ## Experiment Runner Evidence
 
@@ -139,6 +165,13 @@ grant product runtime, provider, client, or public API authority.
 - Bug-hunter fix `DEV_PYTHON=.venv/bin/python make openapi-check` - PASS.
 - Bug-hunter fix `pre-commit run --all-files` - PASS after Black formatted
   `app/bootstrap/route_family.py` and affected tests were rerun.
+- Codex Security diff scan:
+  scan `08025660-053e-4a39-bb72-73277fe7c22f` completed with 0 findings and
+  6/6 coverage rows closed for
+  `8fdcd0ac1668f612de4dca90846fd994967e60df..191a2a317a42b6b7cc255e0011affedfe74e4435`.
+- `pulseplate-pr-review`:
+  `/tmp/pr2073_pulseplate_pr_review.md` completed; one advisory large-diff note
+  dispositioned as NOT-A-BUG above.
 
 ## Merge Readiness
 

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -72,6 +72,21 @@ Reason: The Codex review cited synthetic reviewed commit 7e387ce3981c743b656812d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523410269
 
 Disposition: NOT-A-BUG
+Evidence: git cat-file -e b3eec6be948d67df33a6b1cf082a4d76172f088d^{commit} fails locally while git log origin/main..HEAD contains ac08b4b6f4e241c18b62e24dbc90db027e78d985 with Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>.
+Reason: The Codex review cited synthetic reviewed commit b3eec6be948d67df33a6b1cf082a4d76172f088d, which is not present in the actual PR branch object database. The material Experiment Runner contribution remains the implementation commit ac08b4b6f4e241c18b62e24dbc90db027e78d985; later commits are fix/governance follow-ups.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523434325
+
+Disposition: FIXED
+Commit: f843dddd18b6a76ef5e08d73a0b7342512c24e10
+Evidence: scripts/ci/check_legacy_growth_guard.py:257 recognizes getattr(app, "include_router") call actions, scripts/ci/check_legacy_growth_guard.py:656 treats indirect include_router calls as router-registration calls, and tests/test_legacy_growth_guard.py:1199 covers the recipes router bypass.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523434326 -> f843dddd18b6a76ef5e08d73a0b7342512c24e10
+
+Disposition: NOT-A-BUG
+Evidence: git cat-file -e c036554829af5c11d4703d088647daa3964ba195^{commit} fails locally while git log origin/main..HEAD contains ac08b4b6f4e241c18b62e24dbc90db027e78d985 with Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>.
+Reason: The Codex review cited synthetic reviewed commit c036554829af5c11d4703d088647daa3964ba195, which is not present in the actual PR branch object database. The required trailer is present on the real material Experiment Runner commit, not on synthetic review-context SHAs.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523451234
+
+Disposition: NOT-A-BUG
 Evidence: tests/test_recipe_nutrition_reference_registration_bootstrap.py exercises app.main bootstrap ownership directly, and tests/test_legacy_growth_guard.py pins guard message output for intentional reintroduction regressions.
 Reason: Sourcery raised maintainability considerations, not a correctness/security defect; adding a public test helper or guard-message builder would widen this legacy-removal PR beyond route ownership migration.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#pullrequestreview-4629716524
@@ -133,6 +148,9 @@ runtime, provider, client, or public API authority.
 - `python scripts/orchestration/check_agent_consistency.py` - PASS.
 - `python -m pytest -q tests/test_recipes_api.py tests/test_recipe_preview.py tests/test_nutrition_recommendations_api.py` - PASS.
 - `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py` - PASS.
+- `python -m pytest -q tests/test_legacy_growth_guard.py::test_legacy_growth_guard_rejects_recipe_nutrition_reference_router_reintroduction` - PASS after the indirect include_router regression fix.
+- `python -m pytest -q tests/test_legacy_growth_guard.py` - PASS after the indirect include_router regression fix.
+- `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py` - PASS after the indirect include_router regression fix.
 - `python -m pytest -q tests/test_nutrition_recommendations_api.py::TestFreeRecommendationsSuccess::test_recommendations_success tests/test_recipe_nutrition_reference_registration_bootstrap.py::test_nutrition_recommendations_route_cannot_be_shadowed_by_dynamic_v1_alias` - PASS.
 - `python scripts/ci/check_legacy_growth_guard.py` - PASS.
 - `python -m mypy app/bootstrap/route_family.py app/main.py app/routers/recipes.py app/routers/nutrition_recommendations.py scripts/ci/check_legacy_growth_guard.py` - PASS.

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -46,8 +46,9 @@ local `make verify`.
 
 - [x] Fixed in commit mapping artifact created after GitHub assigned PR number
   `#2073`.
-- [ ] Post-open `qa-engineer-agent` pass completed.
-- [ ] Post-open `bug-hunter` pass completed.
+- [x] Post-open `qa-engineer-agent` pass completed.
+- [x] Post-open `bug-hunter` pass completed; three P2 findings fixed in
+  `8d50f28c1`.
 - [ ] Post-open `security-auditor` pass completed.
 - [ ] Codex Security diff scan / finding discovery completed for current head.
 - [ ] `pulseplate-pr-review` completed for current head.
@@ -58,13 +59,39 @@ local `make verify`.
 
 ## Fixed in Commit Mapping
 
-No review threads or actionable bot comments existed when this artifact was
-created. Future actionable comments must be added here with disposition-specific
-proof before any thread resolution or merge-readiness claim.
+No GitHub review threads or actionable bot comments existed when this artifact
+was created. The post-open `bug-hunter` role pass found three P2 actionables;
+they are dispositioned below.
+
+Disposition: FIXED
+Commit: 8d50f28c1
+Evidence: `app/bootstrap/route_family.py` now rejects existing static-family
+registrations whose FastAPI route order differs from source route order;
+`tests/test_main_paywall_bootstrap.py` covers generic order drift, and
+`tests/test_recipe_nutrition_reference_registration_bootstrap.py` covers
+`/api/v1/recipes/search` before `/api/v1/recipes/{recipe_id}`.
+Reason: Prevents a complete preexisting family from passing membership checks
+while shadowing `/api/v1/recipes/search` through `/{recipe_id}`.
+
+Disposition: FIXED
+Commit: 8d50f28c1
+Evidence:
+`docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md`
+now records the rejected zero-network attempt as an unpromoted infra caveat
+without presenting a duplicated artifact path as review evidence.
+Reason: Keeps Experiment Runner evidence locatable and avoids promoting a
+rejected local infra-flake artifact.
+
+Disposition: FIXED
+Commit: 8d50f28c1
+Evidence: `tests/test_recipe_nutrition_reference_registration_bootstrap.py`
+asserts the JSON `Content-Type` before parsing the recipe search response.
+Reason: Aligns the new bootstrap test with `tests/AGENTS.md` JSON response
+assertion policy.
 
 ## Review Comment Dispositions
 
-No review comments have been dispositioned yet.
+No GitHub review comments have been dispositioned yet.
 
 ## Experiment Runner Evidence
 
@@ -102,6 +129,16 @@ grant product runtime, provider, client, or public API authority.
   `tests/test_recipe_nutrition_reference_registration_bootstrap.py`.
 - Pre-push hooks - PASS: mypy changed files, pip-audit, backend pytest
   pre-push, full-repo Bandit, docker build test.
+- Bug-hunter fix validation:
+  `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_main_paywall_bootstrap.py::test_route_family_rejects_existing_route_order_drift`
+  - PASS.
+- Bug-hunter focused bundle:
+  `python -m pytest -q tests/test_recipes_api.py tests/test_recipe_preview.py tests/test_nutrition_recommendations_api.py tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
+  - PASS.
+- Bug-hunter fix `python scripts/ci/check_legacy_growth_guard.py` - PASS.
+- Bug-hunter fix `DEV_PYTHON=.venv/bin/python make openapi-check` - PASS.
+- Bug-hunter fix `pre-commit run --all-files` - PASS after Black formatted
+  `app/bootstrap/route_family.py` and affected tests were rerun.
 
 ## Merge Readiness
 

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -41,10 +41,25 @@ Evidence: docs/review/PR_2073_FIXED_MAPPING.md now checks the required Discussio
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#pullrequestreview-4629760831 -> 111cc0f77e2ee1b849c92555e85422bb74b39a2e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#pullrequestreview-4629802649 -> 111cc0f77e2ee1b849c92555e85422bb74b39a2e
 
+Disposition: FIXED
+Commit: c6b6fe41bf45317e607cf9e017ecb662c33aef8a
+Evidence: app/main.py:1208 registers recipe/nutrition-reference routes before the nutrition-state alias family, and tests/test_recipe_nutrition_reference_registration_bootstrap.py:187 asserts no dynamic /api/v1/nutrition route can precede GET /api/v1/nutrition/recommendations.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523395325 -> c6b6fe41bf45317e607cf9e017ecb662c33aef8a
+
 Disposition: NOT-A-BUG
 Evidence: git show -s --format=%B ac08b4b6f4e241c18b62e24dbc90db027e78d985 includes the canonical Experiment Runner co-author trailer, and the Phase2 gate inspects origin/main..HEAD for that trailer.
 Reason: The Codex review targeted superseded commit d412942d75db55ec3cbc6c1e296a54f95433f0da; current branch history carries the required trailer on the implementation commit.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523327703
+
+Disposition: NOT-A-BUG
+Evidence: docs/review/PR_2073_FIXED_MAPPING.md now has one checked post-open security-auditor row, and validate_mapping_artifact_text reports no artifact errors.
+Reason: The Codex review targeted superseded commit 3a888230a8 before the pushed mapping-format commits; current head no longer contains the duplicate unchecked row.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523395324
+
+Disposition: NOT-A-BUG
+Evidence: python scripts/ci/check_pr_body_phase2_gates.py --pr-number 2073 --body "$(gh pr view 2073 --json body --jq .body)" --commit-range origin/main..HEAD --experiment-runner-evidence-mode required passed with the current canonical artifact and PR body mirror.
+Reason: The Codex review targeted superseded commit 3a888230a8; current ## Fixed in Commit Mapping contains only parser-valid URL disposition blocks, with role-pass notes moved outside the canonical mapping section.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523395328
 
 Disposition: NOT-A-BUG
 Evidence: tests/test_recipe_nutrition_reference_registration_bootstrap.py exercises app.main bootstrap ownership directly, and tests/test_legacy_growth_guard.py pins guard message output for intentional reintroduction regressions.
@@ -108,6 +123,7 @@ runtime, provider, client, or public API authority.
 - `python scripts/orchestration/check_agent_consistency.py` - PASS.
 - `python -m pytest -q tests/test_recipes_api.py tests/test_recipe_preview.py tests/test_nutrition_recommendations_api.py` - PASS.
 - `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py` - PASS.
+- `python -m pytest -q tests/test_nutrition_recommendations_api.py::TestFreeRecommendationsSuccess::test_recommendations_success tests/test_recipe_nutrition_reference_registration_bootstrap.py::test_nutrition_recommendations_route_cannot_be_shadowed_by_dynamic_v1_alias` - PASS.
 - `python scripts/ci/check_legacy_growth_guard.py` - PASS.
 - `python -m mypy app/bootstrap/route_family.py app/main.py app/routers/recipes.py app/routers/nutrition_recommendations.py scripts/ci/check_legacy_growth_guard.py` - PASS.
 - `DEV_PYTHON=.venv/bin/python make openapi-check` - PASS.

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -1,0 +1,110 @@
+# PR 2073 - Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073
+
+Branch: `codex/move-recipe-nutrition-reference-registration-to-canonical-bootstrap`
+
+## Summary
+
+This PR moves recipe and FREE nutrition-reference route registration ownership
+from `legacy_app.py` to canonical `app/main.py` bootstrap while preserving
+runtime behavior, source route visibility, final public OpenAPI filtering,
+auth/tier posture, nutrition formula behavior, recipe-store behavior, and
+generated client artifacts.
+
+## Scope
+
+- Add static route specs for `recipes_router` and
+  `nutrition_recommendations_router`.
+- Register both routers through canonical route-family bootstrap in
+  `app/main.py`.
+- Remove only those two router imports/includes from `legacy_app.py`.
+- Tighten legacy-growth guard allowlists and regression tests.
+- Update backend routing map and attach premortem / Experiment Runner evidence.
+
+## Out Of Scope
+
+BOLA/authz expansion, BMI/users/restaurants ownership, premium nutrition
+handlers, middleware/lifespan behavior, recipe-store changes, nutrition formula
+changes, OpenAPI/client contract changes, frontend/iOS/macOS changes, and full
+local `make verify`.
+
+## Lane Start Provenance
+
+- Base branch: `main`
+- Branch:
+  `codex/move-recipe-nutrition-reference-registration-to-canonical-bootstrap`
+- Pre-open packet: `artifacts/orchestration/task_packets/3467351ee456.json`
+- Post-open review packet:
+  `artifacts/orchestration/task_packets/f5cb9acbe485.json`
+- Pre-edit role order executed:
+  `agent-coordinator -> backend-engineer -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`
+- Packet creation was treated as routing/provenance only. Role passes were
+  executed explicitly before implementation.
+
+## Discussion Thread Pass
+
+- [x] Fixed in commit mapping artifact created after GitHub assigned PR number
+  `#2073`.
+- [ ] Post-open `qa-engineer-agent` pass completed.
+- [ ] Post-open `bug-hunter` pass completed.
+- [ ] Post-open `security-auditor` pass completed.
+- [ ] Codex Security diff scan / finding discovery completed for current head.
+- [ ] `pulseplate-pr-review` completed for current head.
+- [ ] CodeRabbit actionable review comments checked and dispositioned.
+- [ ] Sourcery actionable review comments checked and dispositioned.
+- [ ] Cubic actionable review comments checked and dispositioned.
+- [ ] Discussion-thread pass completed.
+
+## Fixed in Commit Mapping
+
+No review threads or actionable bot comments existed when this artifact was
+created. Future actionable comments must be added here with disposition-specific
+proof before any thread resolution or merge-readiness claim.
+
+## Review Comment Dispositions
+
+No review comments have been dispositioned yet.
+
+## Experiment Runner Evidence
+
+- Artifact:
+  `artifacts/orchestration/experiments/results/recipe-nutrition-reference-oracle-result-v2.json`
+- Experiment id: `exp-4fe6753a1339`
+- Mode: `oracle_only_governance_reviewer`
+- Result: `accepted`
+- Contribution kind: `oracle_review`
+- `coauthor_required=true`
+- Commit carrying required trailer:
+  `ac08b4b6f4e241c18b62e24dbc90db027e78d985`
+
+Infra caveat: the first zero-network local attempt recorded
+`status=rejected`, `failure_class=infra_flake` because this development host
+does not provide `unshare` for the network-disabled sandbox. The accepted
+`network_budget=1` artifact kept the same local oracle commands and does not
+grant product runtime, provider, client, or public API authority.
+
+## Validation Evidence
+
+- `python scripts/orchestration/check_preflight.py` - PASS, with existing
+  private-index env warning only.
+- `python scripts/orchestration/check_agent_consistency.py` - PASS.
+- `python -m pytest -q tests/test_recipes_api.py tests/test_recipe_preview.py tests/test_nutrition_recommendations_api.py` - PASS.
+- `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py` - PASS.
+- `python scripts/ci/check_legacy_growth_guard.py` - PASS.
+- `python -m mypy app/main.py app/routers/recipes.py app/routers/nutrition_recommendations.py scripts/ci/check_legacy_growth_guard.py` - PASS.
+- `DEV_PYTHON=.venv/bin/python make openapi-check` - PASS.
+- `git diff --exit-code -- frontend/src/api/openapi.json frontend/src/api/schema.ts` - PASS.
+- `pre-commit run --all-files` - PASS after Black formatted the new bootstrap
+  test and the affected tests were rerun.
+- `make validate-changed` - PASS after commit; selected
+  `tests/test_legacy_growth_guard.py` and
+  `tests/test_recipe_nutrition_reference_registration_bootstrap.py`.
+- Pre-push hooks - PASS: mypy changed files, pip-audit, backend pytest
+  pre-push, full-repo Bandit, docker build test.
+
+## Merge Readiness
+
+Not claimed here. Requires current-head CI after the latest mapping/body commit,
+post-open role chain, Codex Security / review-bot pass, discussion-thread
+disposition, strict merge-readiness gate, and resolved review threads.

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -83,9 +83,9 @@ Evidence: scripts/ci/check_legacy_growth_guard.py:257 recognizes getattr(app, "i
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523434326 -> f843dddd18b6a76ef5e08d73a0b7342512c24e10
 
 Disposition: FIXED
-Commit: 41c09ce035c63cde9eb0591af4efa5ddc64123ca
+Commit: 41c09ce0353572b2c631099a77278193225f0cc1
 Evidence: scripts/ci/check_legacy_growth_guard.py:697 resolves getattr method-name aliases through collected static string bindings, and tests/test_legacy_growth_guard.py:1215 covers the bound method-name recipes router bypass.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523515621 -> 41c09ce035c63cde9eb0591af4efa5ddc64123ca
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523515621 -> 41c09ce0353572b2c631099a77278193225f0cc1
 
 Disposition: NOT-A-BUG
 Evidence: git cat-file -e c036554829af5c11d4703d088647daa3964ba195^{commit} fails locally while git log origin/main..HEAD contains ac08b4b6f4e241c18b62e24dbc90db027e78d985 with Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>.

--- a/docs/review/PR_2073_FIXED_MAPPING.md
+++ b/docs/review/PR_2073_FIXED_MAPPING.md
@@ -20,7 +20,7 @@ generated client artifacts.
 - [x] Pre-edit role order completed: `agent-coordinator -> backend-engineer -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`.
 - [x] Post-open role chain completed: `qa-engineer-agent -> bug-hunter -> security-auditor`.
 - [x] Post-open bug-hunter findings fixed and re-reviewed.
-- [x] Initial Codex Security diff scan / finding discovery completed for 191a2a317a42b6b7cc255e0011affedfe74e4435; current-head rescan e82db3b8-d682-4072-b013-ac81071d0663 was started for 55b527d22325ca655e66e8507edea6c15b48bb56 and remains pending in preflight.
+- [x] Codex Security diff scan / finding discovery completed for latest security-relevant head 55b527d22325ca655e66e8507edea6c15b48bb56; later changes only record scan evidence.
 - [x] `pulseplate-pr-review` completed; advisory large-diff note dispositioned below.
 - [x] Codex review actionable comments checked and dispositioned below.
 - [x] CodeRabbit actionable review comments checked and dispositioned below.
@@ -60,6 +60,16 @@ Disposition: NOT-A-BUG
 Evidence: python scripts/ci/check_pr_body_phase2_gates.py --pr-number 2073 --body "$(gh pr view 2073 --json body --jq .body)" --commit-range origin/main..HEAD --experiment-runner-evidence-mode required passed with the current canonical artifact and PR body mirror.
 Reason: The Codex review targeted superseded commit 3a888230a8; current ## Fixed in Commit Mapping contains only parser-valid URL disposition blocks, with role-pass notes moved outside the canonical mapping section.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523395328
+
+Disposition: NOT-A-BUG
+Evidence: git log origin/main..HEAD contains ac08b4b6f4e241c18b62e24dbc90db027e78d985 with Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>; later commits are fix/governance follow-ups, not additional material Experiment Runner contributions.
+Reason: The Codex review cited synthetic reviewed commit 7e387ce3981c743b656812d3cc76e3a885a4fd18, which is not present in the local branch object database; the repo rule requires the trailer on the material runner-shaped implementation commit, not every synthetic review context or docs-only follow-up.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523410266
+
+Disposition: NOT-A-BUG
+Evidence: GH_TOKEN="$(gh auth token)" python scripts/orchestration/check_review_threads_disposition.py --pr-number 2073 --require-auth passed on the actual branch head, and git log origin/main..HEAD contains the mapped FIXED proof commits 8d50f28c1, 111cc0f77e2ee1b849c92555e85422bb74b39a2e, and c6b6fe41bf45317e607cf9e017ecb662c33aef8a.
+Reason: The Codex review cited synthetic reviewed commit 7e387ce3981c743b656812d3cc76e3a885a4fd18 instead of the actual PR branch history. The repo disposition guard is authoritative for resolvable proof SHAs and commit-after-comment validation.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2073#discussion_r3523410269
 
 Disposition: NOT-A-BUG
 Evidence: tests/test_recipe_nutrition_reference_registration_bootstrap.py exercises app.main bootstrap ownership directly, and tests/test_legacy_growth_guard.py pins guard message output for intentional reintroduction regressions.
@@ -132,11 +142,10 @@ runtime, provider, client, or public API authority.
 - `make validate-changed` - PASS on latest implementation head; selected tests/test_legacy_growth_guard.py, tests/test_main_paywall_bootstrap.py, and tests/test_recipe_nutrition_reference_registration_bootstrap.py.
 - Pre-push hooks - PASS on pushed heads: mypy where applicable, pip-audit, backend pytest pre-push, full-repo Bandit, and docker build test where applicable.
 - Codex Security diff scan 08025660-053e-4a39-bb72-73277fe7c22f completed with 0 findings and 6/6 coverage rows closed for 8fdcd0ac1668f612de4dca90846fd994967e60df..191a2a317a42b6b7cc255e0011affedfe74e4435.
-- Current-head Codex Security scan e82db3b8-d682-4072-b013-ac81071d0663 was opened for 8fdcd0ac1668f612de4dca90846fd994967e60df..55b527d22325ca655e66e8507edea6c15b48bb56; it remained in preflight during this pass and is not counted as pass evidence.
+- Current-head Codex Security scan e82db3b8-d682-4072-b013-ac81071d0663 completed for 8fdcd0ac1668f612de4dca90846fd994967e60df..55b527d22325ca655e66e8507edea6c15b48bb56 with 0 findings and complete coverage.
 - `pulseplate-pr-review` completed; one advisory large-diff note dispositioned as NOT-A-BUG above.
 
 ## Merge Readiness
 
 Not claimed here. Requires current-head CI after the latest mapping/body commit,
-current-head Codex Security completion, strict merge-readiness gate, and resolved
-review threads.
+strict merge-readiness gate, and resolved review threads.

--- a/docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md
+++ b/docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md
@@ -1,0 +1,65 @@
+# Recipe/Nutrition Reference Canonical Bootstrap Experiment Runner Evidence
+
+Target branch:
+`codex/move-recipe-nutrition-reference-registration-to-canonical-bootstrap`
+
+Raw Experiment Runner JSON artifacts remain local and gitignored:
+
+- Packet:
+  `artifacts/orchestration/experiments/recipe-nutrition-reference-oracle-v2.json`
+- Result:
+  `artifacts/orchestration/experiments/results/recipe-nutrition-reference-oracle-result-v2.json`
+
+## Result
+
+- Experiment id: `exp-4fe6753a1339`
+- Runner mode: `oracle_only_governance_reviewer`
+- Status: `accepted`
+- Failure class: `None`
+- Mutated paths: `[]`
+- Shared tree untouched: `true`
+- Contribution kind: `oracle_review`
+- Co-author required: `true`
+
+The accepted oracle result applied the current branch diff for:
+
+- `app/main.py`
+- `app/routers/nutrition_recommendations.py`
+- `app/routers/recipes.py`
+- `docs/architecture/backend_routing_map.md`
+- `legacy_app.py`
+- `scripts/ci/check_legacy_growth_guard.py`
+- `tests/test_legacy_growth_guard.py`
+- `tests/test_recipe_nutrition_reference_registration_bootstrap.py`
+
+## Oracle Commands
+
+1. `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
+   - Result: PASS
+   - Evidence summary: pytest completed with returncode `0`.
+2. `python scripts/ci/check_legacy_growth_guard.py`
+   - Result: PASS
+   - Evidence summary: `legacy compatibility seam guard passed`.
+
+## Infra Caveat
+
+The first zero-network local attempt wrote:
+
+- Result:
+  `artifacts/orchestration/experiments/results/artifacts/orchestration/experiments/results/exp-recipe-nutrition-reference-zero-network-result.json`
+- Status: `rejected`
+- Failure class: `infra_flake`
+- Runner error: network-disabled sandbox requires `unshare` on PATH.
+
+The accepted `network_budget=1` artifact keeps the same local oracle intent and
+does not grant product runtime, provider, client, or public API authority. It
+only avoids an unavailable OS-level network sandbox on this development host.
+
+## Attribution
+
+The Experiment Runner oracle-only evidence shaped validation and PR evidence for
+this route-ownership migration. The implementation commit must include:
+
+```text
+Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>
+```

--- a/docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md
+++ b/docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md
@@ -43,10 +43,8 @@ The accepted oracle result applied the current branch diff for:
 
 ## Infra Caveat
 
-The first zero-network local attempt wrote:
+The first zero-network local attempt was not promoted as review evidence:
 
-- Result:
-  `artifacts/orchestration/experiments/results/artifacts/orchestration/experiments/results/exp-recipe-nutrition-reference-zero-network-result.json`
 - Status: `rejected`
 - Failure class: `infra_flake`
 - Runner error: network-disabled sandbox requires `unshare` on PATH.

--- a/docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_PREMORTEM.md
+++ b/docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_PREMORTEM.md
@@ -1,0 +1,107 @@
+# Recipe/Nutrition Reference Canonical Bootstrap Premortem
+
+Mode: `pr-premortem`
+
+Task packet: `artifacts/orchestration/task_packets/3467351ee456.json`
+
+Branch: `codex/move-recipe-nutrition-reference-registration-to-canonical-bootstrap`
+
+## Summary
+
+Plan: move only recipe and FREE nutrition-reference route registration ownership
+from `legacy_app.py` to canonical `app/main.py` bootstrap while preserving
+runtime behavior, OpenAPI filtering, response schemas, auth/tier posture,
+nutrition formulas, recipe store behavior, generated clients, and frontend/iOS
+surfaces.
+
+Failure frame: six months from now this PR failed because the route ownership
+migration looked mechanical, but a subtle registration, guard, OpenAPI, or
+auth/tier drift changed production behavior.
+
+## Most Likely Failure
+
+`recipes_router` or `nutrition_recommendations_router` is reintroduced into
+`legacy_app.py` through an alias, module-qualified include, dynamic import,
+computed import string, destructuring/walrus assignment, or nested wrapper
+router. The product still starts, but canonical bootstrap ownership silently
+splits again and future legacy-removal PRs inherit false evidence.
+
+Closure: FIXED in this PR diff.
+
+Evidence:
+
+- `scripts/ci/check_legacy_growth_guard.py` removes recipes and nutrition
+  recommendations from the legacy allowlist.
+- `tests/test_legacy_growth_guard.py` rejects direct, aliased,
+  module-qualified, dynamic/computed import, destructuring/walrus, and nested
+  wrapper-router reintroduction patterns.
+- `python scripts/ci/check_legacy_growth_guard.py` passes.
+
+## Most Dangerous Failure
+
+Recipes or nutrition recommendations become visible in public `app.openapi()`,
+or their source route visibility drifts, because source-router metadata and
+final public OpenAPI filtering are different proof surfaces. That would create
+a public API/client contract change outside this PR scope.
+
+Closure: FIXED in this PR diff.
+
+Evidence:
+
+- `RECIPES_ROUTE_SPECS` and `NUTRITION_RECOMMENDATIONS_ROUTE_SPECS` preserve
+  source route `include_in_schema=True`.
+- `tests/test_recipe_nutrition_reference_registration_bootstrap.py` verifies
+  source visibility, registered-route visibility, and final public OpenAPI
+  filtering for `/api/v1/recipes*` and `/api/v1/nutrition/recommendations`.
+- `DEV_PYTHON=.venv/bin/python make openapi-check` passes and generated
+  frontend OpenAPI artifacts have no diff.
+
+## Hidden Assumption
+
+This slice assumes route registration can move without changing behavior if the
+same paths still respond. In this repo that is not enough: duplicate
+method/path ownership, partial registration, wrong method, foreign handlers,
+visibility drift, and auth/tier dependency drift are part of the migration
+contract.
+
+Closure: FIXED in this PR diff.
+
+Evidence:
+
+- `app/main.py` registers the route family through
+  `ensure_route_family_registered(...)` with explicit static route members.
+- `tests/test_recipe_nutrition_reference_registration_bootstrap.py` covers empty
+  app registration, bootstrapped app registration, idempotency, partial
+  registration, duplicate method/path, foreign handlers, wrong method,
+  visibility drift, and absence of auth/tier dependencies for this FREE
+  reference slice.
+- Existing recipes and nutrition recommendation behavior tests pass unchanged.
+
+## Revised Plan
+
+1. Keep the diff registration-only: no BOLA/authz expansion, premium
+   nutrition handler move, restaurant/user move, recipe-store changes, formula
+   changes, OpenAPI/client generation changes, or frontend/iOS/macOS changes.
+2. Use the established static route-family bootstrap pattern in `app/main.py`.
+3. Treat OpenAPI, guard, auth/tier, and focused behavior tests as proof
+   surfaces only; do not invent new response metadata or new product behavior.
+4. Keep rollback bounded to restoring the removed legacy imports/includes and
+   removing the new canonical bootstrap helper/spec contracts.
+
+## Pre-Merge Checklist
+
+- Focused recipe/nutrition-reference bootstrap tests pass.
+- Existing recipes and nutrition recommendation behavior tests pass.
+- Legacy-growth guard rejects recipes/nutrition-reference regrowth.
+- Public OpenAPI/client artifacts remain unchanged.
+- Auth/tier static contract tests pass for the moved FREE/reference surface.
+- `make validate-changed` and `pre-commit run --all-files` pass on the
+  committed branch diff.
+- Post-open review chain runs before readiness claims.
+
+## Decision
+
+`proceed with changes`
+
+All premortem findings identified for this PR scope are closed by code,
+deterministic tests, guard narrowing, and routing evidence in this PR diff.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -49,8 +49,6 @@ from app.http_error_details import (
     INVALID_PREMIUM_PLATE_INPUT_DETAIL,
 )
 from app.routers.api_key import api_key_header
-from app.routers.nutrition_recommendations import router as nutrition_recommendations_router
-from app.routers.recipes import router as recipes_router
 from app.routers.restaurants import router as restaurants_router
 from app.routers.users import router as users_router
 from app.schemas.bmr import BMRRequest, BMRRequestLegacy, BMRResponse
@@ -907,9 +905,7 @@ async def admin_status() -> Dict[str, str]:
 
 
 # Include API routers
-app.include_router(nutrition_recommendations_router)
 app.include_router(restaurants_router, include_in_schema=False)
-app.include_router(recipes_router)
 app.include_router(users_router)
 
 # PRO/VIP route registration is owned by app.main canonical bootstrap.

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -101,9 +101,7 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("decorator", "post", "/api/v1/premium/targets", "api_who_targets"),
         LegacyFact("decorator", "post", "/api/v1/premium/plan/week", "api_weekly_menu"),
         LegacyFact("decorator", "post", "/api/v1/premium/gaps", "api_nutrient_gaps"),
-        LegacyFact("registration", "include_router", "nutrition_recommendations_router", ""),
         LegacyFact("registration", "include_router", "restaurants_router", ""),
-        LegacyFact("registration", "include_router", "recipes_router", ""),
         LegacyFact("registration", "include_router", "users_router", ""),
     }
 )
@@ -113,12 +111,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
         LegacyFact("router_import", "app.routers", "vip", "_vip_mod"),
         LegacyFact("router_import", "app.routers.api_key", "api_key_header", ""),
         LegacyFact("router_import", "app.routers.bmi", "bmi_calculate_handler", ""),
-        LegacyFact(
-            "router_import",
-            "app.routers.nutrition_recommendations",
-            "router",
-            "nutrition_recommendations_router",
-        ),
         LegacyFact("router_import", "dynamic", "app.routers.plan_export", "_plan_mod"),
         LegacyFact(
             "router_import", "app.routers.pro_nutrition_contracts", "pro_nutrition_plate", ""
@@ -126,7 +118,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
         LegacyFact(
             "router_import", "app.routers.pro_nutrition_contracts", "pro_nutrition_targets", ""
         ),
-        LegacyFact("router_import", "app.routers.recipes", "router", "recipes_router"),
         LegacyFact("router_import", "app.routers.restaurants", "router", "restaurants_router"),
         LegacyFact("router_import", "app.routers.users", "router", "users_router"),
         LegacyFact(

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -229,6 +229,7 @@ def _app_call_action(
     *,
     app_aliases: frozenset[str] = frozenset({"app"}),
     router_aliases: frozenset[str] = frozenset(),
+    static_string_bindings: Mapping[str, str] | None = None,
 ) -> str | None:
     if isinstance(func, ast.Attribute) and func.attr in methods:
         if isinstance(func.value, ast.Name) and func.value.id in app_aliases:
@@ -248,6 +249,7 @@ def _app_call_action(
         methods,
         app_aliases=app_aliases,
         router_aliases=router_aliases,
+        static_string_bindings=static_string_bindings,
     )
     if getattr_action is not None:
         return getattr_action
@@ -260,8 +262,13 @@ def _getattr_app_call_action(
     *,
     app_aliases: frozenset[str],
     router_aliases: frozenset[str],
+    static_string_bindings: Mapping[str, str] | None = None,
 ) -> str | None:
-    method = _getattr_method_name(func, methods)
+    method = _getattr_method_name(
+        func,
+        methods,
+        static_string_bindings=static_string_bindings,
+    )
     if method is None or not isinstance(func, ast.Call) or not func.args:
         return None
     target = func.args[0]
@@ -288,6 +295,7 @@ def collect_legacy_route_facts(source_text: str, *, filename: str = LEGACY_APP) 
 
     facts: set[LegacyFact] = set()
     app_aliases, router_aliases = _collect_app_aliases(tree)
+    static_string_bindings = _collect_static_string_bindings(tree)
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             for decorator in node.decorator_list:
@@ -298,6 +306,7 @@ def collect_legacy_route_facts(source_text: str, *, filename: str = LEGACY_APP) 
                     APP_ROUTE_METHODS,
                     app_aliases=app_aliases,
                     router_aliases=router_aliases,
+                    static_string_bindings=static_string_bindings,
                 )
                 if action is not None:
                     facts.add(
@@ -310,6 +319,7 @@ def collect_legacy_route_facts(source_text: str, *, filename: str = LEGACY_APP) 
                 APP_REGISTRATION_METHODS,
                 app_aliases=app_aliases,
                 router_aliases=router_aliases,
+                static_string_bindings=static_string_bindings,
             )
             if action is not None:
                 facts.add(LegacyFact("registration", action, _first_arg_label(call), ""))
@@ -335,7 +345,10 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
         import_func_names=dynamic_import_names,
         static_string_bindings=static_string_bindings,
     )
-    registered_router_targets = _collect_registered_router_targets(tree)
+    registered_router_targets = _collect_registered_router_targets(
+        tree,
+        static_string_bindings=static_string_bindings,
+    )
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module is not None:
             if node.module != "app.routers" and not node.module.startswith("app.routers."):
@@ -372,7 +385,10 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
             ):
                 facts.add(LegacyFact("router_import", "dynamic", module_name, target_name))
         elif isinstance(node, ast.Call):
-            if not _is_router_registration_call(node):
+            if not _is_router_registration_call(
+                node,
+                static_string_bindings=static_string_bindings,
+            ):
                 continue
             for module_name in _dynamic_app_router_import_modules(
                 node,
@@ -392,6 +408,7 @@ def collect_router_import_facts(source_text: str, *, filename: str = LEGACY_APP)
             for module_name in _tainted_dynamic_router_modules_in_registration_call(
                 node,
                 dynamic_import_target_modules,
+                static_string_bindings=static_string_bindings,
             ):
                 facts.add(
                     LegacyFact(
@@ -537,10 +554,17 @@ def _static_app_router_hint(
     return False
 
 
-def _collect_registered_router_targets(tree: ast.Module) -> frozenset[str]:
+def _collect_registered_router_targets(
+    tree: ast.Module,
+    *,
+    static_string_bindings: Mapping[str, str] | None = None,
+) -> frozenset[str]:
     targets: set[str] = set()
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not _is_router_registration_call(node):
+        if not isinstance(node, ast.Call) or not _is_router_registration_call(
+            node,
+            static_string_bindings=static_string_bindings,
+        ):
             continue
         if not node.args:
             continue
@@ -653,22 +677,36 @@ def _is_dynamic_import_function_reference(
     return isinstance(node, ast.Attribute) and node.attr == "import_module"
 
 
-def _is_router_registration_call(call: ast.Call) -> bool:
+def _is_router_registration_call(
+    call: ast.Call,
+    *,
+    static_string_bindings: Mapping[str, str] | None = None,
+) -> bool:
     return (
         isinstance(call.func, ast.Attribute)
         and call.func.attr in APP_REGISTRATION_METHODS
-        or _getattr_method_name(call.func, APP_REGISTRATION_METHODS) is not None
+        or _getattr_method_name(
+            call.func,
+            APP_REGISTRATION_METHODS,
+            static_string_bindings=static_string_bindings,
+        )
+        is not None
     )
 
 
-def _getattr_method_name(func: ast.AST, methods: AbstractSet[str]) -> str | None:
+def _getattr_method_name(
+    func: ast.AST,
+    methods: AbstractSet[str],
+    *,
+    static_string_bindings: Mapping[str, str] | None = None,
+) -> str | None:
     if not isinstance(func, ast.Call):
         return None
     if not isinstance(func.func, ast.Name) or func.func.id != "getattr":
         return None
     if len(func.args) < 2:
         return None
-    method = _resolve_static_string(func.args[1], {})
+    method = _resolve_static_string(func.args[1], static_string_bindings or {})
     if method in methods:
         return method
     return None
@@ -738,17 +776,26 @@ def _dynamic_app_router_import_assignments(
 def _tainted_dynamic_router_modules_in_registration_call(
     call: ast.Call,
     dynamic_import_target_modules: Mapping[str, AbstractSet[str]],
+    *,
+    static_string_bindings: Mapping[str, str] | None = None,
 ) -> frozenset[str]:
     """Return unresolved dynamic imports routed through wrapper-router registration args."""
 
     if not call.args:
         return frozenset()
-    if isinstance(call.args[0], ast.Name) and _is_app_include_router_func(call.func):
+    if isinstance(call.args[0], ast.Name) and _is_app_include_router_func(
+        call.func,
+        static_string_bindings=static_string_bindings,
+    ):
         return frozenset()
     return _tainted_dynamic_router_modules_in_node(call.args[0], dynamic_import_target_modules)
 
 
-def _is_app_include_router_func(func: ast.AST) -> bool:
+def _is_app_include_router_func(
+    func: ast.AST,
+    *,
+    static_string_bindings: Mapping[str, str] | None = None,
+) -> bool:
     if (
         isinstance(func, ast.Attribute)
         and func.attr == "include_router"
@@ -756,7 +803,14 @@ def _is_app_include_router_func(func: ast.AST) -> bool:
         and func.value.id == "app"
     ):
         return True
-    if _getattr_method_name(func, frozenset({"include_router"})) != "include_router":
+    if (
+        _getattr_method_name(
+            func,
+            frozenset({"include_router"}),
+            static_string_bindings=static_string_bindings,
+        )
+        != "include_router"
+    ):
         return False
     if not isinstance(func, ast.Call) or not func.args:
         return False
@@ -1038,6 +1092,7 @@ def collect_sensitive_app_surface_counts(
     app_surface_methods = APP_ROUTE_METHODS | APP_REGISTRATION_METHODS
     sensitive_names = _collect_sensitive_names(tree)
     app_aliases, router_aliases = _collect_app_aliases(tree)
+    static_string_bindings = _collect_static_string_bindings(tree)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -1047,6 +1102,7 @@ def collect_sensitive_app_surface_counts(
                 app_surface_methods,
                 app_aliases=app_aliases,
                 router_aliases=router_aliases,
+                static_string_bindings=static_string_bindings,
             )
             is None
         ):

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -230,19 +230,52 @@ def _app_call_action(
     app_aliases: frozenset[str] = frozenset({"app"}),
     router_aliases: frozenset[str] = frozenset(),
 ) -> str | None:
-    if not isinstance(func, ast.Attribute) or func.attr not in methods:
+    if isinstance(func, ast.Attribute) and func.attr in methods:
+        if isinstance(func.value, ast.Name) and func.value.id in app_aliases:
+            return func.attr
+        if isinstance(func.value, ast.Name) and func.value.id in router_aliases:
+            return f"router.{func.attr}"
+        if (
+            isinstance(func.value, ast.Attribute)
+            and func.value.attr == "router"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id in app_aliases
+        ):
+            return f"router.{func.attr}"
+
+    getattr_action = _getattr_app_call_action(
+        func,
+        methods,
+        app_aliases=app_aliases,
+        router_aliases=router_aliases,
+    )
+    if getattr_action is not None:
+        return getattr_action
+    return None
+
+
+def _getattr_app_call_action(
+    func: ast.AST,
+    methods: AbstractSet[str],
+    *,
+    app_aliases: frozenset[str],
+    router_aliases: frozenset[str],
+) -> str | None:
+    method = _getattr_method_name(func, methods)
+    if method is None or not isinstance(func, ast.Call) or not func.args:
         return None
-    if isinstance(func.value, ast.Name) and func.value.id in app_aliases:
-        return func.attr
-    if isinstance(func.value, ast.Name) and func.value.id in router_aliases:
-        return f"router.{func.attr}"
+    target = func.args[0]
+    if isinstance(target, ast.Name) and target.id in app_aliases:
+        return method
+    if isinstance(target, ast.Name) and target.id in router_aliases:
+        return f"router.{method}"
     if (
-        isinstance(func.value, ast.Attribute)
-        and func.value.attr == "router"
-        and isinstance(func.value.value, ast.Name)
-        and func.value.value.id in app_aliases
+        isinstance(target, ast.Attribute)
+        and target.attr == "router"
+        and isinstance(target.value, ast.Name)
+        and target.value.id in app_aliases
     ):
-        return f"router.{func.attr}"
+        return f"router.{method}"
     return None
 
 
@@ -621,7 +654,24 @@ def _is_dynamic_import_function_reference(
 
 
 def _is_router_registration_call(call: ast.Call) -> bool:
-    return isinstance(call.func, ast.Attribute) and call.func.attr in APP_REGISTRATION_METHODS
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr in APP_REGISTRATION_METHODS
+        or _getattr_method_name(call.func, APP_REGISTRATION_METHODS) is not None
+    )
+
+
+def _getattr_method_name(func: ast.AST, methods: AbstractSet[str]) -> str | None:
+    if not isinstance(func, ast.Call):
+        return None
+    if not isinstance(func.func, ast.Name) or func.func.id != "getattr":
+        return None
+    if len(func.args) < 2:
+        return None
+    method = _resolve_static_string(func.args[1], {})
+    if method in methods:
+        return method
+    return None
 
 
 def _assignment_target_names(node: ast.AST) -> tuple[str, ...]:
@@ -693,9 +743,25 @@ def _tainted_dynamic_router_modules_in_registration_call(
 
     if not call.args:
         return frozenset()
-    if isinstance(call.args[0], ast.Name) and _safe_unparse(call.func) == "app.include_router":
+    if isinstance(call.args[0], ast.Name) and _is_app_include_router_func(call.func):
         return frozenset()
     return _tainted_dynamic_router_modules_in_node(call.args[0], dynamic_import_target_modules)
+
+
+def _is_app_include_router_func(func: ast.AST) -> bool:
+    if (
+        isinstance(func, ast.Attribute)
+        and func.attr == "include_router"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "app"
+    ):
+        return True
+    if _getattr_method_name(func, frozenset({"include_router"})) != "include_router":
+        return False
+    if not isinstance(func, ast.Call) or not func.args:
+        return False
+    target = func.args[0]
+    return isinstance(target, ast.Name) and target.id == "app"
 
 
 def _tainted_dynamic_router_modules_in_node(

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -1198,6 +1198,22 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
         ),
         (
             textwrap.dedent("""
+                from importlib import import_module
+
+                getattr(app, "include_router")(
+                    import_module("app.routers.recipes").router
+                )
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:import_module('app.routers.recipes').router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.recipes -> "
+                "getattr(app, 'include_router')",
+            ],
+        ),
+        (
+            textwrap.dedent("""
                 import importlib
 
                 wrapper_router = APIRouter()

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -1214,6 +1214,22 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
         ),
         (
             textwrap.dedent("""
+                from importlib import import_module
+
+                method = "include_" + "router"
+                getattr(app, method)(
+                    import_module("app.routers.recipes").router
+                )
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:import_module('app.routers.recipes').router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.recipes -> getattr(app, method)",
+            ],
+        ),
+        (
+            textwrap.dedent("""
                 import importlib
 
                 wrapper_router = APIRouter()

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -1079,6 +1079,157 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
     [
         (
             textwrap.dedent("""
+                from app.routers.recipes import router as recipes_router
+
+                app.include_router(recipes_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:recipes_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.recipes:router -> recipes_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from app.routers.nutrition_recommendations import (
+                    router as nutrition_recommendations_router,
+                )
+
+                app.include_router(nutrition_recommendations_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:nutrition_recommendations_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.nutrition_recommendations:router -> "
+                "nutrition_recommendations_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from app.routers.recipes import router as canonical_recipes_router
+
+                app.include_router(canonical_recipes_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:canonical_recipes_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.recipes:router -> canonical_recipes_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import app.routers.recipes as recipe_routes
+
+                app.include_router(recipe_routes.router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:recipe_routes.router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:import:app.routers.recipes -> recipe_routes",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                module_name = "app.routers." + "recipes"
+                recipe_router = importlib.import_module(module_name).router
+                app.include_router(recipe_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:recipe_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.recipes -> recipe_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                family = "nutrition_recommendations"
+                module_name = f"app.routers.{family}"
+                nutrition_router = importlib.import_module(module_name).router
+                app.include_router(nutrition_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:nutrition_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.nutrition_recommendations -> "
+                "nutrition_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                nutrition_recommendations_router, _ = (
+                    importlib.import_module("app.routers.nutrition_recommendations").router,
+                    None,
+                )
+                app.include_router(nutrition_recommendations_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:nutrition_recommendations_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.nutrition_recommendations -> "
+                "nutrition_recommendations_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from importlib import import_module
+
+                if (recipes_router := import_module("app.routers.recipes").router):
+                    app.include_router(recipes_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:recipes_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.recipes -> recipes_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                wrapper_router = APIRouter()
+                wrapper_router.include_router(
+                    importlib.import_module("app.routers.nutrition_recommendations").router
+                )
+                app.include_router(wrapper_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:wrapper_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.nutrition_recommendations -> "
+                "wrapper_router.include_router",
+            ],
+        ),
+    ],
+)
+def test_legacy_growth_guard_rejects_recipe_nutrition_reference_router_reintroduction(
+    source: str,
+    expected: list[str],
+) -> None:
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            textwrap.dedent("""
                 import importlib
 
                 module_name = "app.routers." + "foods"
@@ -1086,8 +1237,10 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
                 app.include_router(recipes_router)
                 """),
             [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:recipes_router",
                 "legacy_app.py: unexpected app.routers import growth: "
-                "router_import:dynamic:app.routers.foods -> recipes_router"
+                "router_import:dynamic:app.routers.foods -> recipes_router",
             ],
         ),
         (
@@ -1128,9 +1281,11 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
                 app.include_router(nutrition_recommendations_router)
                 """),
             [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:nutrition_recommendations_router",
                 "legacy_app.py: unexpected app.routers import growth: "
                 "router_import:dynamic:<unresolved app.routers import> -> "
-                "nutrition_recommendations_router"
+                "nutrition_recommendations_router",
             ],
         ),
         (
@@ -1143,8 +1298,10 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
                 app.include_router(recipes_router)
                 """),
             [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:recipes_router",
                 "legacy_app.py: unexpected app.routers import growth: "
-                "router_import:dynamic:<unresolved dynamic router import> -> recipes_router"
+                "router_import:dynamic:<unresolved dynamic router import> -> recipes_router",
             ],
         ),
         (
@@ -1157,9 +1314,11 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
                 app.include_router(recipes_router)
                 """),
             [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:recipes_router",
                 "legacy_app.py: unexpected app.routers import growth: "
                 "router_import:dynamic:<unresolved dynamic router import> -> "
-                "recipes_router.include_router"
+                "recipes_router.include_router",
             ],
         ),
         (
@@ -1173,9 +1332,11 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
                 app.include_router(recipes_router)
                 """),
             [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:recipes_router",
                 "legacy_app.py: unexpected app.routers import growth: "
                 "router_import:dynamic:<unresolved dynamic router import> -> "
-                "recipes_router.include_router"
+                "recipes_router.include_router",
             ],
         ),
         (
@@ -1186,8 +1347,10 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
                 app.include_router(recipes_router)
                 """),
             [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:recipes_router",
                 "legacy_app.py: unexpected app.routers import growth: "
-                "router_import:dynamic:app.routers.foods -> recipes_router"
+                "router_import:dynamic:app.routers.foods -> recipes_router",
             ],
         ),
     ],
@@ -1208,7 +1371,7 @@ def test_legacy_growth_guard_allows_unregistered_dynamic_import_without_router_u
 
         module = import_module(os.getenv("LEGACY_HELPER_MODULE"))
         value = module.VALUE
-        app.include_router(recipes_router)
+        app.include_router(users_router)
         """)
 
     assert legacy_guard.validate_legacy_growth(source) == []
@@ -1675,7 +1838,7 @@ def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_route() -> None:
 
 
 def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_router() -> None:
-    source = "app.include_router(recipes_router, dependencies=[Depends(auth_guard)])\n"
+    source = "app.include_router(users_router, dependencies=[Depends(auth_guard)])\n"
 
     errors = legacy_guard.validate_legacy_growth(source)
 
@@ -1694,7 +1857,7 @@ def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_router() -> None
             """),
         textwrap.dedent("""
             deps = [Depends(auth_guard)]
-            app.include_router(recipes_router, dependencies=deps)
+            app.include_router(users_router, dependencies=deps)
             """),
     ],
 )

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -161,6 +161,42 @@ def test_route_family_contract_builder_rejects_duplicate_source_routes() -> None
         )
 
 
+def test_route_family_rejects_existing_route_order_drift() -> None:
+    router = APIRouter()
+
+    async def _search() -> dict[str, str]:
+        return {"status": "search"}
+
+    async def _item(item_id: str) -> dict[str, str]:
+        return {"status": item_id}
+
+    router.get("/api/v1/static-family/search")(_search)
+    router.get("/api/v1/static-family/{item_id}")(_item)
+
+    target_app = FastAPI()
+    target_app.add_api_route(
+        "/api/v1/static-family/{item_id}",
+        _item,
+        methods=["GET"],
+    )
+    target_app.add_api_route(
+        "/api/v1/static-family/search",
+        _search,
+        methods=["GET"],
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing static family route order does not preserve source route order",
+    ):
+        ensure_route_family_registered(
+            target_app,
+            family_name="Static family",
+            routers=(router,),
+            members=route_member_contracts_from_router("Static family", router),
+        )
+
+
 def test_route_family_rejects_non_http_source_routes_for_static_tail_coverage() -> None:
     router = APIRouter()
 

--- a/tests/test_recipe_nutrition_reference_registration_bootstrap.py
+++ b/tests/test_recipe_nutrition_reference_registration_bootstrap.py
@@ -184,6 +184,25 @@ def test_recipe_search_alias_remains_reachable(
     assert response.json() == []
 
 
+def test_nutrition_recommendations_route_cannot_be_shadowed_by_dynamic_v1_alias() -> None:
+    for route in iter_effective_route_candidates(app_main.app.routes):
+        if not is_api_route_candidate(route) or "GET" not in route_methods(route):
+            continue
+
+        path = route_path(route)
+        if path == "/api/v1/nutrition/recommendations":
+            endpoint = route_endpoint(route)
+            assert endpoint.__module__ == "app.routers.nutrition_recommendations"
+            assert endpoint.__name__ == "get_recommendations"
+            return
+
+        assert not (
+            path.startswith("/api/v1/nutrition/") and "{" in path
+        ), f"{path} is registered before /api/v1/nutrition/recommendations"
+
+    raise AssertionError("missing GET /api/v1/nutrition/recommendations route")
+
+
 def test_recipe_nutrition_reference_registration_rejects_route_order_drift() -> None:
     target_app = FastAPI()
     drifted_order = (

--- a/tests/test_recipe_nutrition_reference_registration_bootstrap.py
+++ b/tests/test_recipe_nutrition_reference_registration_bootstrap.py
@@ -180,7 +180,38 @@ def test_recipe_search_alias_remains_reachable(
     )
 
     assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
     assert response.json() == []
+
+
+def test_recipe_nutrition_reference_registration_rejects_route_order_drift() -> None:
+    target_app = FastAPI()
+    drifted_order = (
+        ("/api/v1/recipes", "GET", True),
+        ("/api/v1/recipes/{recipe_id}", "GET", True),
+        ("/api/v1/recipes/search", "GET", True),
+        ("/api/v1/recipes/preview", "POST", True),
+        ("/api/v1/nutrition/recommendations", "GET", True),
+    )
+
+    for path, method, include_in_schema in drifted_order:
+        source = _source_route(path, method)
+        target_app.add_api_route(
+            path,
+            route_endpoint(source),
+            methods=[method],
+            include_in_schema=include_in_schema,
+            responses=source.responses,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Existing recipe nutrition reference route order does not preserve "
+            "source route order"
+        ),
+    ):
+        app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
 
 
 def test_recipe_nutrition_reference_registration_rejects_partial_existing_family() -> None:

--- a/tests/test_recipe_nutrition_reference_registration_bootstrap.py
+++ b/tests/test_recipe_nutrition_reference_registration_bootstrap.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+import app.main as app_main
+from app.bootstrap.route_family import route_has_dependency_call
+from app.effective_routes import (
+    is_api_route_candidate,
+    iter_effective_route_candidates,
+    route_endpoint,
+    route_include_in_schema,
+    route_methods,
+    route_path,
+    route_responses,
+)
+from app.routers import recipes as recipes_module
+
+_EXPECTED_ROUTE_SPECS = (
+    *app_main._RECIPES_ROUTE_SPECS,
+    *app_main._NUTRITION_RECOMMENDATIONS_ROUTE_SPECS,
+)
+_EXPECTED_ROUTE_KEYS = {
+    (path, method) for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS
+}
+_EXPECTED_ROUTE_PATHS = {path for path, _method in _EXPECTED_ROUTE_KEYS}
+_EXPECTED_ENDPOINTS = {
+    ("/api/v1/recipes", "GET"): "list_recipes",
+    ("/api/v1/recipes/search", "GET"): "list_recipes_search",
+    ("/api/v1/recipes/{recipe_id}", "GET"): "get_recipe",
+    ("/api/v1/recipes/preview", "POST"): "recipe_preview",
+    ("/api/v1/nutrition/recommendations", "GET"): "get_recommendations",
+}
+_EXPECTED_ENDPOINT_MODULES = {
+    ("/api/v1/recipes", "GET"): "app.routers.recipes",
+    ("/api/v1/recipes/search", "GET"): "app.routers.recipes",
+    ("/api/v1/recipes/{recipe_id}", "GET"): "app.routers.recipes",
+    ("/api/v1/recipes/preview", "POST"): "app.routers.recipes",
+    ("/api/v1/nutrition/recommendations", "GET"): ("app.routers.nutrition_recommendations"),
+}
+_FORBIDDEN_DEPENDENCIES = (
+    app_main.require_app_api_key,
+    app_main.require_pro_tier,
+    app_main.get_current_user,
+)
+
+
+def _recipe_nutrition_reference_routes(target_app: FastAPI) -> list[object]:
+    return [
+        route
+        for route in iter_effective_route_candidates(target_app.routes)
+        if is_api_route_candidate(route) and route_path(route) in _EXPECTED_ROUTE_PATHS
+    ]
+
+
+def _registered_route_counts(target_app: FastAPI) -> Counter[tuple[str, str]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for route in _recipe_nutrition_reference_routes(target_app):
+        for method in route_methods(route):
+            key = (route_path(route), method)
+            if key in _EXPECTED_ROUTE_KEYS:
+                counts[key] += 1
+    return counts
+
+
+def _recipe_nutrition_reference_route(target_app: FastAPI, path: str, method: str) -> object:
+    matches = [
+        route
+        for route in _recipe_nutrition_reference_routes(target_app)
+        if route_path(route) == path and method in route_methods(route)
+    ]
+    route_summaries = [
+        f"{route_path(route)}:{sorted(route_methods(route))}:{route_endpoint(route).__module__}"
+        for route in matches
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one recipe/nutrition reference route for {method} {path}; "
+        f"found {len(matches)}: {route_summaries}"
+    )
+    return matches[0]
+
+
+def _source_route(path: str, method: str) -> APIRoute:
+    for router in (app_main.recipes_router, app_main.nutrition_recommendations_router):
+        for route in router.routes:
+            if not isinstance(route, APIRoute):
+                continue
+            if str(route.path) == path and method in (route.methods or set()):
+                return route
+    raise AssertionError(f"missing source route: {method} {path}")
+
+
+def _assert_recipe_nutrition_reference_routes_registered_once(target_app: FastAPI) -> None:
+    counts = _registered_route_counts(target_app)
+    assert set(counts) == _EXPECTED_ROUTE_KEYS
+    assert all(count == 1 for count in counts.values())
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _recipe_nutrition_reference_route(target_app, path, method)
+        assert route_include_in_schema(route) is include_in_schema
+        assert route_responses(route) == _source_route(path, method).responses
+        endpoint = route_endpoint(route)
+        assert getattr(endpoint, "__module__", None) == _EXPECTED_ENDPOINT_MODULES[(path, method)]
+        assert getattr(endpoint, "__name__", None) == _EXPECTED_ENDPOINTS[(path, method)]
+        for dependency in _FORBIDDEN_DEPENDENCIES:
+            assert not route_has_dependency_call(route, dependency)
+
+
+def test_empty_app_registers_all_recipe_nutrition_reference_routes_once() -> None:
+    target_app = FastAPI()
+
+    app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
+
+    _assert_recipe_nutrition_reference_routes_registered_once(target_app)
+
+
+def test_bootstrapped_app_registers_all_recipe_nutrition_reference_routes_once() -> None:
+    _assert_recipe_nutrition_reference_routes_registered_once(app_main.app)
+
+
+def test_recipe_nutrition_reference_registration_is_idempotent() -> None:
+    target_app = FastAPI()
+
+    app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
+    app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
+
+    _assert_recipe_nutrition_reference_routes_registered_once(target_app)
+
+
+def test_recipe_nutrition_reference_members_have_no_auth_or_status_contracts() -> None:
+    members = {
+        (member.path, member.method): member
+        for member in app_main._recipe_nutrition_reference_route_members()
+    }
+
+    assert set(members) == _EXPECTED_ROUTE_KEYS
+    for member in members.values():
+        assert member.required_dependencies == ()
+        assert member.required_status_codes == frozenset()
+
+
+def test_recipe_nutrition_reference_router_source_specs_match_current_visibility() -> None:
+    route_specs: set[tuple[str, str, bool]] = set()
+    for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _source_route(path, method)
+        route_specs.add((str(route.path), method, route.include_in_schema))
+
+    assert route_specs == set(_EXPECTED_ROUTE_SPECS)
+
+
+def test_recipe_nutrition_reference_public_openapi_paths_remain_hidden() -> None:
+    schema = app_main.app.openapi()
+    paths = {str(path) for path in schema.get("paths", {})}
+
+    leaked_paths = sorted(
+        path
+        for path in paths
+        if path.startswith(("/api/v1/recipes", "/api/v1/nutrition/recommendations"))
+    )
+    assert leaked_paths == []
+
+
+def test_recipe_search_alias_remains_reachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        recipes_module.recipe_store,
+        "search_recipes",
+        lambda query, limit, offset: [],
+    )
+
+    response = TestClient(app_main.app).get(
+        "/api/v1/recipes/search",
+        params={"query": "salad", "limit": 1},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_recipe_nutrition_reference_registration_rejects_partial_existing_family() -> None:
+    target_app = FastAPI()
+    path, method, include_in_schema = _EXPECTED_ROUTE_SPECS[0]
+
+    async def _partial_recipe_nutrition_reference_route() -> dict[str, str]:
+        return {"status": "partial"}
+
+    target_app.add_api_route(
+        path,
+        _partial_recipe_nutrition_reference_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Partial recipe nutrition reference route registration detected",
+    ):
+        app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
+
+
+def test_recipe_nutrition_reference_registration_rejects_duplicate_method_path() -> None:
+    target_app = FastAPI()
+    app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
+    path, method, include_in_schema = _EXPECTED_ROUTE_SPECS[0]
+
+    async def _duplicate_recipe_nutrition_reference_route() -> dict[str, str]:
+        return {"status": "duplicate"}
+
+    target_app.add_api_route(
+        path,
+        _duplicate_recipe_nutrition_reference_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different recipe nutrition reference handler",
+    ):
+        app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
+
+
+def test_recipe_nutrition_reference_registration_rejects_foreign_handlers() -> None:
+    target_app = FastAPI()
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+
+        async def _foreign_recipe_nutrition_reference_route(
+            current_route_path: str = path,
+        ) -> dict[str, str]:
+            return {"path": current_route_path}
+
+        target_app.add_api_route(
+            path,
+            _foreign_recipe_nutrition_reference_route,
+            methods=[method],
+            include_in_schema=include_in_schema,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different recipe nutrition reference handler",
+    ):
+        app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
+
+
+def test_recipe_nutrition_reference_registration_rejects_existing_wrong_method() -> None:
+    target_app = FastAPI()
+
+    async def _wrong_method_recipe_nutrition_reference_route() -> dict[str, str]:
+        return {"status": "wrong-method"}
+
+    target_app.add_api_route(
+        "/api/v1/recipes",
+        _wrong_method_recipe_nutrition_reference_route,
+        methods=["POST"],
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Partial recipe nutrition reference route registration detected",
+    ):
+        app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
+
+
+def test_recipe_nutrition_reference_registration_rejects_visibility_drift() -> None:
+    target_app = FastAPI()
+    app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)
+    route = _recipe_nutrition_reference_route(target_app, "/api/v1/recipes", "GET")
+    setattr(route, "include_in_schema", False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve recipe nutrition reference OpenAPI visibility",
+    ):
+        app_main._include_recipe_nutrition_reference_routers_if_needed(target_app)


### PR DESCRIPTION
## Goal

Move recipe and FREE nutrition-reference route registration from `legacy_app.py` to canonical `app/main.py` bootstrap after PR #2071.

## Business Reason

This removes another always-on legacy route owner without changing product behavior, public API contract, generated clients, auth/tier posture, nutrition formulas, or recipe-store behavior.

## Scope

- Add static route specs for recipes and nutrition recommendations.
- Register `recipes_router` and `nutrition_recommendations_router` through canonical route-family bootstrap in `app/main.py`.
- Remove only those two direct includes/imports from `legacy_app.py`.
- Tighten legacy-growth guard allowlists and regression coverage.
- Add shared static route-family order validation after post-open bug-hunter found a `/search` shadowing gap.
- Register recipe/nutrition-reference routes before the nutrition-state alias family and test that `/api/v1/nutrition/recommendations` cannot be shadowed by a dynamic v1 nutrition route.
- Update backend routing map, premortem evidence, Experiment Runner evidence, and fixed-mapping governance.

## Out of Scope

BOLA/authz expansion, BMI/users/restaurants ownership, direct premium nutrition handlers, middleware/lifespan changes, formula/store behavior, OpenAPI/client contract changes, frontend/iOS/macOS changes, and full local `make verify`.

## Files Changed

- `app/bootstrap/route_family.py`
- `app/main.py`
- `app/routers/recipes.py`
- `app/routers/nutrition_recommendations.py`
- `legacy_app.py`
- `scripts/ci/check_legacy_growth_guard.py`
- `tests/test_recipe_nutrition_reference_registration_bootstrap.py`
- `tests/test_legacy_growth_guard.py`
- `tests/test_main_paywall_bootstrap.py`
- `docs/architecture/backend_routing_map.md`
- `docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_PREMORTEM.md`
- `docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md`
- `docs/review/PR_2073_FIXED_MAPPING.md`

## Key Decisions

- Preserve current source route `include_in_schema=True` metadata.
- Preserve final public `app.openapi()` filtering; no generated frontend OpenAPI diff.
- Keep `required_dependencies=()` and `required_status_codes=frozenset()` for this FREE/reference move.
- Use `ensure_route_family_registered(...)` rather than ad-hoc `_has_route` checks.
- Reject existing static-family route-order drift so `/api/v1/recipes/search` cannot be shadowed by `/api/v1/recipes/{recipe_id}`.
- Bootstrap recipe/nutrition-reference before nutrition-state aliases so FREE reference paths stay ahead of any future dynamic v1 nutrition route.

## Tests / Validation

Local evidence across branch commits through `8ab9136d2e541c7603dfe2fc6f7f2b4e0b48dfcb`:

- `python scripts/orchestration/check_preflight.py` - PASS, with existing private-index env warning only.
- `python scripts/orchestration/check_agent_consistency.py` - PASS.
- `python -m pytest -q tests/test_recipes_api.py tests/test_recipe_preview.py tests/test_nutrition_recommendations_api.py` - PASS.
- `python -m pytest -q tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py` - PASS.
- `python -m pytest -q tests/test_nutrition_recommendations_api.py::TestFreeRecommendationsSuccess::test_recommendations_success tests/test_recipe_nutrition_reference_registration_bootstrap.py::test_nutrition_recommendations_route_cannot_be_shadowed_by_dynamic_v1_alias` - PASS.
- Bug-hunter fix bundle: `python -m pytest -q tests/test_recipes_api.py tests/test_recipe_preview.py tests/test_nutrition_recommendations_api.py tests/test_recipe_nutrition_reference_registration_bootstrap.py tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_openapi_namespace_guards.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py` - PASS.
- `python scripts/ci/check_legacy_growth_guard.py` - PASS.
- `python -m mypy app/bootstrap/route_family.py app/main.py app/routers/recipes.py app/routers/nutrition_recommendations.py scripts/ci/check_legacy_growth_guard.py` - PASS.
- `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make openapi-check` - PASS.
- `git diff --exit-code -- frontend/src/api/openapi.json frontend/src/api/schema.ts` - PASS.
- `pre-commit run --all-files` - PASS via repo venv after the latest docs commit.
- `make validate-changed` - PASS after the latest docs commit; selected `tests/test_legacy_growth_guard.py`, `tests/test_main_paywall_bootstrap.py`, and `tests/test_recipe_nutrition_reference_registration_bootstrap.py`.
- Pre-push hooks - PASS on pushed heads: mypy where applicable, pip-audit, backend pytest pre-push, full-repo Bandit, docker build test where applicable.
- `python scripts/ci/check_pr_body_phase2_gates.py --pr-number 2073 --body "$(gh pr view 2073 --json body --jq .body)" --commit-range origin/main..HEAD --experiment-runner-evidence-mode required` - PASS locally before this body refresh.
- `GH_TOKEN="$(gh auth token)" python scripts/orchestration/check_review_threads_disposition.py --pr-number 2073 --require-auth` - PASS locally before the latest push.

## Governance / Role Evidence

- Lane packet: `artifacts/orchestration/task_packets/3467351ee456.json`.
- Post-open packet: `artifacts/orchestration/task_packets/f5cb9acbe485.json`.
- Pre-edit role order executed: `agent-coordinator -> backend-engineer -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`.
- Post-open role chain executed in order: `qa-engineer-agent -> bug-hunter -> security-auditor`.
- Premortem artifact: `docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_PREMORTEM.md`.
- Experiment Runner evidence doc: `docs/review/RECIPE_NUTRITION_REFERENCE_CANONICAL_BOOTSTRAP_EXPERIMENT_RUNNER_EVIDENCE.md`.
- Fixed mapping artifact: `docs/review/PR_2073_FIXED_MAPPING.md`.
- Codex Security scan `08025660-053e-4a39-bb72-73277fe7c22f`: 0 findings, 6/6 coverage rows closed for `8fdcd0ac..191a2a317`.
- Codex Security scan `e82db3b8-d682-4072-b013-ac81071d0663`: 0 findings, complete coverage for latest security-relevant head `8fdcd0ac..55b527d`; later commits only record scan/disposition evidence.
- `pulseplate-pr-review`: completed; one advisory large-diff planning note dispositioned as NOT-A-BUG in the fixed mapping artifact.

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/recipe-nutrition-reference-oracle-result-v2.json`
- Experiment id: `exp-4fe6753a1339`.
- Mode: `oracle_only_governance_reviewer`.
- Status: `accepted`.
- Contribution kind: `oracle_review`.
- `coauthor_required=true`; implementation commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

Infra caveat: the first zero-network attempt was rejected as `infra_flake` because this host lacks `unshare` for the network-disabled sandbox. The accepted `network_budget=1` artifact keeps the same local oracle commands and does not grant runtime/provider/client/API authority.

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/3467351ee456.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Post-open packet: `artifacts/orchestration/task_packets/f5cb9acbe485.json`

## Security Notes

- No new entitlement, billing, quota, LLM, provider, export, or secrets surface.
- Auth/tier contract tests pass for the moved FREE/reference routes.
- The follow-up route-order fix keeps `/api/v1/nutrition/recommendations` ahead of the nutrition-state alias family and adds a regression against dynamic v1 nutrition shadowing.
- Legacy compatibility aliases remain thin; premium/direct handlers, users, restaurants, and BOLA/authz are untouched.
- Latest Codex Security diff scan completed with 0 findings for the latest security-relevant head.

## Risks / Rollback

Rollback is bounded: revert this PR branch to restore the legacy imports/includes and remove the canonical bootstrap helper/spec/test/docs changes.

Main risk was false route-ownership proof if future code reintroduced these routers into `legacy_app.py`, reordered `/search` behind `/{recipe_id}`, or placed a dynamic v1 nutrition route before `/api/v1/nutrition/recommendations`; guard/regression tests now cover those cases.

## Deferred / Follow-ups

- Remaining legacy always-on owners: `restaurants_router` and `users_router`.
- BOLA/authz expansion remains deferred until route ownership is more stable.
- Full local `make verify` was not run per repo local budget policy.

## AGENTS.md / Agent Instruction Updates

None.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_2073_FIXED_MAPPING.md`

## Merge Readiness

Not claimed. Current-head GitHub CI after latest pushed head, strict merge-readiness gate, and resolved review threads are still required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nutrition recommendations and recipes reference endpoints to the canonical app bootstrap under a shared “recipe nutrition reference” route family.
  * Preserved the existing `/api/v1/recipes/search` alias for recipe search.

* **Bug Fixes**
  * Strengthened route-family bootstrap validation to prevent legacy/partial re-registration and to detect route-order drift.
  * Improved safeguards so the targeted reference paths don’t unintentionally appear in public OpenAPI output.

* **Documentation**
  * Updated the backend routing architecture map to reflect the new canonical registration and OpenAPI visibility behavior.

* **Tests**
  * Added/expanded bootstrap and legacy-growth guard tests covering idempotency, ordering, and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
