### PR TITLE
refactor(api): move users CRUD registration to canonical bootstrap

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -226,10 +226,7 @@ _RESTAURANT_MODERATION_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in RESTAURANT_MODERATION_ROUTE_SPECS
 )
-_USERS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
-    (path, method.upper(), include_in_schema)
-    for path, method, include_in_schema in USERS_ROUTE_SPECS
-)
+_USERS_ROUTE_SPECS = USERS_ROUTE_SPECS
 _EXPORT_ROUTE_REQUIRED_STATUS_CODES = frozenset({429})
 _RESTAURANT_MODERATION_REQUIRED_STATUS_CODES = frozenset({404, 422})
 _PLAN_SIGNED_EXPORT_PATHS = frozenset({WEEK_EXPORT_CSV_PATH, WEEK_EXPORT_PDF_PATH})

--- a/app/main.py
+++ b/app/main.py
@@ -111,6 +111,11 @@ from app.routers.test import (
     _ensure_non_production as ensure_test_routes_non_production,
     router as test_router,
 )
+from app.routers.users import (
+    USERS_ROUTE_SPECS,
+    _require_users_api_key,
+    router as users_router,
+)
 from app.routers.vip_registration import register_vip_routes
 from app.schemas.direct_api_root import DirectApiRootProbe
 from app.utils.feature_flags import is_business_module_enabled, is_vip_module_enabled
@@ -220,6 +225,10 @@ _SHOPPING_LIST_PRO_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
 _RESTAURANT_MODERATION_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in RESTAURANT_MODERATION_ROUTE_SPECS
+)
+_USERS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in USERS_ROUTE_SPECS
 )
 _EXPORT_ROUTE_REQUIRED_STATUS_CODES = frozenset({429})
 _RESTAURANT_MODERATION_REQUIRED_STATUS_CODES = frozenset({404, 422})
@@ -452,6 +461,18 @@ def _recipe_nutrition_reference_route_members() -> tuple[RouteMemberContract, ..
             *_RECIPES_ROUTE_SPECS,
             *_NUTRITION_RECOMMENDATIONS_ROUTE_SPECS,
         )
+    )
+
+
+def _users_route_members() -> tuple[RouteMemberContract, ...]:
+    return tuple(
+        RouteMemberContract(
+            path=path,
+            method=method,
+            include_in_schema=include_in_schema,
+            required_dependencies=(_require_users_api_key,),
+        )
+        for path, method, include_in_schema in _USERS_ROUTE_SPECS
     )
 
 
@@ -1032,6 +1053,17 @@ def _include_recipe_nutrition_reference_routers_if_needed(target_app: FastAPI) -
     )
 
 
+def _include_users_router_if_needed(target_app: FastAPI) -> None:
+    """Register internal users CRUD routes as one hidden canonical family."""
+
+    ensure_route_family_registered(
+        target_app,
+        family_name="Users",
+        routers=(users_router,),
+        members=_users_route_members(),
+    )
+
+
 def _include_test_router_if_enabled(target_app: FastAPI) -> None:
     """Register non-production test routes as one hidden canonical family."""
 
@@ -1071,12 +1103,10 @@ def _include_restaurant_moderation_router_if_needed(target_app: FastAPI) -> None
 
 
 def _internalize_users_openapi_surface(target_app: FastAPI) -> None:
-    """Hide legacy users CRUD from the public OpenAPI contract.
+    """Keep users CRUD OpenAPI metadata internal when legacy state is present.
 
-    RU: Скрываем users CRUD из публичной OpenAPI surface в canonical entrypoint,
-    не добавляя новый runtime behavior в legacy compatibility layer.
-    EN: Hide users CRUD from the public OpenAPI surface in the canonical
-    entrypoint instead of introducing new runtime behavior in legacy_app.py.
+    Source users routes are hidden at the router/decorator level. This remains
+    as defensive cleanup for older route state loaded before canonical bootstrap.
     """
 
     for route in _effective_app_routes(target_app):
@@ -1226,6 +1256,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _include_bodyfat_router_if_needed(app)
     _include_business_router_if_enabled(app)
     _include_food_catalog_routers_if_needed(app)
+    _include_users_router_if_needed(app)
     _include_test_router_if_enabled(app)
     _include_plan_export_routers_if_needed(app)
     _include_shoplist_export_router_if_needed(app)

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -22,6 +22,13 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+USERS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = (
+    ("/api/v1/users", "POST", False),
+    ("/api/v1/users", "GET", False),
+    ("/api/v1/users/{user_id}", "GET", False),
+    ("/api/v1/users/{user_id}", "DELETE", False),
+)
+
 
 def _require_users_api_key(api_key: str = Depends(api_key_header)) -> str:
     """Validate app-level API key access for the users CRUD surface."""
@@ -171,7 +178,12 @@ def _execute_with_retry(action: Callable[[Session], T], fallback: T | None = Non
 #       Consider adding lang parameter or translating at HTTP layer per coding guidelines.
 
 
-@router.post("", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=UserRead,
+    status_code=status.HTTP_201_CREATED,
+    include_in_schema=False,
+)
 async def create_user(payload: UserCreate) -> UserRead:
     """RU: Создаёт нового пользователя. EN: Create a new user entry.
 
@@ -194,7 +206,7 @@ async def create_user(payload: UserCreate) -> UserRead:
     return cast(UserRead, await run_in_threadpool(_execute_with_retry, _action))
 
 
-@router.get("", response_model=List[UserRead])
+@router.get("", response_model=List[UserRead], include_in_schema=False)
 async def list_users(
     limit: int = Query(50, ge=1, le=1000),
     offset: int = Query(0, ge=0),
@@ -216,7 +228,7 @@ async def list_users(
     )  # No fallback - fail explicitly if DB unavailable
 
 
-@router.get("/{user_id}", response_model=UserRead)
+@router.get("/{user_id}", response_model=UserRead, include_in_schema=False)
 async def get_user(user_id: int) -> UserRead:
     """RU: Получить пользователя по идентификатору.
 
@@ -232,7 +244,11 @@ async def get_user(user_id: int) -> UserRead:
     return cast(UserRead, await run_in_threadpool(_execute_with_retry, _action))
 
 
-@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    include_in_schema=False,
+)
 async def delete_user(user_id: int) -> Response:
     """RU: Удаляет пользователя. EN: Delete a user by identifier.
 

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -31,7 +31,34 @@ Anchor (stable): `legacy_app.py -> include_router(...) for core API routers`
 Evidence: `legacy_app.py:922-932`
 
 - `restaurants_router` (`app/routers/restaurants.py`, hidden from OpenAPI at registration)
-- `users_router` (`app/routers/users.py`)
+- Users CRUD is no longer legacy-owned; see
+  [Canonical users router](#canonical-users-router-canonical-bootstrap-owned).
+
+### Canonical users router (canonical bootstrap-owned)
+
+Anchor (stable): `app/main.py -> _include_users_router_if_needed(app)`
+
+Evidence:
+- `app/bootstrap/route_family.py` — shared `RouteMemberContract` /
+  `ensure_route_family_registered(...)` guard for exact static route families.
+- `app/main.py` — registers `users_router` as one hidden canonical static route
+  family and validates dependency, visibility, duplicate, partial,
+  foreign-handler, wrong-method, and route-order drift.
+- `app/routers/users.py` — owns users CRUD handlers, `_require_users_api_key`,
+  hidden source-route `USERS_ROUTE_SPECS`, DB retry, conflict, not-found, and
+  idempotent delete semantics.
+- `scripts/ci/check_legacy_growth_guard.py` — rejects reintroducing users router
+  import or registration into `legacy_app.py`.
+
+Runtime effect:
+- `POST /api/v1/users`
+- `GET /api/v1/users`
+- `GET /api/v1/users/{user_id}`
+- `DELETE /api/v1/users/{user_id}`
+
+OpenAPI effect:
+- Users source routes stay hidden from OpenAPI at route metadata level.
+- Final public `app.openapi()` excludes `/api/v1/users*`.
 
 ### Canonical recipe/nutrition-reference routers (canonical bootstrap-owned)
 

--- a/docs/review/PR_2074_FIXED_MAPPING.md
+++ b/docs/review/PR_2074_FIXED_MAPPING.md
@@ -7,14 +7,21 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: a95d3f197
+Evidence: `app/main.py` now aliases `_USERS_ROUTE_SPECS` directly to `app.routers.users.USERS_ROUTE_SPECS`, removing the duplicated normalization copy that Sourcery flagged.
+Evidence: `tests/test_users_registration_bootstrap.py` intentionally exercises `_users_route_members()` and `_include_users_router_if_needed()` because those private bootstrap contracts are the fail-closed surface for partial, duplicate, foreign-handler, visibility, missing-dependency, and route-order drift.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2074#pullrequestreview-4630149255 -> a95d3f197
 
 ## Implementation Evidence
 
 - Commit: `24aaf8f71b2d01939a9e1b2b2057e38e878045df`
+- Commit: `a95d3f197`
 - Evidence: `app/main.py` owns users CRUD registration through
   `_include_users_router_if_needed(...)` and
   `ensure_route_family_registered(...)`.
+- Evidence: `app/main.py` reuses `app.routers.users.USERS_ROUTE_SPECS` as the
+  single canonical users route spec source.
 - Evidence: `legacy_app.py` no longer imports or includes `users_router`.
 - Evidence: `app/routers/users.py` defines hidden source `USERS_ROUTE_SPECS`
   and keeps `_require_users_api_key`.

--- a/docs/review/PR_2074_FIXED_MAPPING.md
+++ b/docs/review/PR_2074_FIXED_MAPPING.md
@@ -72,7 +72,17 @@ Branch: `codex/move-users-registration-to-canonical-bootstrap`
 
 ## Merge Readiness
 
-Not merge-ready yet. Current-head GitHub CI, post-open
-`qa-engineer-agent -> bug-hunter -> security-auditor`, Codex Security diff scan
-/ finding discovery, `pulseplate-pr-review`, bot review actionables, review
-threads, and strict merge-readiness checks remain pending.
+Closeout evidence is maintained by the strict merge wrapper on the latest PR
+head, not by stale checklist prose in this artifact.
+
+- PASS: post-open `qa-engineer-agent -> bug-hunter -> security-auditor` lane.
+- PASS: Codex Security diff scan `42559129-e962-4f95-b560-e332b8931299`
+  reported 0 findings on the reviewed branch diff.
+- PASS: `pulseplate-pr-review` dry run completed with no blocking findings.
+- PASS: current-head GitHub CI completed for head
+  `66a34fd252795d256fbfcb28afd17af265a57910`.
+- PASS: `python scripts/orchestration/check_merge_ready.py --pr-number 2074
+  --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passed with 0
+  unresolved review threads and all actionable bot comments mapped.
+- Guardrail: after any later mapping/body/metadata commit, rerun the strict
+  merge wrapper on the new head before squash merge.

--- a/docs/review/PR_2074_FIXED_MAPPING.md
+++ b/docs/review/PR_2074_FIXED_MAPPING.md
@@ -1,0 +1,69 @@
+# PR 2074 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Pre-open role order completed:
+  `agent-coordinator -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`
+- [x] Fixed in commit mapping initialized for the implementation commit.
+- [ ] Post-open discussion-thread pass pending.
+- [ ] Bot review pass pending.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 24aaf8f71b2d01939a9e1b2b2057e38e878045df
+Evidence: `app/main.py` now owns users CRUD registration through
+`_include_users_router_if_needed(...)` and `ensure_route_family_registered(...)`;
+`legacy_app.py` no longer imports or includes `users_router`; `app/routers/users.py`
+defines hidden source `USERS_ROUTE_SPECS` and keeps `_require_users_api_key`;
+`scripts/ci/check_legacy_growth_guard.py` rejects users registration/import
+reintroduction. Covered by `tests/test_users_registration_bootstrap.py`,
+`tests/test_legacy_growth_guard.py`, `tests/test_openapi_namespace_guards.py`,
+`tests/test_users_api.py`, `tests/test_users_router.py`,
+`tests/test_users_router_retry_logic.py`,
+`tests/security/test_api_auth_tier_contract_pack.py`, and
+`tests/security/test_api_authz_contract_static.py`.
+- Pre-open implementation slice -> 24aaf8f71b2d01939a9e1b2b2057e38e878045df
+
+## Experiment Runner Evidence
+
+Artifact: `artifacts/orchestration/experiments/results/exp-d18b2b538b82.json`
+
+Summary: accepted oracle-only governance review. The runner applied the source
+diff in an isolated checkout, kept `shared_tree_untouched=true`, and passed:
+- `python3 -m pytest -q tests/test_users_registration_bootstrap.py tests/test_openapi_namespace_guards.py tests/test_users_api.py tests/test_users_router.py tests/test_users_router_retry_logic.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py tests/test_legacy_growth_guard.py tests/test_route_family_bootstrap.py`
+- `python3 scripts/ci/check_legacy_growth_guard.py --repo-root .`
+
+The implementation commit includes:
+`Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Lane Start Provenance
+
+Starter: `scripts/orchestration/start_pr_lane.sh`
+
+Packet: `artifacts/orchestration/task_packets/50f8dc5bd549.json`
+
+Branch: `codex/move-users-registration-to-canonical-bootstrap`
+
+## Validation Evidence
+
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_users_registration_bootstrap.py tests/test_legacy_growth_guard.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_route_family_bootstrap.py tests/test_openapi_namespace_guards.py tests/test_users_api.py tests/test_users_router.py tests/test_users_router_retry_logic.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/ci/check_legacy_growth_guard.py --repo-root .`
+- PASS: explicit route probe confirmed four users routes exactly once,
+  `include_in_schema=False`, and no `/api/v1/users*` in public OpenAPI.
+- PASS: `PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/orchestration/check_preflight.py`
+  with warning only for noncanonical local `PULSEPLATE_PYTHON_INDEX_URL`.
+- PASS: `PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/orchestration/check_agent_consistency.py`
+- PASS: `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make openapi-check`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files`
+- PASS: `make validate-changed`
+- PASS during push: pre-push hooks including changed-file mypy, pip-audit,
+  backend tests, full Bandit, and Docker build test.
+
+## Merge Readiness
+
+Not merge-ready yet. Current-head GitHub CI, post-open
+`qa-engineer-agent -> bug-hunter -> security-auditor`, Codex Security diff scan
+/ finding discovery, `pulseplate-pr-review`, bot review actionables, review
+threads, and strict merge-readiness checks remain pending.

--- a/docs/review/PR_2074_FIXED_MAPPING.md
+++ b/docs/review/PR_2074_FIXED_MAPPING.md
@@ -2,28 +2,30 @@
 
 ## Discussion Thread Pass
 
-- [x] Pre-open role order completed:
-  `agent-coordinator -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`
-- [x] Fixed in commit mapping initialized for the implementation commit.
-- [ ] Post-open discussion-thread pass pending.
-- [ ] Bot review pass pending.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-Disposition: FIXED
-Commit: 24aaf8f71b2d01939a9e1b2b2057e38e878045df
-Evidence: `app/main.py` now owns users CRUD registration through
-`_include_users_router_if_needed(...)` and `ensure_route_family_registered(...)`;
-`legacy_app.py` no longer imports or includes `users_router`; `app/routers/users.py`
-defines hidden source `USERS_ROUTE_SPECS` and keeps `_require_users_api_key`;
-`scripts/ci/check_legacy_growth_guard.py` rejects users registration/import
-reintroduction. Covered by `tests/test_users_registration_bootstrap.py`,
-`tests/test_legacy_growth_guard.py`, `tests/test_openapi_namespace_guards.py`,
-`tests/test_users_api.py`, `tests/test_users_router.py`,
-`tests/test_users_router_retry_logic.py`,
-`tests/security/test_api_auth_tier_contract_pack.py`, and
-`tests/security/test_api_authz_contract_static.py`.
-- Pre-open implementation slice -> 24aaf8f71b2d01939a9e1b2b2057e38e878045df
+- No actionable review comments
+
+## Implementation Evidence
+
+- Commit: `24aaf8f71b2d01939a9e1b2b2057e38e878045df`
+- Evidence: `app/main.py` owns users CRUD registration through
+  `_include_users_router_if_needed(...)` and
+  `ensure_route_family_registered(...)`.
+- Evidence: `legacy_app.py` no longer imports or includes `users_router`.
+- Evidence: `app/routers/users.py` defines hidden source `USERS_ROUTE_SPECS`
+  and keeps `_require_users_api_key`.
+- Evidence: `scripts/ci/check_legacy_growth_guard.py` rejects users
+  registration/import reintroduction.
+- Tests: `tests/test_users_registration_bootstrap.py`,
+  `tests/test_legacy_growth_guard.py`, `tests/test_openapi_namespace_guards.py`,
+  `tests/test_users_api.py`, `tests/test_users_router.py`,
+  `tests/test_users_router_retry_logic.py`,
+  `tests/security/test_api_auth_tier_contract_pack.py`, and
+  `tests/security/test_api_authz_contract_static.py`.
 
 ## Experiment Runner Evidence
 
@@ -47,16 +49,16 @@ Branch: `codex/move-users-registration-to-canonical-bootstrap`
 
 ## Validation Evidence
 
-- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_users_registration_bootstrap.py tests/test_legacy_growth_guard.py`
-- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_route_family_bootstrap.py tests/test_openapi_namespace_guards.py tests/test_users_api.py tests/test_users_router.py tests/test_users_router_retry_logic.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
-- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/ci/check_legacy_growth_guard.py --repo-root .`
+- PASS: `.venv/bin/python -m pytest -q tests/test_users_registration_bootstrap.py tests/test_legacy_growth_guard.py`
+- PASS: `.venv/bin/python -m pytest -q tests/test_route_family_bootstrap.py tests/test_openapi_namespace_guards.py tests/test_users_api.py tests/test_users_router.py tests/test_users_router_retry_logic.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
+- PASS: `.venv/bin/python scripts/ci/check_legacy_growth_guard.py --repo-root .`
 - PASS: explicit route probe confirmed four users routes exactly once,
   `include_in_schema=False`, and no `/api/v1/users*` in public OpenAPI.
-- PASS: `PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/orchestration/check_preflight.py`
+- PASS: `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python scripts/orchestration/check_preflight.py`
   with warning only for noncanonical local `PULSEPLATE_PYTHON_INDEX_URL`.
-- PASS: `PYTHONDONTWRITEBYTECODE=1 /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python scripts/orchestration/check_agent_consistency.py`
-- PASS: `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make openapi-check`
-- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files`
+- PASS: `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python scripts/orchestration/check_agent_consistency.py`
+- PASS: `DEV_PYTHON=.venv/bin/python make openapi-check`
+- PASS: `.venv/bin/pre-commit run --all-files`
 - PASS: `make validate-changed`
 - PASS during push: pre-push hooks including changed-file mypy, pip-audit,
   backend tests, full Bandit, and Docker build test.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -50,7 +50,6 @@ from app.http_error_details import (
 )
 from app.routers.api_key import api_key_header
 from app.routers.restaurants import router as restaurants_router
-from app.routers.users import router as users_router
 from app.schemas.bmr import BMRRequest, BMRRequestLegacy, BMRResponse
 from app.schemas.bmi_compat import BMIRequest, BMIRequestV1
 from app.schemas.premium_contracts import (
@@ -906,7 +905,6 @@ async def admin_status() -> Dict[str, str]:
 
 # Include API routers
 app.include_router(restaurants_router, include_in_schema=False)
-app.include_router(users_router)
 
 # PRO/VIP route registration is owned by app.main canonical bootstrap.
 # Compatibility attrs above are populated there after successful registration.

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -102,7 +102,6 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("decorator", "post", "/api/v1/premium/plan/week", "api_weekly_menu"),
         LegacyFact("decorator", "post", "/api/v1/premium/gaps", "api_nutrient_gaps"),
         LegacyFact("registration", "include_router", "restaurants_router", ""),
-        LegacyFact("registration", "include_router", "users_router", ""),
     }
 )
 
@@ -119,7 +118,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
             "router_import", "app.routers.pro_nutrition_contracts", "pro_nutrition_targets", ""
         ),
         LegacyFact("router_import", "app.routers.restaurants", "router", "restaurants_router"),
-        LegacyFact("router_import", "app.routers.users", "router", "users_router"),
         LegacyFact(
             "router_import",
             "app.routers.vip",

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -1079,6 +1079,105 @@ def test_legacy_growth_guard_rejects_food_catalog_router_reintroduction(
     [
         (
             textwrap.dedent("""
+                from app.routers.users import router
+
+                app.include_router(router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.users:router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from app.routers.users import router as users_router
+
+                app.include_router(users_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:users_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:app.routers.users:router -> users_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import app.routers.users as users_routes
+
+                app.include_router(users_routes.router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:users_routes.router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:import:app.routers.users -> users_routes",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                module_name = "app.routers." + "users"
+                users_router = importlib.import_module(module_name).router
+                app.include_router(users_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:users_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.users -> users_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                from importlib import import_module
+
+                if (users_router := import_module("app.routers.users").router):
+                    app.include_router(users_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:users_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.users -> users_router",
+            ],
+        ),
+        (
+            textwrap.dedent("""
+                import importlib
+
+                wrapper_router = APIRouter()
+                wrapper_router.include_router(
+                    importlib.import_module("app.routers.users").router
+                )
+                app.include_router(wrapper_router)
+                """),
+            [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:wrapper_router",
+                "legacy_app.py: unexpected app.routers import growth: "
+                "router_import:dynamic:app.routers.users -> wrapper_router.include_router",
+            ],
+        ),
+    ],
+)
+def test_legacy_growth_guard_rejects_users_router_reintroduction(
+    source: str,
+    expected: list[str],
+) -> None:
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            textwrap.dedent("""
                 from app.routers.recipes import router as recipes_router
 
                 app.include_router(recipes_router)
@@ -1284,8 +1383,10 @@ def test_legacy_growth_guard_rejects_recipe_nutrition_reference_router_reintrodu
                 app.include_router(users_router)
                 """),
             [
+                "legacy_app.py: unexpected legacy route growth: "
+                "registration:include_router:users_router",
                 "legacy_app.py: unexpected app.routers import growth: "
-                "router_import:dynamic:app.routers.catalog -> users_router"
+                "router_import:dynamic:app.routers.catalog -> users_router",
             ],
         ),
         (
@@ -1403,7 +1504,7 @@ def test_legacy_growth_guard_allows_unregistered_dynamic_import_without_router_u
 
         module = import_module(os.getenv("LEGACY_HELPER_MODULE"))
         value = module.VALUE
-        app.include_router(users_router)
+        app.include_router(restaurants_router)
         """)
 
     assert legacy_guard.validate_legacy_growth(source) == []
@@ -1870,7 +1971,7 @@ def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_route() -> None:
 
 
 def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_router() -> None:
-    source = "app.include_router(users_router, dependencies=[Depends(auth_guard)])\n"
+    source = "app.include_router(restaurants_router, dependencies=[Depends(auth_guard)])\n"
 
     errors = legacy_guard.validate_legacy_growth(source)
 
@@ -1889,7 +1990,7 @@ def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_router() -> None
             """),
         textwrap.dedent("""
             deps = [Depends(auth_guard)]
-            app.include_router(users_router, dependencies=deps)
+            app.include_router(restaurants_router, dependencies=deps)
             """),
     ],
 )

--- a/tests/test_users_registration_bootstrap.py
+++ b/tests/test_users_registration_bootstrap.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.routing import APIRoute
+
+import app.main as app_main
+from app.bootstrap.route_family import route_has_dependency_call
+from app.effective_routes import (
+    is_api_route_candidate,
+    iter_effective_route_candidates,
+    route_endpoint,
+    route_include_in_schema,
+    route_methods,
+    route_path,
+)
+
+_EXPECTED_ROUTE_SPECS = app_main._USERS_ROUTE_SPECS
+_EXPECTED_ROUTE_KEYS = {
+    (path, method) for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS
+}
+_EXPECTED_ROUTE_PATHS = {path for path, _method in _EXPECTED_ROUTE_KEYS}
+_EXPECTED_ENDPOINTS = {
+    ("/api/v1/users", "POST"): "create_user",
+    ("/api/v1/users", "GET"): "list_users",
+    ("/api/v1/users/{user_id}", "GET"): "get_user",
+    ("/api/v1/users/{user_id}", "DELETE"): "delete_user",
+}
+_EXPECTED_ENDPOINT_MODULE = "app.routers.users"
+
+
+def _users_routes(target_app: FastAPI) -> list[object]:
+    return [
+        route
+        for route in iter_effective_route_candidates(target_app.routes)
+        if is_api_route_candidate(route) and route_path(route) in _EXPECTED_ROUTE_PATHS
+    ]
+
+
+def _registered_route_counts(target_app: FastAPI) -> Counter[tuple[str, str]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for route in _users_routes(target_app):
+        for method in route_methods(route):
+            key = (route_path(route), method)
+            if key in _EXPECTED_ROUTE_KEYS:
+                counts[key] += 1
+    return counts
+
+
+def _users_route(target_app: FastAPI, path: str, method: str) -> object:
+    matches = [
+        route
+        for route in _users_routes(target_app)
+        if route_path(route) == path and method in route_methods(route)
+    ]
+    route_summaries = [
+        f"{route_path(route)}:{sorted(route_methods(route))}:{route_endpoint(route).__module__}"
+        for route in matches
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one users route for {method} {path}; "
+        f"found {len(matches)}: {route_summaries}"
+    )
+    return matches[0]
+
+
+def _source_route(path: str, method: str) -> APIRoute:
+    for route in app_main.users_router.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        if str(route.path) == path and method in (route.methods or set()):
+            return route
+    raise AssertionError(f"missing source route: {method} {path}")
+
+
+def _clone_endpoint_with_matching_identity(
+    source_endpoint: Callable[..., object],
+    dependency: Callable[..., object] | None,
+) -> Callable[..., object]:
+    if dependency is None:
+
+        async def _endpoint_without_dependency() -> dict[str, str]:
+            return {"status": "stub"}
+
+        endpoint = _endpoint_without_dependency
+    else:
+
+        async def _endpoint_with_dependency(
+            _dependency_result: object = Depends(dependency),
+        ) -> dict[str, str]:
+            return {"status": "stub"}
+
+        endpoint = _endpoint_with_dependency
+
+    endpoint.__module__ = source_endpoint.__module__
+    endpoint.__qualname__ = source_endpoint.__qualname__
+    return endpoint
+
+
+def _assert_users_routes_registered_once(target_app: FastAPI) -> None:
+    counts = _registered_route_counts(target_app)
+    assert set(counts) == _EXPECTED_ROUTE_KEYS
+    assert all(count == 1 for count in counts.values())
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _users_route(target_app, path, method)
+        assert route_include_in_schema(route) is include_in_schema
+        endpoint = route_endpoint(route)
+        assert getattr(endpoint, "__module__", None) == _EXPECTED_ENDPOINT_MODULE
+        assert getattr(endpoint, "__name__", None) == _EXPECTED_ENDPOINTS[(path, method)]
+        assert route_has_dependency_call(route, app_main._require_users_api_key)
+
+
+def test_empty_app_registers_all_users_routes_once() -> None:
+    target_app = FastAPI()
+
+    app_main._include_users_router_if_needed(target_app)
+
+    _assert_users_routes_registered_once(target_app)
+
+
+def test_bootstrapped_app_registers_all_users_routes_once() -> None:
+    _assert_users_routes_registered_once(app_main.app)
+
+
+def test_users_registration_is_idempotent() -> None:
+    target_app = FastAPI()
+
+    app_main._include_users_router_if_needed(target_app)
+    app_main._include_users_router_if_needed(target_app)
+
+    _assert_users_routes_registered_once(target_app)
+
+
+def test_users_route_members_require_users_api_key() -> None:
+    members = {(member.path, member.method): member for member in app_main._users_route_members()}
+
+    assert set(members) == _EXPECTED_ROUTE_KEYS
+    for member in members.values():
+        assert member.required_dependencies == (app_main._require_users_api_key,)
+        assert member.required_status_codes == frozenset()
+
+
+def test_users_router_source_routes_preserve_api_key_dependency() -> None:
+    for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _source_route(path, method)
+
+        assert route_has_dependency_call(route, app_main._require_users_api_key)
+
+
+def test_users_router_source_specs_match_current_visibility() -> None:
+    route_specs: set[tuple[str, str, bool]] = set()
+    for path, method, _include_in_schema in _EXPECTED_ROUTE_SPECS:
+        route = _source_route(path, method)
+        route_specs.add((str(route.path), method, route.include_in_schema))
+
+    assert route_specs == set(_EXPECTED_ROUTE_SPECS)
+
+
+def test_users_public_openapi_paths_remain_hidden() -> None:
+    schema = app_main.app.openapi()
+    paths = {str(path) for path in schema.get("paths", {})}
+
+    leaked_paths = sorted(path for path in paths if path.startswith("/api/v1/users"))
+    assert leaked_paths == []
+
+
+def test_users_registration_rejects_partial_existing_family() -> None:
+    target_app = FastAPI()
+    path, method, include_in_schema = _EXPECTED_ROUTE_SPECS[0]
+
+    async def _partial_users_route() -> dict[str, str]:
+        return {"status": "partial"}
+
+    target_app.add_api_route(
+        path,
+        _partial_users_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(RuntimeError, match="Partial users route registration detected"):
+        app_main._include_users_router_if_needed(target_app)
+
+
+def test_users_registration_rejects_duplicate_method_path() -> None:
+    target_app = FastAPI()
+    app_main._include_users_router_if_needed(target_app)
+    path, method, include_in_schema = _EXPECTED_ROUTE_SPECS[0]
+
+    async def _duplicate_users_route() -> dict[str, str]:
+        return {"status": "duplicate"}
+
+    target_app.add_api_route(
+        path,
+        _duplicate_users_route,
+        methods=[method],
+        include_in_schema=include_in_schema,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different users handler",
+    ):
+        app_main._include_users_router_if_needed(target_app)
+
+
+def test_users_registration_rejects_foreign_handlers() -> None:
+    target_app = FastAPI()
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+
+        async def _foreign_users_route(current_route_path: str = path) -> dict[str, str]:
+            return {"path": current_route_path}
+
+        target_app.add_api_route(
+            path,
+            _foreign_users_route,
+            methods=[method],
+            include_in_schema=include_in_schema,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different users handler",
+    ):
+        app_main._include_users_router_if_needed(target_app)
+
+
+def test_users_registration_rejects_existing_wrong_method() -> None:
+    target_app = FastAPI()
+
+    async def _wrong_method_users_route() -> dict[str, str]:
+        return {"status": "wrong-method"}
+
+    target_app.add_api_route(
+        "/api/v1/users/{user_id}",
+        _wrong_method_users_route,
+        methods=["POST"],
+    )
+
+    with pytest.raises(RuntimeError, match="Partial users route registration detected"):
+        app_main._include_users_router_if_needed(target_app)
+
+
+def test_users_registration_rejects_visibility_drift() -> None:
+    target_app = FastAPI()
+    app_main._include_users_router_if_needed(target_app)
+    route = _users_route(target_app, "/api/v1/users", "GET")
+    setattr(route, "include_in_schema", True)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve users OpenAPI visibility",
+    ):
+        app_main._include_users_router_if_needed(target_app)
+
+
+@pytest.mark.parametrize("missing_key", sorted(_EXPECTED_ROUTE_KEYS))
+def test_users_registration_rejects_missing_required_dependency(
+    missing_key: tuple[str, str],
+) -> None:
+    target_app = FastAPI()
+
+    for path, method, include_in_schema in _EXPECTED_ROUTE_SPECS:
+        source_route = _source_route(path, method)
+        source_endpoint = source_route.endpoint
+        endpoint = (
+            _clone_endpoint_with_matching_identity(source_endpoint, None)
+            if (path, method) == missing_key
+            else source_endpoint
+        )
+        dependencies = (
+            [] if (path, method) == missing_key else [Depends(app_main._require_users_api_key)]
+        )
+        target_app.add_api_route(
+            path,
+            endpoint,
+            methods=[method],
+            include_in_schema=include_in_schema,
+            responses=dict(source_route.responses),
+            dependencies=dependencies,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve users required dependency",
+    ):
+        app_main._include_users_router_if_needed(target_app)
+
+
+def test_users_registration_rejects_route_order_drift() -> None:
+    target_app = FastAPI()
+    drifted_order = (
+        ("/api/v1/users", "GET", False),
+        ("/api/v1/users", "POST", False),
+        ("/api/v1/users/{user_id}", "GET", False),
+        ("/api/v1/users/{user_id}", "DELETE", False),
+    )
+
+    for path, method, include_in_schema in drifted_order:
+        source = _source_route(path, method)
+        target_app.add_api_route(
+            path,
+            route_endpoint(source),
+            methods=[method],
+            include_in_schema=include_in_schema,
+            responses=source.responses,
+            dependencies=[Depends(app_main._require_users_api_key)],
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing users route order does not preserve source route order",
+    ):
+        app_main._include_users_router_if_needed(target_app)


### PR DESCRIPTION
## Summary
Move users CRUD route registration ownership from `legacy_app.py` to canonical `app.main` bootstrap.

The four users CRUD routes remain available at runtime, remain hidden from public OpenAPI, and continue to require `_require_users_api_key`.

## Goal
Preserve existing users CRUD behavior while removing another legacy route registration owner.

## Business reason
Reduce duplicate/legacy route ownership risk and make hidden internal route families easier to audit before further backend route migration work.

## Scope
- Add source `USERS_ROUTE_SPECS` and source-level hidden route metadata in `app/routers/users.py`.
- Register users CRUD through `ensure_route_family_registered(...)` in `app/main.py`.
- Remove `users_router` import/include ownership from `legacy_app.py`.
- Tighten `check_legacy_growth_guard.py` so users registration cannot be reintroduced into `legacy_app.py`.
- Add users-specific bootstrap/fail-closed tests.
- Update the backend routing map.

## Out of scope
Restaurants, recipes, nutrition recommendations, premium/insight extraction, BOLA redesign, principal mapping, DB migrations, frontend, iOS, and macOS.

## Files changed
- `app/main.py`
- `app/routers/users.py`
- `legacy_app.py`
- `scripts/ci/check_legacy_growth_guard.py`
- `tests/test_users_registration_bootstrap.py`
- `tests/test_legacy_growth_guard.py`
- `docs/architecture/backend_routing_map.md`
- `docs/review/PR_2074_FIXED_MAPPING.md`

## Key decisions
- Hidden OpenAPI behavior now lives at users source route metadata, not only post-registration cleanup.
- Canonical bootstrap validates exact users family membership, dependency, visibility, duplicate, foreign-handler, wrong-method, missing dependency, and route-order drift.
- Existing authz contracts remain `USERS_CREDENTIAL`, `LEGACY_HIDDEN`, and `HIDDEN_RUNTIME`; this PR does not redesign BOLA/principal ownership.

## Tests / validation
- PASS: `.venv/bin/python -m pytest -q tests/test_users_registration_bootstrap.py tests/test_legacy_growth_guard.py`
- PASS: `.venv/bin/python -m pytest -q tests/test_route_family_bootstrap.py tests/test_openapi_namespace_guards.py tests/test_users_api.py tests/test_users_router.py tests/test_users_router_retry_logic.py tests/security/test_api_auth_tier_contract_pack.py tests/security/test_api_authz_contract_static.py`
- PASS: `.venv/bin/python scripts/ci/check_legacy_growth_guard.py --repo-root .`
- PASS: explicit route probe confirmed four users routes exactly once, `include_in_schema=False`, no `/api/v1/users*` in public OpenAPI.
- PASS: `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python scripts/orchestration/check_preflight.py` (warning only: noncanonical local `PULSEPLATE_PYTHON_INDEX_URL`).
- PASS: `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python scripts/orchestration/check_agent_consistency.py`
- PASS: `DEV_PYTHON=.venv/bin/python make openapi-check`
- PASS: `.venv/bin/pre-commit run --all-files`
- PASS: `make validate-changed` after implementation commit and after mapping commit.
- PASS: `python -m pytest tests/test_pr_review_report.py tests/test_pr_review_context.py -q` (22 tests via repo venv).
- PASS: `pulseplate-pr-review` dry-run report rendered; only advisory large-diff note, addressed by narrow slice scope and targeted gate evidence.
- PASS during push: pre-push hooks including changed-file mypy, pip-audit, backend tests, full Bandit, and Docker build test.

Note: initial bare `make openapi-check` selected host `python3` in the isolated worktree and lacked `dotenv`; rerun with `DEV_PYTHON` set to the repo venv passed and produced no generated diff.

## Security notes
- No auth expansion, no BOLA redesign, no new principal mapping.
- `_require_users_api_key` remains the required dependency for all users routes.
- Users routes remain hidden runtime routes and absent from public OpenAPI.
- Legacy growth guard now rejects users router import/include reintroduction.
- PASS: Codex Security diff scan `42559129-e962-4f95-b560-e332b8931299` completed with 0 findings and complete branch-diff coverage.

## Risks / rollback
Risk: duplicate ownership or route shadowing if users registration returns to `legacy_app.py`.
Mitigation: canonical route-family tests and legacy growth guard negative cases.
Rollback: revert this PR; users router registration returns to legacy ownership at prior behavior.

## Deferred / Follow-ups
None for this slice.

## Lane Start Provenance
Starter: `scripts/orchestration/start_pr_lane.sh`
Packet: `artifacts/orchestration/task_packets/50f8dc5bd549.json`
Role order completed before implementation: `agent-coordinator -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/exp-d18b2b538b82.json`
Mode: `oracle_only_governance_reviewer`
Status: accepted
Notes: earlier local attempts produced rejected artifacts for packet/schema mismatch, missing staged test context, and missing `unshare`; accepted evidence uses `--network-budget 1` with local pytest/guard oracles only.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2074_FIXED_MAPPING.md`

## Merge Readiness
Post-open review lane completed: `qa-engineer-agent -> bug-hunter -> security-auditor`, Codex Security diff scan/finding discovery, and `pulseplate-pr-review`.
Post-mapping governance refresh landed at `6e31ddc8b06e8f734a29714bc492defc9ac57359`; final merge action requires current-head CI and the strict merge-readiness wrapper to pass on that latest head, plus review-thread state, external bot no-actionables confirmation, and wait-window policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users CRUD routes are now registered via canonical, idempotent bootstrap and kept hidden from the public OpenAPI schema.

* **Bug Fixes**
  * Prevents duplicate, partial, or conflicting users route registrations during bootstrapping.
  * Enforces the required users API key dependency on the registered users routes.
  * Removes legacy wiring that could reintroduce or duplicate users routes.

* **Documentation**
  * Updated backend routing documentation to reflect canonical users-router ownership and OpenAPI hiding.

* **Tests**
  * Added comprehensive tests for users route bootstrap/idempotency/visibility.
  * Updated legacy growth-guard scenarios and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
