### PR TITLE
feat(orchestration): add creative spec learning rollup

### DIFF
--- a/docs/orchestration/AGENT_LEARNING_LOOP.md
+++ b/docs/orchestration/AGENT_LEARNING_LOOP.md
@@ -26,6 +26,16 @@ security/governance failures on the actual diff, while learning-loop records
 repeatable patterns and the process metrics that would show whether later
 promotion improved agent behavior.
 
+Finalized creative-code specification outcomes may feed this loop through the
+local-only creative spec learning rollup. That rollup consumes validated bridge
+metrics, skeptic-review attachment, finalize receipt, and
+`CreativeCodeSpecificationBundle` artifacts, then emits proposal-only
+`agent_learning_record.v1` success/failure records plus coordinator advisory
+hints. These hints may tell reviewers which lesson ids to reuse or avoid, but
+they do not change routing, role order, required gates, agent execution,
+patch generation, semantic cache, graph truth, product runtime truth, or
+merge-readiness authority.
+
 Learning-loop output is not runtime truth, not product behavior, and not
 canonical governance until a reviewed repo diff promotes it into the smallest
 authoritative surface, such as a scoped `AGENTS.md`, an orchestration contract,

--- a/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
+++ b/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
@@ -57,6 +57,7 @@ open the semantic-cache gate.
 | `pr-creative-context` | Expands eligible PR context into 3-5 hypotheses, validates operator-supplied local hypothesis JSON, assigns normalized hypothesis IDs, records cross-domain analogies, emits agent routing/coordinator dispatch, and prepares approval reservations. | Allowed only through local sanitized Experiment Runner creative-context artifacts; no repo-side provider/model call, patch generation, workflow mutation, semantic cache, or GitHub write authority. |
 | `approved-hypothesis-spec-bridge` | Converts a human-approved creative hypothesis into a validated PR-0 creative-code candidate and existing PR-1 prepare artifacts. | Allowed only through local `creative_hypothesis_spec_bridge.py`; no mutable-surface widening, provider calls, patch generation, PR writes, role execution, finalization, semantic cache, graph truth, or product runtime authority. |
 | `reviewed-spec-finalize` | Attaches sanitized local skeptic-review evidence to a prepared bridge run and delegates to existing PR-1 finalize in a sibling reviewed directory. | Allowed only through local `creative_specification_skeptic_review.py`; must preserve `spec_prepare/`; no agent execution, provider calls, patch generation, PR writes, workflow changes, semantic cache, graph truth, product runtime, fixed-mapping edits, review-thread actions, or readiness claims. |
+| `reviewed-spec-learning-rollup` | Converts finalized creative specification outcomes into proposal-only learning records and coordinator advisory hints. | Allowed only through local `creative_spec_learning_rollup.py` and optional `task_bootstrap.py --creative-learning-hints`; no provider calls, agent execution, patch generation, routing authority, required-role changes, lifecycle-gate changes, PR/GitHub/Slack writes, semantic cache, graph truth, product runtime truth, or merge-readiness authority. |
 
 PR-0 sets:
 
@@ -198,6 +199,15 @@ The approved creative-hypothesis specification bridge artifacts are:
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/creative_code_specification_bundle.json`
 - `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/spec_finalize_reviewed/finalize_receipt.json`
 
+The reviewed creative specification learning rollup artifacts are:
+
+- `docs/orchestration/contracts/creative_spec_learning_rollup.v1.schema.json`
+- `docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json`
+- `scripts/orchestration/creative_spec_learning_rollup_contract.py`
+- `scripts/orchestration/creative_spec_learning_rollup.py`
+- `artifacts/orchestration/creative_code/learning_rollup/<rollup-id>/creative_spec_learning_rollup.json`
+- `artifacts/orchestration/creative_code/learning_rollup/<rollup-id>/coordinator_advisory_hints.json`
+
 Bridge output directories must be exactly
 `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/`; bridge refs,
 candidate packets, metrics, and prepare directories must agree on that id.
@@ -260,6 +270,13 @@ PR-0 is a contract-only start point.
   preserve `spec_prepare/`; no agent execution, patches, branch/PR writes,
   provider calls, workflows, product runtime truth, semantic cache, graph truth,
   fixed-mapping edits, review-thread actions, or readiness claims.
+- Creative spec learning rollup: ingest finalized creative spec outcomes into
+  proposal-only `agent_learning_record.v1` success/failure records and
+  coordinator advisory hints; optional task bootstrap packet visibility may
+  expose hint fingerprints and reviewer-focus lesson ids only, without changing
+  routing, role order, required gates, agent execution, patch generation,
+  semantic cache, graph truth, product runtime truth, PR/GitHub/Slack writes,
+  or merge-readiness authority.
 - PR-2: generate isolated candidate patches only in sandboxed evaluation
   workspaces with exact source-bundle fingerprint binding, exact `origin/main`
   base SHA, fixed Codex CLI argv/env, strict patch policy validation, direct
@@ -292,10 +309,10 @@ PR-0 is a contract-only start point.
   workflows, call providers, call product runtime, create branches, open PRs,
   post comments, resolve threads, edit fixed mappings, merge, or claim
   readiness.
-- Bridge follow-ups remain separate reviewed PRs: ingest bridge metrics into
-  the existing telemetry / learning-loop rollup and explore graph/multimodal
-  lineage only after
-  repo-reviewed evidence contracts define asset lineage, fingerprints,
+- Bridge follow-ups remain separate reviewed PRs: the reviewed-spec learning
+  rollup ingests finalized bridge/finalize outcomes into the existing
+  proposal-only learning loop, while graph/multimodal lineage remains deferred
+  until repo-reviewed evidence contracts define asset lineage, fingerprints,
   idempotency, and replay/admission behavior.
 
 Minimum future telemetry fields are defined now for the later train and must not be emitted before PR-1:

--- a/docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json
+++ b/docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json
@@ -50,7 +50,7 @@
   "$defs": {
     "lesson_id": {
       "type": "string",
-      "pattern": "^lesson-[A-Za-z0-9._:-]{1,25}$"
+      "pattern": "^lesson-[a-f0-9]{12}$"
     },
     "lesson_ids": {
       "type": "array",

--- a/docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json
+++ b/docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PulsePlate Creative Spec Coordinator Advisory Hints",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "hints_id",
+    "idempotency_key",
+    "source_rollup_id",
+    "source_rollup_fingerprint",
+    "recommended_role_focus",
+    "reuse_lesson_ids",
+    "avoid_lesson_ids",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_spec_coordinator_advisory_hints" },
+    "policy_version": { "const": "creative-spec-learning-rollup-v1" },
+    "hints_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "idempotency_key": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "source_rollup_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "source_rollup_fingerprint": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "recommended_role_focus": {
+      "type": "array",
+      "maxItems": 6,
+      "items": { "$ref": "#/$defs/role_focus" }
+    },
+    "reuse_lesson_ids": { "$ref": "#/$defs/lesson_ids" },
+    "avoid_lesson_ids": { "$ref": "#/$defs/lesson_ids" },
+    "authority": { "$ref": "#/$defs/advisory_authority" },
+    "sanitized": { "const": true }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "lesson_id": {
+      "type": "string",
+      "pattern": "^lesson-[A-Za-z0-9._:-]{1,25}$"
+    },
+    "lesson_ids": {
+      "type": "array",
+      "maxItems": 6,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/lesson_id" }
+    },
+    "role_focus": {
+      "type": "object",
+      "required": [
+        "agent",
+        "focus",
+        "reason",
+        "source_lesson_ids"
+      ],
+      "properties": {
+        "agent": {
+          "enum": [
+            "agent-coordinator",
+            "architecture-specialist",
+            "security-auditor",
+            "qa-engineer-agent",
+            "bug-hunter",
+            "cursor-specialist-agent"
+          ]
+        },
+        "focus": {
+          "enum": [
+            "authority_boundary_review",
+            "failure_pattern_review",
+            "oracle_and_test_reuse",
+            "specification_pattern_reuse",
+            "creative_learning_review"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 180,
+          "not": {
+            "pattern": "(diff --git|candidate[._ -]?patch|raw[._ -]?(body|prompt|response|context|patch|review|pr)|provider[._ -]?payload|chain[._ -]?of[._ -]?thought|semantic[-_ ]?cache|graph[-_ ]?truth|product[-_ ]?runtime|provider[-_ ]?call|github[-_ ]?write|slack[-_ ]?write|patch[-_ ]?generation|auto[-_ ]?execute|merge[-_ ]?readiness|file://|https?://|/(Users|home|private/var|var/folders|tmp|etc|opt|usr|Volumes|mnt|root|workspace|workspaces)(/|$)|~[/\\\\]|[A-Za-z]:[\\\\/]|sk-[A-Za-z0-9_-]{12,}|gh[psoru]_|github_pat_|xox[abprs]-|GH_TOKEN|GITHUB_TOKEN)"
+          }
+        },
+        "source_lesson_ids": { "$ref": "#/$defs/lesson_ids" }
+      },
+      "additionalProperties": false
+    },
+    "advisory_authority": {
+      "type": "object",
+      "required": [
+        "advisory_only",
+        "call_product_runtime",
+        "call_provider",
+        "change_lifecycle_gates",
+        "change_primary_agent",
+        "claim_merge_readiness",
+        "execute_agents",
+        "force_agent_routing",
+        "generate_patch",
+        "modify_agents",
+        "modify_prompts",
+        "post_github_comment",
+        "resolve_threads",
+        "skip_required_roles",
+        "use_semantic_cache",
+        "write_graph_truth",
+        "write_repository"
+      ],
+      "properties": {
+        "advisory_only": { "const": true },
+        "call_product_runtime": { "const": false },
+        "call_provider": { "const": false },
+        "change_lifecycle_gates": { "const": false },
+        "change_primary_agent": { "const": false },
+        "claim_merge_readiness": { "const": false },
+        "execute_agents": { "const": false },
+        "force_agent_routing": { "const": false },
+        "generate_patch": { "const": false },
+        "modify_agents": { "const": false },
+        "modify_prompts": { "const": false },
+        "post_github_comment": { "const": false },
+        "resolve_threads": { "const": false },
+        "skip_required_roles": { "const": false },
+        "use_semantic_cache": { "const": false },
+        "write_graph_truth": { "const": false },
+        "write_repository": { "const": false }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/docs/orchestration/contracts/creative_spec_learning_rollup.v1.schema.json
+++ b/docs/orchestration/contracts/creative_spec_learning_rollup.v1.schema.json
@@ -1,0 +1,380 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_spec_learning_rollup.v1.schema.json",
+  "title": "CreativeSpecLearningRollup",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "rollup_id",
+    "idempotency_key",
+    "source",
+    "outcomes",
+    "agent_feedback",
+    "learning_records",
+    "learning_summary",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_spec_learning_rollup" },
+    "policy_version": { "const": "creative-spec-learning-rollup-v1" },
+    "rollup_id": { "$ref": "#/$defs/safe_id" },
+    "idempotency_key": { "$ref": "#/$defs/safe_id" },
+    "source": { "$ref": "#/$defs/source" },
+    "outcomes": { "$ref": "#/$defs/outcomes" },
+    "agent_feedback": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 6,
+      "items": { "$ref": "#/$defs/agent_feedback" }
+    },
+    "learning_records": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 6,
+      "items": { "$ref": "#/$defs/agent_learning_record" }
+    },
+    "learning_summary": { "$ref": "#/$defs/learning_summary" },
+    "authority": { "$ref": "#/$defs/authority" },
+    "sanitized": { "const": true }
+  },
+  "$defs": {
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "safe_token": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 96,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "repo_path": {
+      "type": "string",
+      "pattern": "^(?![A-Za-z][A-Za-z0-9+.-]*:)(?!/)(?![A-Za-z]:[\\\\/])(?!~(?:/|$))(?!(?:tmp|var|Users|Volumes|private)(?:/|$))(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+    },
+    "lesson_id": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 32,
+      "pattern": "^lesson-[a-f0-9]{12}$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bridge_metrics_id",
+        "bridge_metrics_fingerprint",
+        "bridge_id",
+        "skeptic_attachment_id",
+        "skeptic_attachment_fingerprint",
+        "finalize_id",
+        "finalize_receipt_fingerprint",
+        "bundle_id",
+        "bundle_fingerprint",
+        "source_packet_id",
+        "source_packet_fingerprint"
+      ],
+      "properties": {
+        "bridge_metrics_id": { "$ref": "#/$defs/safe_id" },
+        "bridge_metrics_fingerprint": { "$ref": "#/$defs/sha256" },
+        "bridge_id": { "$ref": "#/$defs/safe_id" },
+        "skeptic_attachment_id": { "$ref": "#/$defs/safe_id" },
+        "skeptic_attachment_fingerprint": { "$ref": "#/$defs/sha256" },
+        "finalize_id": { "$ref": "#/$defs/safe_id" },
+        "finalize_receipt_fingerprint": { "$ref": "#/$defs/sha256" },
+        "bundle_id": { "$ref": "#/$defs/safe_id" },
+        "bundle_fingerprint": { "$ref": "#/$defs/sha256" },
+        "source_packet_id": { "$ref": "#/$defs/safe_id" },
+        "source_packet_fingerprint": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "outcomes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "variant_count",
+        "selected_variant_id",
+        "synthesis_status",
+        "next_allowed_action",
+        "pass_review_count",
+        "revise_review_count",
+        "reject_review_count",
+        "unsafe_authority_flag_count",
+        "blocker_count",
+        "unresolved_blocker_count",
+        "rejected_variant_count",
+        "rejection_record_count",
+        "generation_status",
+        "oracle_status",
+        "failure_class",
+        "human_decision"
+      ],
+      "properties": {
+        "variant_count": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "selected_variant_id": {
+          "anyOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/safe_id" }
+          ]
+        },
+        "synthesis_status": { "enum": ["selected", "all_rejected"] },
+        "next_allowed_action": {
+          "enum": [
+            "human_review_for_patch_builder",
+            "human_review_for_discard_or_defer"
+          ]
+        },
+        "pass_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
+        "revise_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
+        "reject_review_count": { "type": "integer", "minimum": 0, "maximum": 15 },
+        "unsafe_authority_flag_count": { "type": "integer", "minimum": 0, "maximum": 150 },
+        "blocker_count": { "type": "integer", "minimum": 0, "maximum": 150 },
+        "unresolved_blocker_count": { "type": "integer", "minimum": 0, "maximum": 150 },
+        "rejected_variant_count": { "type": "integer", "minimum": 0, "maximum": 5 },
+        "rejection_record_count": { "type": "integer", "minimum": 0, "maximum": 5 },
+        "generation_status": { "$ref": "#/$defs/safe_token" },
+        "oracle_status": { "$ref": "#/$defs/safe_token" },
+        "failure_class": {
+          "anyOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/safe_token" }
+          ]
+        },
+        "human_decision": { "$ref": "#/$defs/safe_token" }
+      }
+    },
+    "agent_feedback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reviewer_role", "pass_count", "revise_count", "reject_count"],
+      "properties": {
+        "reviewer_role": { "$ref": "#/$defs/safe_token" },
+        "pass_count": { "type": "integer", "minimum": 0, "maximum": 5 },
+        "revise_count": { "type": "integer", "minimum": 0, "maximum": 5 },
+        "reject_count": { "type": "integer", "minimum": 0, "maximum": 5 }
+      }
+    },
+    "agent_learning_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lesson_id",
+        "source",
+        "pattern_kind",
+        "pattern",
+        "severity",
+        "affected_surfaces",
+        "root_cause",
+        "required_oracle",
+        "promotion_target",
+        "learning_metrics",
+        "dedupe_fingerprint",
+        "redaction_status",
+        "human_review_required"
+      ],
+      "properties": {
+        "lesson_id": { "$ref": "#/$defs/lesson_id" },
+        "source": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "pattern_kind": { "enum": ["failure", "successful_iteration"] },
+        "pattern": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "severity": { "enum": ["low", "medium", "high", "critical"] },
+        "affected_surfaces": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/repo_path" },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "root_cause": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "required_oracle": {
+          "enum": [
+            "schema_validator_parity",
+            "fail_closed_security_edge",
+            "deterministic_content_oracle",
+            "canonical_route_ownership_guard",
+            "evidence_hygiene_mapping_timing",
+            "review_source_degraded"
+          ]
+        },
+        "promotion_target": { "$ref": "#/$defs/repo_path" },
+        "learning_metrics": { "$ref": "#/$defs/learning_metrics" },
+        "dedupe_fingerprint": { "$ref": "#/$defs/sha256" },
+        "redaction_status": { "enum": ["clean", "redacted"] },
+        "human_review_required": { "const": true }
+      }
+    },
+    "learning_metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "primary_metric",
+        "secondary_metrics",
+        "measurement_window",
+        "authority_boundary",
+        "runtime_telemetry_allowed",
+        "product_runtime_truth",
+        "semantic_cache_used",
+        "graph_truth_updated"
+      ],
+      "properties": {
+        "schema_version": { "const": "agent_learning_metrics.v1" },
+        "primary_metric": {
+          "enum": [
+            "agent_iteration_quality",
+            "business_risk_clarity",
+            "premortem_code_closure_rate",
+            "project_development_signal",
+            "repeat_failure_reduction",
+            "review_actionable_escape_reduction",
+            "successful_pattern_reuse",
+            "user_impact_clarity"
+          ]
+        },
+        "secondary_metrics": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "agent_iteration_quality",
+              "business_risk_clarity",
+              "premortem_code_closure_rate",
+              "project_development_signal",
+              "repeat_failure_reduction",
+              "review_actionable_escape_reduction",
+              "successful_pattern_reuse",
+              "user_impact_clarity"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "measurement_window": {
+          "enum": [
+            "current_pr",
+            "next_comparable_pr",
+            "next_two_comparable_prs",
+            "release_train"
+          ]
+        },
+        "authority_boundary": { "const": "proposal_only_non_runtime" },
+        "runtime_telemetry_allowed": { "const": false },
+        "product_runtime_truth": { "const": false },
+        "semantic_cache_used": { "const": false },
+        "graph_truth_updated": { "const": false }
+      }
+    },
+    "learning_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "learning_record_count",
+        "successful_iteration_count",
+        "failure_count",
+        "reuse_lesson_ids",
+        "avoid_lesson_ids"
+      ],
+      "properties": {
+        "learning_record_count": { "type": "integer", "minimum": 1, "maximum": 6 },
+        "successful_iteration_count": { "type": "integer", "minimum": 0, "maximum": 1 },
+        "failure_count": { "type": "integer", "minimum": 0, "maximum": 5 },
+        "reuse_lesson_ids": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/lesson_id" },
+          "maxItems": 6,
+          "uniqueItems": true
+        },
+        "avoid_lesson_ids": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/lesson_id" },
+          "maxItems": 6,
+          "uniqueItems": true
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "auto_execute_agents",
+        "call_product_runtime",
+        "call_provider",
+        "change_client_runtime",
+        "change_openapi",
+        "change_primary_agent",
+        "claim_merge_readiness",
+        "create_branch",
+        "edit_fixed_mapping",
+        "emit_coordinator_advisory_hints",
+        "emit_local_artifacts",
+        "emit_proposal_learning_records",
+        "execute_pr2_patch_builder",
+        "force_agent_routing",
+        "generate_candidate_patch",
+        "generate_patch",
+        "merge",
+        "modify_agents",
+        "modify_github_app",
+        "modify_slack",
+        "modify_task_bootstrap",
+        "modify_workflows",
+        "open_pr",
+        "post_github_comment",
+        "push",
+        "read_finalized_spec_outcomes",
+        "read_secrets",
+        "resolve_threads",
+        "skip_required_roles",
+        "use_semantic_cache",
+        "workflow_dispatch",
+        "write_branch",
+        "write_graph_truth",
+        "write_repository"
+      ],
+      "properties": {
+        "read_finalized_spec_outcomes": { "const": true },
+        "emit_local_artifacts": { "const": true },
+        "emit_proposal_learning_records": { "const": true },
+        "emit_coordinator_advisory_hints": { "const": true },
+        "auto_execute_agents": { "const": false },
+        "call_product_runtime": { "const": false },
+        "call_provider": { "const": false },
+        "change_client_runtime": { "const": false },
+        "change_openapi": { "const": false },
+        "change_primary_agent": { "const": false },
+        "claim_merge_readiness": { "const": false },
+        "create_branch": { "const": false },
+        "edit_fixed_mapping": { "const": false },
+        "execute_pr2_patch_builder": { "const": false },
+        "force_agent_routing": { "const": false },
+        "generate_candidate_patch": { "const": false },
+        "generate_patch": { "const": false },
+        "merge": { "const": false },
+        "modify_agents": { "const": false },
+        "modify_github_app": { "const": false },
+        "modify_slack": { "const": false },
+        "modify_task_bootstrap": { "const": false },
+        "modify_workflows": { "const": false },
+        "open_pr": { "const": false },
+        "post_github_comment": { "const": false },
+        "push": { "const": false },
+        "read_secrets": { "const": false },
+        "resolve_threads": { "const": false },
+        "skip_required_roles": { "const": false },
+        "use_semantic_cache": { "const": false },
+        "workflow_dispatch": { "const": false },
+        "write_branch": { "const": false },
+        "write_graph_truth": { "const": false },
+        "write_repository": { "const": false }
+      }
+    }
+  }
+}

--- a/docs/review/PR_2075_FIXED_MAPPING.md
+++ b/docs/review/PR_2075_FIXED_MAPPING.md
@@ -30,6 +30,11 @@ Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` no l
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075#discussion_r3523766542 -> 6bd673ead0706004f224899bde199183515fc0dd
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075#pullrequestreview-4630181858 -> 6bd673ead0706004f224899bde199183515fc0dd
 
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit classified the identity-refresh helper suggestion as a trivial, low-value nitpick, and the repeated identity refresh blocks in `tests/test_creative_spec_learning_rollup.py` keep each recomputed tampered artifact's upstream ids explicit next to the mutation under test. Focused flake8 and `python -m pytest -q tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py` passed after the latest bug-hunter fixes.
+Reason: This is a maintainability preference inside negative tests, not a correctness, security, governance, or runtime defect. Extracting helpers would add unrelated churn after the current PR already fixed the actual validator gaps.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075#pullrequestreview-4630243274
+
 ## Post-Open Role Finding Disposition Evidence
 
 ### qa-engineer-agent F401 Finding
@@ -55,6 +60,14 @@ Role: bug-hunter
 Commit: 5d8bbccbd75c2031db6b3f2b605f527d7f76019f
 Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` now requires canonical `lesson-[a-f0-9]{12}` ids and binds `rejection_record_count`, `rejected_variant_count`, and all-rejected counters to `learning_summary.failure_count` and `outcomes.variant_count`; `docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json` uses the same canonical lesson-id pattern; `tests/test_creative_spec_learning_rollup.py` covers noncanonical lesson ids, undeclared canonical-looking focus ids, and tampered rejection counters after identity recomputation; `tests/test_task_bootstrap.py` covers fail-closed bootstrap ingestion for noncanonical and undeclared lesson ids. Focused flake8, JSON schema parse, and `python -m pytest -q tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py` passed.
 Reason: The post-open bug-hunter pass proved validly re-fingerprinted artifacts could carry noncanonical lesson ids or inconsistent rejection counters into validated rollup/hints outputs.
+
+### bug-hunter Feedback Count and Schema Parity Findings
+
+Disposition: FIXED
+Role: bug-hunter
+Commit: 408ad2a82402eee9afc3677127f44b27ab1e91f6
+Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` now rejects rollups whose summed `agent_feedback` pass/revise/reject counts do not match `outcomes.pass_review_count`, `outcomes.revise_review_count`, and `outcomes.reject_review_count`, and enforces the schema `agent_feedback` maximum of 6 entries. `tests/test_creative_spec_learning_rollup.py` covers both defects with validly recomputed artifact identity. Focused flake8 and `python -m pytest -q tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py` passed.
+Reason: The final bug-hunter pass proved validly re-fingerprinted artifacts could carry contradictory feedback/outcome counts or more feedback rows than the published schema allows.
 
 ## Experiment Runner Evidence
 

--- a/docs/review/PR_2075_FIXED_MAPPING.md
+++ b/docs/review/PR_2075_FIXED_MAPPING.md
@@ -1,0 +1,71 @@
+# PR 2075 - Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075
+
+Branch: `codex/experiment-runner-creative-spec-learning-rollup`
+
+## Summary
+
+This PR adds a local-only creative specification learning rollup that converts
+finalized creative-code specification outcomes into proposal-only
+`agent_learning_record.v1` records and coordinator advisory hints. It does not
+grant provider calls, patch generation, semantic-cache authority,
+graph-truth authority, product runtime truth, GitHub or Slack writes, agent
+execution, fixed-mapping authority, or merge-readiness authority.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Fixed mapping artifact created after GitHub assigned PR number `#2075`.
+- [x] Pre-open role order completed: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent`.
+- [x] Experiment Runner oracle-only evidence captured before PR open.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Post-Open Role Finding Disposition Evidence
+
+### qa-engineer-agent F401 Finding
+
+Disposition: FIXED
+Role: qa-engineer-agent
+Commit: 6bd673ead0706004f224899bde199183515fc0dd
+Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` no longer imports unused artifact-type constants, `tests/test_creative_spec_learning_rollup.py` adds a semantic-cache/graph-truth claim rejection test, `python -m flake8 scripts/orchestration/creative_spec_learning_rollup_contract.py tests/test_creative_spec_learning_rollup.py` passed, and `python -m pytest -q tests/test_creative_spec_learning_rollup.py` passed.
+Reason: The post-open QA pass found flake8 F401 failures in the current PR surface; the fix removes the lint failure and strengthens the advertised authority-boundary coverage.
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/creative-spec-learning-rollup-oracle-result.json`
+- Mode: `oracle_only_governance_reviewer`
+- Result: `accepted`
+- Contribution kind: `oracle_review`
+- `coauthor_required=true`
+- Implementation commit carrying required trailer: `50e9c04aeee09a0d21344d3c046d60ed0009bdce`
+
+Infra caveat: the first zero-network local attempt recorded `status=rejected`
+and `failure_class=infra_flake` because this development host does not provide
+`unshare` for the network-disabled sandbox. The accepted `network_budget=1`
+artifact kept local pytest/json oracles only and does not grant product
+runtime, provider, client, public API, GitHub, Slack, cache, graph, patch, or
+merge-readiness authority.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/e87dde544345.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+
+## Validation Evidence
+
+- `python -m flake8 scripts/orchestration/creative_spec_learning_rollup_contract.py tests/test_creative_spec_learning_rollup.py` - PASS after post-open QA finding fix.
+- `python -m pytest -q tests/test_creative_spec_learning_rollup.py` - PASS after post-open QA finding fix.
+- `python -m pytest -q tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py tests/test_agent_learning_loop.py tests/test_creative_specification_skeptic_review.py tests/test_creative_hypothesis_spec_bridge.py tests/test_skill_router.py` - PASS after post-open QA finding fix.
+- Earlier local bundle on implementation head: `python scripts/orchestration/check_preflight.py`, `python scripts/orchestration/check_agent_consistency.py`, focused tests, `make validate-changed`, `pre-commit run --all-files`, and pre-push hooks passed before PR open.
+
+## Merge Readiness
+
+Not claimed here. Requires current-head CI after the latest pushed head,
+post-open `qa-engineer-agent -> bug-hunter -> security-auditor`, Codex
+Security, `pulseplate-pr-review`, bot review disposition, and strict
+merge-readiness governance.

--- a/docs/review/PR_2075_FIXED_MAPPING.md
+++ b/docs/review/PR_2075_FIXED_MAPPING.md
@@ -20,10 +20,14 @@ execution, fixed-mapping authority, or merge-readiness authority.
 - [x] Fixed mapping artifact created after GitHub assigned PR number `#2075`.
 - [x] Pre-open role order completed: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent`.
 - [x] Experiment Runner oracle-only evidence captured before PR open.
+- [x] CodeRabbit actionable comments checked and dispositioned below.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 6bd673ead0706004f224899bde199183515fc0dd
+Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` no longer imports `BUNDLE_TYPE`, `METRICS_ARTIFACT_TYPE`, `ATTACHMENT_ARTIFACT_TYPE`, or `FINALIZE_RECEIPT_ARTIFACT_TYPE`; `python -m flake8 scripts/orchestration/creative_spec_learning_rollup_contract.py tests/test_creative_spec_learning_rollup.py` passed; `python -m pytest -q tests/test_creative_spec_learning_rollup.py` passed; CodeRabbit marked the thread addressed in commits `6bd673e` to `8d68363`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075#discussion_r3523766542 -> 6bd673ead0706004f224899bde199183515fc0dd
 
 ## Post-Open Role Finding Disposition Evidence
 

--- a/docs/review/PR_2075_FIXED_MAPPING.md
+++ b/docs/review/PR_2075_FIXED_MAPPING.md
@@ -28,6 +28,7 @@ Disposition: FIXED
 Commit: 6bd673ead0706004f224899bde199183515fc0dd
 Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` no longer imports `BUNDLE_TYPE`, `METRICS_ARTIFACT_TYPE`, `ATTACHMENT_ARTIFACT_TYPE`, or `FINALIZE_RECEIPT_ARTIFACT_TYPE`; `python -m flake8 scripts/orchestration/creative_spec_learning_rollup_contract.py tests/test_creative_spec_learning_rollup.py` passed; `python -m pytest -q tests/test_creative_spec_learning_rollup.py` passed; CodeRabbit marked the thread addressed in commits `6bd673e` to `8d68363`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075#discussion_r3523766542 -> 6bd673ead0706004f224899bde199183515fc0dd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075#pullrequestreview-4630181858 -> 6bd673ead0706004f224899bde199183515fc0dd
 
 ## Post-Open Role Finding Disposition Evidence
 
@@ -38,6 +39,14 @@ Role: qa-engineer-agent
 Commit: 6bd673ead0706004f224899bde199183515fc0dd
 Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` no longer imports unused artifact-type constants, `tests/test_creative_spec_learning_rollup.py` adds a semantic-cache/graph-truth claim rejection test, `python -m flake8 scripts/orchestration/creative_spec_learning_rollup_contract.py tests/test_creative_spec_learning_rollup.py` passed, and `python -m pytest -q tests/test_creative_spec_learning_rollup.py` passed.
 Reason: The post-open QA pass found flake8 F401 failures in the current PR surface; the fix removes the lint failure and strengthens the advertised authority-boundary coverage.
+
+### qa-engineer-agent Undeclared Lesson Reference Finding
+
+Disposition: FIXED
+Role: qa-engineer-agent
+Commit: 851f3aa51adae1c3a273ee90ae0405aadafa4597
+Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` now rejects coordinator advisory hints whose focus `source_lesson_ids` are not declared in `reuse_lesson_ids` or `avoid_lesson_ids`; `tests/test_creative_spec_learning_rollup.py` covers the contract rejection with recomputed valid identity, and `tests/test_task_bootstrap.py` covers fail-closed packet ingestion. `python -m pytest -q tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py` and focused flake8 passed.
+Reason: The post-open QA pass proved a validly re-fingerprinted hints artifact could carry undeclared lesson ids into `task_bootstrap`; the validator now closes that cross-field binding gap.
 
 ## Experiment Runner Evidence
 

--- a/docs/review/PR_2075_FIXED_MAPPING.md
+++ b/docs/review/PR_2075_FIXED_MAPPING.md
@@ -48,6 +48,14 @@ Commit: 851f3aa51adae1c3a273ee90ae0405aadafa4597
 Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` now rejects coordinator advisory hints whose focus `source_lesson_ids` are not declared in `reuse_lesson_ids` or `avoid_lesson_ids`; `tests/test_creative_spec_learning_rollup.py` covers the contract rejection with recomputed valid identity, and `tests/test_task_bootstrap.py` covers fail-closed packet ingestion. `python -m pytest -q tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py` and focused flake8 passed.
 Reason: The post-open QA pass proved a validly re-fingerprinted hints artifact could carry undeclared lesson ids into `task_bootstrap`; the validator now closes that cross-field binding gap.
 
+### bug-hunter Lesson Id and Counter Binding Findings
+
+Disposition: FIXED
+Role: bug-hunter
+Commit: 5d8bbccbd75c2031db6b3f2b605f527d7f76019f
+Evidence: `scripts/orchestration/creative_spec_learning_rollup_contract.py` now requires canonical `lesson-[a-f0-9]{12}` ids and binds `rejection_record_count`, `rejected_variant_count`, and all-rejected counters to `learning_summary.failure_count` and `outcomes.variant_count`; `docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json` uses the same canonical lesson-id pattern; `tests/test_creative_spec_learning_rollup.py` covers noncanonical lesson ids, undeclared canonical-looking focus ids, and tampered rejection counters after identity recomputation; `tests/test_task_bootstrap.py` covers fail-closed bootstrap ingestion for noncanonical and undeclared lesson ids. Focused flake8, JSON schema parse, and `python -m pytest -q tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py` passed.
+Reason: The post-open bug-hunter pass proved validly re-fingerprinted artifacts could carry noncanonical lesson ids or inconsistent rejection counters into validated rollup/hints outputs.
+
 ## Experiment Runner Evidence
 
 - Artifact: `artifacts/orchestration/experiments/results/creative-spec-learning-rollup-oracle-result.json`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -11037,9 +11037,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Follow-up bridge metrics ingestion:
       - Priority: P1 learning-loop leverage.
       - Owner: orchestration.
-      - Target PR: separate reviewed PR after the approved-hypothesis bridge.
-      - Reason: bridge metrics are deterministic local sidecars but are not yet ingested into the existing telemetry / learning-loop rollup.
-      - DoD: bridge metrics ingest into the existing advisory telemetry / learning-loop rollup with redaction, bounded fields, no runtime telemetry, no product truth, no semantic-cache use, and no graph truth.
+      - Target PR: `codex/experiment-runner-creative-spec-learning-rollup`.
+      - Status: active reviewed PR lane.
+      - Reason: bridge metrics and reviewed finalize outcomes are deterministic local sidecars but need proposal-only learning-loop ingestion before patch-builder admission can be considered.
+      - DoD: finalized bridge metrics, skeptic-review attachment, finalize receipt, and `CreativeCodeSpecificationBundle` ingest into `agent_learning_record.v1` success/failure records plus coordinator advisory hints with redaction, bounded fields, no runtime telemetry, no product truth, no semantic-cache use, no graph truth, no provider calls, no patch generation, and no routing or merge-readiness authority.
+      - Evidence target: `scripts/orchestration/creative_spec_learning_rollup.py`; `scripts/orchestration/creative_spec_learning_rollup_contract.py`; `docs/orchestration/contracts/creative_spec_learning_rollup.v1.schema.json`; `docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json`; `tests/test_creative_spec_learning_rollup.py`; `tests/test_task_bootstrap.py`.
     - Follow-up bridge authority schema single-source:
       - Priority: P2 maintainability.
       - Owner: orchestration.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -72,6 +72,20 @@
   create/write branches, push/open PRs, edit fixed mappings, resolve review
   threads, modify workflows, call product runtime, use semantic cache, write
   graph truth, or claim readiness.
+- Creative spec learning rollup artifacts stay local under
+  `artifacts/orchestration/creative_code/learning_rollup/<rollup-id>/`. The
+  `creative_spec_learning_rollup.py` CLI may only read validated bridge
+  metrics, skeptic-review attachment, finalize receipt, and
+  `CreativeCodeSpecificationBundle` artifacts; emit proposal-only
+  `agent_learning_record.v1` records and coordinator advisory hints; and
+  validate those local artifacts. Hints may be surfaced in `task_bootstrap.py`
+  packets with `--creative-learning-hints`, but only as reviewer-focus context.
+  They must not change primary/reviewer/role order, execute agents, auto-route
+  roles, skip required roles, generate patches, create/write branches,
+  push/open PRs, post GitHub comments, edit fixed mappings, resolve review
+  threads, claim readiness, merge, release, call providers, call product
+  runtime, use semantic cache, write graph truth, or mutate GitHub App / Slack
+  settings.
 - The runner must apply patches only inside an isolated temporary checkout and must leave the shared working tree untouched.
 - Mutable surfaces, immutable oracles, budgets, and promotion boundaries are defined by `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or relax them here.
 - Runner mutation of `scripts/ci/**`, `docs/review/**`, `AGENTS.md`, merge

--- a/scripts/orchestration/context_pack.py
+++ b/scripts/orchestration/context_pack.py
@@ -251,6 +251,7 @@ def compute_task_packet_id(
     requested_agents: list[str] | tuple[str, ...] = (),
     pr_phase: str = "none",
     design_fingerprint: str = "",
+    creative_learning_hints_fingerprint: str = "",
 ) -> str:
     """Return deterministic short task packet id."""
 
@@ -261,6 +262,7 @@ def compute_task_packet_id(
             domain.strip(),
             pr_phase.strip(),
             design_fingerprint.strip(),
+            creative_learning_hints_fingerprint.strip(),
             *repo_relative_paths(candidate_paths),
             *requested_agents,
         ]

--- a/scripts/orchestration/creative_spec_learning_rollup.py
+++ b/scripts/orchestration/creative_spec_learning_rollup.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Collect proposal-only learning rollups from finalized creative specs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.orchestration.creative_spec_learning_rollup_contract import (
+    CreativeSpecLearningRollupError,
+    build_coordinator_advisory_hints,
+    build_creative_spec_learning_rollup,
+    validate_coordinator_advisory_hints,
+    validate_creative_spec_learning_rollup,
+)
+
+CREATIVE_CODE_ROOT = REPO_ROOT / "artifacts" / "orchestration" / "creative_code"
+SPEC_BRIDGE_ROOT = CREATIVE_CODE_ROOT / "spec_bridge"
+LEARNING_ROLLUP_ROOT = CREATIVE_CODE_ROOT / "learning_rollup"
+
+ROLLUP_FILENAME = "creative_spec_learning_rollup.json"
+HINTS_FILENAME = "coordinator_advisory_hints.json"
+COLLECT_SUCCESS_OUTPUT = "PASS: creative spec learning rollup collected"
+HINTS_SUCCESS_OUTPUT = "PASS: creative spec coordinator advisory hints written"
+VALIDATE_SUCCESS_OUTPUT = "PASS: creative spec learning artifact valid"
+
+
+class CreativeSpecLearningRollupCliError(ValueError):
+    """Raised when local learning-rollup CLI I/O cannot safely complete."""
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _existing_components(path: Path) -> list[Path]:
+    components: list[Path] = []
+    current_path = Path(path.anchor) if path.anchor else Path(".")
+    parts = path.parts[1:] if path.anchor else path.parts
+    for part in parts:
+        current_path = current_path / part
+        if current_path.exists() or current_path.is_symlink():
+            components.append(current_path)
+    return components
+
+
+def _reject_symlink_components(path: Path, *, label: str) -> None:
+    for component in _existing_components(path):
+        if component.is_symlink():
+            raise CreativeSpecLearningRollupCliError(f"{label} must not traverse symlinks.")
+
+
+def _ensure_artifact_root(root: Path) -> Path:
+    _reject_symlink_components(root, label="creative-code artifact root")
+    root.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_components(root, label="creative-code artifact root")
+    resolved = root.resolve(strict=True)
+    if not resolved.is_dir():
+        raise CreativeSpecLearningRollupCliError("creative-code artifact root must be a directory.")
+    return resolved
+
+
+def _resolve_repo_json_file(raw_path: Path, *, label: str) -> Path:
+    candidate = raw_path if raw_path.is_absolute() else REPO_ROOT / raw_path
+    _reject_symlink_components(candidate, label=label)
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise CreativeSpecLearningRollupCliError(f"{label} must exist.") from exc
+    repo_root = REPO_ROOT.resolve()
+    artifact_root = CREATIVE_CODE_ROOT.resolve(strict=False)
+    if not _is_relative_to(resolved, repo_root) or not _is_relative_to(resolved, artifact_root):
+        raise CreativeSpecLearningRollupCliError(
+            f"{label} must stay under creative-code artifacts."
+        )
+    if not resolved.is_file() or resolved.suffix != ".json":
+        raise CreativeSpecLearningRollupCliError(f"{label} must be a JSON file.")
+    return resolved
+
+
+def _resolve_output_dir(raw_output: str | None, *, rollup_id: str) -> Path:
+    root = _ensure_artifact_root(LEARNING_ROLLUP_ROOT)
+    if raw_output:
+        candidate = Path(raw_output)
+        path = candidate if candidate.is_absolute() else REPO_ROOT / candidate
+    else:
+        path = LEARNING_ROLLUP_ROOT / rollup_id
+    _reject_symlink_components(path, label="output directory")
+    resolved = path.resolve(strict=False)
+    if not _is_relative_to(resolved, root):
+        raise CreativeSpecLearningRollupCliError(
+            "output directory must stay under creative-code learning rollup artifacts."
+        )
+    if path.exists() or path.is_symlink():
+        raise CreativeSpecLearningRollupCliError(
+            "output directory already exists; remove the local artifact before rerun."
+        )
+    path.mkdir(parents=True, exist_ok=False)
+    _reject_symlink_components(path, label="output directory")
+    return path.resolve(strict=True)
+
+
+def _resolve_output_file(raw_output: str | Path, *, label: str) -> Path:
+    candidate = Path(raw_output)
+    path = candidate if candidate.is_absolute() else REPO_ROOT / candidate
+    _reject_symlink_components(path.parent, label=f"{label} parent")
+    root = _ensure_artifact_root(LEARNING_ROLLUP_ROOT)
+    resolved = path.resolve(strict=False)
+    if not _is_relative_to(resolved, root):
+        raise CreativeSpecLearningRollupCliError(
+            f"{label} must stay under creative-code learning rollup artifacts."
+        )
+    if path.exists() or path.is_symlink():
+        raise CreativeSpecLearningRollupCliError(f"{label} already exists.")
+    if path.suffix != ".json":
+        raise CreativeSpecLearningRollupCliError(f"{label} must be a JSON file.")
+    return path
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    resolved = _resolve_repo_json_file(path, label=label)
+    try:
+        payload = json.loads(
+            resolved.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_object_keys,
+        )
+    except CreativeSpecLearningRollupCliError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CreativeSpecLearningRollupCliError(f"unable to read {label}.") from exc
+    if not isinstance(payload, dict):
+        raise CreativeSpecLearningRollupCliError(f"{label} must be a JSON object.")
+    return payload
+
+
+def _reject_duplicate_json_object_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: set[str] = set()
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise CreativeSpecLearningRollupCliError(
+                f"creative spec learning JSON has duplicate key: {key}"
+            )
+        seen.add(key)
+        payload[key] = value
+    return payload
+
+
+def _write_json_atomic(path: Path, payload: Any) -> None:
+    if path.suffix != ".json":
+        raise CreativeSpecLearningRollupCliError("output artifact must be JSON.")
+    _reject_symlink_components(path.parent, label="output artifact parent")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_components(path.parent, label="output artifact parent")
+    if path.exists() or path.is_symlink():
+        raise CreativeSpecLearningRollupCliError("output artifact already exists.")
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_name = temp_file.name
+            json.dump(payload, temp_file, indent=2, sort_keys=True)
+            temp_file.write("\n")
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_name, path)
+        temp_name = None
+    finally:
+        if temp_name is not None:
+            try:
+                Path(temp_name).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _collect(args: argparse.Namespace) -> int:
+    bridge_metrics = _read_json_object(args.bridge_metrics, label="bridge metrics")
+    skeptic_attachment = _read_json_object(args.skeptic_attachment, label="skeptic attachment")
+    finalize_receipt = _read_json_object(args.finalize_receipt, label="finalize receipt")
+    bundle = _read_json_object(args.bundle, label="creative specification bundle")
+    rollup = build_creative_spec_learning_rollup(
+        bridge_metrics=bridge_metrics,
+        skeptic_attachment=skeptic_attachment,
+        finalize_receipt=finalize_receipt,
+        bundle=bundle,
+    )
+    hints = build_coordinator_advisory_hints(rollup)
+    output_dir = _resolve_output_dir(args.output_dir, rollup_id=str(rollup["rollup_id"]))
+    try:
+        _write_json_atomic(output_dir / ROLLUP_FILENAME, rollup)
+        _write_json_atomic(output_dir / HINTS_FILENAME, hints)
+    except Exception:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        raise
+    print(COLLECT_SUCCESS_OUTPUT)
+    print(output_dir.relative_to(REPO_ROOT).as_posix())
+    return 0
+
+
+def _emit_hints(args: argparse.Namespace) -> int:
+    rollup = validate_creative_spec_learning_rollup(
+        _read_json_object(args.rollup, label="learning rollup")
+    )
+    hints = build_coordinator_advisory_hints(rollup)
+    output_path = _resolve_output_file(args.output, label="coordinator advisory hints output")
+    _write_json_atomic(output_path, hints)
+    print(HINTS_SUCCESS_OUTPUT)
+    print(output_path.relative_to(REPO_ROOT).as_posix())
+    return 0
+
+
+def _summarize(args: argparse.Namespace) -> int:
+    rollup = validate_creative_spec_learning_rollup(
+        _read_json_object(args.rollup, label="learning rollup")
+    )
+    payload = {
+        "rollup_id": rollup["rollup_id"],
+        "synthesis_status": rollup["outcomes"]["synthesis_status"],
+        "selected_variant_id": rollup["outcomes"]["selected_variant_id"],
+        "learning_summary": rollup["learning_summary"],
+        "authority_boundary": "proposal_only_non_runtime",
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def _validate(args: argparse.Namespace) -> int:
+    if args.rollup:
+        validate_creative_spec_learning_rollup(
+            _read_json_object(args.rollup, label="learning rollup")
+        )
+    if args.hints:
+        validate_coordinator_advisory_hints(
+            _read_json_object(args.hints, label="coordinator advisory hints")
+        )
+    print(VALIDATE_SUCCESS_OUTPUT)
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="creative_spec_learning_rollup",
+        description="Collect proposal-only learning from finalized creative specs.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    collect = subparsers.add_parser("collect")
+    collect.add_argument("--bridge-metrics", type=Path, required=True)
+    collect.add_argument("--skeptic-attachment", type=Path, required=True)
+    collect.add_argument("--finalize-receipt", type=Path, required=True)
+    collect.add_argument("--bundle", type=Path, required=True)
+    collect.add_argument("--output-dir", default=None)
+    collect.set_defaults(func=_collect)
+
+    summarize = subparsers.add_parser("summarize")
+    summarize.add_argument("--rollup", type=Path, required=True)
+    summarize.set_defaults(func=_summarize)
+
+    emit_hints = subparsers.add_parser("emit-coordinator-hints")
+    emit_hints.add_argument("--rollup", type=Path, required=True)
+    emit_hints.add_argument("--output", required=True)
+    emit_hints.set_defaults(func=_emit_hints)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--rollup", type=Path, default=None)
+    validate.add_argument("--hints", type=Path, default=None)
+    validate.set_defaults(func=_validate)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.command == "validate" and not args.rollup and not args.hints:
+        print("FAIL: validate requires --rollup or --hints")
+        return 1
+    try:
+        return int(args.func(args))
+    except (CreativeSpecLearningRollupCliError, CreativeSpecLearningRollupError) as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/creative_spec_learning_rollup_contract.py
+++ b/scripts/orchestration/creative_spec_learning_rollup_contract.py
@@ -438,6 +438,7 @@ def validate_coordinator_advisory_hints(payload: Mapping[str, Any]) -> dict[str,
         "authority": _normalize_hints_authority(payload["authority"], label=f"{label}.authority"),
         "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
     }
+    _validate_hints_lesson_references(normalized, label=label)
     _validate_identity(
         normalized,
         id_key="hints_id",
@@ -449,6 +450,28 @@ def validate_coordinator_advisory_hints(payload: Mapping[str, Any]) -> dict[str,
     )
     _reject_payload_safety(normalized, label=label)
     return normalized
+
+
+def _validate_hints_lesson_references(hints: Mapping[str, Any], *, label: str) -> None:
+    declared_reuse = set(cast(Sequence[str], hints["reuse_lesson_ids"]))
+    declared_avoid = set(cast(Sequence[str], hints["avoid_lesson_ids"]))
+    overlap = sorted(declared_reuse.intersection(declared_avoid))
+    if overlap:
+        raise CreativeSpecLearningRollupError(
+            f"{label}.reuse_lesson_ids and avoid_lesson_ids must be disjoint."
+        )
+    declared = declared_reuse | declared_avoid
+    for index, focus in enumerate(
+        cast(Sequence[Mapping[str, Any]], hints["recommended_role_focus"])
+    ):
+        source_ids = set(cast(Sequence[str], focus["source_lesson_ids"]))
+        undeclared = sorted(source_ids.difference(declared))
+        if undeclared:
+            joined = ", ".join(undeclared)
+            raise CreativeSpecLearningRollupError(
+                f"{label}.recommended_role_focus[{index}].source_lesson_ids "
+                f"references undeclared lesson ids: {joined}."
+            )
 
 
 def _validate_source_chain(

--- a/scripts/orchestration/creative_spec_learning_rollup_contract.py
+++ b/scripts/orchestration/creative_spec_learning_rollup_contract.py
@@ -1,0 +1,1198 @@
+"""Proposal-only learning rollups for finalized creative-code specifications.
+
+This module is a local orchestration contract. It consumes already-finalized,
+reviewed creative-code specification artifacts and emits proposal-only agent
+learning records plus coordinator advisory hints. It has no provider calls,
+runtime authority, semantic-cache authority, graph-truth authority, patch
+generation authority, PR authority, or role-execution authority.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import re
+from typing import Any, cast
+
+from core.evidence.fingerprints import build_asset_id, build_idempotency_key, fingerprint_payload
+from scripts.orchestration.agent_learning_loop import (
+    AUTHORITY_BOUNDARY as LEARNING_AUTHORITY_BOUNDARY,
+    build_agent_learning_record,
+    validate_agent_learning_record,
+)
+from scripts.orchestration.creative_code_specification import (
+    BUNDLE_TYPE,
+    CreativeCodeSpecificationError,
+    validate_creative_code_specification_bundle,
+)
+from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
+    METRICS_ARTIFACT_TYPE,
+    CreativeHypothesisSpecBridgeError,
+    validate_bridge_metrics,
+)
+from scripts.orchestration.creative_specification_skeptic_review_contract import (
+    ATTACHMENT_ARTIFACT_TYPE,
+    FINALIZE_RECEIPT_ARTIFACT_TYPE,
+    CreativeSpecificationSkepticReviewError,
+    validate_finalize_receipt,
+    validate_skeptic_review_attachment,
+)
+
+SCHEMA_VERSION = "1.0"
+POLICY_VERSION = "creative-spec-learning-rollup-v1"
+ROLLUP_ARTIFACT_TYPE = "creative_spec_learning_rollup"
+HINTS_ARTIFACT_TYPE = "creative_spec_coordinator_advisory_hints"
+
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
+SHA256_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+SECRET_RE = re.compile(
+    r"(sk-[A-Za-z0-9_-]{12,}|gh[psoru]_[A-Za-z0-9_.-]{12,}|github_pat_|"
+    r"xox[abprs]-|authorization:\s*bearer|private[_ -]?key|api[_ -]?key|"
+    r"GH_TOKEN|GITHUB_TOKEN)",
+    re.IGNORECASE,
+)
+LEAK_TEXT_RE = re.compile(
+    r"(diff --git|^\+\+\+ |^--- |@@ |candidate\.patch|candidate_patch|"
+    r"raw[_ -]?(body|prompt|response|context|patch|review|pr)|"
+    r"review[_ -]?thread[_ -]?body|pull[_ -]?request[_ -]?body|"
+    r"chain[_ -]?of[_ -]?thought|provider[_ -]?payload|oracle[_ -]?(stdout|stderr)|"
+    r"file://|https?://|"
+    r"/(?:Users|home|private/var|var/folders|tmp|etc|opt|usr|Volumes|mnt|root|"
+    r"workspace|workspaces)(?:/|$)|~[/\\]|[A-Za-z]:[\\/]|\.venv/|\.git/|"
+    r"worktrees([:/._-]|$)|github_pat_|gh[psoru]_|xox[abprs]-|"
+    r"sk-[A-Za-z0-9_-]{12,}|GH_TOKEN|GITHUB_TOKEN)",
+    re.IGNORECASE | re.MULTILINE,
+)
+UNSAFE_CLAIM_RE = re.compile(
+    r"(semantic[-_ ]?cache[-_ ]?(used|updated|write|truth|serving)|"
+    r"graph[-_ ]?truth[-_ ]?(used|updated|write|serving)|"
+    r"product[-_ ]?runtime[-_ ]?truth|runtime[-_ ]?authority|"
+    r"provider[-_ ]?call|github[-_ ]?write|slack[-_ ]?write|"
+    r"patch[-_ ]?generation|auto[-_ ]?execute[-_ ]?agents|merge[-_ ]?readiness)",
+    re.IGNORECASE,
+)
+
+AGENT_SLUGS = frozenset(
+    {
+        "agent-coordinator",
+        "architecture-specialist",
+        "security-auditor",
+        "qa-engineer-agent",
+        "bug-hunter",
+        "cursor-specialist-agent",
+    }
+)
+FOCUS_IDS = frozenset(
+    {
+        "authority_boundary_review",
+        "failure_pattern_review",
+        "oracle_and_test_reuse",
+        "specification_pattern_reuse",
+        "creative_learning_review",
+    }
+)
+
+ROLLUP_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "rollup_id",
+        "idempotency_key",
+        "source",
+        "outcomes",
+        "agent_feedback",
+        "learning_records",
+        "learning_summary",
+        "authority",
+        "sanitized",
+    }
+)
+ROLLUP_SOURCE_KEYS = frozenset(
+    {
+        "bridge_metrics_id",
+        "bridge_metrics_fingerprint",
+        "bridge_id",
+        "skeptic_attachment_id",
+        "skeptic_attachment_fingerprint",
+        "finalize_id",
+        "finalize_receipt_fingerprint",
+        "bundle_id",
+        "bundle_fingerprint",
+        "source_packet_id",
+        "source_packet_fingerprint",
+    }
+)
+OUTCOME_KEYS = frozenset(
+    {
+        "variant_count",
+        "selected_variant_id",
+        "synthesis_status",
+        "next_allowed_action",
+        "pass_review_count",
+        "revise_review_count",
+        "reject_review_count",
+        "unsafe_authority_flag_count",
+        "blocker_count",
+        "unresolved_blocker_count",
+        "rejected_variant_count",
+        "rejection_record_count",
+        "generation_status",
+        "oracle_status",
+        "failure_class",
+        "human_decision",
+    }
+)
+AGENT_FEEDBACK_KEYS = frozenset({"reviewer_role", "pass_count", "revise_count", "reject_count"})
+LEARNING_SUMMARY_KEYS = frozenset(
+    {
+        "learning_record_count",
+        "successful_iteration_count",
+        "failure_count",
+        "reuse_lesson_ids",
+        "avoid_lesson_ids",
+    }
+)
+ROLLUP_AUTHORITY_TRUE_KEYS = frozenset(
+    {
+        "read_finalized_spec_outcomes",
+        "emit_local_artifacts",
+        "emit_proposal_learning_records",
+        "emit_coordinator_advisory_hints",
+    }
+)
+ROLLUP_AUTHORITY_FALSE_KEYS = frozenset(
+    {
+        "auto_execute_agents",
+        "call_product_runtime",
+        "call_provider",
+        "change_client_runtime",
+        "change_openapi",
+        "change_primary_agent",
+        "claim_merge_readiness",
+        "create_branch",
+        "edit_fixed_mapping",
+        "execute_pr2_patch_builder",
+        "force_agent_routing",
+        "generate_candidate_patch",
+        "generate_patch",
+        "merge",
+        "modify_agents",
+        "modify_github_app",
+        "modify_slack",
+        "modify_task_bootstrap",
+        "modify_workflows",
+        "open_pr",
+        "post_github_comment",
+        "push",
+        "read_secrets",
+        "resolve_threads",
+        "skip_required_roles",
+        "use_semantic_cache",
+        "workflow_dispatch",
+        "write_branch",
+        "write_graph_truth",
+        "write_repository",
+    }
+)
+ROLLUP_AUTHORITY_KEYS = ROLLUP_AUTHORITY_TRUE_KEYS | ROLLUP_AUTHORITY_FALSE_KEYS
+
+HINTS_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "hints_id",
+        "idempotency_key",
+        "source_rollup_id",
+        "source_rollup_fingerprint",
+        "recommended_role_focus",
+        "reuse_lesson_ids",
+        "avoid_lesson_ids",
+        "authority",
+        "sanitized",
+    }
+)
+FOCUS_KEYS = frozenset({"agent", "focus", "reason", "source_lesson_ids"})
+HINTS_AUTHORITY_KEYS = frozenset(
+    {
+        "advisory_only",
+        "call_product_runtime",
+        "call_provider",
+        "change_lifecycle_gates",
+        "change_primary_agent",
+        "claim_merge_readiness",
+        "execute_agents",
+        "force_agent_routing",
+        "generate_patch",
+        "modify_agents",
+        "modify_prompts",
+        "post_github_comment",
+        "resolve_threads",
+        "skip_required_roles",
+        "use_semantic_cache",
+        "write_graph_truth",
+        "write_repository",
+    }
+)
+
+
+class CreativeSpecLearningRollupError(ValueError):
+    """Raised when creative spec learning inputs or outputs violate policy."""
+
+
+def default_rollup_authority() -> dict[str, bool]:
+    """Return the only authority granted to finalized-spec learning rollups."""
+
+    values = {key: False for key in ROLLUP_AUTHORITY_KEYS}
+    for key in ROLLUP_AUTHORITY_TRUE_KEYS:
+        values[key] = True
+    return dict(sorted(values.items()))
+
+
+def default_hints_authority() -> dict[str, bool]:
+    """Return the only authority granted to coordinator advisory hints."""
+
+    values = {key: False for key in HINTS_AUTHORITY_KEYS}
+    values["advisory_only"] = True
+    return dict(sorted(values.items()))
+
+
+def build_creative_spec_learning_rollup(
+    *,
+    bridge_metrics: Mapping[str, Any],
+    skeptic_attachment: Mapping[str, Any],
+    finalize_receipt: Mapping[str, Any],
+    bundle: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build a deterministic proposal-only learning rollup."""
+
+    normalized = _validate_source_chain(
+        bridge_metrics=bridge_metrics,
+        skeptic_attachment=skeptic_attachment,
+        finalize_receipt=finalize_receipt,
+        bundle=bundle,
+    )
+    metrics = normalized["bridge_metrics"]
+    attachment = normalized["skeptic_attachment"]
+    receipt = normalized["finalize_receipt"]
+    spec_bundle = normalized["bundle"]
+    learning_records = _learning_records_for_bundle(
+        finalize_receipt=receipt,
+        bundle=spec_bundle,
+    )
+    outcomes = _outcomes(
+        bridge_metrics=metrics,
+        skeptic_attachment=attachment,
+        finalize_receipt=receipt,
+        bundle=spec_bundle,
+    )
+    rollup: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": ROLLUP_ARTIFACT_TYPE,
+        "policy_version": POLICY_VERSION,
+        "rollup_id": "pending",
+        "idempotency_key": "pending",
+        "source": {
+            "bridge_metrics_id": metrics["metrics_id"],
+            "bridge_metrics_fingerprint": fingerprint_payload(metrics),
+            "bridge_id": metrics["bridge_id"],
+            "skeptic_attachment_id": attachment["attachment_id"],
+            "skeptic_attachment_fingerprint": fingerprint_payload(attachment),
+            "finalize_id": receipt["finalize_id"],
+            "finalize_receipt_fingerprint": fingerprint_payload(receipt),
+            "bundle_id": spec_bundle["bundle_id"],
+            "bundle_fingerprint": fingerprint_payload(spec_bundle),
+            "source_packet_id": spec_bundle["source_packet_id"],
+            "source_packet_fingerprint": spec_bundle["source_packet_fingerprint"],
+        },
+        "outcomes": outcomes,
+        "agent_feedback": _agent_feedback(spec_bundle),
+        "learning_records": learning_records,
+        "learning_summary": _learning_summary(learning_records),
+        "authority": default_rollup_authority(),
+        "sanitized": True,
+    }
+    _set_identity(
+        rollup,
+        id_key="rollup_id",
+        asset_type=ROLLUP_ARTIFACT_TYPE,
+        upstream_ids=(
+            str(receipt["finalize_id"]),
+            str(receipt["bundle_id"]),
+            str(attachment["source"]["metrics_id"]),
+        ),
+    )
+    return validate_creative_spec_learning_rollup(rollup)
+
+
+def validate_creative_spec_learning_rollup(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a finalized-spec learning rollup."""
+
+    label = "CreativeSpecLearningRollup"
+    _require_exact_keys(payload, ROLLUP_KEYS, label=label)
+    learning_records = _normalize_learning_records(
+        payload["learning_records"], label=f"{label}.learning_records"
+    )
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(
+            payload,
+            "artifact_type",
+            ROLLUP_ARTIFACT_TYPE,
+            label=label,
+        ),
+        "policy_version": _require_const(payload, "policy_version", POLICY_VERSION, label=label),
+        "rollup_id": _require_id(payload, "rollup_id", label=label),
+        "idempotency_key": _require_id(payload, "idempotency_key", label=label),
+        "source": _normalize_rollup_source(payload["source"], label=f"{label}.source"),
+        "outcomes": _normalize_outcomes(payload["outcomes"], label=f"{label}.outcomes"),
+        "agent_feedback": _normalize_agent_feedback(
+            payload["agent_feedback"], label=f"{label}.agent_feedback"
+        ),
+        "learning_records": learning_records,
+        "learning_summary": _normalize_learning_summary(
+            payload["learning_summary"], label=f"{label}.learning_summary"
+        ),
+        "authority": _normalize_rollup_authority(payload["authority"], label=f"{label}.authority"),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    if normalized["learning_summary"] != _learning_summary(learning_records):
+        raise CreativeSpecLearningRollupError(
+            f"{label}.learning_summary does not match learning_records."
+        )
+    _validate_rollup_outcome_consistency(normalized)
+    _validate_identity(
+        normalized,
+        id_key="rollup_id",
+        asset_type=ROLLUP_ARTIFACT_TYPE,
+        upstream_ids=(
+            normalized["source"]["finalize_id"],
+            normalized["source"]["bundle_id"],
+            normalized["source"]["bridge_metrics_id"],
+        ),
+    )
+    _reject_payload_safety(normalized, label=label)
+    return normalized
+
+
+def build_coordinator_advisory_hints(rollup: Mapping[str, Any]) -> dict[str, Any]:
+    """Build advisory-only coordinator hints from a validated rollup."""
+
+    normalized_rollup = validate_creative_spec_learning_rollup(rollup)
+    records = cast(list[dict[str, Any]], normalized_rollup["learning_records"])
+    reuse_lesson_ids = [
+        str(record["lesson_id"])
+        for record in records
+        if record["pattern_kind"] == "successful_iteration"
+    ]
+    avoid_lesson_ids = [
+        str(record["lesson_id"]) for record in records if record["pattern_kind"] == "failure"
+    ]
+    hints: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": HINTS_ARTIFACT_TYPE,
+        "policy_version": POLICY_VERSION,
+        "hints_id": "pending",
+        "idempotency_key": "pending",
+        "source_rollup_id": normalized_rollup["rollup_id"],
+        "source_rollup_fingerprint": fingerprint_payload(normalized_rollup),
+        "recommended_role_focus": _recommended_role_focus(records),
+        "reuse_lesson_ids": reuse_lesson_ids,
+        "avoid_lesson_ids": avoid_lesson_ids,
+        "authority": default_hints_authority(),
+        "sanitized": True,
+    }
+    _set_identity(
+        hints,
+        id_key="hints_id",
+        asset_type=HINTS_ARTIFACT_TYPE,
+        upstream_ids=(str(normalized_rollup["rollup_id"]), fingerprint_payload(normalized_rollup)),
+    )
+    return validate_coordinator_advisory_hints(hints)
+
+
+def validate_coordinator_advisory_hints(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate coordinator advisory hints before packet ingestion."""
+
+    label = "CoordinatorAdvisoryHints"
+    _require_exact_keys(payload, HINTS_KEYS, label=label)
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(payload, "artifact_type", HINTS_ARTIFACT_TYPE, label=label),
+        "policy_version": _require_const(payload, "policy_version", POLICY_VERSION, label=label),
+        "hints_id": _require_id(payload, "hints_id", label=label),
+        "idempotency_key": _require_id(payload, "idempotency_key", label=label),
+        "source_rollup_id": _require_id(payload, "source_rollup_id", label=label),
+        "source_rollup_fingerprint": _require_fingerprint(
+            payload,
+            "source_rollup_fingerprint",
+            label=label,
+        ),
+        "recommended_role_focus": _normalize_focus_list(
+            payload["recommended_role_focus"],
+            label=f"{label}.recommended_role_focus",
+        ),
+        "reuse_lesson_ids": _normalize_lesson_ids(
+            payload["reuse_lesson_ids"], label=f"{label}.reuse_lesson_ids"
+        ),
+        "avoid_lesson_ids": _normalize_lesson_ids(
+            payload["avoid_lesson_ids"], label=f"{label}.avoid_lesson_ids"
+        ),
+        "authority": _normalize_hints_authority(payload["authority"], label=f"{label}.authority"),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    _validate_identity(
+        normalized,
+        id_key="hints_id",
+        asset_type=HINTS_ARTIFACT_TYPE,
+        upstream_ids=(
+            normalized["source_rollup_id"],
+            normalized["source_rollup_fingerprint"],
+        ),
+    )
+    _reject_payload_safety(normalized, label=label)
+    return normalized
+
+
+def _validate_source_chain(
+    *,
+    bridge_metrics: Mapping[str, Any],
+    skeptic_attachment: Mapping[str, Any],
+    finalize_receipt: Mapping[str, Any],
+    bundle: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    try:
+        metrics = validate_bridge_metrics(bridge_metrics)
+        attachment = validate_skeptic_review_attachment(skeptic_attachment)
+        receipt = validate_finalize_receipt(finalize_receipt)
+        spec_bundle = validate_creative_code_specification_bundle(bundle)
+    except (
+        CreativeHypothesisSpecBridgeError,
+        CreativeSpecificationSkepticReviewError,
+        CreativeCodeSpecificationError,
+    ) as exc:
+        raise CreativeSpecLearningRollupError(str(exc)) from exc
+
+    attachment_source = cast(Mapping[str, Any], attachment["source"])
+    if attachment_source["metrics_id"] != metrics["metrics_id"]:
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: attachment metrics_id does not match bridge metrics."
+        )
+    if attachment_source["metrics_fingerprint"] != fingerprint_payload(metrics):
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: attachment metrics_fingerprint does not match metrics."
+        )
+    if attachment_source["bridge_id"] != metrics["bridge_id"]:
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: attachment bridge_id does not match metrics."
+        )
+    if attachment_source["candidate_id"] != metrics["candidate_id"]:
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: attachment candidate_id does not match metrics."
+        )
+    if attachment_source["source_packet_fingerprint"] != spec_bundle["source_packet_fingerprint"]:
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: attachment source_packet_fingerprint does not match bundle."
+        )
+    if attachment_source["variants_fingerprint"] != fingerprint_payload(spec_bundle["variants"]):
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: attachment variants_fingerprint does not match bundle."
+        )
+    if cast(Mapping[str, Any], attachment["reviewed_run"])[
+        "normalized_reviews_fingerprint"
+    ] != fingerprint_payload(spec_bundle["skeptic_reviews"]):
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: attachment normalized reviews do not match bundle reviews."
+        )
+    if receipt["source_attachment_id"] != attachment["attachment_id"]:
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: receipt source_attachment_id does not match attachment."
+        )
+    if receipt["source_attachment_fingerprint"] != fingerprint_payload(attachment):
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: receipt source_attachment_fingerprint does not match attachment."
+        )
+    if receipt["bundle_id"] != spec_bundle["bundle_id"]:
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: receipt bundle_id does not match bundle."
+        )
+    if receipt["bundle_fingerprint"] != fingerprint_payload(spec_bundle):
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: receipt bundle_fingerprint does not match bundle."
+        )
+    if receipt["bundle_idempotency_key"] != spec_bundle["idempotency_key"]:
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: receipt bundle_idempotency_key does not match bundle."
+        )
+    if receipt["selected_variant_id"] != spec_bundle["synthesis"]["selected_variant_id"]:
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: receipt selected_variant_id does not match bundle synthesis."
+        )
+    expected_status = (
+        "selected"
+        if spec_bundle["synthesis"]["selected_variant_id"] is not None
+        else "all_rejected"
+    )
+    if receipt["synthesis_status"] != expected_status:
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: receipt synthesis_status does not match bundle synthesis."
+        )
+    if int(cast(Mapping[str, Any], metrics["counts"])["variant_count"]) != len(
+        spec_bundle["variants"]
+    ):
+        raise CreativeSpecLearningRollupError(
+            "fingerprint_mismatch: metrics variant_count does not match bundle."
+        )
+    return {
+        "bridge_metrics": metrics,
+        "skeptic_attachment": attachment,
+        "finalize_receipt": receipt,
+        "bundle": spec_bundle,
+    }
+
+
+def _learning_records_for_bundle(
+    *,
+    finalize_receipt: Mapping[str, Any],
+    bundle: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    target_surface = [str(path) for path in cast(Sequence[Any], bundle["target_surface"])]
+    source_prefix = f"creative_spec_finalize:{finalize_receipt['finalize_id']}"
+    records: list[dict[str, Any]] = []
+    selected_variant_id = cast(Mapping[str, Any], bundle["synthesis"])["selected_variant_id"]
+    if selected_variant_id is not None:
+        records.append(
+            _learning_record(
+                source=f"{source_prefix}:selected:{selected_variant_id}",
+                pattern=(
+                    "Selected creative specification variant passed required skeptic review "
+                    "within proposal-only authority."
+                ),
+                severity="low",
+                affected_surfaces=target_surface,
+                root_cause=(
+                    "Complete skeptic-review pass coverage produced a reusable "
+                    "creative specification pattern."
+                ),
+                required_oracle="deterministic_content_oracle",
+                pattern_kind="successful_iteration",
+            )
+        )
+
+    for rejection in cast(Sequence[Mapping[str, Any]], bundle["rejection_index"]["records"]):
+        reason_codes = sorted(
+            str(reason) for reason in cast(Sequence[Any], rejection["reason_codes"])
+        )
+        reason_text = ", ".join(reason_codes)
+        variant_id = str(rejection["variant_id"])
+        unsafe = any(
+            "unsafe" in reason or "authority" in reason or "policy" in reason
+            for reason in reason_codes
+        )
+        rejected = any("review_reject" == reason for reason in reason_codes)
+        records.append(
+            _learning_record(
+                source=f"{source_prefix}:rejected:{variant_id}",
+                pattern=f"Creative specification variant was blocked by {reason_text}.",
+                severity="high" if unsafe else "medium" if rejected else "low",
+                affected_surfaces=target_surface,
+                root_cause=f"Variant {variant_id} did not satisfy reviewed specification criteria.",
+                required_oracle=(
+                    "fail_closed_security_edge" if unsafe else "deterministic_content_oracle"
+                ),
+                pattern_kind="failure",
+            )
+        )
+    return records
+
+
+def _learning_record(
+    *,
+    source: str,
+    pattern: str,
+    severity: str,
+    affected_surfaces: list[str],
+    root_cause: str,
+    required_oracle: str,
+    pattern_kind: str,
+) -> dict[str, Any]:
+    return cast(
+        dict[str, Any],
+        validate_agent_learning_record(
+            build_agent_learning_record(
+                source=source,
+                pattern=pattern,
+                severity=severity,
+                affected_surfaces=affected_surfaces,
+                root_cause=root_cause,
+                required_oracle=required_oracle,
+                promotion_target="docs/orchestration/AGENT_LEARNING_LOOP.md",
+                pattern_kind=pattern_kind,
+            )
+        ),
+    )
+
+
+def _outcomes(
+    *,
+    bridge_metrics: Mapping[str, Any],
+    skeptic_attachment: Mapping[str, Any],
+    finalize_receipt: Mapping[str, Any],
+    bundle: Mapping[str, Any],
+) -> dict[str, Any]:
+    coverage = cast(Mapping[str, Any], skeptic_attachment["coverage"])
+    counts = cast(Mapping[str, Any], finalize_receipt["counts"])
+    synthesis = cast(Mapping[str, Any], bundle["synthesis"])
+    return {
+        "variant_count": counts["variant_count"],
+        "selected_variant_id": finalize_receipt["selected_variant_id"],
+        "synthesis_status": finalize_receipt["synthesis_status"],
+        "next_allowed_action": finalize_receipt["next_allowed_action"],
+        "pass_review_count": coverage["pass_review_count"],
+        "revise_review_count": coverage["revise_review_count"],
+        "reject_review_count": coverage["reject_review_count"],
+        "unsafe_authority_flag_count": coverage["unsafe_authority_flag_count"],
+        "blocker_count": coverage["blocker_count"],
+        "unresolved_blocker_count": len(cast(Sequence[Any], synthesis["unresolved_blockers"])),
+        "rejected_variant_count": counts["rejected_variant_count"],
+        "rejection_record_count": counts["rejection_record_count"],
+        "generation_status": bundle["generation_status"],
+        "oracle_status": bundle["oracle_status"],
+        "failure_class": bundle["failure_class"],
+        "human_decision": bundle["human_decision"],
+    }
+
+
+def _agent_feedback(bundle: Mapping[str, Any]) -> list[dict[str, Any]]:
+    decisions = ("pass", "revise", "reject")
+    rows: dict[str, dict[str, int | str]] = {}
+    for review in cast(Sequence[Mapping[str, Any]], bundle["skeptic_reviews"]):
+        role = str(review["reviewer_role"])
+        row = rows.setdefault(
+            role,
+            {
+                "reviewer_role": role,
+                "pass_count": 0,
+                "revise_count": 0,
+                "reject_count": 0,
+            },
+        )
+        decision = str(review["decision"])
+        if decision in decisions:
+            row[f"{decision}_count"] = int(row[f"{decision}_count"]) + 1
+    return [cast(dict[str, Any], rows[key]) for key in sorted(rows)]
+
+
+def _learning_summary(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    reuse_lesson_ids = [
+        str(record["lesson_id"])
+        for record in records
+        if str(record["pattern_kind"]) == "successful_iteration"
+    ]
+    avoid_lesson_ids = [
+        str(record["lesson_id"]) for record in records if str(record["pattern_kind"]) == "failure"
+    ]
+    return {
+        "learning_record_count": len(records),
+        "successful_iteration_count": len(reuse_lesson_ids),
+        "failure_count": len(avoid_lesson_ids),
+        "reuse_lesson_ids": reuse_lesson_ids,
+        "avoid_lesson_ids": avoid_lesson_ids,
+    }
+
+
+def _recommended_role_focus(records: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    failure_ids = [
+        str(record["lesson_id"]) for record in records if str(record["pattern_kind"]) == "failure"
+    ]
+    success_ids = [
+        str(record["lesson_id"])
+        for record in records
+        if str(record["pattern_kind"]) == "successful_iteration"
+    ]
+    authority_failure_ids = [
+        str(record["lesson_id"])
+        for record in records
+        if record["pattern_kind"] == "failure"
+        and (
+            record["required_oracle"] == "fail_closed_security_edge"
+            or "authority" in str(record["pattern"]).lower()
+            or "unsafe" in str(record["pattern"]).lower()
+        )
+    ]
+    focus: list[dict[str, Any]] = []
+    if failure_ids:
+        focus.append(
+            {
+                "agent": "agent-coordinator",
+                "focus": "creative_learning_review",
+                "reason": "Review avoid lessons before the next creative specification lane.",
+                "source_lesson_ids": failure_ids,
+            }
+        )
+    if authority_failure_ids:
+        focus.append(
+            {
+                "agent": "security-auditor",
+                "focus": "authority_boundary_review",
+                "reason": "Inspect authority boundaries tied to failed creative specification lessons.",
+                "source_lesson_ids": authority_failure_ids,
+            }
+        )
+    elif failure_ids:
+        focus.append(
+            {
+                "agent": "bug-hunter",
+                "focus": "failure_pattern_review",
+                "reason": "Inspect failed creative specification lesson patterns.",
+                "source_lesson_ids": failure_ids,
+            }
+        )
+    if success_ids:
+        focus.append(
+            {
+                "agent": "qa-engineer-agent",
+                "focus": "oracle_and_test_reuse",
+                "reason": "Reuse successful skeptic-review and oracle coverage patterns.",
+                "source_lesson_ids": success_ids,
+            }
+        )
+        focus.append(
+            {
+                "agent": "architecture-specialist",
+                "focus": "specification_pattern_reuse",
+                "reason": "Inspect successful creative specification structure for repeatable use.",
+                "source_lesson_ids": success_ids,
+            }
+        )
+    return focus
+
+
+def _normalize_rollup_source(raw_source: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(raw_source, dict):
+        raise CreativeSpecLearningRollupError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_source, ROLLUP_SOURCE_KEYS, label=label)
+    return {
+        "bridge_metrics_id": _require_id(raw_source, "bridge_metrics_id", label=label),
+        "bridge_metrics_fingerprint": _require_fingerprint(
+            raw_source, "bridge_metrics_fingerprint", label=label
+        ),
+        "bridge_id": _require_id(raw_source, "bridge_id", label=label),
+        "skeptic_attachment_id": _require_id(raw_source, "skeptic_attachment_id", label=label),
+        "skeptic_attachment_fingerprint": _require_fingerprint(
+            raw_source, "skeptic_attachment_fingerprint", label=label
+        ),
+        "finalize_id": _require_id(raw_source, "finalize_id", label=label),
+        "finalize_receipt_fingerprint": _require_fingerprint(
+            raw_source, "finalize_receipt_fingerprint", label=label
+        ),
+        "bundle_id": _require_id(raw_source, "bundle_id", label=label),
+        "bundle_fingerprint": _require_fingerprint(raw_source, "bundle_fingerprint", label=label),
+        "source_packet_id": _require_id(raw_source, "source_packet_id", label=label),
+        "source_packet_fingerprint": _require_fingerprint(
+            raw_source, "source_packet_fingerprint", label=label
+        ),
+    }
+
+
+def _normalize_outcomes(raw_outcomes: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(raw_outcomes, dict):
+        raise CreativeSpecLearningRollupError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_outcomes, OUTCOME_KEYS, label=label)
+    selected_variant_id = _optional_id(
+        raw_outcomes.get("selected_variant_id"),
+        label=f"{label}.selected_variant_id",
+    )
+    synthesis_status = _require_token(raw_outcomes, "synthesis_status", label=label)
+    if synthesis_status not in {"selected", "all_rejected"}:
+        raise CreativeSpecLearningRollupError(f"{label}.synthesis_status is unsupported.")
+    next_allowed_action = _require_token(raw_outcomes, "next_allowed_action", label=label)
+    if selected_variant_id is None:
+        if synthesis_status != "all_rejected":
+            raise CreativeSpecLearningRollupError(
+                f"{label}.synthesis_status must be all_rejected without a selected variant."
+            )
+    elif synthesis_status != "selected":
+        raise CreativeSpecLearningRollupError(
+            f"{label}.synthesis_status must be selected when selected_variant_id is set."
+        )
+    return {
+        "variant_count": _bounded_int(
+            raw_outcomes, "variant_count", label=label, minimum=1, maximum=5
+        ),
+        "selected_variant_id": selected_variant_id,
+        "synthesis_status": synthesis_status,
+        "next_allowed_action": next_allowed_action,
+        "pass_review_count": _bounded_int(
+            raw_outcomes, "pass_review_count", label=label, maximum=15
+        ),
+        "revise_review_count": _bounded_int(
+            raw_outcomes, "revise_review_count", label=label, maximum=15
+        ),
+        "reject_review_count": _bounded_int(
+            raw_outcomes, "reject_review_count", label=label, maximum=15
+        ),
+        "unsafe_authority_flag_count": _bounded_int(
+            raw_outcomes, "unsafe_authority_flag_count", label=label, maximum=150
+        ),
+        "blocker_count": _bounded_int(raw_outcomes, "blocker_count", label=label, maximum=150),
+        "unresolved_blocker_count": _bounded_int(
+            raw_outcomes, "unresolved_blocker_count", label=label, maximum=150
+        ),
+        "rejected_variant_count": _bounded_int(
+            raw_outcomes, "rejected_variant_count", label=label, maximum=5
+        ),
+        "rejection_record_count": _bounded_int(
+            raw_outcomes, "rejection_record_count", label=label, maximum=5
+        ),
+        "generation_status": _require_token(raw_outcomes, "generation_status", label=label),
+        "oracle_status": _require_token(raw_outcomes, "oracle_status", label=label),
+        "failure_class": _optional_token(
+            raw_outcomes.get("failure_class"), label=f"{label}.failure_class"
+        ),
+        "human_decision": _require_token(raw_outcomes, "human_decision", label=label),
+    }
+
+
+def _normalize_agent_feedback(raw_feedback: Any, *, label: str) -> list[dict[str, Any]]:
+    if not isinstance(raw_feedback, list):
+        raise CreativeSpecLearningRollupError(f"{label} must be an array.")
+    if not raw_feedback:
+        raise CreativeSpecLearningRollupError(f"{label} must be non-empty.")
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw_feedback):
+        item_label = f"{label}[{index}]"
+        if not isinstance(item, dict):
+            raise CreativeSpecLearningRollupError(f"{item_label} must be a JSON object.")
+        _require_exact_keys(item, AGENT_FEEDBACK_KEYS, label=item_label)
+        role = _require_token(item, "reviewer_role", label=item_label)
+        if role in seen:
+            raise CreativeSpecLearningRollupError(f"{label} must not repeat reviewer_role.")
+        seen.add(role)
+        rows.append(
+            {
+                "reviewer_role": role,
+                "pass_count": _bounded_int(item, "pass_count", label=item_label, maximum=5),
+                "revise_count": _bounded_int(item, "revise_count", label=item_label, maximum=5),
+                "reject_count": _bounded_int(item, "reject_count", label=item_label, maximum=5),
+            }
+        )
+    return rows
+
+
+def _normalize_learning_records(raw_records: Any, *, label: str) -> list[dict[str, Any]]:
+    if not isinstance(raw_records, list):
+        raise CreativeSpecLearningRollupError(f"{label} must be an array.")
+    if not raw_records:
+        raise CreativeSpecLearningRollupError(f"{label} must be non-empty.")
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw_records):
+        if not isinstance(item, dict):
+            raise CreativeSpecLearningRollupError(f"{label}[{index}] must be a JSON object.")
+        try:
+            record = validate_agent_learning_record(cast(dict[str, Any], dict(item)))
+        except ValueError as exc:
+            raise CreativeSpecLearningRollupError(str(exc)) from exc
+        if record["lesson_id"] in seen:
+            raise CreativeSpecLearningRollupError(f"{label} must not repeat lesson_id.")
+        seen.add(str(record["lesson_id"]))
+        metrics = cast(Mapping[str, Any], record["learning_metrics"])
+        if metrics["authority_boundary"] != LEARNING_AUTHORITY_BOUNDARY:
+            raise CreativeSpecLearningRollupError(
+                f"{label}[{index}].learning_metrics.authority_boundary is invalid."
+            )
+        records.append(record)
+    return records
+
+
+def _normalize_learning_summary(raw_summary: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(raw_summary, dict):
+        raise CreativeSpecLearningRollupError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_summary, LEARNING_SUMMARY_KEYS, label=label)
+    return {
+        "learning_record_count": _bounded_int(
+            raw_summary, "learning_record_count", label=label, minimum=1, maximum=6
+        ),
+        "successful_iteration_count": _bounded_int(
+            raw_summary, "successful_iteration_count", label=label, maximum=1
+        ),
+        "failure_count": _bounded_int(raw_summary, "failure_count", label=label, maximum=5),
+        "reuse_lesson_ids": _normalize_lesson_ids(
+            raw_summary["reuse_lesson_ids"], label=f"{label}.reuse_lesson_ids"
+        ),
+        "avoid_lesson_ids": _normalize_lesson_ids(
+            raw_summary["avoid_lesson_ids"], label=f"{label}.avoid_lesson_ids"
+        ),
+    }
+
+
+def _normalize_focus_list(raw_focus: Any, *, label: str) -> list[dict[str, Any]]:
+    if not isinstance(raw_focus, list):
+        raise CreativeSpecLearningRollupError(f"{label} must be an array.")
+    if len(raw_focus) > 6:
+        raise CreativeSpecLearningRollupError(f"{label} must contain at most 6 entries.")
+    rows: list[dict[str, Any]] = []
+    for index, item in enumerate(raw_focus):
+        item_label = f"{label}[{index}]"
+        if not isinstance(item, dict):
+            raise CreativeSpecLearningRollupError(f"{item_label} must be a JSON object.")
+        _require_exact_keys(item, FOCUS_KEYS, label=item_label)
+        agent = _require_token(item, "agent", label=item_label)
+        if agent not in AGENT_SLUGS:
+            raise CreativeSpecLearningRollupError(f"{item_label}.agent is unsupported.")
+        focus = _require_token(item, "focus", label=item_label)
+        if focus not in FOCUS_IDS:
+            raise CreativeSpecLearningRollupError(f"{item_label}.focus is unsupported.")
+        rows.append(
+            {
+                "agent": agent,
+                "focus": focus,
+                "reason": _require_safe_text(item, "reason", label=item_label, max_length=180),
+                "source_lesson_ids": _normalize_lesson_ids(
+                    item["source_lesson_ids"], label=f"{item_label}.source_lesson_ids"
+                ),
+            }
+        )
+    return rows
+
+
+def _normalize_lesson_ids(raw_values: Any, *, label: str) -> list[str]:
+    if not isinstance(raw_values, list):
+        raise CreativeSpecLearningRollupError(f"{label} must be an array.")
+    if len(raw_values) > 6:
+        raise CreativeSpecLearningRollupError(f"{label} must contain at most 6 items.")
+    values: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw_values):
+        if not isinstance(item, str) or not item.startswith("lesson-") or len(item) > 32:
+            raise CreativeSpecLearningRollupError(f"{label}[{index}] must be a lesson id.")
+        if item in seen:
+            raise CreativeSpecLearningRollupError(f"{label} must not contain duplicates.")
+        seen.add(item)
+        values.append(item)
+    return values
+
+
+def _normalize_rollup_authority(raw_authority: Any, *, label: str) -> dict[str, bool]:
+    expected = default_rollup_authority()
+    return _normalize_authority(raw_authority, expected=expected, label=label)
+
+
+def _normalize_hints_authority(raw_authority: Any, *, label: str) -> dict[str, bool]:
+    expected = default_hints_authority()
+    return _normalize_authority(raw_authority, expected=expected, label=label)
+
+
+def _normalize_authority(
+    raw_authority: Any,
+    *,
+    expected: Mapping[str, bool],
+    label: str,
+) -> dict[str, bool]:
+    if not isinstance(raw_authority, dict):
+        raise CreativeSpecLearningRollupError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_authority, frozenset(expected), label=label)
+    for key, expected_value in expected.items():
+        if raw_authority[key] is not expected_value:
+            raise CreativeSpecLearningRollupError(f"{label}.{key} has invalid authority.")
+    return dict(sorted((key, bool(raw_authority[key])) for key in expected))
+
+
+def _validate_rollup_outcome_consistency(rollup: Mapping[str, Any]) -> None:
+    outcomes = cast(Mapping[str, Any], rollup["outcomes"])
+    summary = cast(Mapping[str, Any], rollup["learning_summary"])
+    if outcomes["synthesis_status"] == "all_rejected":
+        if outcomes["selected_variant_id"] is not None:
+            raise CreativeSpecLearningRollupError("all_rejected rollup must not select a variant.")
+        if summary["successful_iteration_count"] != 0:
+            raise CreativeSpecLearningRollupError(
+                "all_rejected rollup must not emit successful_iteration records."
+            )
+    if outcomes["synthesis_status"] == "selected" and summary["successful_iteration_count"] != 1:
+        raise CreativeSpecLearningRollupError(
+            "selected rollup must emit exactly one successful_iteration record."
+        )
+
+
+def _set_identity(
+    payload: dict[str, Any],
+    *,
+    id_key: str,
+    asset_type: str,
+    upstream_ids: Sequence[str],
+) -> None:
+    payload[id_key] = "pending"
+    payload["idempotency_key"] = "pending"
+    fingerprint = fingerprint_payload(_identity_payload(payload, id_key=id_key))
+    payload[id_key] = build_asset_id(
+        asset_type=asset_type,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=tuple(upstream_ids),
+    )
+    payload["idempotency_key"] = build_idempotency_key(
+        asset_type=asset_type,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=tuple(upstream_ids),
+    )
+
+
+def _validate_identity(
+    payload: Mapping[str, Any],
+    *,
+    id_key: str,
+    asset_type: str,
+    upstream_ids: Sequence[str],
+) -> None:
+    body = dict(payload)
+    body[id_key] = "pending"
+    body["idempotency_key"] = "pending"
+    fingerprint = fingerprint_payload(_identity_payload(body, id_key=id_key))
+    expected_id = build_asset_id(
+        asset_type=asset_type,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=tuple(upstream_ids),
+    )
+    expected_key = build_idempotency_key(
+        asset_type=asset_type,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=tuple(upstream_ids),
+    )
+    if payload[id_key] != expected_id or payload["idempotency_key"] != expected_key:
+        raise CreativeSpecLearningRollupError(f"{id_key} or idempotency_key is invalid.")
+
+
+def _identity_payload(payload: Mapping[str, Any], *, id_key: str) -> dict[str, Any]:
+    return {key: payload[key] for key in sorted(set(payload) - {id_key, "idempotency_key"})}
+
+
+def _require_exact_keys(payload: Mapping[str, Any], keys: frozenset[str], *, label: str) -> None:
+    missing = sorted(keys.difference(payload))
+    extra = sorted(set(payload).difference(keys))
+    if missing:
+        raise CreativeSpecLearningRollupError(f"{label} missing fields: {', '.join(missing)}.")
+    if extra:
+        raise CreativeSpecLearningRollupError(f"{label} unexpected fields: {', '.join(extra)}.")
+
+
+def _require_const(
+    payload: Mapping[str, Any],
+    key: str,
+    expected: Any,
+    *,
+    label: str,
+) -> Any:
+    if payload.get(key) != expected:
+        raise CreativeSpecLearningRollupError(f"{label}.{key} must be {expected!r}.")
+    return expected
+
+
+def _require_id(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not ID_RE.fullmatch(value):
+        raise CreativeSpecLearningRollupError(f"{label}.{key} must be a safe id.")
+    return value
+
+
+def _optional_id(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not ID_RE.fullmatch(value):
+        raise CreativeSpecLearningRollupError(f"{label} must be null or a safe id.")
+    return value
+
+
+def _require_fingerprint(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise CreativeSpecLearningRollupError(f"{label}.{key} must be a sha256 digest.")
+    return value
+
+
+def _require_token(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not SAFE_TOKEN_RE.fullmatch(value):
+        raise CreativeSpecLearningRollupError(f"{label}.{key} must be a safe token.")
+    return value
+
+
+def _optional_token(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not SAFE_TOKEN_RE.fullmatch(value):
+        raise CreativeSpecLearningRollupError(f"{label} must be null or a safe token.")
+    return value
+
+
+def _require_safe_text(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    label: str,
+    max_length: int,
+) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip() or len(value) > max_length:
+        raise CreativeSpecLearningRollupError(f"{label}.{key} must be bounded safe text.")
+    _reject_payload_safety(value, label=f"{label}.{key}")
+    return value.strip()
+
+
+def _require_bool(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    expected: bool,
+    label: str,
+) -> bool:
+    if payload.get(key) is not expected:
+        raise CreativeSpecLearningRollupError(f"{label}.{key} must be {expected}.")
+    return expected
+
+
+def _bounded_int(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    label: str,
+    minimum: int = 0,
+    maximum: int,
+) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CreativeSpecLearningRollupError(f"{label}.{key} must be an integer.")
+    if value < minimum or value > maximum:
+        raise CreativeSpecLearningRollupError(
+            f"{label}.{key} must be between {minimum} and {maximum}."
+        )
+    return value
+
+
+def _reject_payload_safety(value: Any, *, label: str) -> None:
+    if isinstance(value, str):
+        if SECRET_RE.search(value) or LEAK_TEXT_RE.search(value) or UNSAFE_CLAIM_RE.search(value):
+            raise CreativeSpecLearningRollupError(
+                f"{label} contains unsafe creative learning text."
+            )
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_payload_safety(item, label=f"{label}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _reject_payload_safety(item, label=f"{label}.{key}")

--- a/scripts/orchestration/creative_spec_learning_rollup_contract.py
+++ b/scripts/orchestration/creative_spec_learning_rollup_contract.py
@@ -880,6 +880,8 @@ def _normalize_agent_feedback(raw_feedback: Any, *, label: str) -> list[dict[str
         raise CreativeSpecLearningRollupError(f"{label} must be an array.")
     if not raw_feedback:
         raise CreativeSpecLearningRollupError(f"{label} must be non-empty.")
+    if len(raw_feedback) > 6:
+        raise CreativeSpecLearningRollupError(f"{label} must contain at most 6 entries.")
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
     for index, item in enumerate(raw_feedback):
@@ -1024,10 +1026,21 @@ def _normalize_authority(
 def _validate_rollup_outcome_consistency(rollup: Mapping[str, Any]) -> None:
     outcomes = cast(Mapping[str, Any], rollup["outcomes"])
     summary = cast(Mapping[str, Any], rollup["learning_summary"])
+    agent_feedback = cast(Sequence[Mapping[str, Any]], rollup["agent_feedback"])
     failure_count = int(summary["failure_count"])
     rejected_variant_count = int(outcomes["rejected_variant_count"])
     rejection_record_count = int(outcomes["rejection_record_count"])
     variant_count = int(outcomes["variant_count"])
+    feedback_counts = {
+        "pass_review_count": sum(int(row["pass_count"]) for row in agent_feedback),
+        "revise_review_count": sum(int(row["revise_count"]) for row in agent_feedback),
+        "reject_review_count": sum(int(row["reject_count"]) for row in agent_feedback),
+    }
+    for outcome_key, feedback_count in feedback_counts.items():
+        if int(outcomes[outcome_key]) != feedback_count:
+            raise CreativeSpecLearningRollupError(
+                f"rollup agent_feedback counts must match outcomes.{outcome_key}."
+            )
     if rejection_record_count != failure_count:
         raise CreativeSpecLearningRollupError(
             "rollup rejection_record_count must match learning_summary.failure_count."

--- a/scripts/orchestration/creative_spec_learning_rollup_contract.py
+++ b/scripts/orchestration/creative_spec_learning_rollup_contract.py
@@ -20,18 +20,14 @@ from scripts.orchestration.agent_learning_loop import (
     validate_agent_learning_record,
 )
 from scripts.orchestration.creative_code_specification import (
-    BUNDLE_TYPE,
     CreativeCodeSpecificationError,
     validate_creative_code_specification_bundle,
 )
 from scripts.orchestration.creative_hypothesis_spec_bridge_contract import (
-    METRICS_ARTIFACT_TYPE,
     CreativeHypothesisSpecBridgeError,
     validate_bridge_metrics,
 )
 from scripts.orchestration.creative_specification_skeptic_review_contract import (
-    ATTACHMENT_ARTIFACT_TYPE,
-    FINALIZE_RECEIPT_ARTIFACT_TYPE,
     CreativeSpecificationSkepticReviewError,
     validate_finalize_receipt,
     validate_skeptic_review_attachment,

--- a/scripts/orchestration/creative_spec_learning_rollup_contract.py
+++ b/scripts/orchestration/creative_spec_learning_rollup_contract.py
@@ -41,6 +41,7 @@ HINTS_ARTIFACT_TYPE = "creative_spec_coordinator_advisory_hints"
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
 SHA256_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+LESSON_ID_RE = re.compile(r"^lesson-[a-f0-9]{12}$")
 SECRET_RE = re.compile(
     r"(sk-[A-Za-z0-9_-]{12,}|gh[psoru]_[A-Za-z0-9_.-]{12,}|github_pat_|"
     r"xox[abprs]-|authorization:\s*bearer|private[_ -]?key|api[_ -]?key|"
@@ -986,7 +987,7 @@ def _normalize_lesson_ids(raw_values: Any, *, label: str) -> list[str]:
     values: list[str] = []
     seen: set[str] = set()
     for index, item in enumerate(raw_values):
-        if not isinstance(item, str) or not item.startswith("lesson-") or len(item) > 32:
+        if not isinstance(item, str) or not LESSON_ID_RE.fullmatch(item):
             raise CreativeSpecLearningRollupError(f"{label}[{index}] must be a lesson id.")
         if item in seen:
             raise CreativeSpecLearningRollupError(f"{label} must not contain duplicates.")
@@ -1023,12 +1024,32 @@ def _normalize_authority(
 def _validate_rollup_outcome_consistency(rollup: Mapping[str, Any]) -> None:
     outcomes = cast(Mapping[str, Any], rollup["outcomes"])
     summary = cast(Mapping[str, Any], rollup["learning_summary"])
+    failure_count = int(summary["failure_count"])
+    rejected_variant_count = int(outcomes["rejected_variant_count"])
+    rejection_record_count = int(outcomes["rejection_record_count"])
+    variant_count = int(outcomes["variant_count"])
+    if rejection_record_count != failure_count:
+        raise CreativeSpecLearningRollupError(
+            "rollup rejection_record_count must match learning_summary.failure_count."
+        )
+    if failure_count == 0 and (rejected_variant_count != 0 or rejection_record_count != 0):
+        raise CreativeSpecLearningRollupError(
+            "rollup rejected counts must be zero when failure_count is zero."
+        )
+    if rejected_variant_count > failure_count:
+        raise CreativeSpecLearningRollupError(
+            "rollup rejected_variant_count must not exceed learning_summary.failure_count."
+        )
     if outcomes["synthesis_status"] == "all_rejected":
         if outcomes["selected_variant_id"] is not None:
             raise CreativeSpecLearningRollupError("all_rejected rollup must not select a variant.")
         if summary["successful_iteration_count"] != 0:
             raise CreativeSpecLearningRollupError(
                 "all_rejected rollup must not emit successful_iteration records."
+            )
+        if failure_count != variant_count or rejected_variant_count != variant_count:
+            raise CreativeSpecLearningRollupError(
+                "all_rejected rollup failure and rejected counts must match variant_count."
             )
     if outcomes["synthesis_status"] == "selected" and summary["successful_iteration_count"] != 1:
         raise CreativeSpecLearningRollupError(

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -11,12 +11,13 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 BOOTSTRAP_REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(BOOTSTRAP_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(BOOTSTRAP_REPO_ROOT))
 
+from core.evidence.fingerprints import fingerprint_payload
 from core.judgment import (
     CLAIM_EVIDENCE_FIELDS,
     CLAIM_TYPES,
@@ -37,6 +38,9 @@ from scripts.orchestration.context_pack import (
 from scripts.orchestration.context_pack_compression import (
     build_context_pack_compression,
     to_stable_mapping as context_compression_to_stable_mapping,
+)
+from scripts.orchestration.creative_spec_learning_rollup_contract import (
+    validate_coordinator_advisory_hints,
 )
 from scripts.orchestration.embedding_retrieval_admission_telemetry import (
     build_embedding_retrieval_admission_telemetry,
@@ -105,6 +109,9 @@ from scripts.orchestration.shadow_reuse_telemetry import (
 
 SCHEMA_VERSION = "2.0"
 TASK_PACKET_DIR: Path = REPO_ROOT / "artifacts" / "orchestration" / "task_packets"
+CREATIVE_LEARNING_HINTS_ROOT: Path = (
+    REPO_ROOT / "artifacts" / "orchestration" / "creative_code" / "learning_rollup"
+)
 REQUESTED_AGENT_STATUS_REJECTED_UNKNOWN = "rejected_unknown_agent"
 REQUESTED_AGENT_STATUS_HONORED_PRIMARY = "honored_primary"
 REQUESTED_AGENT_STATUS_HONORED_SECONDARY = "honored_secondary"
@@ -180,6 +187,123 @@ def _read_json(path: Path) -> dict[str, Any] | None:
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
     return payload if isinstance(payload, dict) else None
+
+
+def _reject_duplicate_json_object_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    seen: set[str] = set()
+    for key, value in pairs:
+        if key in seen:
+            raise ValueError(f"creative learning hints JSON has duplicate key: {key}")
+        seen.add(key)
+        payload[key] = value
+    return payload
+
+
+def _existing_components(path: Path) -> list[Path]:
+    components: list[Path] = []
+    current_path = Path(path.anchor) if path.anchor else Path(".")
+    parts = path.parts[1:] if path.anchor else path.parts
+    for part in parts:
+        current_path = current_path / part
+        if current_path.exists() or current_path.is_symlink():
+            components.append(current_path)
+    return components
+
+
+def _reject_symlink_components(path: Path, *, label: str) -> None:
+    for component in _existing_components(path):
+        if component.is_symlink():
+            raise ValueError(f"{label} must not traverse symlinks")
+
+
+def _resolve_creative_learning_hints_path(raw_path: str | Path) -> Path:
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = REPO_ROOT / candidate
+    _reject_symlink_components(candidate, label="--creative-learning-hints")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise ValueError("--creative-learning-hints must point to an existing JSON file") from exc
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+        resolved.relative_to(CREATIVE_LEARNING_HINTS_ROOT.resolve(strict=False))
+    except ValueError as exc:
+        raise ValueError(
+            "--creative-learning-hints must stay under "
+            "artifacts/orchestration/creative_code/learning_rollup"
+        ) from exc
+    if not resolved.is_file() or resolved.suffix != ".json":
+        raise ValueError("--creative-learning-hints must point to a JSON file")
+    return resolved
+
+
+def _read_creative_learning_hints(raw_path: str | Path | None) -> dict[str, Any] | None:
+    if raw_path is None:
+        return None
+    hints_path = _resolve_creative_learning_hints_path(raw_path)
+    try:
+        payload = json.loads(
+            hints_path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_object_keys,
+        )
+    except json.JSONDecodeError as exc:
+        raise ValueError("unable to read --creative-learning-hints JSON") from exc
+    except ValueError:
+        raise
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValueError("unable to read --creative-learning-hints JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("--creative-learning-hints must contain a JSON object")
+    return cast(dict[str, Any], validate_coordinator_advisory_hints(payload))
+
+
+def _build_creative_learning_hints_packet(
+    hints: dict[str, Any] | None,
+    *,
+    hints_fingerprint: str,
+) -> dict[str, Any]:
+    if hints is None:
+        source_hints_id = ""
+        source_rollup_id = ""
+        source_rollup_fingerprint = ""
+        recommended_role_focus: list[dict[str, Any]] = []
+        reuse_lesson_ids: list[str] = []
+        avoid_lesson_ids: list[str] = []
+    else:
+        source_hints_id = str(hints["hints_id"])
+        source_rollup_id = str(hints["source_rollup_id"])
+        source_rollup_fingerprint = str(hints["source_rollup_fingerprint"])
+        recommended_role_focus = list(hints["recommended_role_focus"])
+        reuse_lesson_ids = list(hints["reuse_lesson_ids"])
+        avoid_lesson_ids = list(hints["avoid_lesson_ids"])
+
+    return {
+        "schema_version": "creative_learning_hints_packet.v1",
+        "current_packet_includes_hints": hints is not None,
+        "source_hints_id": source_hints_id,
+        "source_hints_fingerprint": hints_fingerprint,
+        "source_rollup_id": source_rollup_id,
+        "source_rollup_fingerprint": source_rollup_fingerprint,
+        "recommended_role_focus": recommended_role_focus,
+        "reuse_lesson_ids": reuse_lesson_ids,
+        "avoid_lesson_ids": avoid_lesson_ids,
+        "authority_boundary": "advisory_only_non_runtime",
+        "side_effects_allowed": False,
+        "routing_authority": False,
+        "execution_authority": False,
+        "merge_readiness_authority": False,
+        "patch_generation_authority": False,
+        "semantic_cache_used": False,
+        "graph_truth_updated": False,
+        "product_runtime_truth": False,
+        "change_primary_agent": False,
+        "force_agent_routing": False,
+        "skip_required_roles": False,
+        "execute_agents": False,
+        "change_lifecycle_gates": False,
+    }
 
 
 def _design_fingerprint(*, design_lane_mode: str, design_lane_contract: dict[str, Any]) -> str:
@@ -917,6 +1041,7 @@ def build_task_packet(
     explicit_creation_mode: bool = False,
     native_bridge_transport: str = BRIDGE_TRANSPORT,
     telemetry_path: Path = TELEMETRY_PATH,
+    creative_learning_hints_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Build a deterministic task packet for orchestration tooling."""
 
@@ -931,6 +1056,10 @@ def build_task_packet(
         )
     normalized_requested_agents = normalize_requested_agents(requested_agents)
     normalized_pr_phase = _normalize_pr_phase(pr_phase)
+    creative_learning_hints = _read_creative_learning_hints(creative_learning_hints_path)
+    creative_learning_hints_fingerprint = (
+        fingerprint_payload(creative_learning_hints) if creative_learning_hints is not None else ""
+    )
     design_lane_mode, design_lane_contract, design_lane_enabled = _build_design_lane_contract(
         design_source=design_source,
         source_url=source_url,
@@ -967,6 +1096,7 @@ def build_task_packet(
             design_lane_mode=design_lane_mode,
             design_lane_contract=design_lane_contract,
         ),
+        creative_learning_hints_fingerprint=creative_learning_hints_fingerprint,
     )
     context_pack = collect_context_pack(
         normalized_paths,
@@ -1267,6 +1397,10 @@ def build_task_packet(
             "runtime_authority": False,
             "canonical_until_promoted_by_repo_diff": False,
         },
+        "creative_learning_hints": _build_creative_learning_hints_packet(
+            creative_learning_hints,
+            hints_fingerprint=creative_learning_hints_fingerprint,
+        ),
         "message_envelope": message_envelope,
         "recommended_skills": recommended_skills,
         "skill_routing": skill_routing,
@@ -1346,6 +1480,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Native subagent bridge transport label for runtime-specific packets.",
     )
     parser.add_argument(
+        "--creative-learning-hints",
+        default=None,
+        help=(
+            "Optional coordinator advisory hints JSON under "
+            "artifacts/orchestration/creative_code/learning_rollup."
+        ),
+    )
+    parser.add_argument(
         "--design-source",
         choices=DESIGN_SOURCES,
         default=None,
@@ -1390,25 +1532,35 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    packet = build_task_packet(
-        goal=args.goal,
-        task_class=args.task_class,
-        candidate_paths=args.path,
-        requested_agents=args.requested_agent,
-        pr_phase=args.pr_phase,
-        design_source=args.design_source,
-        source_url=args.source_url,
-        file_key_or_workspace=args.file_key_or_workspace,
-        node_id_or_frame_id=args.node_id_or_frame_id,
-        target_surface=args.target_surface,
-        task_mode=args.task_mode,
-        figma_lane_tool=args.figma_lane_tool,
-        design_blockers=args.design_blocker,
-        code_native_design_brief_path=args.code_native_design_brief_path,
-        explicit_creation_mode=args.explicit_creation_mode,
-        native_bridge_transport=args.native_bridge_transport,
-        telemetry_path=Path(args.telemetry),
-    )
+    try:
+        packet = build_task_packet(
+            goal=args.goal,
+            task_class=args.task_class,
+            candidate_paths=args.path,
+            requested_agents=args.requested_agent,
+            pr_phase=args.pr_phase,
+            design_source=args.design_source,
+            source_url=args.source_url,
+            file_key_or_workspace=args.file_key_or_workspace,
+            node_id_or_frame_id=args.node_id_or_frame_id,
+            target_surface=args.target_surface,
+            task_mode=args.task_mode,
+            figma_lane_tool=args.figma_lane_tool,
+            design_blockers=args.design_blocker,
+            code_native_design_brief_path=args.code_native_design_brief_path,
+            explicit_creation_mode=args.explicit_creation_mode,
+            native_bridge_transport=args.native_bridge_transport,
+            telemetry_path=Path(args.telemetry),
+            creative_learning_hints_path=args.creative_learning_hints,
+        )
+    except ValueError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+    if not isinstance(packet.get("creative_learning_hints"), dict):
+        packet["creative_learning_hints"] = _build_creative_learning_hints_packet(
+            None,
+            hints_fingerprint="",
+        )
     try:
         out_path = _resolve_output_path(args.output, packet["task_packet_id"])
     except ValueError as exc:
@@ -1449,6 +1601,9 @@ def main(argv: list[str] | None = None) -> int:
                 "reviewer": packet["reviewer"],
                 "requested_agents": packet["requested_agents"],
                 "recommended_skills": packet["recommended_skills"],
+                "creative_learning_hints_fingerprint": packet["creative_learning_hints"][
+                    "source_hints_fingerprint"
+                ],
                 "primary_native_agent_type": packet["native_subagent_bridge"]["primary"][
                     "native_agent_type"
                 ],

--- a/tests/test_creative_spec_learning_rollup.py
+++ b/tests/test_creative_spec_learning_rollup.py
@@ -19,6 +19,7 @@ from scripts.orchestration.agent_learning_loop import (
 )
 from scripts.orchestration.creative_spec_learning_rollup_contract import (
     CreativeSpecLearningRollupError,
+    HINTS_ARTIFACT_TYPE,
     ROLLUP_ARTIFACT_TYPE,
     build_coordinator_advisory_hints,
     build_creative_spec_learning_rollup,
@@ -205,6 +206,31 @@ def test_hints_reject_unsafe_text_and_authority_widening(
         widened_hints["authority"]["force_agent_routing"] = True
         with pytest.raises(CreativeSpecLearningRollupError, match="invalid authority"):
             validate_coordinator_advisory_hints(widened_hints)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_hints_reject_focus_lesson_ids_not_declared_in_reuse_or_avoid(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-undeclared-lesson-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    try:
+        hints = build_coordinator_advisory_hints(build_creative_spec_learning_rollup(**artifacts))
+        hints["recommended_role_focus"][0]["source_lesson_ids"] = ["lesson-notdeclared"]
+        set_creative_learning_identity(
+            hints,
+            id_key="hints_id",
+            asset_type=HINTS_ARTIFACT_TYPE,
+            upstream_ids=(
+                str(hints["source_rollup_id"]),
+                str(hints["source_rollup_fingerprint"]),
+            ),
+        )
+
+        with pytest.raises(CreativeSpecLearningRollupError, match="undeclared lesson ids"):
+            validate_coordinator_advisory_hints(hints)
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)

--- a/tests/test_creative_spec_learning_rollup.py
+++ b/tests/test_creative_spec_learning_rollup.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+import shutil
+import uuid
+
+import pytest
+
+from scripts.orchestration import (
+    creative_hypothesis_spec_bridge as bridge_cli,
+    creative_spec_learning_rollup as rollup_cli,
+    creative_specification_skeptic_review as review_cli,
+)
+from scripts.orchestration.agent_learning_loop import AUTHORITY_BOUNDARY
+from scripts.orchestration.creative_spec_learning_rollup_contract import (
+    CreativeSpecLearningRollupError,
+    build_coordinator_advisory_hints,
+    build_creative_spec_learning_rollup,
+    validate_coordinator_advisory_hints,
+    validate_creative_spec_learning_rollup,
+)
+from tests.test_creative_specification_skeptic_review import (
+    REPO_ROOT,
+    _prepared_bridge,
+    _read_json,
+    _review_input,
+    _refresh_receipt_identity,
+    _write_review_input,
+)
+
+
+def _finalized_artifacts(
+    capsys: pytest.CaptureFixture[str],
+    *,
+    suffix: str,
+    all_rejected: bool = False,
+) -> tuple[Path, Path, dict[str, dict[str, object]]]:
+    output_dir, input_dir = _prepared_bridge(capsys, suffix=suffix)
+    reviews_path = _write_review_input(
+        output_dir,
+        _review_input(output_dir, all_rejected=all_rejected),
+    )
+    assert (
+        review_cli.main(
+            [
+                "attach",
+                "--bridge",
+                str(output_dir / bridge_cli.BRIDGE_FILENAME),
+                "--reviews",
+                str(reviews_path),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    reviewed_dir = output_dir / "spec_finalize_reviewed"
+    attachment_path = reviewed_dir / review_cli.ATTACHMENT_FILENAME
+    assert review_cli.main(["finalize", "--attachment", str(attachment_path)]) == 0
+    capsys.readouterr()
+    return (
+        output_dir,
+        input_dir,
+        {
+            "bridge_metrics": _read_json(output_dir / bridge_cli.METRICS_FILENAME),
+            "skeptic_attachment": _read_json(attachment_path),
+            "finalize_receipt": _read_json(reviewed_dir / review_cli.FINALIZE_RECEIPT_FILENAME),
+            "bundle": _read_json(reviewed_dir / review_cli.BUNDLE_FILENAME),
+        },
+    )
+
+
+def test_collect_selected_variant_builds_success_learning_rollup_and_hints(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-selected-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    rollup_dir = rollup_cli.LEARNING_ROLLUP_ROOT / f"pytest-{suffix}"
+    shutil.rmtree(rollup_dir, ignore_errors=True)
+    try:
+        exit_code = rollup_cli.main(
+            [
+                "collect",
+                "--bridge-metrics",
+                str(output_dir / bridge_cli.METRICS_FILENAME),
+                "--skeptic-attachment",
+                str(output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME),
+                "--finalize-receipt",
+                str(output_dir / "spec_finalize_reviewed" / review_cli.FINALIZE_RECEIPT_FILENAME),
+                "--bundle",
+                str(output_dir / "spec_finalize_reviewed" / review_cli.BUNDLE_FILENAME),
+                "--output-dir",
+                str(rollup_dir),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 0, captured.out
+        assert rollup_cli.COLLECT_SUCCESS_OUTPUT in captured.out
+
+        rollup = validate_creative_spec_learning_rollup(
+            _read_json(rollup_dir / rollup_cli.ROLLUP_FILENAME)
+        )
+        hints = validate_coordinator_advisory_hints(
+            _read_json(rollup_dir / rollup_cli.HINTS_FILENAME)
+        )
+        records = rollup["learning_records"]
+        assert rollup["outcomes"]["synthesis_status"] == "selected"
+        assert rollup["learning_summary"]["successful_iteration_count"] == 1
+        assert any(record["pattern_kind"] == "successful_iteration" for record in records)
+        for record in records:
+            metrics = record["learning_metrics"]
+            assert record["human_review_required"] is True
+            assert metrics["authority_boundary"] == AUTHORITY_BOUNDARY
+            assert metrics["semantic_cache_used"] is False
+            assert metrics["graph_truth_updated"] is False
+            assert metrics["product_runtime_truth"] is False
+        success_records = [
+            record for record in records if record["pattern_kind"] == "successful_iteration"
+        ]
+        assert success_records[0]["learning_metrics"]["primary_metric"] == (
+            "successful_pattern_reuse"
+        )
+        assert hints["reuse_lesson_ids"] == rollup["learning_summary"]["reuse_lesson_ids"]
+        assert hints["avoid_lesson_ids"] == rollup["learning_summary"]["avoid_lesson_ids"]
+        assert hints["authority"]["advisory_only"] is True
+        assert hints["authority"]["force_agent_routing"] is False
+        assert hints["authority"]["execute_agents"] is False
+        assert hints["source_rollup_id"] == rollup["rollup_id"]
+        assert artifacts["finalize_receipt"]["synthesis_status"] == "selected"
+    finally:
+        shutil.rmtree(rollup_dir, ignore_errors=True)
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_all_rejected_builds_failure_records_without_reuse_hints(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-all-rejected-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(
+        capsys,
+        suffix=suffix,
+        all_rejected=True,
+    )
+    try:
+        rollup = build_creative_spec_learning_rollup(**artifacts)
+        hints = build_coordinator_advisory_hints(rollup)
+        assert rollup["outcomes"]["synthesis_status"] == "all_rejected"
+        assert rollup["outcomes"]["selected_variant_id"] is None
+        assert rollup["learning_summary"]["successful_iteration_count"] == 0
+        assert rollup["learning_summary"]["failure_count"] == rollup["outcomes"]["variant_count"]
+        assert all(record["pattern_kind"] == "failure" for record in rollup["learning_records"])
+        assert all(
+            record["learning_metrics"]["primary_metric"] == "repeat_failure_reduction"
+            for record in rollup["learning_records"]
+        )
+        assert hints["reuse_lesson_ids"] == []
+        assert hints["avoid_lesson_ids"] == rollup["learning_summary"]["avoid_lesson_ids"]
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_rollup_rejects_tampered_finalize_bundle_fingerprint(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-tampered-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    try:
+        tampered_receipt = deepcopy(artifacts["finalize_receipt"])
+        tampered_receipt["bundle_fingerprint"] = "sha256:" + ("a" * 64)
+        tampered_receipt = _refresh_receipt_identity(tampered_receipt)
+        with pytest.raises(CreativeSpecLearningRollupError, match="fingerprint_mismatch"):
+            build_creative_spec_learning_rollup(
+                bridge_metrics=artifacts["bridge_metrics"],
+                skeptic_attachment=artifacts["skeptic_attachment"],
+                finalize_receipt=tampered_receipt,
+                bundle=artifacts["bundle"],
+            )
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_hints_reject_unsafe_text_and_authority_widening(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-unsafe-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    try:
+        hints = build_coordinator_advisory_hints(build_creative_spec_learning_rollup(**artifacts))
+
+        unsafe_hints = deepcopy(hints)
+        unsafe_hints["recommended_role_focus"][0]["reason"] = "raw prompt leaked"
+        with pytest.raises(CreativeSpecLearningRollupError, match="unsafe"):
+            validate_coordinator_advisory_hints(unsafe_hints)
+
+        widened_hints = deepcopy(hints)
+        widened_hints["authority"]["force_agent_routing"] = True
+        with pytest.raises(CreativeSpecLearningRollupError, match="invalid authority"):
+            validate_coordinator_advisory_hints(widened_hints)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_collect_rejects_duplicate_json_keys_before_validation(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-duplicate-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, _artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    duplicate_metrics = output_dir / "duplicate_metrics.json"
+    duplicate_metrics.write_text(
+        '{"schema_version": "1.0", "schema_version": "1.0"}\n',
+        encoding="utf-8",
+    )
+    try:
+        exit_code = rollup_cli.main(
+            [
+                "collect",
+                "--bridge-metrics",
+                str(duplicate_metrics),
+                "--skeptic-attachment",
+                str(output_dir / "spec_finalize_reviewed" / review_cli.ATTACHMENT_FILENAME),
+                "--finalize-receipt",
+                str(output_dir / "spec_finalize_reviewed" / review_cli.FINALIZE_RECEIPT_FILENAME),
+                "--bundle",
+                str(output_dir / "spec_finalize_reviewed" / review_cli.BUNDLE_FILENAME),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "duplicate key" in captured.out
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_learning_rollup_schemas_are_closed() -> None:
+    for schema_name in (
+        "creative_spec_learning_rollup.v1.schema.json",
+        "creative_spec_coordinator_advisory_hints.v1.schema.json",
+    ):
+        schema = json.loads(
+            (REPO_ROOT / "docs" / "orchestration" / "contracts" / schema_name).read_text(
+                encoding="utf-8"
+            )
+        )
+        assert schema["additionalProperties"] is False
+        for definition in schema.get("$defs", {}).values():
+            if definition.get("type") == "object":
+                assert definition["additionalProperties"] is False

--- a/tests/test_creative_spec_learning_rollup.py
+++ b/tests/test_creative_spec_learning_rollup.py
@@ -218,7 +218,7 @@ def test_hints_reject_focus_lesson_ids_not_declared_in_reuse_or_avoid(
     output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
     try:
         hints = build_coordinator_advisory_hints(build_creative_spec_learning_rollup(**artifacts))
-        hints["recommended_role_focus"][0]["source_lesson_ids"] = ["lesson-notdeclared"]
+        hints["recommended_role_focus"][0]["source_lesson_ids"] = ["lesson-ffffffffffff"]
         set_creative_learning_identity(
             hints,
             id_key="hints_id",
@@ -231,6 +231,91 @@ def test_hints_reject_focus_lesson_ids_not_declared_in_reuse_or_avoid(
 
         with pytest.raises(CreativeSpecLearningRollupError, match="undeclared lesson ids"):
             validate_coordinator_advisory_hints(hints)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_hints_reject_noncanonical_declared_lesson_ids(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-noncanonical-lesson-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    try:
+        hints = build_coordinator_advisory_hints(build_creative_spec_learning_rollup(**artifacts))
+        hints["reuse_lesson_ids"] = ["lesson-nothex"]
+        hints["recommended_role_focus"][0]["source_lesson_ids"] = ["lesson-nothex"]
+        set_creative_learning_identity(
+            hints,
+            id_key="hints_id",
+            asset_type=HINTS_ARTIFACT_TYPE,
+            upstream_ids=(
+                str(hints["source_rollup_id"]),
+                str(hints["source_rollup_fingerprint"]),
+            ),
+        )
+
+        with pytest.raises(CreativeSpecLearningRollupError, match="lesson id"):
+            validate_coordinator_advisory_hints(hints)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_rollup_rejects_rejection_counters_without_failure_records(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-tampered-counters-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    try:
+        rollup = build_creative_spec_learning_rollup(**artifacts)
+        success_record = next(
+            record
+            for record in rollup["learning_records"]
+            if record["pattern_kind"] == "successful_iteration"
+        )
+        tampered_rejected = deepcopy(rollup)
+        tampered_rejected["learning_records"] = [success_record]
+        tampered_rejected["learning_summary"] = {
+            "learning_record_count": 1,
+            "successful_iteration_count": 1,
+            "failure_count": 0,
+            "reuse_lesson_ids": [success_record["lesson_id"]],
+            "avoid_lesson_ids": [],
+        }
+        tampered_rejected["outcomes"]["rejected_variant_count"] = 1
+        tampered_rejected["outcomes"]["rejection_record_count"] = 0
+        set_creative_learning_identity(
+            tampered_rejected,
+            id_key="rollup_id",
+            asset_type=ROLLUP_ARTIFACT_TYPE,
+            upstream_ids=(
+                str(tampered_rejected["source"]["finalize_id"]),
+                str(tampered_rejected["source"]["bundle_id"]),
+                str(tampered_rejected["source"]["bridge_metrics_id"]),
+            ),
+        )
+
+        with pytest.raises(CreativeSpecLearningRollupError, match="rejected counts"):
+            validate_creative_spec_learning_rollup(tampered_rejected)
+
+        tampered_records = deepcopy(rollup)
+        failure_count = int(tampered_records["learning_summary"]["failure_count"])
+        assert failure_count < 5
+        tampered_records["outcomes"]["rejection_record_count"] = failure_count + 1
+        set_creative_learning_identity(
+            tampered_records,
+            id_key="rollup_id",
+            asset_type=ROLLUP_ARTIFACT_TYPE,
+            upstream_ids=(
+                str(tampered_records["source"]["finalize_id"]),
+                str(tampered_records["source"]["bundle_id"]),
+                str(tampered_records["source"]["bridge_metrics_id"]),
+            ),
+        )
+
+        with pytest.raises(CreativeSpecLearningRollupError, match="rejection_record_count"):
+            validate_creative_spec_learning_rollup(tampered_records)
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)
@@ -253,13 +338,21 @@ def test_rollup_rejects_semantic_cache_and_graph_truth_claims(
             promotion_target="docs/orchestration/AGENT_LEARNING_LOOP.md",
             pattern_kind="successful_iteration",
         )
-        rollup["learning_records"] = [unsafe_record]
+        rollup["learning_records"] = [
+            unsafe_record if record["pattern_kind"] == "successful_iteration" else record
+            for record in rollup["learning_records"]
+        ]
+        avoid_lesson_ids = [
+            record["lesson_id"]
+            for record in rollup["learning_records"]
+            if record["pattern_kind"] == "failure"
+        ]
         rollup["learning_summary"] = {
-            "learning_record_count": 1,
+            "learning_record_count": len(rollup["learning_records"]),
             "successful_iteration_count": 1,
-            "failure_count": 0,
+            "failure_count": len(avoid_lesson_ids),
             "reuse_lesson_ids": [unsafe_record["lesson_id"]],
-            "avoid_lesson_ids": [],
+            "avoid_lesson_ids": avoid_lesson_ids,
         }
         set_creative_learning_identity(
             rollup,

--- a/tests/test_creative_spec_learning_rollup.py
+++ b/tests/test_creative_spec_learning_rollup.py
@@ -321,6 +321,68 @@ def test_rollup_rejects_rejection_counters_without_failure_records(
         shutil.rmtree(input_dir, ignore_errors=True)
 
 
+def test_rollup_rejects_agent_feedback_counts_that_do_not_match_outcomes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-feedback-mismatch-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    try:
+        rollup = build_creative_spec_learning_rollup(**artifacts)
+        assert int(rollup["outcomes"]["pass_review_count"]) > 0
+        for row in rollup["agent_feedback"]:
+            row["pass_count"] = 0
+        set_creative_learning_identity(
+            rollup,
+            id_key="rollup_id",
+            asset_type=ROLLUP_ARTIFACT_TYPE,
+            upstream_ids=(
+                str(rollup["source"]["finalize_id"]),
+                str(rollup["source"]["bundle_id"]),
+                str(rollup["source"]["bridge_metrics_id"]),
+            ),
+        )
+
+        with pytest.raises(CreativeSpecLearningRollupError, match="pass_review_count"):
+            validate_creative_spec_learning_rollup(rollup)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_rollup_rejects_agent_feedback_over_schema_max_items(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-feedback-max-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    try:
+        rollup = build_creative_spec_learning_rollup(**artifacts)
+        rollup["agent_feedback"] = [
+            {
+                "reviewer_role": f"reviewer-{index}",
+                "pass_count": 0,
+                "revise_count": 0,
+                "reject_count": 0,
+            }
+            for index in range(7)
+        ]
+        set_creative_learning_identity(
+            rollup,
+            id_key="rollup_id",
+            asset_type=ROLLUP_ARTIFACT_TYPE,
+            upstream_ids=(
+                str(rollup["source"]["finalize_id"]),
+                str(rollup["source"]["bundle_id"]),
+                str(rollup["source"]["bridge_metrics_id"]),
+            ),
+        )
+
+        with pytest.raises(CreativeSpecLearningRollupError, match="at most 6"):
+            validate_creative_spec_learning_rollup(rollup)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
 def test_rollup_rejects_semantic_cache_and_graph_truth_claims(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_creative_spec_learning_rollup.py
+++ b/tests/test_creative_spec_learning_rollup.py
@@ -13,13 +13,18 @@ from scripts.orchestration import (
     creative_spec_learning_rollup as rollup_cli,
     creative_specification_skeptic_review as review_cli,
 )
-from scripts.orchestration.agent_learning_loop import AUTHORITY_BOUNDARY
+from scripts.orchestration.agent_learning_loop import (
+    AUTHORITY_BOUNDARY,
+    build_agent_learning_record,
+)
 from scripts.orchestration.creative_spec_learning_rollup_contract import (
     CreativeSpecLearningRollupError,
+    ROLLUP_ARTIFACT_TYPE,
     build_coordinator_advisory_hints,
     build_creative_spec_learning_rollup,
     validate_coordinator_advisory_hints,
     validate_creative_spec_learning_rollup,
+    _set_identity as set_creative_learning_identity,
 )
 from tests.test_creative_specification_skeptic_review import (
     REPO_ROOT,
@@ -200,6 +205,49 @@ def test_hints_reject_unsafe_text_and_authority_widening(
         widened_hints["authority"]["force_agent_routing"] = True
         with pytest.raises(CreativeSpecLearningRollupError, match="invalid authority"):
             validate_coordinator_advisory_hints(widened_hints)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(input_dir, ignore_errors=True)
+
+
+def test_rollup_rejects_semantic_cache_and_graph_truth_claims(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suffix = f"learning-cache-claim-{uuid.uuid4().hex[:8]}"
+    output_dir, input_dir, artifacts = _finalized_artifacts(capsys, suffix=suffix)
+    try:
+        rollup = build_creative_spec_learning_rollup(**artifacts)
+        unsafe_record = build_agent_learning_record(
+            source="creative_spec_finalize:finalize-test:selected:variant-test",
+            pattern="Selected variant reused semantic cache used and graph truth updated.",
+            severity="low",
+            affected_surfaces=["scripts/orchestration/creative_spec_learning_rollup.py"],
+            root_cause="Unsafe authority claim must remain outside creative learning records.",
+            required_oracle="deterministic_content_oracle",
+            promotion_target="docs/orchestration/AGENT_LEARNING_LOOP.md",
+            pattern_kind="successful_iteration",
+        )
+        rollup["learning_records"] = [unsafe_record]
+        rollup["learning_summary"] = {
+            "learning_record_count": 1,
+            "successful_iteration_count": 1,
+            "failure_count": 0,
+            "reuse_lesson_ids": [unsafe_record["lesson_id"]],
+            "avoid_lesson_ids": [],
+        }
+        set_creative_learning_identity(
+            rollup,
+            id_key="rollup_id",
+            asset_type=ROLLUP_ARTIFACT_TYPE,
+            upstream_ids=(
+                str(rollup["source"]["finalize_id"]),
+                str(rollup["source"]["bundle_id"]),
+                str(rollup["source"]["bridge_metrics_id"]),
+            ),
+        )
+
+        with pytest.raises(CreativeSpecLearningRollupError, match="unsafe"):
+            validate_creative_spec_learning_rollup(rollup)
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(input_dir, ignore_errors=True)

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 import scripts.orchestration.task_bootstrap as task_bootstrap_module
+from core.evidence.fingerprints import fingerprint_payload
 from core.judgment import (
     CLAIM_EVIDENCE_FIELDS,
     CLAIM_TYPES,
@@ -27,6 +28,16 @@ from scripts.orchestration.context_pack import repo_relative_paths
 from scripts.orchestration.context_pack_compression import _ROLE_FINGERPRINT_RE
 from scripts.orchestration.design_lane_contract import canonicalize_design_blockers
 from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
+from scripts.orchestration.agent_learning_loop import build_agent_learning_record
+from scripts.orchestration.creative_spec_learning_rollup_contract import (
+    POLICY_VERSION as CREATIVE_LEARNING_POLICY_VERSION,
+    ROLLUP_ARTIFACT_TYPE,
+    SCHEMA_VERSION as CREATIVE_LEARNING_SCHEMA_VERSION,
+    build_coordinator_advisory_hints,
+    default_rollup_authority,
+    validate_creative_spec_learning_rollup,
+    _set_identity as set_creative_learning_identity,
+)
 from scripts.orchestration.routing_graph_loader import (
     BootstrapLaneActivation,
     REQUIRED_BOOTSTRAP_LANE,
@@ -47,6 +58,92 @@ from scripts.orchestration.task_bootstrap import (
 )
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "orchestration"
+
+
+def _valid_creative_learning_hints() -> dict[str, object]:
+    record = build_agent_learning_record(
+        source="creative_spec_finalize:finalize-test:selected:variant-test",
+        pattern="Selected creative specification variant passed skeptic review.",
+        severity="low",
+        affected_surfaces=["scripts/orchestration/task_bootstrap.py"],
+        root_cause="Skeptic-review coverage created a reusable specification pattern.",
+        required_oracle="deterministic_content_oracle",
+        promotion_target="docs/orchestration/AGENT_LEARNING_LOOP.md",
+        pattern_kind="successful_iteration",
+    )
+    rollup: dict[str, object] = {
+        "schema_version": CREATIVE_LEARNING_SCHEMA_VERSION,
+        "artifact_type": ROLLUP_ARTIFACT_TYPE,
+        "policy_version": CREATIVE_LEARNING_POLICY_VERSION,
+        "rollup_id": "pending",
+        "idempotency_key": "pending",
+        "source": {
+            "bridge_metrics_id": "metrics-test",
+            "bridge_metrics_fingerprint": "sha256:" + ("1" * 64),
+            "bridge_id": "bridge-test",
+            "skeptic_attachment_id": "attachment-test",
+            "skeptic_attachment_fingerprint": "sha256:" + ("2" * 64),
+            "finalize_id": "finalize-test",
+            "finalize_receipt_fingerprint": "sha256:" + ("3" * 64),
+            "bundle_id": "bundle-test",
+            "bundle_fingerprint": "sha256:" + ("4" * 64),
+            "source_packet_id": "packet-test",
+            "source_packet_fingerprint": "sha256:" + ("5" * 64),
+        },
+        "outcomes": {
+            "variant_count": 1,
+            "selected_variant_id": "variant-test",
+            "synthesis_status": "selected",
+            "next_allowed_action": "human_review_for_patch_builder",
+            "pass_review_count": 1,
+            "revise_review_count": 0,
+            "reject_review_count": 0,
+            "unsafe_authority_flag_count": 0,
+            "blocker_count": 0,
+            "unresolved_blocker_count": 0,
+            "rejected_variant_count": 0,
+            "rejection_record_count": 0,
+            "generation_status": "ready",
+            "oracle_status": "ready",
+            "failure_class": None,
+            "human_decision": "pending",
+        },
+        "agent_feedback": [
+            {
+                "reviewer_role": "qa-engineer-agent",
+                "pass_count": 1,
+                "revise_count": 0,
+                "reject_count": 0,
+            }
+        ],
+        "learning_records": [record],
+        "learning_summary": {
+            "learning_record_count": 1,
+            "successful_iteration_count": 1,
+            "failure_count": 0,
+            "reuse_lesson_ids": [record["lesson_id"]],
+            "avoid_lesson_ids": [],
+        },
+        "authority": default_rollup_authority(),
+        "sanitized": True,
+    }
+    set_creative_learning_identity(
+        rollup,
+        id_key="rollup_id",
+        asset_type=ROLLUP_ARTIFACT_TYPE,
+        upstream_ids=("finalize-test", "bundle-test", "metrics-test"),
+    )
+    return build_coordinator_advisory_hints(validate_creative_spec_learning_rollup(rollup))
+
+
+def _write_creative_learning_hints(payload: dict[str, object]) -> Path:
+    hints_dir = task_bootstrap_module.CREATIVE_LEARNING_HINTS_ROOT / (
+        f"pytest-task-bootstrap-{uuid.uuid4().hex}"
+    )
+    hints_dir.mkdir(parents=True, exist_ok=False)
+    hints_path = hints_dir / "coordinator_advisory_hints.json"
+    hints_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return hints_path
 
 
 def _privileged_surface_cases() -> list[dict[str, object]]:
@@ -272,6 +369,31 @@ def test_task_bootstrap_adds_automation_metadata_defaults() -> None:
     assert packet["agent_learning_loop"]["promoter"].endswith("agent_lesson_promoter.py")
     assert packet["agent_learning_loop"]["runtime_authority"] is False
     assert packet["skill_routing"]["envelope_mode_hint"] == "docs_only"
+    assert packet["creative_learning_hints"] == {
+        "schema_version": "creative_learning_hints_packet.v1",
+        "current_packet_includes_hints": False,
+        "source_hints_id": "",
+        "source_hints_fingerprint": "",
+        "source_rollup_id": "",
+        "source_rollup_fingerprint": "",
+        "recommended_role_focus": [],
+        "reuse_lesson_ids": [],
+        "avoid_lesson_ids": [],
+        "authority_boundary": "advisory_only_non_runtime",
+        "side_effects_allowed": False,
+        "routing_authority": False,
+        "execution_authority": False,
+        "merge_readiness_authority": False,
+        "patch_generation_authority": False,
+        "semantic_cache_used": False,
+        "graph_truth_updated": False,
+        "product_runtime_truth": False,
+        "change_primary_agent": False,
+        "force_agent_routing": False,
+        "skip_required_roles": False,
+        "execute_agents": False,
+        "change_lifecycle_gates": False,
+    }
     _docs_paths = ["docs/ENGINEERING_LESSONS.md"]
     _norm_docs = repo_relative_paths([p.strip() for p in _docs_paths if p.strip()])
     assert packet["skill_routing"]["envelope_mode_hint"] == resolve_analysis_envelope_mode(
@@ -288,6 +410,115 @@ def test_task_bootstrap_adds_automation_metadata_defaults() -> None:
     assert packet["needs_backlog_update"] is False
     assert packet["needs_docs_sync"] is False
     assert packet["needs_agents_sync"] is False
+
+
+def test_task_bootstrap_creative_learning_hints_are_advisory_only() -> None:
+    hints = _valid_creative_learning_hints()
+    hints_path = _write_creative_learning_hints(hints)
+    try:
+        kwargs = {
+            "goal": "Use creative spec learning hints for reviewer focus",
+            "task_class": "Orchestration",
+            "candidate_paths": [
+                "scripts/orchestration/task_bootstrap.py",
+                "docs/orchestration/AGENT_LEARNING_LOOP.md",
+            ],
+            "requested_agents": [
+                "architecture-specialist",
+                "security-auditor",
+                "qa-engineer-agent",
+            ],
+            "pr_phase": "pre_open",
+        }
+        base_packet = build_task_packet(**kwargs)
+        hinted_packet = build_task_packet(
+            **kwargs,
+            creative_learning_hints_path=hints_path,
+        )
+
+        assert hinted_packet["task_packet_id"] != base_packet["task_packet_id"]
+        for stable_routing_key in (
+            "primary_agent",
+            "secondary_agents",
+            "reviewer",
+            "requested_agent_disposition",
+            "native_subagent_bridge",
+            "role_agent_dispatch_contract",
+            "pr_lifecycle_contract",
+        ):
+            assert hinted_packet[stable_routing_key] == base_packet[stable_routing_key]
+
+        packet_hints = hinted_packet["creative_learning_hints"]
+        assert packet_hints["current_packet_includes_hints"] is True
+        assert packet_hints["source_hints_id"] == hints["hints_id"]
+        assert packet_hints["source_hints_fingerprint"] == fingerprint_payload(hints)
+        assert packet_hints["source_rollup_id"] == hints["source_rollup_id"]
+        assert packet_hints["source_rollup_fingerprint"] == hints["source_rollup_fingerprint"]
+        assert packet_hints["recommended_role_focus"] == hints["recommended_role_focus"]
+        assert packet_hints["reuse_lesson_ids"] == hints["reuse_lesson_ids"]
+        assert packet_hints["avoid_lesson_ids"] == hints["avoid_lesson_ids"]
+        assert packet_hints["routing_authority"] is False
+        assert packet_hints["execution_authority"] is False
+        assert packet_hints["merge_readiness_authority"] is False
+        assert packet_hints["patch_generation_authority"] is False
+        assert packet_hints["semantic_cache_used"] is False
+        assert packet_hints["graph_truth_updated"] is False
+        assert packet_hints["product_runtime_truth"] is False
+    finally:
+        shutil.rmtree(hints_path.parent, ignore_errors=True)
+
+
+def test_task_bootstrap_rejects_invalid_creative_learning_hints() -> None:
+    hints = _valid_creative_learning_hints()
+    hints["authority"]["force_agent_routing"] = True
+    hints_path = _write_creative_learning_hints(hints)
+    try:
+        with pytest.raises(ValueError, match="invalid authority"):
+            build_task_packet(
+                goal="Reject invalid creative spec learning hints",
+                task_class="Orchestration",
+                candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+                creative_learning_hints_path=hints_path,
+            )
+    finally:
+        shutil.rmtree(hints_path.parent, ignore_errors=True)
+
+
+def test_task_bootstrap_cli_accepts_creative_learning_hints(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    hints = _valid_creative_learning_hints()
+    hints_path = _write_creative_learning_hints(hints)
+    output_path = (
+        task_bootstrap_module.TASK_PACKET_DIR
+        / f"pytest-creative-learning-hints-{uuid.uuid4().hex}.json"
+    )
+    try:
+        exit_code = main(
+            [
+                "--goal",
+                "Expose creative spec learning hints in packet",
+                "--task-class",
+                "Orchestration",
+                "--path",
+                "scripts/orchestration/task_bootstrap.py",
+                "--creative-learning-hints",
+                str(hints_path),
+                "--output",
+                str(output_path),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 0, captured.out
+        packet = json.loads(output_path.read_text(encoding="utf-8"))
+        summary = json.loads(captured.out)
+        assert summary["creative_learning_hints_fingerprint"] == fingerprint_payload(hints)
+        assert packet["creative_learning_hints"]["source_hints_fingerprint"] == (
+            fingerprint_payload(hints)
+        )
+    finally:
+        output_path.unlink(missing_ok=True)
+        shutil.rmtree(hints_path.parent, ignore_errors=True)
 
 
 def test_task_bootstrap_requires_learning_loop_for_repeated_premortem_failure() -> None:

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -487,7 +487,7 @@ def test_task_bootstrap_rejects_invalid_creative_learning_hints() -> None:
 
 def test_task_bootstrap_rejects_creative_learning_hints_with_undeclared_focus_lessons() -> None:
     hints = _valid_creative_learning_hints()
-    hints["recommended_role_focus"][0]["source_lesson_ids"] = ["lesson-notdeclared"]
+    hints["recommended_role_focus"][0]["source_lesson_ids"] = ["lesson-ffffffffffff"]
     set_creative_learning_identity(
         hints,
         id_key="hints_id",
@@ -502,6 +502,32 @@ def test_task_bootstrap_rejects_creative_learning_hints_with_undeclared_focus_le
         with pytest.raises(ValueError, match="undeclared lesson ids"):
             build_task_packet(
                 goal="Reject undeclared creative spec learning hint lesson ids",
+                task_class="Orchestration",
+                candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+                creative_learning_hints_path=hints_path,
+            )
+    finally:
+        shutil.rmtree(hints_path.parent, ignore_errors=True)
+
+
+def test_task_bootstrap_rejects_noncanonical_creative_learning_lesson_ids() -> None:
+    hints = _valid_creative_learning_hints()
+    hints["reuse_lesson_ids"] = ["lesson-nothex"]
+    hints["recommended_role_focus"][0]["source_lesson_ids"] = ["lesson-nothex"]
+    set_creative_learning_identity(
+        hints,
+        id_key="hints_id",
+        asset_type=HINTS_ARTIFACT_TYPE,
+        upstream_ids=(
+            str(hints["source_rollup_id"]),
+            str(hints["source_rollup_fingerprint"]),
+        ),
+    )
+    hints_path = _write_creative_learning_hints(hints)
+    try:
+        with pytest.raises(ValueError, match="lesson id"):
+            build_task_packet(
+                goal="Reject noncanonical creative spec learning hint lesson ids",
                 task_class="Orchestration",
                 candidate_paths=["scripts/orchestration/task_bootstrap.py"],
                 creative_learning_hints_path=hints_path,

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -30,6 +30,7 @@ from scripts.orchestration.design_lane_contract import canonicalize_design_block
 from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
 from scripts.orchestration.agent_learning_loop import build_agent_learning_record
 from scripts.orchestration.creative_spec_learning_rollup_contract import (
+    HINTS_ARTIFACT_TYPE,
     POLICY_VERSION as CREATIVE_LEARNING_POLICY_VERSION,
     ROLLUP_ARTIFACT_TYPE,
     SCHEMA_VERSION as CREATIVE_LEARNING_SCHEMA_VERSION,
@@ -476,6 +477,31 @@ def test_task_bootstrap_rejects_invalid_creative_learning_hints() -> None:
         with pytest.raises(ValueError, match="invalid authority"):
             build_task_packet(
                 goal="Reject invalid creative spec learning hints",
+                task_class="Orchestration",
+                candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+                creative_learning_hints_path=hints_path,
+            )
+    finally:
+        shutil.rmtree(hints_path.parent, ignore_errors=True)
+
+
+def test_task_bootstrap_rejects_creative_learning_hints_with_undeclared_focus_lessons() -> None:
+    hints = _valid_creative_learning_hints()
+    hints["recommended_role_focus"][0]["source_lesson_ids"] = ["lesson-notdeclared"]
+    set_creative_learning_identity(
+        hints,
+        id_key="hints_id",
+        asset_type=HINTS_ARTIFACT_TYPE,
+        upstream_ids=(
+            str(hints["source_rollup_id"]),
+            str(hints["source_rollup_fingerprint"]),
+        ),
+    )
+    hints_path = _write_creative_learning_hints(hints)
+    try:
+        with pytest.raises(ValueError, match="undeclared lesson ids"):
+            build_task_packet(
+                goal="Reject undeclared creative spec learning hint lesson ids",
                 task_class="Orchestration",
                 candidate_paths=["scripts/orchestration/task_bootstrap.py"],
                 creative_learning_hints_path=hints_path,


### PR DESCRIPTION
## Goal
Feed finalized creative-code specification outcomes into proposal-only agent learning records and coordinator advisory hints.

## Business Reason
This closes the next orchestration feedback loop: accepted/rejected creative spec outcomes can improve reviewer focus without granting patch generation, provider calls, runtime behavior, semantic cache, graph truth, GitHub/Slack writes, or merge-readiness authority.

## Scope
- Add `creative_spec_learning_rollup_contract.py` and `creative_spec_learning_rollup.py`.
- Add closed JSON schemas for the rollup and coordinator advisory hints.
- Reuse `agent_learning_record.v1` for success/failure learning records.
- Add `task_bootstrap.py --creative-learning-hints` packet visibility with deterministic packet identity fingerprinting.
- Update scoped orchestration docs, review governance artifact, and backlog evidence.

## Out Of Scope
No patch-builder admission, candidate patch generation, provider/model calls, product runtime, OpenAPI/client, DB, app/frontend/iOS, workflow, Slack, GitHub App, semantic-cache, graph-truth, fixed-mapping, review-thread, or merge authority changes.

## Key Decisions
- The rollup validates bridge metrics, skeptic-review attachment, finalize receipt, and `CreativeCodeSpecificationBundle` as one fingerprint-bound chain.
- Success outcomes emit `successful_iteration` records with `successful_pattern_reuse`; rejected/revise/unsafe/malformed outcomes emit `failure` records with `repeat_failure_reduction`.
- Coordinator hints are advisory only and cannot change primary/reviewer, role order, required gates, execution, routing, patch generation, cache/graph truth, or merge readiness.
- `task_bootstrap` accepts hints only from local learning-rollup artifacts and includes the hints fingerprint in packet identity.
- Coordinator hint focus lesson ids must be declared in `reuse_lesson_ids` or `avoid_lesson_ids`; undeclared ids fail closed before packet ingestion.
- Learning lesson ids are canonical `lesson-[a-f0-9]{12}` in runtime and schema.
- Rollup rejection counters and summed agent feedback pass/revise/reject counts must match the corresponding outcome counters.

## Tests / Validation
- `python -m json.tool docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json` - PASS after schema tightening.
- `python -m flake8 scripts/orchestration/creative_spec_learning_rollup_contract.py tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py` - PASS after post-open bug-hunter fixes.
- `python -m pytest -q tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py` - PASS after final bug-hunter fixes.
- `python -m pytest -q tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py tests/test_agent_learning_loop.py tests/test_creative_specification_skeptic_review.py tests/test_creative_hypothesis_spec_bridge.py tests/test_skill_router.py` - PASS after earlier post-open fixes.
- `python scripts/ci/check_pr_body_phase2_gates.py --pr-number 2075 --body "$(gh pr view 2075 --json body --jq .body)" --commit-range origin/main..HEAD --experiment-runner-evidence-mode advisory` - PASS locally after mapping updates.
- `GH_TOKEN="$(gh auth token)" python scripts/orchestration/check_review_threads_disposition.py --pr-number 2075 --require-auth` - PASS locally after mapping updates.
- `GITHUB_TOKEN/GH_TOKEN=$(gh auth token) python scripts/ci/check_pr_merge_readiness.py --pr-number 2075 --repo Katsiarynakavaleuskaya/PulsePlate` - PASS locally after mapping updates.
- Earlier local bundle on implementation head: `python scripts/orchestration/check_preflight.py`, `python scripts/orchestration/check_agent_consistency.py`, focused tests, `make validate-changed`, `pre-commit run --all-files`, and pre-push hooks passed before PR open.
- Experiment Runner oracle-only evidence: accepted; local artifact `artifacts/orchestration/experiments/results/creative-spec-learning-rollup-oracle-result.json`, `status=accepted`, 3 oracle commands returncode 0, `source_diff_applied=true`, `mutated_paths=[]`, `promotion_ready=false`.

## Security Notes
Duplicate JSON keys, unsafe text, secrets, raw prompts/responses, patch text, local absolute paths, semantic-cache claims, graph-truth claims, undeclared or noncanonical lesson ids, inconsistent rejection/feedback counters, and authority widening fail closed. Artifacts remain local-only under `artifacts/orchestration/creative_code/learning_rollup/<rollup-id>/`.

## Risks / Rollback
Rollback is straightforward: remove the new rollup CLI/contract/schemas/tests, remove `--creative-learning-hints` packet ingestion and packet identity input, and revert the narrow docs/backlog/review-artifact updates. No runtime coordination is needed.

## Deferred / Follow-ups
- Patch-builder admission remains the next separate candidate only after this learning rollup lands.
- Graph/multimodal lineage remains deferred until evidence lineage/admission contracts are reviewed.

## AGENTS / Instruction Updates
`scripts/AGENTS.md` now records the local-only creative spec learning rollup boundary and `task_bootstrap` advisory-hints constraints.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075#discussion_r3523766542 -> 6bd673ead0706004f224899bde199183515fc0dd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075#pullrequestreview-4630181858 -> 6bd673ead0706004f224899bde199183515fc0dd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2075#pullrequestreview-4630243274
- canonical artifact: `docs/review/PR_2075_FIXED_MAPPING.md`

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/creative-spec-learning-rollup-oracle-result.json`

## Lane Start Provenance
Packet: `artifacts/orchestration/task_packets/e87dde544345.json`
Starter: `scripts/orchestration/start_pr_lane.sh`

## Merge Readiness
Not claiming merge readiness. Current-head CI after the latest pushed head, final post-open role chain, Codex Security scan handoff, bot review disposition, and strict merge-readiness governance still need final verification.
