### PR TITLE
feat(orchestration): admit finalized creative specs to patch-builder requests

### DIFF
--- a/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
+++ b/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
@@ -233,7 +233,9 @@ after reviewed finalize evidence emits a selected
 `spec_finalize_reviewed/creative_code_specification_bundle.json` plus a
 `finalize_receipt.json` whose next allowed action is
 `human_review_for_patch_builder`. The admission layer calls the existing PR-2
-request builder and keeps its own executed authority prepare-only.
+request builder, validates the request through the existing PR-2 request
+validator, and keeps its own executed authority prepare-only with
+`validate_patch_builder_request=true`.
 
 The packet, bundle, request, result, local `candidate.patch`, plan, validation,
 approval, receipt, applied-candidate run plan, and generated PR body may

--- a/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
+++ b/docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md
@@ -208,16 +208,32 @@ The reviewed creative specification learning rollup artifacts are:
 - `artifacts/orchestration/creative_code/learning_rollup/<rollup-id>/creative_spec_learning_rollup.json`
 - `artifacts/orchestration/creative_code/learning_rollup/<rollup-id>/coordinator_advisory_hints.json`
 
+The finalized creative specification patch-admission artifacts are:
+
+- `docs/orchestration/contracts/CREATIVE_SPEC_PATCH_ADMISSION_CONTRACT.md`
+- `docs/orchestration/contracts/creative_spec_patch_human_admission.v1.schema.json`
+- `docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json`
+- `scripts/orchestration/creative_spec_patch_admission_contract.py`
+- `scripts/orchestration/creative_spec_patch_admission.py`
+- `artifacts/orchestration/creative_code/patch_admission/<admission-id>/human_admission.json`
+- `artifacts/orchestration/creative_code/patch_admission/<admission-id>/finalize_receipt.json`
+- `artifacts/orchestration/creative_code/patch_admission/<admission-id>/source_bundle.json`
+- `artifacts/orchestration/creative_code/patch_admission/<admission-id>/request.json`
+- `artifacts/orchestration/creative_code/patch_admission/<admission-id>/creative_spec_patch_admission.json`
+
 Bridge output directories must be exactly
 `artifacts/orchestration/creative_code/spec_bridge/<bridge-id>/`; bridge refs,
 candidate packets, metrics, and prepare directories must agree on that id.
 Build-only artifacts may only allow `prepare_specification`; agent skeptic
 review is the next action only after the four PR-1 prepare artifacts exist.
 
-`patch_request.json` remains a PR-2 `CreativeCodePatchBuildRequest` handoff
-artifact. It is built and validated only after PR-1 emits
-`spec_runs/<candidate-id>/bundle.json`, because its identity and fingerprint are
-bound to that canonical specification bundle.
+`request.json` in a patch-admission directory is a PR-2
+`CreativeCodePatchBuildRequest` handoff artifact. It is built and validated only
+after reviewed finalize evidence emits a selected
+`spec_finalize_reviewed/creative_code_specification_bundle.json` plus a
+`finalize_receipt.json` whose next allowed action is
+`human_review_for_patch_builder`. The admission layer calls the existing PR-2
+request builder and keeps its own executed authority prepare-only.
 
 The packet, bundle, request, result, local `candidate.patch`, plan, validation,
 approval, receipt, applied-candidate run plan, and generated PR body may
@@ -277,6 +293,14 @@ PR-0 is a contract-only start point.
   routing, role order, required gates, agent execution, patch generation,
   semantic cache, graph truth, product runtime truth, PR/GitHub/Slack writes,
   or merge-readiness authority.
+- Creative spec patch admission: admit a finalized selected creative spec to a
+  valid PR-2 `CreativeCodePatchBuildRequest` and optionally run builder
+  `prepare` only, proving `request.json`, `source_bundle.json`,
+  `selected_variant.json`, and `state.json` exist while `candidate.patch` and
+  `result.json` remain absent; no `generate`, `evaluate`, Codex exec,
+  promotion, branch/PR writes, workflow changes, product runtime truth,
+  semantic cache, graph truth, fixed-mapping edits, review-thread actions, or
+  readiness claims.
 - PR-2: generate isolated candidate patches only in sandboxed evaluation
   workspaces with exact source-bundle fingerprint binding, exact `origin/main`
   base SHA, fixed Codex CLI argv/env, strict patch policy validation, direct

--- a/docs/orchestration/contracts/CREATIVE_SPEC_PATCH_ADMISSION_CONTRACT.md
+++ b/docs/orchestration/contracts/CREATIVE_SPEC_PATCH_ADMISSION_CONTRACT.md
@@ -1,0 +1,150 @@
+# Creative Spec Patch Admission Contract
+
+Status: active local control-plane contract.
+
+This contract admits an already finalized creative-code specification bundle to
+the existing PR-2 `CreativeCodePatchBuildRequest` shape and optionally proves
+that patch-builder `prepare` can create its isolated checkout artifacts.
+
+It does not generate a patch, evaluate a candidate, call Codex, promote a
+candidate, write a branch, open or edit a PR, resolve review threads, edit fixed
+mapping, change workflows, call product runtime, use semantic cache, or write
+graph truth.
+
+## Inputs
+
+The admission CLI reads only sanitized local JSON artifacts:
+
+- `spec_finalize_reviewed/finalize_receipt.json`
+- `spec_finalize_reviewed/creative_code_specification_bundle.json`
+- `creative_spec_patch_human_admission.v1` operator approval
+
+The finalize receipt must have:
+
+- `synthesis_status == selected`
+- `next_allowed_action == human_review_for_patch_builder`
+- `counts.selected_variant_count == 1`
+- a `bundle_id`, `bundle_fingerprint`, and selected variant binding that match
+  the supplied bundle
+
+The human admission must bind:
+
+- bundle id and fingerprint
+- selected variant id and fingerprint
+- non-empty oracle commands
+- non-empty metrics
+- bounded PR-2 budgets
+- explicit prepare-only authority
+
+## Outputs
+
+`creative_spec_patch_admission.py build-request` writes a local admission
+directory under:
+
+`artifacts/orchestration/creative_code/patch_admission/<operator-run-id>/`
+
+The directory contains:
+
+- `creative_spec_patch_admission.json`
+- `human_admission.json`
+- `finalize_receipt.json`
+- `source_bundle.json`
+- `request.json`
+
+`request.json` is a normal PR-2 `CreativeCodePatchBuildRequest` built by
+`build_creative_code_patch_build_request(...)` and then validated by
+`validate_creative_code_patch_build_request(...)`. This admission layer does not
+duplicate the PR-2 request contract logic.
+
+`creative_spec_patch_admission.json` records prepare-only executed effects. It
+intentionally separates this admission authority from the PR-2 request
+authority. The request remains a valid PR-2 builder request; this CLI only
+executes build, validate, summarize, and builder `prepare`.
+
+## Prepare Proof
+
+`creative_spec_patch_admission.py prepare-builder` calls only
+`creative_code_patch_builder.prepare(...)`. It writes the existing builder
+prepare artifacts under `patch_runs/<run-id>/`:
+
+- `request.json`
+- `source_bundle.json`
+- `selected_variant.json`
+- `state.json`
+
+The admission summary must prove:
+
+- `candidate.patch` is absent
+- `result.json` is absent
+- `candidate_patch_generated == false`
+- `candidate_patch_evaluated == false`
+- no Codex exec, provider call, product runtime call, semantic-cache write,
+  graph-truth write, branch write, PR write, review-thread action, fixed-mapping
+  edit, or merge-readiness claim occurred
+
+## CLI
+
+Commands:
+
+- `build-request`
+- `validate`
+- `prepare-builder`
+- `build-and-prepare`
+- `summarize`
+
+`build-request`, `prepare-builder`, and `build-and-prepare` require the shared
+worktree to be clean and `base_sha` to match current `origin/main`.
+
+`validate` and `summarize` re-check the admission bindings and current
+`origin/main` base SHA before reporting success.
+
+## Authority
+
+True authority is limited to:
+
+- read finalized creative specs
+- approve/build a patch-builder request
+- validate the request
+- run builder `prepare`
+- emit local artifacts
+
+False authority includes:
+
+- `run_patch_builder_generate`
+- `run_patch_builder_evaluate`
+- `generate_candidate_patch`
+- `call_local_codex_exec`
+- `call_provider`
+- `call_product_runtime`
+- `write_repository`
+- `write_shared_worktree`
+- `create_branch`
+- `push_branch`
+- `open_pull_request`
+- `resolve_review_threads`
+- `edit_fixed_mapping`
+- `claim_merge_readiness`
+- `merge`
+- `modify_workflows`
+- `use_semantic_cache`
+- `write_graph_truth`
+- `read_secrets`
+
+## Schemas And Validators
+
+Tracked contract surfaces:
+
+- `docs/orchestration/contracts/creative_spec_patch_human_admission.v1.schema.json`
+- `docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json`
+- `scripts/orchestration/creative_spec_patch_admission_contract.py`
+- `scripts/orchestration/creative_spec_patch_admission.py`
+
+Regression surface:
+
+- `tests/test_creative_spec_patch_admission.py`
+- `tests/test_creative_code_patch_builder.py`
+- `tests/test_creative_code_specification.py`
+- `tests/test_creative_specification_skeptic_review.py`
+- `tests/test_creative_hypothesis_spec_bridge.py`
+- `tests/test_creative_spec_learning_rollup.py`
+- `tests/test_task_bootstrap.py`

--- a/docs/orchestration/contracts/CREATIVE_SPEC_PATCH_ADMISSION_CONTRACT.md
+++ b/docs/orchestration/contracts/CREATIVE_SPEC_PATCH_ADMISSION_CONTRACT.md
@@ -59,7 +59,9 @@ duplicate the PR-2 request contract logic.
 `creative_spec_patch_admission.json` records prepare-only executed effects. It
 intentionally separates this admission authority from the PR-2 request
 authority. The request remains a valid PR-2 builder request; this CLI only
-executes build, validate, summarize, and builder `prepare`.
+executes build, validate, summarize, and builder `prepare`. Its authority block
+must keep `validate_patch_builder_request=true` to make the PR-2 validator call
+an explicit admission condition, not an implied side effect.
 
 ## Prepare Proof
 
@@ -104,7 +106,7 @@ True authority is limited to:
 
 - read finalized creative specs
 - approve/build a patch-builder request
-- validate the request
+- validate the patch-builder request through the PR-2 request validator
 - run builder `prepare`
 - emit local artifacts
 

--- a/docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json
+++ b/docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json
@@ -1,0 +1,288 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_spec_patch_admission.v1.schema.json",
+  "title": "CreativeSpecPatchAdmission",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "admission_id",
+    "idempotency_key",
+    "source",
+    "selected_variant",
+    "base",
+    "human_admission",
+    "patch_request",
+    "builder_prepare",
+    "executed_effects",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_spec_patch_admission" },
+    "policy_version": { "const": "creative-spec-patch-admission-v1" },
+    "admission_id": { "$ref": "#/$defs/safe_id" },
+    "idempotency_key": { "$ref": "#/$defs/safe_id" },
+    "source": { "$ref": "#/$defs/source" },
+    "selected_variant": { "$ref": "#/$defs/selected_variant" },
+    "base": { "$ref": "#/$defs/base" },
+    "human_admission": { "$ref": "#/$defs/human_admission" },
+    "patch_request": { "$ref": "#/$defs/patch_request" },
+    "builder_prepare": { "$ref": "#/$defs/builder_prepare" },
+    "executed_effects": { "$ref": "#/$defs/executed_effects" },
+    "authority": { "$ref": "#/$defs/authority" },
+    "sanitized": { "const": true }
+  },
+  "$defs": {
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "safe_token": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 96,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "git_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "artifact_ref": {
+      "type": "string",
+      "pattern": "^artifacts/orchestration/creative_code/[A-Za-z0-9._:/-]+\\.json$",
+      "not": { "pattern": "(?:^|/)\\.\\.?(?:/|$)" }
+    },
+    "repo_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/|~|[A-Za-z][A-Za-z0-9+.-]*:)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*\\\\).+"
+    },
+    "repo_path_array": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/repo_path" }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "finalize_id",
+        "finalize_receipt_fingerprint",
+        "finalize_receipt_ref",
+        "bundle_id",
+        "bundle_fingerprint",
+        "bundle_ref",
+        "source_packet_id"
+      ],
+      "properties": {
+        "finalize_id": { "$ref": "#/$defs/safe_id" },
+        "finalize_receipt_fingerprint": { "$ref": "#/$defs/sha256" },
+        "finalize_receipt_ref": { "$ref": "#/$defs/artifact_ref" },
+        "bundle_id": { "$ref": "#/$defs/safe_id" },
+        "bundle_fingerprint": { "$ref": "#/$defs/sha256" },
+        "bundle_ref": { "$ref": "#/$defs/artifact_ref" },
+        "source_packet_id": { "$ref": "#/$defs/safe_id" }
+      }
+    },
+    "selected_variant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["variant_id", "variant_fingerprint", "target_paths", "tests_to_add"],
+      "properties": {
+        "variant_id": { "$ref": "#/$defs/safe_id" },
+        "variant_fingerprint": { "$ref": "#/$defs/sha256" },
+        "target_paths": { "$ref": "#/$defs/repo_path_array" },
+        "tests_to_add": { "$ref": "#/$defs/repo_path_array" }
+      }
+    },
+    "base": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base_ref", "base_commit_sha"],
+      "properties": {
+        "base_ref": { "const": "origin/main" },
+        "base_commit_sha": { "$ref": "#/$defs/git_sha" }
+      }
+    },
+    "human_admission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision",
+        "approval_ref",
+        "approved_by",
+        "approved_at_utc",
+        "human_admission_fingerprint",
+        "human_admission_ref"
+      ],
+      "properties": {
+        "decision": { "const": "approved_for_patch_builder_prepare" },
+        "approval_ref": { "$ref": "#/$defs/safe_id" },
+        "approved_by": { "$ref": "#/$defs/safe_token" },
+        "approved_at_utc": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+        },
+        "human_admission_fingerprint": { "$ref": "#/$defs/sha256" },
+        "human_admission_ref": { "$ref": "#/$defs/artifact_ref" }
+      }
+    },
+    "patch_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_id",
+        "request_idempotency_key",
+        "request_fingerprint",
+        "request_ref",
+        "source_bundle_ref",
+        "contract_policy_version",
+        "request_authority_scope"
+      ],
+      "properties": {
+        "request_id": { "$ref": "#/$defs/safe_id" },
+        "request_idempotency_key": { "$ref": "#/$defs/safe_id" },
+        "request_fingerprint": { "$ref": "#/$defs/sha256" },
+        "request_ref": { "$ref": "#/$defs/artifact_ref" },
+        "source_bundle_ref": { "$ref": "#/$defs/artifact_ref" },
+        "contract_policy_version": { "const": "creative-code-patch-builder-pr2" },
+        "request_authority_scope": { "const": "pr2_builder_request_contract" }
+      }
+    },
+    "builder_prepare": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "prepared",
+        "run_id",
+        "state_fingerprint",
+        "request_file_present",
+        "source_bundle_file_present",
+        "selected_variant_file_present",
+        "state_file_present",
+        "candidate_patch_path_present",
+        "result_file_present",
+        "candidate_patch_generated",
+        "candidate_patch_evaluated"
+      ],
+      "properties": {
+        "prepared": { "type": "boolean" },
+        "run_id": {
+          "anyOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/safe_id" }
+          ]
+        },
+        "state_fingerprint": {
+          "anyOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/sha256" }
+          ]
+        },
+        "request_file_present": { "type": "boolean" },
+        "source_bundle_file_present": { "type": "boolean" },
+        "selected_variant_file_present": { "type": "boolean" },
+        "state_file_present": { "type": "boolean" },
+        "candidate_patch_path_present": { "const": false },
+        "result_file_present": { "const": false },
+        "candidate_patch_generated": { "const": false },
+        "candidate_patch_evaluated": { "const": false }
+      }
+    },
+    "executed_effects": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_built",
+        "builder_prepared",
+        "candidate_patch_generated",
+        "candidate_patch_evaluated",
+        "codex_exec_called",
+        "shared_worktree_modified",
+        "branch_written",
+        "pull_request_opened",
+        "fixed_mapping_edited",
+        "semantic_cache_used",
+        "graph_truth_written"
+      ],
+      "properties": {
+        "request_built": { "const": true },
+        "builder_prepared": { "type": "boolean" },
+        "candidate_patch_generated": { "const": false },
+        "candidate_patch_evaluated": { "const": false },
+        "codex_exec_called": { "const": false },
+        "shared_worktree_modified": { "const": false },
+        "branch_written": { "const": false },
+        "pull_request_opened": { "const": false },
+        "fixed_mapping_edited": { "const": false },
+        "semantic_cache_used": { "const": false },
+        "graph_truth_written": { "const": false }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "build_patch_builder_request",
+        "call_local_codex_exec",
+        "call_product_runtime",
+        "call_provider",
+        "claim_merge_readiness",
+        "create_branch",
+        "edit_fixed_mapping",
+        "emit_local_artifacts",
+        "generate_candidate_patch",
+        "merge",
+        "modify_workflows",
+        "open_pull_request",
+        "promote_candidate",
+        "push_branch",
+        "read_secrets",
+        "resolve_review_threads",
+        "run_patch_builder_evaluate",
+        "run_patch_builder_generate",
+        "run_patch_builder_prepare",
+        "use_semantic_cache",
+        "write_graph_truth",
+        "write_repository",
+        "write_shared_worktree"
+      ],
+      "properties": {
+        "build_patch_builder_request": { "const": true },
+        "emit_local_artifacts": { "const": true },
+        "run_patch_builder_prepare": { "const": true },
+        "call_local_codex_exec": { "const": false },
+        "call_product_runtime": { "const": false },
+        "call_provider": { "const": false },
+        "claim_merge_readiness": { "const": false },
+        "create_branch": { "const": false },
+        "edit_fixed_mapping": { "const": false },
+        "generate_candidate_patch": { "const": false },
+        "merge": { "const": false },
+        "modify_workflows": { "const": false },
+        "open_pull_request": { "const": false },
+        "promote_candidate": { "const": false },
+        "push_branch": { "const": false },
+        "read_secrets": { "const": false },
+        "resolve_review_threads": { "const": false },
+        "run_patch_builder_evaluate": { "const": false },
+        "run_patch_builder_generate": { "const": false },
+        "use_semantic_cache": { "const": false },
+        "write_graph_truth": { "const": false },
+        "write_repository": { "const": false },
+        "write_shared_worktree": { "const": false }
+      }
+    }
+  }
+}

--- a/docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json
+++ b/docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json
@@ -36,6 +36,44 @@
     "authority": { "$ref": "#/$defs/authority" },
     "sanitized": { "const": true }
   },
+  "allOf": [
+    {
+      "if": {
+        "required": ["builder_prepare"],
+        "properties": {
+          "builder_prepare": {
+            "required": ["prepared"],
+            "properties": { "prepared": { "const": true } }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "executed_effects": {
+            "properties": { "builder_prepared": { "const": true } }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["builder_prepare"],
+        "properties": {
+          "builder_prepare": {
+            "required": ["prepared"],
+            "properties": { "prepared": { "const": false } }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "executed_effects": {
+            "properties": { "builder_prepared": { "const": false } }
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
     "safe_id": {
       "type": "string",
@@ -198,7 +236,41 @@
         "result_file_present": { "const": false },
         "candidate_patch_generated": { "const": false },
         "candidate_patch_evaluated": { "const": false }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["prepared"],
+            "properties": { "prepared": { "const": true } }
+          },
+          "then": {
+            "properties": {
+              "run_id": { "$ref": "#/$defs/safe_id" },
+              "state_fingerprint": { "$ref": "#/$defs/sha256" },
+              "request_file_present": { "const": true },
+              "source_bundle_file_present": { "const": true },
+              "selected_variant_file_present": { "const": true },
+              "state_file_present": { "const": true }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["prepared"],
+            "properties": { "prepared": { "const": false } }
+          },
+          "then": {
+            "properties": {
+              "run_id": { "type": "null" },
+              "state_fingerprint": { "type": "null" },
+              "request_file_present": { "const": false },
+              "source_bundle_file_present": { "const": false },
+              "selected_variant_file_present": { "const": false },
+              "state_file_present": { "const": false }
+            }
+          }
+        }
+      ]
     },
     "executed_effects": {
       "type": "object",

--- a/docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json
+++ b/docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json
@@ -326,6 +326,7 @@
         "run_patch_builder_generate",
         "run_patch_builder_prepare",
         "use_semantic_cache",
+        "validate_patch_builder_request",
         "write_graph_truth",
         "write_repository",
         "write_shared_worktree"
@@ -334,6 +335,7 @@
         "build_patch_builder_request": { "const": true },
         "emit_local_artifacts": { "const": true },
         "run_patch_builder_prepare": { "const": true },
+        "validate_patch_builder_request": { "const": true },
         "call_local_codex_exec": { "const": false },
         "call_product_runtime": { "const": false },
         "call_provider": { "const": false },

--- a/docs/orchestration/contracts/creative_spec_patch_human_admission.v1.schema.json
+++ b/docs/orchestration/contracts/creative_spec_patch_human_admission.v1.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.local/contracts/creative_spec_patch_human_admission.v1.schema.json",
+  "title": "CreativeSpecPatchHumanAdmission",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "policy_version",
+    "decision",
+    "approval_ref",
+    "approved_by",
+    "approved_at_utc",
+    "approved_source_bundle_id",
+    "approved_source_bundle_fingerprint",
+    "approved_selected_variant_id",
+    "approved_selected_variant_fingerprint",
+    "allowed_existing_paths",
+    "allowed_new_paths",
+    "oracle_commands",
+    "metrics",
+    "budgets",
+    "authority",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "artifact_type": { "const": "creative_spec_patch_human_admission" },
+    "policy_version": { "const": "creative-spec-patch-admission-v1" },
+    "decision": { "const": "approved_for_patch_builder_prepare" },
+    "approval_ref": { "$ref": "#/$defs/safe_id" },
+    "approved_by": { "$ref": "#/$defs/safe_token" },
+    "approved_at_utc": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+    },
+    "approved_source_bundle_id": { "$ref": "#/$defs/safe_id" },
+    "approved_source_bundle_fingerprint": { "$ref": "#/$defs/sha256" },
+    "approved_selected_variant_id": { "$ref": "#/$defs/safe_id" },
+    "approved_selected_variant_fingerprint": { "$ref": "#/$defs/sha256" },
+    "allowed_existing_paths": { "$ref": "#/$defs/path_array_allow_empty" },
+    "allowed_new_paths": { "$ref": "#/$defs/path_array_allow_empty" },
+    "oracle_commands": { "$ref": "#/$defs/non_empty_string_array" },
+    "metrics": { "$ref": "#/$defs/non_empty_string_array" },
+    "budgets": { "$ref": "#/$defs/budgets" },
+    "authority": { "$ref": "#/$defs/authority" },
+    "sanitized": { "const": true }
+  },
+  "anyOf": [
+    { "properties": { "allowed_existing_paths": { "minItems": 1 } } },
+    { "properties": { "allowed_new_paths": { "minItems": 1 } } }
+  ],
+  "$defs": {
+    "safe_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "safe_token": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 96,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "repo_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/|~|[A-Za-z][A-Za-z0-9+.-]*:)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*\\\\).+"
+    },
+    "path_array_allow_empty": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/repo_path" }
+    },
+    "non_empty_string_array": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "not": {
+          "pattern": "(candidate\\.patch|diff --git|raw[_ -]?(prompt|response|context|patch|review|body)|chain[_ -]?of[_ -]?thought|provider[_ -]?payload|oracle[_ -]?(stdout|stderr)|sk-[A-Za-z0-9_-]{12,}|gh[psoru]_|github_pat_|xox[abprs]-|authorization:\\s*bearer|private[_ -]?key|api[_ -]?key|/Users/|/tmp/)"
+        }
+      }
+    },
+    "budgets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "generation_attempts",
+        "generation_timeout_seconds",
+        "evaluation_timeout_seconds",
+        "max_changed_files",
+        "max_diff_lines",
+        "max_patch_bytes"
+      ],
+      "properties": {
+        "generation_attempts": { "const": 1 },
+        "generation_timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 600 },
+        "evaluation_timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 600 },
+        "max_changed_files": { "type": "integer", "minimum": 1, "maximum": 5, "default": 3 },
+        "max_diff_lines": { "type": "integer", "minimum": 1, "maximum": 800 },
+        "max_patch_bytes": { "type": "integer", "minimum": 1, "maximum": 524288 }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "approve_patch_builder_request",
+        "call_local_codex_exec",
+        "call_product_runtime",
+        "call_provider",
+        "claim_merge_readiness",
+        "create_branch",
+        "edit_fixed_mapping",
+        "emit_local_artifacts",
+        "generate_candidate_patch",
+        "merge",
+        "modify_workflows",
+        "open_pull_request",
+        "promote_candidate",
+        "push_branch",
+        "read_finalized_creative_spec",
+        "read_secrets",
+        "resolve_review_threads",
+        "run_patch_builder_evaluate",
+        "run_patch_builder_generate",
+        "run_patch_builder_prepare",
+        "use_semantic_cache",
+        "validate_patch_builder_request",
+        "write_graph_truth",
+        "write_repository",
+        "write_shared_worktree"
+      ],
+      "properties": {
+        "approve_patch_builder_request": { "const": true },
+        "emit_local_artifacts": { "const": true },
+        "read_finalized_creative_spec": { "const": true },
+        "run_patch_builder_prepare": { "const": true },
+        "validate_patch_builder_request": { "const": true },
+        "call_local_codex_exec": { "const": false },
+        "call_product_runtime": { "const": false },
+        "call_provider": { "const": false },
+        "claim_merge_readiness": { "const": false },
+        "create_branch": { "const": false },
+        "edit_fixed_mapping": { "const": false },
+        "generate_candidate_patch": { "const": false },
+        "merge": { "const": false },
+        "modify_workflows": { "const": false },
+        "open_pull_request": { "const": false },
+        "promote_candidate": { "const": false },
+        "push_branch": { "const": false },
+        "read_secrets": { "const": false },
+        "resolve_review_threads": { "const": false },
+        "run_patch_builder_evaluate": { "const": false },
+        "run_patch_builder_generate": { "const": false },
+        "use_semantic_cache": { "const": false },
+        "write_graph_truth": { "const": false },
+        "write_repository": { "const": false },
+        "write_shared_worktree": { "const": false }
+      }
+    }
+  }
+}

--- a/docs/review/PR_2080_FIXED_MAPPING.md
+++ b/docs/review/PR_2080_FIXED_MAPPING.md
@@ -47,6 +47,15 @@ Commit: f6b96ef4286f69ecce03a8db80af41abfcff19bc
 Evidence: `scripts/orchestration/creative_spec_patch_admission.py` and `scripts/orchestration/creative_spec_patch_admission_contract.py` remove unused imports; `tests/test_creative_spec_patch_admission.py` adds direct negative validator tests; focused pytest passed with 14 tests, `ruff check` passed, then preflight, agent consistency, `make validate-changed`, `pre-commit run --all-files`, and pre-push hooks passed.
 Reason: The second post-open QA pass found targeted lint failures and requested direct validator negative coverage for the prior schema-parity bug class.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080 -> f6b96ef4286f69ecce03a8db80af41abfcff19bc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080#discussion_r3524885015 -> f6b96ef4286f69ecce03a8db80af41abfcff19bc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080#discussion_r3524885018 -> f6b96ef4286f69ecce03a8db80af41abfcff19bc
+
+Disposition: FIXED
+Commit: 1ea21520401f0e44cb00ee1c7287571f16a269a9
+Evidence: `scripts/orchestration/creative_spec_patch_admission.py` cleans a newly-created builder run directory when post-prepare proof rejects forbidden artifacts; `tests/test_creative_spec_patch_admission.py` adds a regression where `prepare()` returns but leaves `candidate.patch`; `scripts/orchestration/creative_spec_patch_admission_contract.py` removes the no-op `max_changed_files` branch; the admission schema/docs now require `validate_patch_builder_request=true`; focused pytest passed with 15 tests and commit hooks passed.
+Reason: The post-open bug-hunter pass found an invalid-prepare-proof cleanup gap, and CodeRabbit found both an unresolved no-op budget branch and a missing explicit PR-2 request-validation signal in the admission schema.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080#discussion_r3524885014 -> 1ea21520401f0e44cb00ee1c7287571f16a269a9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080#discussion_r3524885016 -> 1ea21520401f0e44cb00ee1c7287571f16a269a9
 
 ## Role-Agent Evidence
 
@@ -59,6 +68,10 @@ Reason: The second post-open QA pass found targeted lint failures and requested 
 - Final QA rerun passed for the creative admission diff at
   `f6b96ef4286f69ecce03a8db80af41abfcff19bc`; it also identified the missing
   Phase2 artifact and stale Trivy policy as current-head gate blockers.
+- Post-open bug-hunter found the invalid prepare-proof cleanup gap, the missing
+  fixed-mapping entries for resolved CodeRabbit discussions, and the no-op
+  budget branch. Commit `1ea21520401f0e44cb00ee1c7287571f16a269a9` fixes the
+  code/test/schema/docs issues; this mapping records the thread proof.
 - The stale Trivy policy blocker is intentionally out of scope for PR #2080 and
   is owned by PR #2081 before this PR can be merge-ready.
 
@@ -93,10 +106,13 @@ graph-truth, patch-generation, or merge-readiness authority.
 - `python scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration/contracts --path docs/roadmap/BACKLOG_LEDGER.md --path tests` - PASS.
 - `python scripts/orchestration/check_agent_consistency.py` - PASS.
 - `python -m pytest -q tests/test_creative_spec_patch_admission.py` - PASS,
-  14 passed after post-open QA fixes.
+  15 passed after post-open bug-hunter fixes.
 - Requested creative-code regression pytest bundle - PASS before PR open.
 - `make validate-changed` - PASS after implementation and post-open QA commits;
   rerun required after the latest mapping commit.
+- Commit hooks for `1ea21520401f0e44cb00ee1c7287571f16a269a9` - PASS:
+  black, ruff, bandit changed-files, backend changed tests, detect-secrets, and
+  commitizen.
 - `pre-commit run --all-files` - PASS before initial PR push and after post-open
   QA commits; rerun required after the latest mapping commit.
 

--- a/docs/review/PR_2080_FIXED_MAPPING.md
+++ b/docs/review/PR_2080_FIXED_MAPPING.md
@@ -1,0 +1,110 @@
+# PR 2080 - Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080
+
+Branch: `codex/er-creative-spec-patch-admission`
+
+## Summary
+
+This PR admits finalized creative-code specification bundles into valid PR-2
+`CreativeCodePatchBuildRequest` artifacts and proves patch-builder `prepare`
+works without generating or evaluating a candidate patch. The admission lane is
+prepare-only and does not grant Codex exec, provider calls, branch or PR writes,
+promotion, product runtime truth, semantic-cache authority, or graph-truth
+authority.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Fixed mapping artifact created after GitHub assigned PR number `#2080`.
+- [x] Pre-open role order completed:
+  `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent`.
+- [x] Experiment Runner oracle-only evidence captured before PR open.
+- [x] Post-open QA pass completed after current-head fixes on
+  `f6b96ef4286f69ecce03a8db80af41abfcff19bc`.
+- [ ] Remaining post-open role chain after the latest mapping commit:
+  `bug-hunter -> security-auditor -> Codex Security diff scan -> pulseplate-pr-review`.
+- [ ] CodeRabbit, Sourcery, Cubic, and current-head CI must be checked again
+  after the latest pushed head.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 598ce1e94807210ea78ca652abf2d4583bcf8d5b
+Evidence: `scripts/orchestration/creative_spec_patch_admission_contract.py`, `scripts/orchestration/creative_spec_patch_admission.py`, admission contracts/schemas, and `tests/test_creative_spec_patch_admission.py` implement prepare-only admission; preflight, agent consistency, focused pytest, requested regression pytest bundle, `make validate-changed`, `pre-commit run --all-files`, CLI help smoke, Experiment Runner oracle fallback, and pre-push hooks passed.
+Reason: Implements the requested creative-spec-to-patch-builder prepare-only admission bridge by delegating request construction to the existing PR-2 patch builder contract instead of duplicating generation/evaluation logic.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080 -> 598ce1e94807210ea78ca652abf2d4583bcf8d5b
+
+Disposition: FIXED
+Commit: e5427e3f1b44268ba36f8cd25cb4a04c50853d72
+Evidence: `docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json` ties `builder_prepare.prepared` to required proof and `executed_effects.builder_prepared`; `tests/test_creative_spec_patch_admission.py` asserts schema parity; focused pytest, preflight, agent consistency, `make validate-changed`, `pre-commit run --all-files`, and pre-push hooks passed.
+Reason: The first post-open QA pass found the JSON Schema was looser than the Python validator for prepare proof; this closes that schema/validator drift.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080 -> e5427e3f1b44268ba36f8cd25cb4a04c50853d72
+
+Disposition: FIXED
+Commit: f6b96ef4286f69ecce03a8db80af41abfcff19bc
+Evidence: `scripts/orchestration/creative_spec_patch_admission.py` and `scripts/orchestration/creative_spec_patch_admission_contract.py` remove unused imports; `tests/test_creative_spec_patch_admission.py` adds direct negative validator tests; focused pytest passed with 14 tests, `ruff check` passed, then preflight, agent consistency, `make validate-changed`, `pre-commit run --all-files`, and pre-push hooks passed.
+Reason: The second post-open QA pass found targeted lint failures and requested direct validator negative coverage for the prior schema-parity bug class.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080 -> f6b96ef4286f69ecce03a8db80af41abfcff19bc
+
+## Role-Agent Evidence
+
+- Bootstrap packet: `artifacts/orchestration/task_packets/7d18e89bf74f.json`.
+- Pre-open dispatch order completed:
+  `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent`.
+- Post-open QA found schema-parity drift, then lint/test hardening gaps; commits
+  `e5427e3f1b44268ba36f8cd25cb4a04c50853d72` and
+  `f6b96ef4286f69ecce03a8db80af41abfcff19bc` fixed them.
+- Final QA rerun passed for the creative admission diff at
+  `f6b96ef4286f69ecce03a8db80af41abfcff19bc`; it also identified the missing
+  Phase2 artifact and stale Trivy policy as current-head gate blockers.
+- The stale Trivy policy blocker is intentionally out of scope for PR #2080 and
+  is owned by PR #2081 before this PR can be merge-ready.
+
+## Experiment Runner Evidence
+
+Artifact: `artifacts/orchestration/experiments/results/er-creative-spec-patch-admission-oracle-result-network-fallback.json`
+- Experiment id: `exp-df392704ff9d`
+- Mode: `oracle_only_governance_reviewer`
+- Result: `accepted`
+- Contribution kind: `none`
+- Oracle commands passed:
+  `python3 -m pytest -q tests/test_creative_spec_patch_admission.py` and the
+  requested creative-code regression pytest bundle.
+- `mutated_paths=[]`; shared tree untouched.
+
+Infra caveat: the first zero-network local attempt recorded `status=rejected`
+and `failure_class=infra_flake` because this macOS development host did not
+provide `unshare` for the network-disabled sandbox. The accepted
+`network_budget=1` artifact kept local oracle commands only and did not grant
+product runtime, provider, client, public API, GitHub, Slack, semantic-cache,
+graph-truth, patch-generation, or merge-readiness authority.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/7d18e89bf74f.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Base observed before branch creation: `origin/main` at
+  `632076f92f59e923a7f423c496d3d6192d316b75`.
+
+## Validation Evidence
+
+- `python scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration/contracts --path docs/roadmap/BACKLOG_LEDGER.md --path tests` - PASS.
+- `python scripts/orchestration/check_agent_consistency.py` - PASS.
+- `python -m pytest -q tests/test_creative_spec_patch_admission.py` - PASS,
+  14 passed after post-open QA fixes.
+- Requested creative-code regression pytest bundle - PASS before PR open.
+- `make validate-changed` - PASS after implementation and post-open QA commits;
+  rerun required after the latest mapping commit.
+- `pre-commit run --all-files` - PASS before initial PR push and after post-open
+  QA commits; rerun required after the latest mapping commit.
+
+## Merge Readiness
+
+Not claimed here. Requires current-head CI after the latest pushed head,
+completion of the remaining post-open role chain, Codex Security diff scan /
+finding discovery when available, `pulseplate-pr-review`, bot review
+disposition, strict merge-readiness wrapper with auth, and the mandatory
+wait-window. The stale Trivy ignore-policy gate is external to this PR and must
+be cleared by PR #2081 merging to `main`.

--- a/docs/review/PR_2080_FIXED_MAPPING.md
+++ b/docs/review/PR_2080_FIXED_MAPPING.md
@@ -54,6 +54,7 @@ Disposition: FIXED
 Commit: 1ea21520401f0e44cb00ee1c7287571f16a269a9
 Evidence: `scripts/orchestration/creative_spec_patch_admission.py` cleans a newly-created builder run directory when post-prepare proof rejects forbidden artifacts; `tests/test_creative_spec_patch_admission.py` adds a regression where `prepare()` returns but leaves `candidate.patch`; `scripts/orchestration/creative_spec_patch_admission_contract.py` removes the no-op `max_changed_files` branch; the admission schema/docs now require `validate_patch_builder_request=true`; focused pytest passed with 15 tests and commit hooks passed.
 Reason: The post-open bug-hunter pass found an invalid-prepare-proof cleanup gap, and CodeRabbit found both an unresolved no-op budget branch and a missing explicit PR-2 request-validation signal in the admission schema.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080#pullrequestreview-4631302269 -> 1ea21520401f0e44cb00ee1c7287571f16a269a9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080#discussion_r3524885014 -> 1ea21520401f0e44cb00ee1c7287571f16a269a9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080#discussion_r3524885016 -> 1ea21520401f0e44cb00ee1c7287571f16a269a9
 

--- a/docs/review/PR_2080_FIXED_MAPPING.md
+++ b/docs/review/PR_2080_FIXED_MAPPING.md
@@ -58,6 +58,11 @@ Reason: The post-open bug-hunter pass found an invalid-prepare-proof cleanup gap
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080#discussion_r3524885014 -> 1ea21520401f0e44cb00ee1c7287571f16a269a9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080#discussion_r3524885016 -> 1ea21520401f0e44cb00ee1c7287571f16a269a9
 
+Disposition: FIXED
+Commit: 52f400a7b8c7f92b4aee9fad7f8507f2682a613b
+Evidence: `scripts/orchestration/creative_spec_patch_admission_contract.py` removes the stale `DEFAULT_MAX_CHANGED_FILES` import left after the no-op budget branch was deleted; focused `flake8`, focused `ruff`, and `tests/test_creative_spec_patch_admission.py` passed before commit, and commit hooks passed.
+Reason: The post-open bug-hunter rerun found that CI Flake8 would still fail on an unused import after the no-op branch fix.
+
 ## Role-Agent Evidence
 
 - Bootstrap packet: `artifacts/orchestration/task_packets/7d18e89bf74f.json`.
@@ -73,6 +78,8 @@ Reason: The post-open bug-hunter pass found an invalid-prepare-proof cleanup gap
   fixed-mapping entries for resolved CodeRabbit discussions, and the no-op
   budget branch. Commit `1ea21520401f0e44cb00ee1c7287571f16a269a9` fixes the
   code/test/schema/docs issues; this mapping records the thread proof.
+- Post-open bug-hunter rerun found one stale import after the no-op branch
+  removal. Commit `52f400a7b8c7f92b4aee9fad7f8507f2682a613b` removes it.
 - The stale Trivy policy blocker is intentionally out of scope for PR #2080 and
   is owned by PR #2081 before this PR can be merge-ready.
 

--- a/docs/review/PR_2080_FIXED_MAPPING.md
+++ b/docs/review/PR_2080_FIXED_MAPPING.md
@@ -62,6 +62,7 @@ Disposition: FIXED
 Commit: 52f400a7b8c7f92b4aee9fad7f8507f2682a613b
 Evidence: `scripts/orchestration/creative_spec_patch_admission_contract.py` removes the stale `DEFAULT_MAX_CHANGED_FILES` import left after the no-op budget branch was deleted; focused `flake8`, focused `ruff`, and `tests/test_creative_spec_patch_admission.py` passed before commit, and commit hooks passed.
 Reason: The post-open bug-hunter rerun found that CI Flake8 would still fail on an unused import after the no-op branch fix.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2080 -> 52f400a7b8c7f92b4aee9fad7f8507f2682a613b
 
 ## Role-Agent Evidence
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -10951,8 +10951,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Governed creative-code execution lane (PR-0 through PR-6)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (research-to-implementation leverage with closed authority)
-  - Target PR: PR-0 `feat/experiment-runner-creative-code-authority-pr0` -> PR-1 `codex/creative-code-specification-pr1` -> PR-2 `#2022` -> PR-3 `#2030` -> PR-4 `#2044` -> PR-5 `#2048` -> PR-6 `codex/creative-code-first-applied-candidate-pr6` -> private-pilot loop operator `codex/creative-code-private-pilot-loop-operator` -> GitHub App capability gate `codex/experiment-runner-github-app-capability-gate` -> approved creative-hypothesis specification bridge `codex/experiment-runner-approved-hypothesis-spec-bridge`
-  - Status: PR-0 merged baseline; PR-1 merged as a repo-only specification-bundle control-plane layer; PR-2 merged in PR `#2022` as a local sandboxed candidate-patch builder; PR-3 merged in PR `#2030` as human-approved non-draft PR promotion tooling; PR-4 merged in PR `#2044` at `a7e19b78c7d36b783ec2575ab0eab9f1402f2a0d` as local candidate evaluation telemetry and rejection taxonomy; PR-5 merged in PR `#2048` at `71af9d208b26435352fc821b79a2d78cebb319f5` as read-only local review-disposition integration; PR-6 is active as the first governed applied creative-code candidate lane targeting `docs/prompts/cv/program.md` through normal PR governance; the private-pilot loop operator adds sanitized local lifecycle state and checklist-only next-candidate planning without write/push/PR/thread/fixed-mapping/provider/runtime authority; the GitHub App capability gate slice feeds that state with a strict sanitized read-only permission report requiring Pull requests read and Checks read while keeping Actions write optional for fixed workflow dispatch only; the approved creative-hypothesis specification bridge consumes human-approved local creative-context artifacts and emits only a validated candidate packet, deterministic local metrics, and existing PR-1 prepare artifacts
+  - Target PR: PR-0 `feat/experiment-runner-creative-code-authority-pr0` -> PR-1 `codex/creative-code-specification-pr1` -> PR-2 `#2022` -> PR-3 `#2030` -> PR-4 `#2044` -> PR-5 `#2048` -> PR-6 `codex/creative-code-first-applied-candidate-pr6` -> private-pilot loop operator `codex/creative-code-private-pilot-loop-operator` -> GitHub App capability gate `codex/experiment-runner-github-app-capability-gate` -> approved creative-hypothesis specification bridge `codex/experiment-runner-approved-hypothesis-spec-bridge` -> creative spec learning rollup `#2075` -> patch-builder admission `codex/er-creative-spec-patch-admission`
+  - Status: PR-0 merged baseline; PR-1 merged as a repo-only specification-bundle control-plane layer; PR-2 merged in PR `#2022` as a local sandboxed candidate-patch builder; PR-3 merged in PR `#2030` as human-approved non-draft PR promotion tooling; PR-4 merged in PR `#2044` at `a7e19b78c7d36b783ec2575ab0eab9f1402f2a0d` as local candidate evaluation telemetry and rejection taxonomy; PR-5 merged in PR `#2048` at `71af9d208b26435352fc821b79a2d78cebb319f5` as read-only local review-disposition integration; PR-6 is active as the first governed applied creative-code candidate lane targeting `docs/prompts/cv/program.md` through normal PR governance; the private-pilot loop operator adds sanitized local lifecycle state and checklist-only next-candidate planning without write/push/PR/thread/fixed-mapping/provider/runtime authority; the GitHub App capability gate slice feeds that state with a strict sanitized read-only permission report requiring Pull requests read and Checks read while keeping Actions write optional for fixed workflow dispatch only; the approved creative-hypothesis specification bridge consumes human-approved local creative-context artifacts and emits only a validated candidate packet, deterministic local metrics, and existing PR-1 prepare artifacts; the creative spec learning rollup landed in PR `#2075` as proposal-only reviewer-focus learning; the patch-builder admission slice is active as a prepare-only bridge from finalized selected specs to valid PR-2 requests
   - Dependencies:
     - [P1: Creative research eval lane under governed experimentation epic](#ledger-p1-creative-research-eval-lane)
     - [P1: Governed agent experimentation lane (PR1-PR6 orchestration epic)](#ledger-p1-agent-experimentation-lane)
@@ -10980,6 +10980,9 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/contracts/creative_code_rejection_taxonomy.v1.json`
     - `docs/orchestration/contracts/creative_hypothesis_specification_bridge.v1.schema.json`
     - `docs/orchestration/contracts/creative_hypothesis_spec_bridge_metrics.v1.schema.json`
+    - `docs/orchestration/contracts/CREATIVE_SPEC_PATCH_ADMISSION_CONTRACT.md`
+    - `docs/orchestration/contracts/creative_spec_patch_human_admission.v1.schema.json`
+    - `docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json`
     - `docs/orchestration/CREATIVE_CODE_REVIEW_DISPOSITION_PR5_PREMORTEM.md`
     - `docs/orchestration/contracts/CREATIVE_CODE_REVIEW_DISPOSITION_CONTRACT.md`
     - `docs/orchestration/contracts/creative_code_review_feedback_record.v1.schema.json`
@@ -11009,6 +11012,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `scripts/orchestration/github_app_private_pilot_capability.py`
     - `scripts/orchestration/creative_hypothesis_spec_bridge_contract.py`
     - `scripts/orchestration/creative_hypothesis_spec_bridge.py`
+    - `scripts/orchestration/creative_spec_patch_admission_contract.py`
+    - `scripts/orchestration/creative_spec_patch_admission.py`
     - `tests/test_creative_code_contract.py`
     - `tests/test_creative_code_patch_builder.py`
     - `tests/test_creative_code_pr_promotion.py`
@@ -11017,6 +11022,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `tests/test_creative_code_applied_candidate_pr6.py`
     - `tests/test_creative_code_private_pilot_loop.py`
     - `tests/test_creative_hypothesis_spec_bridge.py`
+    - `tests/test_creative_spec_patch_admission.py`
   - PR train:
     - PR-0: closed authority contract, schema, reference packet, validator, and tests; no model calls, patches, workflows, Slack/GitHub settings, or `experiment_runner.py` changes.
     - PR-1: emit deterministic implementation specification bundles from promoted creative research, with skeptic reviews, synthesis, telemetry summary, safe local artifact I/O, and fingerprint-only rejection indexes; no candidate patches, provider calls, repo writes, runtime truth, review-thread disposition authority, or merge-readiness evidence.
@@ -11038,10 +11044,18 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
       - Priority: P1 learning-loop leverage.
       - Owner: orchestration.
       - Target PR: `codex/experiment-runner-creative-spec-learning-rollup`.
-      - Status: active reviewed PR lane.
+      - Status: merged in PR `#2075`.
       - Reason: bridge metrics and reviewed finalize outcomes are deterministic local sidecars but need proposal-only learning-loop ingestion before patch-builder admission can be considered.
       - DoD: finalized bridge metrics, skeptic-review attachment, finalize receipt, and `CreativeCodeSpecificationBundle` ingest into `agent_learning_record.v1` success/failure records plus coordinator advisory hints with redaction, bounded fields, no runtime telemetry, no product truth, no semantic-cache use, no graph truth, no provider calls, no patch generation, and no routing or merge-readiness authority.
-      - Evidence target: `scripts/orchestration/creative_spec_learning_rollup.py`; `scripts/orchestration/creative_spec_learning_rollup_contract.py`; `docs/orchestration/contracts/creative_spec_learning_rollup.v1.schema.json`; `docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json`; `tests/test_creative_spec_learning_rollup.py`; `tests/test_task_bootstrap.py`.
+      - Evidence: `scripts/orchestration/creative_spec_learning_rollup.py`; `scripts/orchestration/creative_spec_learning_rollup_contract.py`; `docs/orchestration/contracts/creative_spec_learning_rollup.v1.schema.json`; `docs/orchestration/contracts/creative_spec_coordinator_advisory_hints.v1.schema.json`; `tests/test_creative_spec_learning_rollup.py`; `tests/test_task_bootstrap.py`.
+    - Follow-up finalized spec patch-builder admission:
+      - Priority: P1 automation leverage.
+      - Owner: orchestration.
+      - Target PR: `codex/er-creative-spec-patch-admission`.
+      - Status: active reviewed PR lane.
+      - Reason: finalized selected creative specs need a typed prepare-only handoff into the existing PR-2 patch-builder request contract without widening into generation, evaluation, Codex exec, promotion, branch/PR writes, workflows, product runtime, semantic cache, or graph truth.
+      - DoD: `creative_spec_patch_admission.py` validates a finalized receipt, selected bundle, explicit human admission, bounded budgets, non-empty oracle commands/metrics, exact current `origin/main` base SHA, and clean shared worktree; builds the request only through `build_creative_code_patch_build_request(...)`; optionally calls builder `prepare` only; records `candidate.patch` and `result.json` absent with `candidate_patch_generated=false` and `candidate_patch_evaluated=false`; and adds deterministic tests for binding, authority, path, stale-base, dirty-tree, unsafe-string, budget, no-generate/evaluate, and cleanup behavior.
+      - Evidence target: `scripts/orchestration/creative_spec_patch_admission.py`; `scripts/orchestration/creative_spec_patch_admission_contract.py`; `docs/orchestration/contracts/CREATIVE_SPEC_PATCH_ADMISSION_CONTRACT.md`; `docs/orchestration/contracts/creative_spec_patch_human_admission.v1.schema.json`; `docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json`; `tests/test_creative_spec_patch_admission.py`.
     - Follow-up bridge authority schema single-source:
       - Priority: P2 maintainability.
       - Owner: orchestration.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -86,6 +86,19 @@
   threads, claim readiness, merge, release, call providers, call product
   runtime, use semantic cache, write graph truth, or mutate GitHub App / Slack
   settings.
+- Creative spec patch admission artifacts stay local under
+  `artifacts/orchestration/creative_code/patch_admission/<admission-id>/`. The
+  `creative_spec_patch_admission.py` CLI may only read validated finalized
+  creative-spec bundle and receipt artifacts plus an explicit operator human
+  admission, build an existing PR-2 `CreativeCodePatchBuildRequest` through
+  `build_creative_code_patch_build_request(...)`, validate the request, and
+  optionally call patch-builder `prepare` only. It must not call patch-builder
+  `generate` or `evaluate`, call Codex, produce `candidate.patch`, execute
+  Experiment Runner candidate mode, promote candidates, create or write
+  branches, push/open PRs, resolve review threads, edit fixed mappings, claim
+  readiness, merge, release, call providers, call product runtime, modify
+  workflows, use semantic cache, write graph truth, or mutate GitHub App / Slack
+  settings.
 - The runner must apply patches only inside an isolated temporary checkout and must leave the shared working tree untouched.
 - Mutable surfaces, immutable oracles, budgets, and promotion boundaries are defined by `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or relax them here.
 - Runner mutation of `scripts/ci/**`, `docs/review/**`, `AGENTS.md`, merge

--- a/scripts/orchestration/creative_spec_patch_admission.py
+++ b/scripts/orchestration/creative_spec_patch_admission.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Admit finalized creative specs to prepare-only patch-builder requests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.orchestration import creative_code_patch_builder
+from scripts.orchestration.creative_code_patch_contract import (
+    CreativeCodePatchContractError,
+)
+from scripts.orchestration.creative_code_patch_workspace import (
+    CreativeCodePatchWorkspaceError,
+    cleanup_run_dir,
+    read_json,
+    resolve_run_dir,
+    resolve_run_file,
+    shared_tree_status,
+    verify_origin_main_base,
+    write_json_atomic,
+)
+from scripts.orchestration.creative_spec_patch_admission_contract import (
+    ADMISSION_ARTIFACT_TYPE,
+    CreativeSpecPatchAdmissionError,
+    attach_builder_prepare_summary,
+    build_builder_prepare_summary,
+    build_creative_spec_patch_admission,
+    validate_admission_bindings,
+    validate_creative_spec_patch_admission,
+    validate_human_admission,
+)
+
+CREATIVE_CODE_ROOT = REPO_ROOT / "artifacts" / "orchestration" / "creative_code"
+PATCH_ADMISSION_ROOT = CREATIVE_CODE_ROOT / "patch_admission"
+
+ADMISSION_FILENAME = "creative_spec_patch_admission.json"
+FINALIZE_RECEIPT_FILENAME = "finalize_receipt.json"
+HUMAN_ADMISSION_FILENAME = "human_admission.json"
+REQUEST_FILENAME = creative_code_patch_builder.REQUEST_FILE
+SOURCE_BUNDLE_FILENAME = creative_code_patch_builder.SOURCE_BUNDLE_FILE
+
+BUILD_SUCCESS_OUTPUT = "PASS: creative spec patch admission request built"
+VALIDATE_SUCCESS_OUTPUT = "PASS: creative spec patch admission valid"
+PREPARE_SUCCESS_OUTPUT = "PASS: creative spec patch admission prepare complete"
+SUMMARY_AUTHORITY_BOUNDARY = "prepare_only_non_runtime"
+
+
+class CreativeSpecPatchAdmissionCliError(ValueError):
+    """Raised when local admission CLI I/O cannot safely complete."""
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _existing_components(path: Path) -> list[Path]:
+    components: list[Path] = []
+    current_path = Path(path.anchor) if path.anchor else Path(".")
+    parts = path.parts[1:] if path.anchor else path.parts
+    for part in parts:
+        current_path = current_path / part
+        if current_path.exists() or current_path.is_symlink():
+            components.append(current_path)
+    return components
+
+
+def _reject_symlink_components(path: Path, *, label: str) -> None:
+    for component in _existing_components(path):
+        if component.is_symlink():
+            raise CreativeSpecPatchAdmissionCliError(f"{label} must not traverse symlinks.")
+
+
+def _ensure_artifact_root(root: Path) -> Path:
+    _reject_symlink_components(root, label="creative-code artifact root")
+    root.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_components(root, label="creative-code artifact root")
+    resolved = root.resolve(strict=True)
+    if not resolved.is_dir():
+        raise CreativeSpecPatchAdmissionCliError("creative-code artifact root must be a directory.")
+    return resolved
+
+
+def _resolve_repo_json_file(raw_path: Path, *, label: str) -> Path:
+    candidate = raw_path if raw_path.is_absolute() else REPO_ROOT / raw_path
+    _reject_symlink_components(candidate, label=label)
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise CreativeSpecPatchAdmissionCliError(f"{label} must exist.") from exc
+    repo_root = REPO_ROOT.resolve()
+    artifact_root = CREATIVE_CODE_ROOT.resolve(strict=False)
+    if not _is_relative_to(resolved, repo_root) or not _is_relative_to(resolved, artifact_root):
+        raise CreativeSpecPatchAdmissionCliError(
+            f"{label} must stay under creative-code artifacts."
+        )
+    if not resolved.is_file() or resolved.suffix != ".json":
+        raise CreativeSpecPatchAdmissionCliError(f"{label} must be a JSON file.")
+    return resolved
+
+
+def _resolve_ref(raw_ref: str, *, label: str) -> Path:
+    return _resolve_repo_json_file(Path(raw_ref), label=label)
+
+
+def _resolve_output_dir(raw_output: str) -> Path:
+    root = _ensure_artifact_root(PATCH_ADMISSION_ROOT)
+    candidate = Path(raw_output)
+    path = candidate if candidate.is_absolute() else REPO_ROOT / candidate
+    _reject_symlink_components(path, label="output directory")
+    resolved = path.resolve(strict=False)
+    if not _is_relative_to(resolved, root):
+        raise CreativeSpecPatchAdmissionCliError(
+            "output directory must stay under creative-code patch admission artifacts."
+        )
+    if path.exists() or path.is_symlink():
+        raise CreativeSpecPatchAdmissionCliError(
+            "output directory already exists; remove the local artifact before rerun."
+        )
+    path.mkdir(parents=True, exist_ok=False)
+    _reject_symlink_components(path, label="output directory")
+    return path.resolve(strict=True)
+
+
+def _repo_ref(path: Path) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError as exc:
+        raise CreativeSpecPatchAdmissionCliError(
+            "artifact path must stay under repo root."
+        ) from exc
+
+
+def _reject_duplicate_json_object_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: set[str] = set()
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise CreativeSpecPatchAdmissionCliError(
+                f"creative spec patch admission JSON has duplicate key: {key}"
+            )
+        seen.add(key)
+        payload[key] = value
+    return payload
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    resolved = _resolve_repo_json_file(path, label=label)
+    try:
+        payload = json.loads(
+            resolved.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_object_keys,
+        )
+    except CreativeSpecPatchAdmissionCliError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CreativeSpecPatchAdmissionCliError(f"unable to read {label}.") from exc
+    if not isinstance(payload, dict):
+        raise CreativeSpecPatchAdmissionCliError(f"{label} must be a JSON object.")
+    return payload
+
+
+def _write_json_new(path: Path, payload: Any) -> None:
+    if path.suffix != ".json":
+        raise CreativeSpecPatchAdmissionCliError("output artifact must be JSON.")
+    _reject_symlink_components(path.parent, label="output artifact parent")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_components(path.parent, label="output artifact parent")
+    if path.exists() or path.is_symlink():
+        raise CreativeSpecPatchAdmissionCliError("output artifact already exists.")
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_name = temp_file.name
+            json.dump(payload, temp_file, indent=2, sort_keys=True)
+            temp_file.write("\n")
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_name, path)
+        temp_name = None
+    finally:
+        if temp_name is not None:
+            try:
+                Path(temp_name).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _require_clean_shared_tree() -> None:
+    status = shared_tree_status()
+    if status.strip():
+        raise CreativeSpecPatchAdmissionCliError(
+            "shared worktree must be clean before creative spec patch admission."
+        )
+
+
+def _require_origin_main_base(base_commit_sha: str) -> None:
+    verify_origin_main_base(base_commit_sha)
+
+
+def _read_admission_with_sources(
+    admission_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    admission = validate_creative_spec_patch_admission(
+        _read_json_object(admission_path, label="creative spec patch admission")
+    )
+    request = _read_json_object(
+        _resolve_ref(admission["patch_request"]["request_ref"], label="patch request"),
+        label="patch request",
+    )
+    bundle = _read_json_object(
+        _resolve_ref(admission["patch_request"]["source_bundle_ref"], label="source bundle"),
+        label="source bundle",
+    )
+    finalize_receipt = _read_json_object(
+        _resolve_ref(admission["source"]["finalize_receipt_ref"], label="finalize receipt"),
+        label="finalize receipt",
+    )
+    human_admission = _read_json_object(
+        _resolve_ref(
+            admission["human_admission"]["human_admission_ref"],
+            label="human admission",
+        ),
+        label="human admission",
+    )
+    validate_admission_bindings(
+        admission,
+        request=request,
+        source_bundle=bundle,
+        finalize_receipt=finalize_receipt,
+        human_admission=human_admission,
+    )
+    return admission, request, bundle, finalize_receipt, human_admission
+
+
+def _build_request_artifacts(args: argparse.Namespace) -> Path:
+    _require_clean_shared_tree()
+    _require_origin_main_base(args.base_sha)
+    finalize_receipt = _read_json_object(args.finalize_receipt, label="finalize receipt")
+    source_bundle = _read_json_object(args.bundle, label="creative specification bundle")
+    human_admission = validate_human_admission(
+        _read_json_object(args.human_admission, label="human admission")
+    )
+    output_dir = _resolve_output_dir(args.output_dir)
+    request_path = output_dir / REQUEST_FILENAME
+    source_bundle_path = output_dir / SOURCE_BUNDLE_FILENAME
+    human_path = output_dir / HUMAN_ADMISSION_FILENAME
+    finalize_path = output_dir / FINALIZE_RECEIPT_FILENAME
+    admission_path = output_dir / ADMISSION_FILENAME
+    try:
+        admission, request = build_creative_spec_patch_admission(
+            finalize_receipt=finalize_receipt,
+            source_bundle=source_bundle,
+            human_admission=human_admission,
+            base_commit_sha=args.base_sha,
+            finalize_receipt_ref=_repo_ref(finalize_path),
+            bundle_ref=_repo_ref(source_bundle_path),
+            human_admission_ref=_repo_ref(human_path),
+            request_ref=_repo_ref(request_path),
+            source_bundle_ref=_repo_ref(source_bundle_path),
+        )
+        _write_json_new(finalize_path, finalize_receipt)
+        _write_json_new(source_bundle_path, source_bundle)
+        _write_json_new(human_path, human_admission)
+        _write_json_new(request_path, request)
+        _write_json_new(admission_path, admission)
+    except Exception:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        raise
+    return admission_path
+
+
+def _build_request(args: argparse.Namespace) -> int:
+    admission_path = _build_request_artifacts(args)
+    print(BUILD_SUCCESS_OUTPUT)
+    print(_repo_ref(admission_path))
+    return 0
+
+
+def _prepare_builder_from_admission(admission_path: Path, *, run_id: str) -> Path:
+    _require_clean_shared_tree()
+    admission, _request, _bundle, _finalize_receipt, _human_admission = (
+        _read_admission_with_sources(admission_path)
+    )
+    _require_origin_main_base(admission["base"]["base_commit_sha"])
+    request_path = _resolve_ref(admission["patch_request"]["request_ref"], label="patch request")
+    source_bundle_path = _resolve_ref(
+        admission["patch_request"]["source_bundle_ref"],
+        label="source bundle",
+    )
+    run_dir_existed = True
+    try:
+        resolve_run_dir(run_id, create=False)
+    except CreativeCodePatchWorkspaceError:
+        run_dir_existed = False
+    try:
+        state = creative_code_patch_builder.prepare(
+            spec_bundle_path=source_bundle_path,
+            request_path=request_path,
+            run_id=run_id,
+        )
+    except Exception:
+        if not run_dir_existed:
+            try:
+                cleanup_run_dir(run_id)
+            except CreativeCodePatchWorkspaceError as cleanup_exc:
+                raise CreativeSpecPatchAdmissionCliError(
+                    "prepare failed and partial run cleanup failed."
+                ) from cleanup_exc
+        raise
+    run_dir = resolve_run_dir(run_id, create=False)
+    builder_prepare = build_builder_prepare_summary(
+        run_id=run_id,
+        state=state,
+        request_file_present=resolve_run_file(
+            run_dir, creative_code_patch_builder.REQUEST_FILE
+        ).exists(),
+        source_bundle_file_present=resolve_run_file(
+            run_dir,
+            creative_code_patch_builder.SOURCE_BUNDLE_FILE,
+        ).exists(),
+        selected_variant_file_present=resolve_run_file(
+            run_dir,
+            creative_code_patch_builder.SELECTED_VARIANT_FILE,
+        ).exists(),
+        state_file_present=resolve_run_file(
+            run_dir, creative_code_patch_builder.STATE_FILE
+        ).exists(),
+        candidate_patch_path_present=(
+            run_dir / creative_code_patch_builder.CANDIDATE_PATCH_FILE
+        ).exists(),
+        result_file_present=(run_dir / creative_code_patch_builder.RESULT_FILE).exists(),
+    )
+    updated = attach_builder_prepare_summary(admission, builder_prepare=builder_prepare)
+    write_json_atomic(admission_path, updated)
+    return admission_path
+
+
+def _prepare_builder(args: argparse.Namespace) -> int:
+    admission_path = _resolve_repo_json_file(args.admission, label="creative spec patch admission")
+    output = _prepare_builder_from_admission(admission_path, run_id=args.run_id)
+    print(PREPARE_SUCCESS_OUTPUT)
+    print(_repo_ref(output))
+    return 0
+
+
+def _build_and_prepare(args: argparse.Namespace) -> int:
+    build_args = argparse.Namespace(
+        finalize_receipt=args.finalize_receipt,
+        bundle=args.bundle,
+        human_admission=args.human_admission,
+        base_sha=args.base_sha,
+        output_dir=args.output_dir,
+    )
+    admission_path = _build_request_artifacts(build_args)
+    try:
+        _prepare_builder_from_admission(admission_path, run_id=args.run_id)
+    except Exception:
+        output_dir = admission_path.parent
+        shutil.rmtree(output_dir, ignore_errors=True)
+        raise
+    print(PREPARE_SUCCESS_OUTPUT)
+    print(_repo_ref(admission_path))
+    return 0
+
+
+def _validate(args: argparse.Namespace) -> int:
+    admission, _request, _bundle, _finalize_receipt, _human_admission = (
+        _read_admission_with_sources(args.admission)
+    )
+    _require_origin_main_base(admission["base"]["base_commit_sha"])
+    print(VALIDATE_SUCCESS_OUTPUT)
+    return 0
+
+
+def _summarize(args: argparse.Namespace) -> int:
+    admission, _request, _bundle, _finalize_receipt, _human_admission = (
+        _read_admission_with_sources(args.admission)
+    )
+    _require_origin_main_base(admission["base"]["base_commit_sha"])
+    payload = {
+        "artifact_type": ADMISSION_ARTIFACT_TYPE,
+        "admission_id": admission["admission_id"],
+        "request_id": admission["patch_request"]["request_id"],
+        "base_commit_sha": admission["base"]["base_commit_sha"],
+        "selected_variant_id": admission["selected_variant"]["variant_id"],
+        "prepared": admission["builder_prepare"]["prepared"],
+        "run_id": admission["builder_prepare"]["run_id"],
+        "candidate_patch_generated": admission["builder_prepare"]["candidate_patch_generated"],
+        "candidate_patch_evaluated": admission["builder_prepare"]["candidate_patch_evaluated"],
+        "candidate_patch_path_present": admission["builder_prepare"][
+            "candidate_patch_path_present"
+        ],
+        "authority_boundary": SUMMARY_AUTHORITY_BOUNDARY,
+        "next_allowed_action": "human_review_before_patch_generation",
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="creative_spec_patch_admission",
+        description="Admit finalized creative specs to prepare-only patch-builder requests.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_request = subparsers.add_parser("build-request")
+    build_request.add_argument("--finalize-receipt", type=Path, required=True)
+    build_request.add_argument("--bundle", type=Path, required=True)
+    build_request.add_argument("--human-admission", type=Path, required=True)
+    build_request.add_argument("--base-sha", required=True)
+    build_request.add_argument("--output-dir", required=True)
+    build_request.set_defaults(func=_build_request)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--admission", type=Path, required=True)
+    validate.set_defaults(func=_validate)
+
+    prepare = subparsers.add_parser("prepare-builder")
+    prepare.add_argument("--admission", type=Path, required=True)
+    prepare.add_argument("--run-id", required=True)
+    prepare.set_defaults(func=_prepare_builder)
+
+    build_and_prepare = subparsers.add_parser("build-and-prepare")
+    build_and_prepare.add_argument("--finalize-receipt", type=Path, required=True)
+    build_and_prepare.add_argument("--bundle", type=Path, required=True)
+    build_and_prepare.add_argument("--human-admission", type=Path, required=True)
+    build_and_prepare.add_argument("--base-sha", required=True)
+    build_and_prepare.add_argument("--output-dir", required=True)
+    build_and_prepare.add_argument("--run-id", required=True)
+    build_and_prepare.set_defaults(func=_build_and_prepare)
+
+    summarize = subparsers.add_parser("summarize")
+    summarize.add_argument("--admission", type=Path, required=True)
+    summarize.set_defaults(func=_summarize)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (
+        CreativeSpecPatchAdmissionCliError,
+        CreativeSpecPatchAdmissionError,
+        CreativeCodePatchContractError,
+        CreativeCodePatchWorkspaceError,
+        creative_code_patch_builder.CreativeCodePatchBuilderError,
+    ) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/creative_spec_patch_admission.py
+++ b/scripts/orchestration/creative_spec_patch_admission.py
@@ -319,40 +319,40 @@ def _prepare_builder_from_admission(admission_path: Path, *, run_id: str) -> Pat
             request_path=request_path,
             run_id=run_id,
         )
+        run_dir = resolve_run_dir(run_id, create=False)
+        builder_prepare = build_builder_prepare_summary(
+            run_id=run_id,
+            state=state,
+            request_file_present=resolve_run_file(
+                run_dir, creative_code_patch_builder.REQUEST_FILE
+            ).exists(),
+            source_bundle_file_present=resolve_run_file(
+                run_dir,
+                creative_code_patch_builder.SOURCE_BUNDLE_FILE,
+            ).exists(),
+            selected_variant_file_present=resolve_run_file(
+                run_dir,
+                creative_code_patch_builder.SELECTED_VARIANT_FILE,
+            ).exists(),
+            state_file_present=resolve_run_file(
+                run_dir, creative_code_patch_builder.STATE_FILE
+            ).exists(),
+            candidate_patch_path_present=(
+                run_dir / creative_code_patch_builder.CANDIDATE_PATCH_FILE
+            ).exists(),
+            result_file_present=(run_dir / creative_code_patch_builder.RESULT_FILE).exists(),
+        )
+        updated = attach_builder_prepare_summary(admission, builder_prepare=builder_prepare)
+        write_json_atomic(admission_path, updated)
     except Exception:
         if not run_dir_existed:
             try:
                 cleanup_run_dir(run_id)
             except CreativeCodePatchWorkspaceError as cleanup_exc:
                 raise CreativeSpecPatchAdmissionCliError(
-                    "prepare failed and partial run cleanup failed."
+                    "prepare failed or produced invalid proof, and partial run cleanup failed."
                 ) from cleanup_exc
         raise
-    run_dir = resolve_run_dir(run_id, create=False)
-    builder_prepare = build_builder_prepare_summary(
-        run_id=run_id,
-        state=state,
-        request_file_present=resolve_run_file(
-            run_dir, creative_code_patch_builder.REQUEST_FILE
-        ).exists(),
-        source_bundle_file_present=resolve_run_file(
-            run_dir,
-            creative_code_patch_builder.SOURCE_BUNDLE_FILE,
-        ).exists(),
-        selected_variant_file_present=resolve_run_file(
-            run_dir,
-            creative_code_patch_builder.SELECTED_VARIANT_FILE,
-        ).exists(),
-        state_file_present=resolve_run_file(
-            run_dir, creative_code_patch_builder.STATE_FILE
-        ).exists(),
-        candidate_patch_path_present=(
-            run_dir / creative_code_patch_builder.CANDIDATE_PATCH_FILE
-        ).exists(),
-        result_file_present=(run_dir / creative_code_patch_builder.RESULT_FILE).exists(),
-    )
-    updated = attach_builder_prepare_summary(admission, builder_prepare=builder_prepare)
-    write_json_atomic(admission_path, updated)
     return admission_path
 
 

--- a/scripts/orchestration/creative_spec_patch_admission.py
+++ b/scripts/orchestration/creative_spec_patch_admission.py
@@ -23,7 +23,6 @@ from scripts.orchestration.creative_code_patch_contract import (
 from scripts.orchestration.creative_code_patch_workspace import (
     CreativeCodePatchWorkspaceError,
     cleanup_run_dir,
-    read_json,
     resolve_run_dir,
     resolve_run_file,
     shared_tree_status,

--- a/scripts/orchestration/creative_spec_patch_admission_contract.py
+++ b/scripts/orchestration/creative_spec_patch_admission_contract.py
@@ -1,0 +1,1274 @@
+"""Prepare-only admission for finalized creative-code specifications.
+
+This module bridges a reviewed/finalized PR-1 creative-code specification into
+the existing PR-2 patch-builder request contract. It does not generate patches,
+evaluate candidates, call Codex, write branches, touch GitHub, promote
+candidates, mutate runtime truth, use semantic cache, or write graph truth.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import PurePosixPath
+import re
+from typing import Any, cast
+
+from core.evidence.fingerprints import build_asset_id, build_idempotency_key, fingerprint_payload
+from scripts.orchestration.creative_code_patch_contract import (
+    DEFAULT_MAX_CHANGED_FILES,
+    GENERATION_ATTEMPTS,
+    HARD_MAX_CHANGED_FILES,
+    HARD_MAX_DIFF_LINES,
+    HARD_MAX_PATCH_BYTES,
+    HARD_TIMEOUT_SECONDS,
+    CreativeCodePatchContractError,
+    build_creative_code_patch_build_request,
+    source_bundle_fingerprint,
+    validate_creative_code_patch_build_request,
+)
+from scripts.orchestration.creative_code_specification import (
+    CreativeCodeSpecificationError,
+    validate_creative_code_specification_bundle,
+)
+from scripts.orchestration.creative_specification_skeptic_review_contract import (
+    NEXT_ACTION_SELECTED,
+    CreativeSpecificationSkepticReviewError,
+    validate_finalize_receipt,
+)
+
+SCHEMA_VERSION = "1.0"
+POLICY_VERSION = "creative-spec-patch-admission-v1"
+HUMAN_ADMISSION_ARTIFACT_TYPE = "creative_spec_patch_human_admission"
+ADMISSION_ARTIFACT_TYPE = "creative_spec_patch_admission"
+HUMAN_DECISION = "approved_for_patch_builder_prepare"
+
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
+SHA_RE = re.compile(r"^[a-f0-9]{40}$")
+SHA256_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+SECRET_RE = re.compile(
+    r"(sk-[A-Za-z0-9_-]{12,}|gh[psoru]_[A-Za-z0-9_.-]{12,}|github_pat_|"
+    r"xox[abprs]-|authorization:\s*bearer|private[_ -]?key|api[_ -]?key|"
+    r"GH_TOKEN|GITHUB_TOKEN)",
+    re.IGNORECASE,
+)
+LEAK_TEXT_RE = re.compile(
+    r"(candidate\.patch|diff --git|^\+\+\+ |^--- |@@ |"
+    r"raw[_ -]?(prompt|response|context|patch|review|body)|"
+    r"chain[_ -]?of[_ -]?thought|provider[_ -]?payload|"
+    r"oracle[_ -]?(stdout|stderr)|review[_ -]?thread[_ -]?body|"
+    r"pull[_ -]?request[_ -]?body|file://|https?://|"
+    r"/(?:Users|home|private/var|var/folders|tmp|etc|opt|usr|Volumes|mnt|root|"
+    r"workspace|workspaces)(?:/|$)|~[/\\]|[A-Za-z]:[\\/]|\.venv/|\.git/|"
+    r"worktrees([:/._-]|$)|github_pat_|gh[psoru]_|xox[abprs]-|"
+    r"sk-[A-Za-z0-9_-]{12,}|GH_TOKEN|GITHUB_TOKEN)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+HUMAN_ADMISSION_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "decision",
+        "approval_ref",
+        "approved_by",
+        "approved_at_utc",
+        "approved_source_bundle_id",
+        "approved_source_bundle_fingerprint",
+        "approved_selected_variant_id",
+        "approved_selected_variant_fingerprint",
+        "allowed_existing_paths",
+        "allowed_new_paths",
+        "oracle_commands",
+        "metrics",
+        "budgets",
+        "authority",
+        "sanitized",
+    }
+)
+HUMAN_AUTHORITY_TRUE_KEYS = frozenset(
+    {
+        "approve_patch_builder_request",
+        "emit_local_artifacts",
+        "read_finalized_creative_spec",
+        "run_patch_builder_prepare",
+        "validate_patch_builder_request",
+    }
+)
+HUMAN_AUTHORITY_FALSE_KEYS = frozenset(
+    {
+        "call_local_codex_exec",
+        "call_product_runtime",
+        "call_provider",
+        "claim_merge_readiness",
+        "create_branch",
+        "edit_fixed_mapping",
+        "generate_candidate_patch",
+        "merge",
+        "modify_workflows",
+        "open_pull_request",
+        "promote_candidate",
+        "push_branch",
+        "read_secrets",
+        "resolve_review_threads",
+        "run_patch_builder_evaluate",
+        "run_patch_builder_generate",
+        "use_semantic_cache",
+        "write_graph_truth",
+        "write_repository",
+        "write_shared_worktree",
+    }
+)
+HUMAN_AUTHORITY_KEYS = HUMAN_AUTHORITY_TRUE_KEYS | HUMAN_AUTHORITY_FALSE_KEYS
+BUDGET_KEYS = frozenset(
+    {
+        "generation_attempts",
+        "generation_timeout_seconds",
+        "evaluation_timeout_seconds",
+        "max_changed_files",
+        "max_diff_lines",
+        "max_patch_bytes",
+    }
+)
+
+ADMISSION_KEYS = frozenset(
+    {
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "admission_id",
+        "idempotency_key",
+        "source",
+        "selected_variant",
+        "base",
+        "human_admission",
+        "patch_request",
+        "builder_prepare",
+        "executed_effects",
+        "authority",
+        "sanitized",
+    }
+)
+SOURCE_KEYS = frozenset(
+    {
+        "finalize_id",
+        "finalize_receipt_fingerprint",
+        "finalize_receipt_ref",
+        "bundle_id",
+        "bundle_fingerprint",
+        "bundle_ref",
+        "source_packet_id",
+    }
+)
+SELECTED_VARIANT_KEYS = frozenset(
+    {
+        "variant_id",
+        "variant_fingerprint",
+        "target_paths",
+        "tests_to_add",
+    }
+)
+BASE_KEYS = frozenset({"base_ref", "base_commit_sha"})
+ADMISSION_HUMAN_KEYS = frozenset(
+    {
+        "decision",
+        "approval_ref",
+        "approved_by",
+        "approved_at_utc",
+        "human_admission_fingerprint",
+        "human_admission_ref",
+    }
+)
+PATCH_REQUEST_KEYS = frozenset(
+    {
+        "request_id",
+        "request_idempotency_key",
+        "request_fingerprint",
+        "request_ref",
+        "source_bundle_ref",
+        "contract_policy_version",
+        "request_authority_scope",
+    }
+)
+BUILDER_PREPARE_KEYS = frozenset(
+    {
+        "prepared",
+        "run_id",
+        "state_fingerprint",
+        "request_file_present",
+        "source_bundle_file_present",
+        "selected_variant_file_present",
+        "state_file_present",
+        "candidate_patch_path_present",
+        "result_file_present",
+        "candidate_patch_generated",
+        "candidate_patch_evaluated",
+    }
+)
+EXECUTED_EFFECT_KEYS = frozenset(
+    {
+        "request_built",
+        "builder_prepared",
+        "candidate_patch_generated",
+        "candidate_patch_evaluated",
+        "codex_exec_called",
+        "shared_worktree_modified",
+        "branch_written",
+        "pull_request_opened",
+        "fixed_mapping_edited",
+        "semantic_cache_used",
+        "graph_truth_written",
+    }
+)
+ADMISSION_AUTHORITY_TRUE_KEYS = frozenset(
+    {"build_patch_builder_request", "emit_local_artifacts", "run_patch_builder_prepare"}
+)
+ADMISSION_AUTHORITY_FALSE_KEYS = frozenset(
+    {
+        "call_local_codex_exec",
+        "call_product_runtime",
+        "call_provider",
+        "claim_merge_readiness",
+        "create_branch",
+        "edit_fixed_mapping",
+        "generate_candidate_patch",
+        "merge",
+        "modify_workflows",
+        "open_pull_request",
+        "promote_candidate",
+        "push_branch",
+        "read_secrets",
+        "resolve_review_threads",
+        "run_patch_builder_evaluate",
+        "run_patch_builder_generate",
+        "use_semantic_cache",
+        "write_graph_truth",
+        "write_repository",
+        "write_shared_worktree",
+    }
+)
+ADMISSION_AUTHORITY_KEYS = ADMISSION_AUTHORITY_TRUE_KEYS | ADMISSION_AUTHORITY_FALSE_KEYS
+
+
+class CreativeSpecPatchAdmissionError(ValueError):
+    """Raised when creative-spec patch-builder admission fails closed."""
+
+
+def default_human_admission_authority() -> dict[str, bool]:
+    """Return the prepare-only authority for operator admission."""
+
+    return _authority(
+        true_keys=HUMAN_AUTHORITY_TRUE_KEYS,
+        false_keys=HUMAN_AUTHORITY_FALSE_KEYS,
+    )
+
+
+def default_admission_authority() -> dict[str, bool]:
+    """Return the prepare-only authority for generated admission artifacts."""
+
+    return _authority(
+        true_keys=ADMISSION_AUTHORITY_TRUE_KEYS,
+        false_keys=ADMISSION_AUTHORITY_FALSE_KEYS,
+    )
+
+
+def empty_builder_prepare_summary() -> dict[str, Any]:
+    """Return the unprepared builder summary shape."""
+
+    return {
+        "prepared": False,
+        "run_id": None,
+        "state_fingerprint": None,
+        "request_file_present": False,
+        "source_bundle_file_present": False,
+        "selected_variant_file_present": False,
+        "state_file_present": False,
+        "candidate_patch_path_present": False,
+        "result_file_present": False,
+        "candidate_patch_generated": False,
+        "candidate_patch_evaluated": False,
+    }
+
+
+def executed_effects(*, builder_prepared: bool = False) -> dict[str, bool]:
+    """Return sanitized effects executed by this admission layer."""
+
+    return {
+        "request_built": True,
+        "builder_prepared": builder_prepared,
+        "candidate_patch_generated": False,
+        "candidate_patch_evaluated": False,
+        "codex_exec_called": False,
+        "shared_worktree_modified": False,
+        "branch_written": False,
+        "pull_request_opened": False,
+        "fixed_mapping_edited": False,
+        "semantic_cache_used": False,
+        "graph_truth_written": False,
+    }
+
+
+def validate_human_admission(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize operator approval for prepare-only admission."""
+
+    label = "CreativeSpecPatchHumanAdmission"
+    _require_exact_keys(payload, HUMAN_ADMISSION_KEYS, label=label)
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(
+            payload,
+            "artifact_type",
+            HUMAN_ADMISSION_ARTIFACT_TYPE,
+            label=label,
+        ),
+        "policy_version": _require_const(
+            payload,
+            "policy_version",
+            POLICY_VERSION,
+            label=label,
+        ),
+        "decision": _require_const(payload, "decision", HUMAN_DECISION, label=label),
+        "approval_ref": _require_id(payload, "approval_ref", label=label),
+        "approved_by": _require_token(payload, "approved_by", label=label),
+        "approved_at_utc": _require_utc(payload, "approved_at_utc", label=label),
+        "approved_source_bundle_id": _require_id(payload, "approved_source_bundle_id", label=label),
+        "approved_source_bundle_fingerprint": _require_fingerprint(
+            payload,
+            "approved_source_bundle_fingerprint",
+            label=label,
+        ),
+        "approved_selected_variant_id": _require_id(
+            payload,
+            "approved_selected_variant_id",
+            label=label,
+        ),
+        "approved_selected_variant_fingerprint": _require_fingerprint(
+            payload,
+            "approved_selected_variant_fingerprint",
+            label=label,
+        ),
+        "allowed_existing_paths": _normalize_path_list(
+            payload,
+            "allowed_existing_paths",
+            label=label,
+            allow_empty=True,
+        ),
+        "allowed_new_paths": _normalize_path_list(
+            payload,
+            "allowed_new_paths",
+            label=label,
+            allow_empty=True,
+        ),
+        "oracle_commands": _normalize_string_list(payload, "oracle_commands", label=label),
+        "metrics": _normalize_string_list(payload, "metrics", label=label),
+        "budgets": _normalize_budgets(payload["budgets"], label=f"{label}.budgets"),
+        "authority": _normalize_authority(
+            payload["authority"],
+            expected=default_human_admission_authority(),
+            label=f"{label}.authority",
+        ),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    if not (normalized["allowed_existing_paths"] or normalized["allowed_new_paths"]):
+        raise CreativeSpecPatchAdmissionError("human admission requires at least one allowed path.")
+    _reject_payload_safety(normalized, label=label)
+    return normalized
+
+
+def build_creative_spec_patch_admission(
+    *,
+    finalize_receipt: Mapping[str, Any],
+    source_bundle: Mapping[str, Any],
+    human_admission: Mapping[str, Any],
+    base_commit_sha: str,
+    finalize_receipt_ref: str,
+    bundle_ref: str,
+    human_admission_ref: str,
+    request_ref: str,
+    source_bundle_ref: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build a deterministic admission artifact and PR-2 patch-builder request."""
+
+    bundle = _validated_bundle(source_bundle)
+    receipt = _validated_finalize_receipt(finalize_receipt)
+    admission = validate_human_admission(human_admission)
+    base_sha = _normalize_sha(base_commit_sha, label="base_commit_sha")
+    _validate_finalized_binding(
+        receipt=receipt,
+        bundle=bundle,
+        human_admission=admission,
+    )
+    request = build_creative_code_patch_build_request(
+        source_bundle=dict(bundle),
+        base_commit_sha=base_sha,
+        approval_ref=admission["approval_ref"],
+        allowed_existing_paths=list(admission["allowed_existing_paths"]),
+        allowed_new_paths=list(admission["allowed_new_paths"]),
+        oracle_commands=list(admission["oracle_commands"]),
+        metrics=list(admission["metrics"]),
+        budgets=dict(admission["budgets"]),
+    )
+    request = validate_creative_code_patch_build_request(request, source_bundle=dict(bundle))
+    variant = _selected_variant(bundle)
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": ADMISSION_ARTIFACT_TYPE,
+        "policy_version": POLICY_VERSION,
+        "admission_id": "pending",
+        "idempotency_key": "pending",
+        "source": {
+            "finalize_id": receipt["finalize_id"],
+            "finalize_receipt_fingerprint": fingerprint_payload(dict(receipt)),
+            "finalize_receipt_ref": _normalize_artifact_ref(
+                finalize_receipt_ref, label="source.finalize_receipt_ref"
+            ),
+            "bundle_id": bundle["bundle_id"],
+            "bundle_fingerprint": source_bundle_fingerprint(bundle),
+            "bundle_ref": _normalize_artifact_ref(bundle_ref, label="source.bundle_ref"),
+            "source_packet_id": bundle["source_packet_id"],
+        },
+        "selected_variant": {
+            "variant_id": variant["variant_id"],
+            "variant_fingerprint": variant["variant_fingerprint"],
+            "target_paths": list(variant["target_paths"]),
+            "tests_to_add": list(variant["tests_to_add"]),
+        },
+        "base": {"base_ref": "origin/main", "base_commit_sha": base_sha},
+        "human_admission": {
+            "decision": admission["decision"],
+            "approval_ref": admission["approval_ref"],
+            "approved_by": admission["approved_by"],
+            "approved_at_utc": admission["approved_at_utc"],
+            "human_admission_fingerprint": fingerprint_payload(dict(admission)),
+            "human_admission_ref": _normalize_artifact_ref(
+                human_admission_ref, label="human_admission.human_admission_ref"
+            ),
+        },
+        "patch_request": {
+            "request_id": request["request_id"],
+            "request_idempotency_key": request["idempotency_key"],
+            "request_fingerprint": fingerprint_payload(dict(request)),
+            "request_ref": _normalize_artifact_ref(request_ref, label="patch_request.request_ref"),
+            "source_bundle_ref": _normalize_artifact_ref(
+                source_bundle_ref,
+                label="patch_request.source_bundle_ref",
+            ),
+            "contract_policy_version": request["policy_version"],
+            "request_authority_scope": "pr2_builder_request_contract",
+        },
+        "builder_prepare": empty_builder_prepare_summary(),
+        "executed_effects": executed_effects(builder_prepared=False),
+        "authority": default_admission_authority(),
+        "sanitized": True,
+    }
+    _set_admission_identity(body)
+    normalized = validate_creative_spec_patch_admission(body)
+    validate_admission_bindings(
+        normalized,
+        request=request,
+        source_bundle=bundle,
+        finalize_receipt=receipt,
+        human_admission=admission,
+    )
+    return normalized, request
+
+
+def build_builder_prepare_summary(
+    *,
+    run_id: str,
+    state: Mapping[str, Any],
+    request_file_present: bool,
+    source_bundle_file_present: bool,
+    selected_variant_file_present: bool,
+    state_file_present: bool,
+    candidate_patch_path_present: bool,
+    result_file_present: bool,
+) -> dict[str, Any]:
+    """Build the prepare-only proof summary after builder ``prepare``."""
+
+    label = "builder_prepare"
+    normalized_run_id = _normalize_optional_id(run_id, label=f"{label}.run_id")
+    if not isinstance(state, Mapping):
+        raise CreativeSpecPatchAdmissionError("builder state must be a JSON object.")
+    candidate_generated = state.get("candidate_patch_generated")
+    candidate_evaluated = state.get("candidate_patch_evaluated")
+    if candidate_generated is not False or candidate_evaluated is not False:
+        raise CreativeSpecPatchAdmissionError("builder prepare must not generate or evaluate.")
+    if candidate_patch_path_present:
+        raise CreativeSpecPatchAdmissionError("builder prepare must not create candidate.patch.")
+    if result_file_present:
+        raise CreativeSpecPatchAdmissionError("builder prepare must not create result.json.")
+    summary = {
+        "prepared": True,
+        "run_id": normalized_run_id,
+        "state_fingerprint": fingerprint_payload(dict(state)),
+        "request_file_present": _normalize_bool_value(
+            request_file_present,
+            label=f"{label}.request_file_present",
+        ),
+        "source_bundle_file_present": _normalize_bool_value(
+            source_bundle_file_present,
+            label=f"{label}.source_bundle_file_present",
+        ),
+        "selected_variant_file_present": _normalize_bool_value(
+            selected_variant_file_present,
+            label=f"{label}.selected_variant_file_present",
+        ),
+        "state_file_present": _normalize_bool_value(
+            state_file_present,
+            label=f"{label}.state_file_present",
+        ),
+        "candidate_patch_path_present": False,
+        "result_file_present": False,
+        "candidate_patch_generated": False,
+        "candidate_patch_evaluated": False,
+    }
+    return _normalize_builder_prepare(summary)
+
+
+def attach_builder_prepare_summary(
+    admission: Mapping[str, Any],
+    *,
+    builder_prepare: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return an admission artifact updated with prepare-only builder proof."""
+
+    normalized = validate_creative_spec_patch_admission(admission)
+    updated = dict(normalized)
+    updated["builder_prepare"] = _normalize_builder_prepare(builder_prepare)
+    updated["executed_effects"] = _normalize_executed_effects(
+        executed_effects(builder_prepared=True)
+    )
+    _validate_admission_identity(updated)
+    return validate_creative_spec_patch_admission(updated)
+
+
+def validate_creative_spec_patch_admission(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the metadata-only admission artifact."""
+
+    label = "CreativeSpecPatchAdmission"
+    _require_exact_keys(payload, ADMISSION_KEYS, label=label)
+    normalized = {
+        "schema_version": _require_const(payload, "schema_version", SCHEMA_VERSION, label=label),
+        "artifact_type": _require_const(
+            payload,
+            "artifact_type",
+            ADMISSION_ARTIFACT_TYPE,
+            label=label,
+        ),
+        "policy_version": _require_const(payload, "policy_version", POLICY_VERSION, label=label),
+        "admission_id": _require_id(payload, "admission_id", label=label),
+        "idempotency_key": _require_id(payload, "idempotency_key", label=label),
+        "source": _normalize_source(payload["source"]),
+        "selected_variant": _normalize_selected_variant(payload["selected_variant"]),
+        "base": _normalize_base(payload["base"]),
+        "human_admission": _normalize_admission_human(payload["human_admission"]),
+        "patch_request": _normalize_patch_request(payload["patch_request"]),
+        "builder_prepare": _normalize_builder_prepare(payload["builder_prepare"]),
+        "executed_effects": _normalize_executed_effects(payload["executed_effects"]),
+        "authority": _normalize_authority(
+            payload["authority"],
+            expected=default_admission_authority(),
+            label=f"{label}.authority",
+        ),
+        "sanitized": _require_bool(payload, "sanitized", expected=True, label=label),
+    }
+    if (
+        normalized["builder_prepare"]["prepared"]
+        != normalized["executed_effects"]["builder_prepared"]
+    ):
+        raise CreativeSpecPatchAdmissionError("builder_prepare and executed_effects disagree.")
+    _validate_admission_identity(normalized)
+    _reject_payload_safety(normalized, label=label)
+    return normalized
+
+
+def validate_admission_bindings(
+    admission: Mapping[str, Any],
+    *,
+    request: Mapping[str, Any],
+    source_bundle: Mapping[str, Any],
+    finalize_receipt: Mapping[str, Any],
+    human_admission: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate admission refs against the concrete source/request payloads."""
+
+    normalized = validate_creative_spec_patch_admission(admission)
+    bundle = _validated_bundle(source_bundle)
+    receipt = _validated_finalize_receipt(finalize_receipt)
+    human = validate_human_admission(human_admission)
+    _validate_finalized_binding(receipt=receipt, bundle=bundle, human_admission=human)
+    normalized_request = validate_creative_code_patch_build_request(
+        dict(request),
+        source_bundle=dict(bundle),
+    )
+    if normalized["source"]["finalize_id"] != receipt["finalize_id"]:
+        raise CreativeSpecPatchAdmissionError("admission finalize_id does not match receipt.")
+    if normalized["source"]["finalize_receipt_fingerprint"] != fingerprint_payload(dict(receipt)):
+        raise CreativeSpecPatchAdmissionError(
+            "admission finalize_receipt_fingerprint does not match receipt."
+        )
+    if normalized["source"]["bundle_id"] != bundle["bundle_id"]:
+        raise CreativeSpecPatchAdmissionError("admission bundle_id does not match bundle.")
+    if normalized["source"]["bundle_fingerprint"] != source_bundle_fingerprint(bundle):
+        raise CreativeSpecPatchAdmissionError("admission bundle_fingerprint does not match bundle.")
+    if normalized["human_admission"]["human_admission_fingerprint"] != fingerprint_payload(
+        dict(human)
+    ):
+        raise CreativeSpecPatchAdmissionError("human admission fingerprint does not match.")
+    if normalized["patch_request"]["request_id"] != normalized_request["request_id"]:
+        raise CreativeSpecPatchAdmissionError("patch request id does not match admission.")
+    if (
+        normalized["patch_request"]["request_idempotency_key"]
+        != normalized_request["idempotency_key"]
+    ):
+        raise CreativeSpecPatchAdmissionError("patch request idempotency key does not match.")
+    if normalized["patch_request"]["request_fingerprint"] != fingerprint_payload(
+        dict(normalized_request)
+    ):
+        raise CreativeSpecPatchAdmissionError("patch request fingerprint does not match.")
+    if normalized["base"]["base_commit_sha"] != normalized_request["base_commit_sha"]:
+        raise CreativeSpecPatchAdmissionError("patch request base SHA does not match admission.")
+    if (
+        normalized["human_admission"]["approval_ref"]
+        != normalized_request["human_admission"]["approval_ref"]
+    ):
+        raise CreativeSpecPatchAdmissionError("patch request approval_ref does not match.")
+    variant = _selected_variant(bundle)
+    if normalized["selected_variant"]["variant_id"] != variant["variant_id"]:
+        raise CreativeSpecPatchAdmissionError("selected variant id does not match bundle.")
+    if normalized["selected_variant"]["variant_fingerprint"] != variant["variant_fingerprint"]:
+        raise CreativeSpecPatchAdmissionError("selected variant fingerprint does not match bundle.")
+    return normalized
+
+
+def _validated_bundle(payload: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        return cast(dict[str, Any], validate_creative_code_specification_bundle(payload))
+    except CreativeCodeSpecificationError as exc:
+        raise CreativeSpecPatchAdmissionError(str(exc)) from exc
+
+
+def _validated_finalize_receipt(payload: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        return cast(dict[str, Any], validate_finalize_receipt(payload))
+    except CreativeSpecificationSkepticReviewError as exc:
+        raise CreativeSpecPatchAdmissionError(str(exc)) from exc
+
+
+def _validate_finalized_binding(
+    *,
+    receipt: Mapping[str, Any],
+    bundle: Mapping[str, Any],
+    human_admission: Mapping[str, Any],
+) -> None:
+    if receipt["next_allowed_action"] != NEXT_ACTION_SELECTED:
+        raise CreativeSpecPatchAdmissionError(
+            "finalize receipt next_allowed_action must be human_review_for_patch_builder."
+        )
+    if receipt["synthesis_status"] != "selected":
+        raise CreativeSpecPatchAdmissionError("finalize receipt must have selected status.")
+    if receipt["counts"]["selected_variant_count"] != 1:
+        raise CreativeSpecPatchAdmissionError("finalize receipt must select exactly one variant.")
+    if receipt["bundle_id"] != bundle["bundle_id"]:
+        raise CreativeSpecPatchAdmissionError("finalize receipt bundle_id does not match bundle.")
+    if receipt["bundle_idempotency_key"] != bundle["idempotency_key"]:
+        raise CreativeSpecPatchAdmissionError(
+            "finalize receipt bundle_idempotency_key does not match bundle."
+        )
+    bundle_fingerprint = source_bundle_fingerprint(bundle)
+    if receipt["bundle_fingerprint"] != bundle_fingerprint:
+        raise CreativeSpecPatchAdmissionError(
+            "finalize receipt bundle_fingerprint does not match bundle."
+        )
+    variant = _selected_variant(bundle)
+    if receipt["selected_variant_id"] != variant["variant_id"]:
+        raise CreativeSpecPatchAdmissionError(
+            "finalize receipt selected_variant_id does not match bundle."
+        )
+    if human_admission["approved_source_bundle_id"] != bundle["bundle_id"]:
+        raise CreativeSpecPatchAdmissionError("human admission bundle id does not match bundle.")
+    if human_admission["approved_source_bundle_fingerprint"] != bundle_fingerprint:
+        raise CreativeSpecPatchAdmissionError(
+            "human admission bundle fingerprint does not match bundle."
+        )
+    if human_admission["approved_selected_variant_id"] != variant["variant_id"]:
+        raise CreativeSpecPatchAdmissionError(
+            "human admission selected variant id does not match bundle."
+        )
+    if human_admission["approved_selected_variant_fingerprint"] != variant["variant_fingerprint"]:
+        raise CreativeSpecPatchAdmissionError(
+            "human admission selected variant fingerprint does not match bundle."
+        )
+
+
+def _selected_variant(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    synthesis = cast(Mapping[str, Any], bundle["synthesis"])
+    selected_id = synthesis.get("selected_variant_id")
+    selected_fingerprint = synthesis.get("selected_variant_fingerprint")
+    if not selected_id or not selected_fingerprint:
+        raise CreativeSpecPatchAdmissionError("finalized bundle must have a selected variant.")
+    variants = cast(Sequence[Mapping[str, Any]], bundle["variants"])
+    matches = [
+        variant
+        for variant in variants
+        if variant["variant_id"] == selected_id
+        and variant["variant_fingerprint"] == selected_fingerprint
+    ]
+    if len(matches) != 1:
+        raise CreativeSpecPatchAdmissionError("selected variant binding is invalid.")
+    reviews = cast(Sequence[Mapping[str, Any]], bundle["skeptic_reviews"])
+    selected_reviews = [review for review in reviews if review["variant_id"] == selected_id]
+    if not selected_reviews or any(review["decision"] != "pass" for review in selected_reviews):
+        raise CreativeSpecPatchAdmissionError("selected variant must have only passing reviews.")
+    return dict(matches[0])
+
+
+def _authority(*, true_keys: frozenset[str], false_keys: frozenset[str]) -> dict[str, bool]:
+    return {key: key in true_keys for key in sorted(true_keys | false_keys)}
+
+
+def _require_exact_keys(
+    payload: Mapping[str, Any],
+    expected_keys: frozenset[str],
+    *,
+    label: str,
+) -> None:
+    actual = set(payload)
+    missing = sorted(expected_keys - actual)
+    extra = sorted(actual - expected_keys)
+    if missing:
+        raise CreativeSpecPatchAdmissionError(
+            f"{label} is missing required fields: {', '.join(missing)}"
+        )
+    if extra:
+        raise CreativeSpecPatchAdmissionError(f"{label} has unsupported fields: {', '.join(extra)}")
+
+
+def _require_const(payload: Mapping[str, Any], key: str, expected: Any, *, label: str) -> Any:
+    value = payload.get(key)
+    if value != expected:
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must equal {expected!r}.")
+    return value
+
+
+def _require_id(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    return _normalize_id(value, label=f"{label}.{key}")
+
+
+def _normalize_id(value: Any, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise CreativeSpecPatchAdmissionError(f"{label} must be a string.")
+    normalized = value.strip()
+    if not normalized or not ID_RE.fullmatch(normalized):
+        raise CreativeSpecPatchAdmissionError(f"{label} must be a safe identifier.")
+    return normalized
+
+
+def _normalize_optional_id(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    return _normalize_id(value, label=label)
+
+
+def _require_token(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be a string.")
+    normalized = value.strip()
+    if not normalized or not SAFE_TOKEN_RE.fullmatch(normalized):
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be a safe token.")
+    return normalized
+
+
+def _require_utc(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not UTC_RE.fullmatch(value):
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be UTC second precision.")
+    return value
+
+
+def _require_sha(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    return _normalize_sha(payload.get(key), label=f"{label}.{key}")
+
+
+def _normalize_sha(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not SHA_RE.fullmatch(value):
+        raise CreativeSpecPatchAdmissionError(f"{label} must be a 40-char git SHA.")
+    return value
+
+
+def _require_fingerprint(payload: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be a sha256 digest.")
+    return value
+
+
+def _normalize_optional_fingerprint(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise CreativeSpecPatchAdmissionError(f"{label} must be null or a sha256 digest.")
+    return value
+
+
+def _require_bool(payload: Mapping[str, Any], key: str, *, expected: bool, label: str) -> bool:
+    value = payload.get(key)
+    if value is not expected:
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be {expected}.")
+    return expected
+
+
+def _normalize_bool_value(value: Any, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise CreativeSpecPatchAdmissionError(f"{label} must be a boolean.")
+    return value
+
+
+def _require_int(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    min_value: int,
+    max_value: int,
+    label: str,
+) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be an integer.")
+    if not min_value <= value <= max_value:
+        raise CreativeSpecPatchAdmissionError(
+            f"{label}.{key} must be between {min_value} and {max_value}."
+        )
+    return value
+
+
+def _normalize_path_list(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    label: str,
+    allow_empty: bool = False,
+) -> list[str]:
+    value = payload.get(key)
+    if not isinstance(value, list):
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be an array.")
+    if not value and not allow_empty:
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be non-empty.")
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        path = _normalize_repo_path(item, label=f"{label}.{key}[{index}]")
+        if path in seen:
+            raise CreativeSpecPatchAdmissionError(f"{label}.{key} must not contain duplicates.")
+        seen.add(path)
+        normalized.append(path)
+    return normalized
+
+
+def _normalize_repo_path(raw_path: Any, *, label: str) -> str:
+    if not isinstance(raw_path, str):
+        raise CreativeSpecPatchAdmissionError(f"{label} must be a string.")
+    value = raw_path.strip()
+    if not value:
+        raise CreativeSpecPatchAdmissionError(f"{label} must be non-empty.")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise CreativeSpecPatchAdmissionError(f"{label} must not contain control characters.")
+    if "\\" in value:
+        raise CreativeSpecPatchAdmissionError(f"{label} must use POSIX separators.")
+    if value.startswith(("/", "~")):
+        raise CreativeSpecPatchAdmissionError(f"{label} must be repo-relative.")
+    if SCHEME_RE.match(value):
+        raise CreativeSpecPatchAdmissionError(f"{label} must not be a URL or scheme path.")
+    path = PurePosixPath(value)
+    if not path.parts or "." in path.parts or ".." in path.parts:
+        raise CreativeSpecPatchAdmissionError(f"{label} must not contain traversal segments.")
+    return path.as_posix()
+
+
+def _normalize_artifact_ref(raw_ref: Any, *, label: str) -> str:
+    ref = _normalize_repo_path(raw_ref, label=label)
+    if not ref.startswith("artifacts/orchestration/creative_code/"):
+        raise CreativeSpecPatchAdmissionError(f"{label} must stay under creative-code artifacts.")
+    if not ref.endswith(".json"):
+        raise CreativeSpecPatchAdmissionError(f"{label} must point to a JSON artifact.")
+    return ref
+
+
+def _normalize_string_list(payload: Mapping[str, Any], key: str, *, label: str) -> list[str]:
+    value = payload.get(key)
+    if not isinstance(value, list):
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be an array.")
+    if not value:
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be non-empty.")
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise CreativeSpecPatchAdmissionError(f"{label}.{key}[{index}] must be a string.")
+        text = item.strip()
+        if not text:
+            raise CreativeSpecPatchAdmissionError(f"{label}.{key}[{index}] must be non-empty.")
+        if SECRET_RE.search(text) or LEAK_TEXT_RE.search(text):
+            raise CreativeSpecPatchAdmissionError(f"{label}.{key}[{index}] contains unsafe text.")
+        if text in seen:
+            raise CreativeSpecPatchAdmissionError(f"{label}.{key} must not contain duplicates.")
+        seen.add(text)
+        normalized.append(text)
+    return normalized
+
+
+def _normalize_budgets(raw_budgets: Any, *, label: str) -> dict[str, int]:
+    if not isinstance(raw_budgets, dict):
+        raise CreativeSpecPatchAdmissionError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_budgets, BUDGET_KEYS, label=label)
+    budgets = {
+        "generation_attempts": _require_int(
+            raw_budgets,
+            "generation_attempts",
+            min_value=GENERATION_ATTEMPTS,
+            max_value=GENERATION_ATTEMPTS,
+            label=label,
+        ),
+        "generation_timeout_seconds": _require_int(
+            raw_budgets,
+            "generation_timeout_seconds",
+            min_value=1,
+            max_value=HARD_TIMEOUT_SECONDS,
+            label=label,
+        ),
+        "evaluation_timeout_seconds": _require_int(
+            raw_budgets,
+            "evaluation_timeout_seconds",
+            min_value=1,
+            max_value=HARD_TIMEOUT_SECONDS,
+            label=label,
+        ),
+        "max_changed_files": _require_int(
+            raw_budgets,
+            "max_changed_files",
+            min_value=1,
+            max_value=HARD_MAX_CHANGED_FILES,
+            label=label,
+        ),
+        "max_diff_lines": _require_int(
+            raw_budgets,
+            "max_diff_lines",
+            min_value=1,
+            max_value=HARD_MAX_DIFF_LINES,
+            label=label,
+        ),
+        "max_patch_bytes": _require_int(
+            raw_budgets,
+            "max_patch_bytes",
+            min_value=1,
+            max_value=HARD_MAX_PATCH_BYTES,
+            label=label,
+        ),
+    }
+    if budgets["max_changed_files"] > DEFAULT_MAX_CHANGED_FILES:
+        return budgets
+    return budgets
+
+
+def _normalize_authority(
+    raw_authority: Any,
+    *,
+    expected: Mapping[str, bool],
+    label: str,
+) -> dict[str, bool]:
+    if not isinstance(raw_authority, dict):
+        raise CreativeSpecPatchAdmissionError(f"{label} must be a JSON object.")
+    _require_exact_keys(raw_authority, frozenset(expected), label=label)
+    normalized: dict[str, bool] = {}
+    for key in sorted(expected):
+        value = raw_authority.get(key)
+        if value is not expected[key]:
+            raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be {expected[key]}.")
+        normalized[key] = expected[key]
+    return normalized
+
+
+def _normalize_source(raw_source: Any) -> dict[str, Any]:
+    if not isinstance(raw_source, dict):
+        raise CreativeSpecPatchAdmissionError("CreativeSpecPatchAdmission.source is invalid.")
+    label = "CreativeSpecPatchAdmission.source"
+    _require_exact_keys(raw_source, SOURCE_KEYS, label=label)
+    return {
+        "finalize_id": _require_id(raw_source, "finalize_id", label=label),
+        "finalize_receipt_fingerprint": _require_fingerprint(
+            raw_source, "finalize_receipt_fingerprint", label=label
+        ),
+        "finalize_receipt_ref": _normalize_artifact_ref(
+            raw_source.get("finalize_receipt_ref"), label=f"{label}.finalize_receipt_ref"
+        ),
+        "bundle_id": _require_id(raw_source, "bundle_id", label=label),
+        "bundle_fingerprint": _require_fingerprint(raw_source, "bundle_fingerprint", label=label),
+        "bundle_ref": _normalize_artifact_ref(
+            raw_source.get("bundle_ref"), label=f"{label}.bundle_ref"
+        ),
+        "source_packet_id": _require_id(raw_source, "source_packet_id", label=label),
+    }
+
+
+def _normalize_selected_variant(raw_variant: Any) -> dict[str, Any]:
+    if not isinstance(raw_variant, dict):
+        raise CreativeSpecPatchAdmissionError(
+            "CreativeSpecPatchAdmission.selected_variant is invalid."
+        )
+    label = "CreativeSpecPatchAdmission.selected_variant"
+    _require_exact_keys(raw_variant, SELECTED_VARIANT_KEYS, label=label)
+    return {
+        "variant_id": _require_id(raw_variant, "variant_id", label=label),
+        "variant_fingerprint": _require_fingerprint(
+            raw_variant, "variant_fingerprint", label=label
+        ),
+        "target_paths": _normalize_path_list(raw_variant, "target_paths", label=label),
+        "tests_to_add": _normalize_path_list(raw_variant, "tests_to_add", label=label),
+    }
+
+
+def _normalize_base(raw_base: Any) -> dict[str, str]:
+    if not isinstance(raw_base, dict):
+        raise CreativeSpecPatchAdmissionError("CreativeSpecPatchAdmission.base is invalid.")
+    label = "CreativeSpecPatchAdmission.base"
+    _require_exact_keys(raw_base, BASE_KEYS, label=label)
+    return {
+        "base_ref": _require_const(raw_base, "base_ref", "origin/main", label=label),
+        "base_commit_sha": _require_sha(raw_base, "base_commit_sha", label=label),
+    }
+
+
+def _normalize_admission_human(raw_human: Any) -> dict[str, str]:
+    if not isinstance(raw_human, dict):
+        raise CreativeSpecPatchAdmissionError(
+            "CreativeSpecPatchAdmission.human_admission is invalid."
+        )
+    label = "CreativeSpecPatchAdmission.human_admission"
+    _require_exact_keys(raw_human, ADMISSION_HUMAN_KEYS, label=label)
+    return {
+        "decision": _require_const(raw_human, "decision", HUMAN_DECISION, label=label),
+        "approval_ref": _require_id(raw_human, "approval_ref", label=label),
+        "approved_by": _require_token(raw_human, "approved_by", label=label),
+        "approved_at_utc": _require_utc(raw_human, "approved_at_utc", label=label),
+        "human_admission_fingerprint": _require_fingerprint(
+            raw_human, "human_admission_fingerprint", label=label
+        ),
+        "human_admission_ref": _normalize_artifact_ref(
+            raw_human.get("human_admission_ref"), label=f"{label}.human_admission_ref"
+        ),
+    }
+
+
+def _normalize_patch_request(raw_request: Any) -> dict[str, str]:
+    if not isinstance(raw_request, dict):
+        raise CreativeSpecPatchAdmissionError(
+            "CreativeSpecPatchAdmission.patch_request is invalid."
+        )
+    label = "CreativeSpecPatchAdmission.patch_request"
+    _require_exact_keys(raw_request, PATCH_REQUEST_KEYS, label=label)
+    return {
+        "request_id": _require_id(raw_request, "request_id", label=label),
+        "request_idempotency_key": _require_id(raw_request, "request_idempotency_key", label=label),
+        "request_fingerprint": _require_fingerprint(
+            raw_request, "request_fingerprint", label=label
+        ),
+        "request_ref": _normalize_artifact_ref(
+            raw_request.get("request_ref"), label=f"{label}.request_ref"
+        ),
+        "source_bundle_ref": _normalize_artifact_ref(
+            raw_request.get("source_bundle_ref"), label=f"{label}.source_bundle_ref"
+        ),
+        "contract_policy_version": _require_const(
+            raw_request,
+            "contract_policy_version",
+            "creative-code-patch-builder-pr2",
+            label=label,
+        ),
+        "request_authority_scope": _require_const(
+            raw_request,
+            "request_authority_scope",
+            "pr2_builder_request_contract",
+            label=label,
+        ),
+    }
+
+
+def _normalize_builder_prepare(raw_prepare: Any) -> dict[str, Any]:
+    if not isinstance(raw_prepare, dict):
+        raise CreativeSpecPatchAdmissionError(
+            "CreativeSpecPatchAdmission.builder_prepare is invalid."
+        )
+    label = "CreativeSpecPatchAdmission.builder_prepare"
+    _require_exact_keys(raw_prepare, BUILDER_PREPARE_KEYS, label=label)
+    normalized = {
+        "prepared": _normalize_bool_value(raw_prepare.get("prepared"), label=f"{label}.prepared"),
+        "run_id": _normalize_optional_id(raw_prepare.get("run_id"), label=f"{label}.run_id"),
+        "state_fingerprint": _normalize_optional_fingerprint(
+            raw_prepare.get("state_fingerprint"), label=f"{label}.state_fingerprint"
+        ),
+        "request_file_present": _normalize_bool_value(
+            raw_prepare.get("request_file_present"), label=f"{label}.request_file_present"
+        ),
+        "source_bundle_file_present": _normalize_bool_value(
+            raw_prepare.get("source_bundle_file_present"),
+            label=f"{label}.source_bundle_file_present",
+        ),
+        "selected_variant_file_present": _normalize_bool_value(
+            raw_prepare.get("selected_variant_file_present"),
+            label=f"{label}.selected_variant_file_present",
+        ),
+        "state_file_present": _normalize_bool_value(
+            raw_prepare.get("state_file_present"), label=f"{label}.state_file_present"
+        ),
+        "candidate_patch_path_present": _require_false(
+            raw_prepare,
+            "candidate_patch_path_present",
+            label=label,
+        ),
+        "result_file_present": _require_false(raw_prepare, "result_file_present", label=label),
+        "candidate_patch_generated": _require_false(
+            raw_prepare,
+            "candidate_patch_generated",
+            label=label,
+        ),
+        "candidate_patch_evaluated": _require_false(
+            raw_prepare,
+            "candidate_patch_evaluated",
+            label=label,
+        ),
+    }
+    if normalized["prepared"]:
+        if normalized["run_id"] is None:
+            raise CreativeSpecPatchAdmissionError("prepared builder summary requires run_id.")
+        if normalized["state_fingerprint"] is None:
+            raise CreativeSpecPatchAdmissionError(
+                "prepared builder summary requires state_fingerprint."
+            )
+        for key in (
+            "request_file_present",
+            "source_bundle_file_present",
+            "selected_variant_file_present",
+            "state_file_present",
+        ):
+            if normalized[key] is not True:
+                raise CreativeSpecPatchAdmissionError(f"prepared builder summary requires {key}.")
+    else:
+        if normalized["run_id"] is not None or normalized["state_fingerprint"] is not None:
+            raise CreativeSpecPatchAdmissionError(
+                "unprepared builder summary must not include run_id or state_fingerprint."
+            )
+        for key in (
+            "request_file_present",
+            "source_bundle_file_present",
+            "selected_variant_file_present",
+            "state_file_present",
+        ):
+            if normalized[key] is not False:
+                raise CreativeSpecPatchAdmissionError(
+                    f"unprepared builder summary must keep {key} false."
+                )
+    return normalized
+
+
+def _require_false(payload: Mapping[str, Any], key: str, *, label: str) -> bool:
+    value = payload.get(key)
+    if value is not False:
+        raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be false.")
+    return False
+
+
+def _normalize_executed_effects(raw_effects: Any) -> dict[str, bool]:
+    if not isinstance(raw_effects, dict):
+        raise CreativeSpecPatchAdmissionError(
+            "CreativeSpecPatchAdmission.executed_effects is invalid."
+        )
+    label = "CreativeSpecPatchAdmission.executed_effects"
+    _require_exact_keys(raw_effects, EXECUTED_EFFECT_KEYS, label=label)
+    normalized: dict[str, bool] = {}
+    for key in sorted(EXECUTED_EFFECT_KEYS):
+        expected = key == "request_built" or (
+            key == "builder_prepared" and raw_effects.get("builder_prepared") is True
+        )
+        if key not in {"request_built", "builder_prepared"}:
+            expected = False
+        value = raw_effects.get(key)
+        if value is not expected:
+            raise CreativeSpecPatchAdmissionError(f"{label}.{key} must be {expected}.")
+        normalized[key] = expected
+    return normalized
+
+
+def _set_admission_identity(body: dict[str, Any]) -> None:
+    fingerprint = fingerprint_payload(_admission_identity_payload(body))
+    upstream_ids = (
+        str(body["source"]["finalize_id"]),
+        str(body["source"]["finalize_receipt_fingerprint"]),
+        str(body["source"]["bundle_fingerprint"]),
+        str(body["selected_variant"]["variant_fingerprint"]),
+        str(body["base"]["base_commit_sha"]),
+        str(body["human_admission"]["human_admission_fingerprint"]),
+        str(body["patch_request"]["request_fingerprint"]),
+    )
+    body["admission_id"] = build_asset_id(
+        asset_type=ADMISSION_ARTIFACT_TYPE,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=upstream_ids,
+    )
+    body["idempotency_key"] = build_idempotency_key(
+        asset_type=ADMISSION_ARTIFACT_TYPE,
+        rail="control_plane",
+        version=SCHEMA_VERSION,
+        policy_version=POLICY_VERSION,
+        fingerprint=fingerprint,
+        upstream_ids=upstream_ids,
+    )
+
+
+def _admission_identity_payload(admission: Mapping[str, Any]) -> dict[str, Any]:
+    identity_keys = (
+        "schema_version",
+        "artifact_type",
+        "policy_version",
+        "source",
+        "selected_variant",
+        "base",
+        "human_admission",
+        "patch_request",
+        "authority",
+        "sanitized",
+    )
+    return {key: admission[key] for key in identity_keys}
+
+
+def _validate_admission_identity(admission: Mapping[str, Any]) -> None:
+    expected = dict(admission)
+    _set_admission_identity(expected)
+    if admission["admission_id"] != expected["admission_id"]:
+        raise CreativeSpecPatchAdmissionError("admission_id does not match admission content.")
+    if admission["idempotency_key"] != expected["idempotency_key"]:
+        raise CreativeSpecPatchAdmissionError(
+            "admission idempotency_key does not match admission content."
+        )
+
+
+def _reject_payload_safety(value: Any, *, label: str) -> None:
+    if isinstance(value, str):
+        if SECRET_RE.search(value) or LEAK_TEXT_RE.search(value):
+            raise CreativeSpecPatchAdmissionError(f"{label} contains unsafe text.")
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            _reject_payload_safety(item, label=f"{label}.{key}")
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for index, item in enumerate(value):
+            _reject_payload_safety(item, label=f"{label}[{index}]")

--- a/scripts/orchestration/creative_spec_patch_admission_contract.py
+++ b/scripts/orchestration/creative_spec_patch_admission_contract.py
@@ -223,7 +223,12 @@ EXECUTED_EFFECT_KEYS = frozenset(
     }
 )
 ADMISSION_AUTHORITY_TRUE_KEYS = frozenset(
-    {"build_patch_builder_request", "emit_local_artifacts", "run_patch_builder_prepare"}
+    {
+        "build_patch_builder_request",
+        "emit_local_artifacts",
+        "run_patch_builder_prepare",
+        "validate_patch_builder_request",
+    }
 )
 ADMISSION_AUTHORITY_FALSE_KEYS = frozenset(
     {
@@ -970,8 +975,6 @@ def _normalize_budgets(raw_budgets: Any, *, label: str) -> dict[str, int]:
             label=label,
         ),
     }
-    if budgets["max_changed_files"] > DEFAULT_MAX_CHANGED_FILES:
-        return budgets
     return budgets
 
 

--- a/scripts/orchestration/creative_spec_patch_admission_contract.py
+++ b/scripts/orchestration/creative_spec_patch_admission_contract.py
@@ -15,7 +15,6 @@ from typing import Any, cast
 
 from core.evidence.fingerprints import build_asset_id, build_idempotency_key, fingerprint_payload
 from scripts.orchestration.creative_code_patch_contract import (
-    DEFAULT_MAX_CHANGED_FILES,
     GENERATION_ATTEMPTS,
     HARD_MAX_CHANGED_FILES,
     HARD_MAX_DIFF_LINES,

--- a/scripts/orchestration/creative_spec_patch_admission_contract.py
+++ b/scripts/orchestration/creative_spec_patch_admission_contract.py
@@ -21,7 +21,6 @@ from scripts.orchestration.creative_code_patch_contract import (
     HARD_MAX_DIFF_LINES,
     HARD_MAX_PATCH_BYTES,
     HARD_TIMEOUT_SECONDS,
-    CreativeCodePatchContractError,
     build_creative_code_patch_build_request,
     source_bundle_fingerprint,
     validate_creative_code_patch_build_request,

--- a/tests/test_creative_spec_patch_admission.py
+++ b/tests/test_creative_spec_patch_admission.py
@@ -617,6 +617,35 @@ def test_schemas_closed_and_cli_has_no_generate_or_evaluate_commands() -> None:
         ]
         is False
     )
+    prepared_rules = admission_schema["$defs"]["builder_prepare"]["allOf"]
+    prepared_then = prepared_rules[0]["then"]["properties"]
+    unprepared_then = prepared_rules[1]["then"]["properties"]
+    for key in (
+        "request_file_present",
+        "source_bundle_file_present",
+        "selected_variant_file_present",
+        "state_file_present",
+    ):
+        assert prepared_then[key]["const"] is True
+        assert unprepared_then[key]["const"] is False
+    assert prepared_then["run_id"]["$ref"] == "#/$defs/safe_id"
+    assert prepared_then["state_fingerprint"]["$ref"] == "#/$defs/sha256"
+    assert unprepared_then["run_id"]["type"] == "null"
+    assert unprepared_then["state_fingerprint"]["type"] == "null"
+
+    admission_prepare_effect_rules = admission_schema["allOf"]
+    assert (
+        admission_prepare_effect_rules[0]["then"]["properties"]["executed_effects"]["properties"][
+            "builder_prepared"
+        ]["const"]
+        is True
+    )
+    assert (
+        admission_prepare_effect_rules[1]["then"]["properties"]["executed_effects"]["properties"][
+            "builder_prepared"
+        ]["const"]
+        is False
+    )
 
     with pytest.raises(SystemExit):
         admission_cli._parse_args(["generate"])

--- a/tests/test_creative_spec_patch_admission.py
+++ b/tests/test_creative_spec_patch_admission.py
@@ -1,0 +1,624 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+import pytest
+
+from core.evidence.fingerprints import fingerprint_payload
+from scripts.orchestration import (
+    creative_code_patch_builder,
+    creative_code_patch_workspace,
+    creative_spec_patch_admission as admission_cli,
+    creative_specification_skeptic_review_contract as review_contract,
+)
+from scripts.orchestration.creative_code_patch_contract import (
+    source_bundle_fingerprint,
+    validate_creative_code_patch_build_request,
+)
+from scripts.orchestration.creative_code_specification import (
+    read_creative_code_specification_bundle,
+)
+from scripts.orchestration.creative_spec_patch_admission_contract import (
+    HUMAN_ADMISSION_ARTIFACT_TYPE,
+    HUMAN_DECISION,
+    POLICY_VERSION,
+    CreativeSpecPatchAdmissionError,
+    default_human_admission_authority,
+    validate_creative_spec_patch_admission,
+    validate_human_admission,
+)
+from scripts.orchestration.creative_specification_skeptic_review_contract import (
+    FINALIZE_RECEIPT_ARTIFACT_TYPE,
+    default_finalize_receipt_authority,
+    validate_finalize_receipt,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REFERENCE_BUNDLE = REPO_ROOT / "docs/orchestration/contracts/creative_code_specification.v1.json"
+HUMAN_SCHEMA = (
+    REPO_ROOT / "docs/orchestration/contracts/creative_spec_patch_human_admission.v1.schema.json"
+)
+ADMISSION_SCHEMA = (
+    REPO_ROOT / "docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json"
+)
+
+
+def _git(repo: Path, *args: str, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    git_binary = shutil.which("git")
+    if not git_binary:
+        raise AssertionError("git binary is required for creative-spec admission tests.")
+    if git_binary.endswith("/usr/libexec/git-core/git"):
+        git_binary = "/usr/bin/git"
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    return subprocess.run(
+        [git_binary, *args],
+        cwd=str(repo),
+        env=env,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _init_patch_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    (repo / "core" / "rag").mkdir(parents=True)
+    (repo / "docs" / "orchestration").mkdir(parents=True)
+    (repo / "tests").mkdir()
+    (repo / ".gitignore").write_text("artifacts/\n", encoding="utf-8")
+    (repo / "core" / "rag" / "orchestration.py").write_text(
+        "def value() -> int:\n    return 1\n",
+        encoding="utf-8",
+    )
+    (repo / "docs" / "orchestration" / "GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md").write_text(
+        "# Contract\n",
+        encoding="utf-8",
+    )
+    (repo / "tests" / "test_creative_code_contract.py").write_text(
+        "def test_placeholder() -> None:\n    assert True\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    base_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", base_sha)
+    return repo, base_sha
+
+
+def _patch_modules_to_repo(monkeypatch: pytest.MonkeyPatch, repo: Path) -> None:
+    creative_root = repo / "artifacts" / "orchestration" / "creative_code"
+    monkeypatch.setattr(creative_code_patch_workspace, "REPO_ROOT", repo)
+    monkeypatch.setattr(
+        creative_code_patch_workspace, "ARTIFACT_ROOT", creative_root / "patch_runs"
+    )
+    monkeypatch.setattr(creative_code_patch_builder, "REPO_ROOT", repo)
+    monkeypatch.setattr(admission_cli, "REPO_ROOT", repo)
+    monkeypatch.setattr(admission_cli, "CREATIVE_CODE_ROOT", creative_root)
+    monkeypatch.setattr(admission_cli, "PATCH_ADMISSION_ROOT", creative_root / "patch_admission")
+
+
+def _reference_bundle() -> dict[str, Any]:
+    return read_creative_code_specification_bundle(REFERENCE_BUNDLE)
+
+
+def _selected_variant(bundle: dict[str, Any]) -> dict[str, Any]:
+    selected_id = bundle["synthesis"]["selected_variant_id"]
+    selected_fingerprint = bundle["synthesis"]["selected_variant_fingerprint"]
+    for variant in bundle["variants"]:
+        if (
+            variant["variant_id"] == selected_id
+            and variant["variant_fingerprint"] == selected_fingerprint
+        ):
+            return dict(variant)
+    raise AssertionError("reference bundle must contain selected variant")
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _refresh_receipt_identity(receipt: dict[str, Any]) -> dict[str, Any]:
+    receipt["finalize_id"] = "pending"
+    receipt["idempotency_key"] = "pending"
+    review_contract._set_identity(
+        receipt,
+        id_key="finalize_id",
+        asset_type=FINALIZE_RECEIPT_ARTIFACT_TYPE,
+    )
+    return receipt
+
+
+def _finalize_receipt(bundle: dict[str, Any], *, bundle_ref: str) -> dict[str, Any]:
+    selected = _selected_variant(bundle)
+    rejected_variant_ids = {record["variant_id"] for record in bundle["rejection_index"]["records"]}
+    reviewed_dir_ref = str(Path(bundle_ref).parent)
+    receipt = {
+        "schema_version": "1.0",
+        "artifact_type": FINALIZE_RECEIPT_ARTIFACT_TYPE,
+        "finalize_id": "pending",
+        "idempotency_key": "pending",
+        "policy_version": "creative-specification-skeptic-review-finalize-v1",
+        "source_attachment_id": "creative-spec-patch-admission-test-attachment",
+        "source_attachment_fingerprint": "sha256:" + ("1" * 64),
+        "source_attachment_ref": f"{reviewed_dir_ref}/skeptic_review_attachment.json",
+        "reviewed_run_dir_ref": reviewed_dir_ref,
+        "bundle_ref": bundle_ref,
+        "bundle_id": bundle["bundle_id"],
+        "bundle_fingerprint": source_bundle_fingerprint(bundle),
+        "bundle_idempotency_key": bundle["idempotency_key"],
+        "selected_variant_id": selected["variant_id"],
+        "synthesis_status": "selected",
+        "next_allowed_action": "human_review_for_patch_builder",
+        "counts": {
+            "variant_count": len(bundle["variants"]),
+            "review_count": len(bundle["skeptic_reviews"]),
+            "selected_variant_count": 1,
+            "rejected_variant_count": len(rejected_variant_ids),
+            "unresolved_blocker_count": len(bundle["synthesis"]["unresolved_blockers"]),
+            "rejection_record_count": len(bundle["rejection_index"]["records"]),
+        },
+        "authority": default_finalize_receipt_authority(),
+        "sanitized": True,
+    }
+    return validate_finalize_receipt(_refresh_receipt_identity(receipt))
+
+
+def _human_admission(bundle: dict[str, Any]) -> dict[str, Any]:
+    selected = _selected_variant(bundle)
+    return {
+        "schema_version": "1.0",
+        "artifact_type": HUMAN_ADMISSION_ARTIFACT_TYPE,
+        "policy_version": POLICY_VERSION,
+        "decision": HUMAN_DECISION,
+        "approval_ref": "creative-spec-patch-admission-test",
+        "approved_by": "operator",
+        "approved_at_utc": "2026-07-05T00:00:00Z",
+        "approved_source_bundle_id": bundle["bundle_id"],
+        "approved_source_bundle_fingerprint": source_bundle_fingerprint(bundle),
+        "approved_selected_variant_id": selected["variant_id"],
+        "approved_selected_variant_fingerprint": selected["variant_fingerprint"],
+        "allowed_existing_paths": ["core/rag/orchestration.py"],
+        "allowed_new_paths": [],
+        "oracle_commands": ["pytest -q tests/test_creative_code_contract.py"],
+        "metrics": [
+            "request preserves selected creative spec binding",
+            "builder prepare leaves candidate patch absent",
+        ],
+        "budgets": {
+            "generation_attempts": 1,
+            "generation_timeout_seconds": 60,
+            "evaluation_timeout_seconds": 60,
+            "max_changed_files": 3,
+            "max_diff_lines": 200,
+            "max_patch_bytes": 20000,
+        },
+        "authority": default_human_admission_authority(),
+        "sanitized": True,
+    }
+
+
+def _write_inputs(repo: Path) -> tuple[dict[str, Any], Path, Path, Path]:
+    bundle = _reference_bundle()
+    reviewed_dir = (
+        repo
+        / "artifacts"
+        / "orchestration"
+        / "creative_code"
+        / "spec_bridge"
+        / "admission-test"
+        / "spec_finalize_reviewed"
+    )
+    bundle_path = reviewed_dir / "creative_code_specification_bundle.json"
+    bundle_ref = bundle_path.relative_to(repo).as_posix()
+    receipt = _finalize_receipt(bundle, bundle_ref=bundle_ref)
+    receipt_path = reviewed_dir / "finalize_receipt.json"
+    human_path = (
+        repo
+        / "artifacts"
+        / "orchestration"
+        / "creative_code"
+        / "patch_admission"
+        / "operator-input"
+        / "human_admission.json"
+    )
+    _write_json(bundle_path, bundle)
+    _write_json(receipt_path, receipt)
+    _write_json(human_path, _human_admission(bundle))
+    return bundle, bundle_path, receipt_path, human_path
+
+
+def _output_dir(repo: Path, name: str = "admission-run") -> Path:
+    return repo / "artifacts" / "orchestration" / "creative_code" / "patch_admission" / name
+
+
+def test_build_and_prepare_happy_path_no_generate_evaluate_or_candidate_patch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, base_sha = _init_patch_repo(tmp_path)
+    _patch_modules_to_repo(monkeypatch, repo)
+    bundle, _bundle_path, receipt_path, human_path = _write_inputs(repo)
+    output_dir = _output_dir(repo)
+    run_id = "admission-prepare-test"
+
+    def fail_generate(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("generate must not be called")
+
+    def fail_evaluate(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("evaluate must not be called")
+
+    monkeypatch.setattr(creative_code_patch_builder, "generate", fail_generate)
+    monkeypatch.setattr(creative_code_patch_builder, "evaluate", fail_evaluate)
+
+    assert (
+        admission_cli.main(
+            [
+                "build-and-prepare",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(_bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                base_sha,
+                "--output-dir",
+                str(output_dir),
+                "--run-id",
+                run_id,
+            ]
+        )
+        == 0
+    )
+    captured = capsys.readouterr()
+    assert admission_cli.BUILD_SUCCESS_OUTPUT not in captured.out
+    assert admission_cli.PREPARE_SUCCESS_OUTPUT in captured.out
+
+    admission_path = output_dir / admission_cli.ADMISSION_FILENAME
+    request_path = output_dir / admission_cli.REQUEST_FILENAME
+    admission = validate_creative_spec_patch_admission(json.loads(admission_path.read_text()))
+    request = json.loads(request_path.read_text())
+    assert validate_creative_code_patch_build_request(request, source_bundle=bundle) == request
+    assert admission["builder_prepare"]["prepared"] is True
+    assert admission["builder_prepare"]["candidate_patch_path_present"] is False
+    assert admission["builder_prepare"]["candidate_patch_generated"] is False
+    assert admission["builder_prepare"]["candidate_patch_evaluated"] is False
+    assert admission["executed_effects"]["codex_exec_called"] is False
+
+    run_dir = creative_code_patch_workspace.resolve_run_dir(run_id, create=False)
+    assert (run_dir / creative_code_patch_builder.REQUEST_FILE).is_file()
+    assert (run_dir / creative_code_patch_builder.SOURCE_BUNDLE_FILE).is_file()
+    assert (run_dir / creative_code_patch_builder.SELECTED_VARIANT_FILE).is_file()
+    assert (run_dir / creative_code_patch_builder.STATE_FILE).is_file()
+    assert not (run_dir / creative_code_patch_builder.CANDIDATE_PATCH_FILE).exists()
+    assert not (run_dir / creative_code_patch_builder.RESULT_FILE).exists()
+
+    assert admission_cli.main(["summarize", "--admission", str(admission_path)]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["authority_boundary"] == admission_cli.SUMMARY_AUTHORITY_BOUNDARY
+    assert summary["candidate_patch_generated"] is False
+    assert summary["candidate_patch_path_present"] is False
+
+    creative_code_patch_workspace.cleanup_run_dir(run_id)
+    assert not run_dir.exists()
+
+
+def test_build_request_rejects_receipt_bundle_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, base_sha = _init_patch_repo(tmp_path)
+    _patch_modules_to_repo(monkeypatch, repo)
+    _bundle, bundle_path, receipt_path, human_path = _write_inputs(repo)
+    receipt = json.loads(receipt_path.read_text())
+    receipt["bundle_fingerprint"] = "sha256:" + ("0" * 64)
+    _write_json(receipt_path, _refresh_receipt_identity(receipt))
+
+    assert (
+        admission_cli.main(
+            [
+                "build-request",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                base_sha,
+                "--output-dir",
+                str(_output_dir(repo, "receipt-mismatch")),
+            ]
+        )
+        == 1
+    )
+    assert "bundle_fingerprint" in capsys.readouterr().err
+
+
+def test_human_admission_selected_variant_mismatch_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, base_sha = _init_patch_repo(tmp_path)
+    _patch_modules_to_repo(monkeypatch, repo)
+    _bundle, bundle_path, receipt_path, human_path = _write_inputs(repo)
+    human = json.loads(human_path.read_text())
+    human["approved_selected_variant_id"] = "creative-code-pr0-reference:spec-2"
+    _write_json(human_path, human)
+
+    assert (
+        admission_cli.main(
+            [
+                "build-request",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                base_sha,
+                "--output-dir",
+                str(_output_dir(repo, "human-mismatch")),
+            ]
+        )
+        == 1
+    )
+    assert "human admission selected variant id" in capsys.readouterr().err
+
+
+def test_stale_origin_main_and_dirty_shared_worktree_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, base_sha = _init_patch_repo(tmp_path)
+    _patch_modules_to_repo(monkeypatch, repo)
+    _bundle, bundle_path, receipt_path, human_path = _write_inputs(repo)
+
+    assert (
+        admission_cli.main(
+            [
+                "build-request",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                "b" * 40,
+                "--output-dir",
+                str(_output_dir(repo, "stale-base")),
+            ]
+        )
+        == 1
+    )
+    assert "base_commit_sha must match current origin/main" in capsys.readouterr().err
+
+    (repo / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+    assert (
+        admission_cli.main(
+            [
+                "build-request",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                base_sha,
+                "--output-dir",
+                str(_output_dir(repo, "dirty-tree")),
+            ]
+        )
+        == 1
+    )
+    assert "shared worktree must be clean" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("mutator", "match"),
+    [
+        (
+            lambda human: human["authority"].update({"run_patch_builder_generate": True}),
+            "run_patch_builder_generate",
+        ),
+        (lambda human: human.update({"oracle_commands": []}), "oracle_commands"),
+        (lambda human: human.update({"metrics": ["diff --git a/file b/file"]}), "unsafe text"),
+        (lambda human: human["budgets"].update({"max_changed_files": 6}), "max_changed_files"),
+        (
+            lambda human: human["budgets"].update({"generation_attempts": True}),
+            "generation_attempts",
+        ),
+    ],
+)
+def test_human_admission_rejects_authority_strings_empty_and_budget_bounds(
+    mutator: Any,
+    match: str,
+) -> None:
+    human = _human_admission(_reference_bundle())
+    mutator(human)
+
+    with pytest.raises(CreativeSpecPatchAdmissionError, match=match):
+        validate_human_admission(human)
+
+
+def test_allowed_path_must_stay_inside_selected_variant_surface(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, base_sha = _init_patch_repo(tmp_path)
+    _patch_modules_to_repo(monkeypatch, repo)
+    _bundle, bundle_path, receipt_path, human_path = _write_inputs(repo)
+    human = json.loads(human_path.read_text())
+    human["allowed_existing_paths"] = ["core/rag/other.py"]
+    _write_json(human_path, human)
+
+    assert (
+        admission_cli.main(
+            [
+                "build-request",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                base_sha,
+                "--output-dir",
+                str(_output_dir(repo, "bad-path")),
+            ]
+        )
+        == 1
+    )
+    assert "selected variant target paths" in capsys.readouterr().err
+
+
+def test_prepare_builder_rejects_stale_base_after_request_build(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, base_sha = _init_patch_repo(tmp_path)
+    _patch_modules_to_repo(monkeypatch, repo)
+    _bundle, bundle_path, receipt_path, human_path = _write_inputs(repo)
+    output_dir = _output_dir(repo, "stale-before-prepare")
+
+    assert (
+        admission_cli.main(
+            [
+                "build-request",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                base_sha,
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    (repo / "core" / "rag" / "second.py").write_text("value = 2\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "--quiet", "-m", "advance main")
+    new_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", new_sha)
+
+    assert (
+        admission_cli.main(
+            [
+                "prepare-builder",
+                "--admission",
+                str(output_dir / admission_cli.ADMISSION_FILENAME),
+                "--run-id",
+                "stale-prepare",
+            ]
+        )
+        == 1
+    )
+    assert "base_commit_sha must match current origin/main" in capsys.readouterr().err
+
+
+def test_prepare_builder_cleans_new_run_dir_on_prepare_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, base_sha = _init_patch_repo(tmp_path)
+    _patch_modules_to_repo(monkeypatch, repo)
+    _bundle, bundle_path, receipt_path, human_path = _write_inputs(repo)
+    output_dir = _output_dir(repo, "cleanup")
+    run_id = "cleanup-run"
+
+    assert (
+        admission_cli.main(
+            [
+                "build-request",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                base_sha,
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    def fail_prepare(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        run_dir = creative_code_patch_workspace.resolve_run_dir(run_id, create=True)
+        (run_dir / "partial.json").write_text("{}", encoding="utf-8")
+        raise creative_code_patch_builder.CreativeCodePatchBuilderError("injected prepare failure")
+
+    monkeypatch.setattr(creative_code_patch_builder, "prepare", fail_prepare)
+
+    assert (
+        admission_cli.main(
+            [
+                "prepare-builder",
+                "--admission",
+                str(output_dir / admission_cli.ADMISSION_FILENAME),
+                "--run-id",
+                run_id,
+            ]
+        )
+        == 1
+    )
+    assert "injected prepare failure" in capsys.readouterr().err
+    with pytest.raises(creative_code_patch_workspace.CreativeCodePatchWorkspaceError):
+        creative_code_patch_workspace.resolve_run_dir(run_id, create=False)
+
+
+def test_schemas_closed_and_cli_has_no_generate_or_evaluate_commands() -> None:
+    human_schema = json.loads(HUMAN_SCHEMA.read_text(encoding="utf-8"))
+    admission_schema = json.loads(ADMISSION_SCHEMA.read_text(encoding="utf-8"))
+
+    assert human_schema["additionalProperties"] is False
+    assert admission_schema["additionalProperties"] is False
+    assert human_schema["$defs"]["authority"]["additionalProperties"] is False
+    assert (
+        admission_schema["$defs"]["authority"]["properties"]["run_patch_builder_generate"]["const"]
+        is False
+    )
+    assert (
+        admission_schema["$defs"]["authority"]["properties"]["run_patch_builder_evaluate"]["const"]
+        is False
+    )
+    assert (
+        admission_schema["$defs"]["builder_prepare"]["properties"]["candidate_patch_generated"][
+            "const"
+        ]
+        is False
+    )
+
+    with pytest.raises(SystemExit):
+        admission_cli._parse_args(["generate"])
+    with pytest.raises(SystemExit):
+        admission_cli._parse_args(["evaluate"])

--- a/tests/test_creative_spec_patch_admission.py
+++ b/tests/test_creative_spec_patch_admission.py
@@ -314,6 +314,65 @@ def test_build_and_prepare_happy_path_no_generate_evaluate_or_candidate_patch(
     assert not run_dir.exists()
 
 
+def test_admission_validator_rejects_prepare_proof_parity_regressions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, base_sha = _init_patch_repo(tmp_path)
+    _patch_modules_to_repo(monkeypatch, repo)
+    _bundle, bundle_path, receipt_path, human_path = _write_inputs(repo)
+    output_dir = _output_dir(repo, "validator-negatives")
+
+    assert (
+        admission_cli.main(
+            [
+                "build-request",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                base_sha,
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    admission = json.loads((output_dir / admission_cli.ADMISSION_FILENAME).read_text())
+
+    prepared_with_missing_file = json.loads(json.dumps(admission))
+    prepared_with_missing_file["builder_prepare"].update(
+        {
+            "prepared": True,
+            "run_id": "validator-negative-run",
+            "state_fingerprint": "sha256:" + ("2" * 64),
+            "request_file_present": True,
+            "source_bundle_file_present": False,
+            "selected_variant_file_present": True,
+            "state_file_present": True,
+        }
+    )
+    prepared_with_missing_file["executed_effects"]["builder_prepared"] = True
+    with pytest.raises(CreativeSpecPatchAdmissionError, match="source_bundle_file_present"):
+        validate_creative_spec_patch_admission(prepared_with_missing_file)
+
+    unprepared_with_prepare_proof = json.loads(json.dumps(admission))
+    unprepared_with_prepare_proof["builder_prepare"]["run_id"] = "validator-negative-run"
+    unprepared_with_prepare_proof["builder_prepare"]["state_fingerprint"] = "sha256:" + ("3" * 64)
+    with pytest.raises(CreativeSpecPatchAdmissionError, match="must not include run_id"):
+        validate_creative_spec_patch_admission(unprepared_with_prepare_proof)
+
+    effects_disagree = json.loads(json.dumps(admission))
+    effects_disagree["executed_effects"]["builder_prepared"] = True
+    with pytest.raises(CreativeSpecPatchAdmissionError, match="disagree"):
+        validate_creative_spec_patch_admission(effects_disagree)
+
+
 def test_build_request_rejects_receipt_bundle_mismatch(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_creative_spec_patch_admission.py
+++ b/tests/test_creative_spec_patch_admission.py
@@ -655,6 +655,64 @@ def test_prepare_builder_cleans_new_run_dir_on_prepare_failure(
         creative_code_patch_workspace.resolve_run_dir(run_id, create=False)
 
 
+def test_build_and_prepare_cleans_new_run_dir_when_prepare_proof_rejects_candidate_patch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, base_sha = _init_patch_repo(tmp_path)
+    _patch_modules_to_repo(monkeypatch, repo)
+    _bundle, bundle_path, receipt_path, human_path = _write_inputs(repo)
+    output_dir = _output_dir(repo, "cleanup-invalid-proof")
+    run_id = "cleanup-invalid-proof-run"
+    original_prepare = creative_code_patch_builder.prepare
+
+    def prepare_with_candidate_patch(
+        *,
+        spec_bundle_path: Path,
+        request_path: Path,
+        run_id: str,
+    ) -> dict[str, Any]:
+        state = original_prepare(
+            spec_bundle_path=spec_bundle_path,
+            request_path=request_path,
+            run_id=run_id,
+        )
+        run_dir = creative_code_patch_workspace.resolve_run_dir(run_id, create=False)
+        (run_dir / creative_code_patch_builder.CANDIDATE_PATCH_FILE).write_text(
+            "diff --git a/core/rag/orchestration.py b/core/rag/orchestration.py\n",
+            encoding="utf-8",
+        )
+        return state
+
+    monkeypatch.setattr(creative_code_patch_builder, "prepare", prepare_with_candidate_patch)
+
+    assert (
+        admission_cli.main(
+            [
+                "build-and-prepare",
+                "--finalize-receipt",
+                str(receipt_path),
+                "--bundle",
+                str(bundle_path),
+                "--human-admission",
+                str(human_path),
+                "--base-sha",
+                base_sha,
+                "--output-dir",
+                str(output_dir),
+                "--run-id",
+                run_id,
+            ]
+        )
+        == 1
+    )
+    assert "candidate.patch" in capsys.readouterr().err
+    assert not output_dir.exists()
+    with pytest.raises(creative_code_patch_workspace.CreativeCodePatchWorkspaceError):
+        creative_code_patch_workspace.resolve_run_dir(run_id, create=False)
+
+
 def test_schemas_closed_and_cli_has_no_generate_or_evaluate_commands() -> None:
     human_schema = json.loads(HUMAN_SCHEMA.read_text(encoding="utf-8"))
     admission_schema = json.loads(ADMISSION_SCHEMA.read_text(encoding="utf-8"))
@@ -662,6 +720,13 @@ def test_schemas_closed_and_cli_has_no_generate_or_evaluate_commands() -> None:
     assert human_schema["additionalProperties"] is False
     assert admission_schema["additionalProperties"] is False
     assert human_schema["$defs"]["authority"]["additionalProperties"] is False
+    assert "validate_patch_builder_request" in admission_schema["$defs"]["authority"]["required"]
+    assert (
+        admission_schema["$defs"]["authority"]["properties"]["validate_patch_builder_request"][
+            "const"
+        ]
+        is True
+    )
     assert (
         admission_schema["$defs"]["authority"]["properties"]["run_patch_builder_generate"]["const"]
         is False


### PR DESCRIPTION
## Summary

Admits finalized creative-code specification bundles into valid PR-2 `CreativeCodePatchBuildRequest` handoff artifacts and proves patch-builder `prepare` works without generating or evaluating a candidate patch.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [ ] Docs
- [x] Linked issues/PRs: follows PR #2075 creative spec learning rollup.

## Goal

Bridge a finalized selected creative spec into the existing PR-2 patch-builder request contract while keeping this PR prepare-only.

## Business reason

This adds the missing governed handoff between creative-spec finalization and patch-builder preparation, increasing automation leverage without giving research artifacts runtime, PR, workflow, semantic-cache, graph-truth, or merge-readiness authority.

## Scope

- Added closed admission contracts and schemas under `docs/orchestration/contracts/`.
- Added `creative_spec_patch_admission_contract.py` and `creative_spec_patch_admission.py` with `build-request`, `validate`, `prepare-builder`, `build-and-prepare`, and `summarize`.
- Added focused tests for successful build/prepare and fail-closed binding, authority, path, budget, stale-base, dirty-tree, unsafe-string, cleanup, and no-generate/evaluate behavior.
- Updated only narrow governance docs: `scripts/AGENTS.md`, `docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md`, and `docs/roadmap/BACKLOG_LEDGER.md`.

## Out of scope

No `generate`, `evaluate`, Codex exec, `candidate.patch`, promotion, branch/PR write automation, workflow changes, product runtime, semantic cache, graph truth, fixed-mapping authority, or review-thread authority.

## Files changed / likely touched

- `docs/orchestration/contracts/CREATIVE_SPEC_PATCH_ADMISSION_CONTRACT.md`
- `docs/orchestration/contracts/creative_spec_patch_human_admission.v1.schema.json`
- `docs/orchestration/contracts/creative_spec_patch_admission.v1.schema.json`
- `scripts/orchestration/creative_spec_patch_admission_contract.py`
- `scripts/orchestration/creative_spec_patch_admission.py`
- `tests/test_creative_spec_patch_admission.py`
- `scripts/AGENTS.md`
- `docs/orchestration/GOVERNED_CREATIVE_CODE_EXECUTION_CONTRACT.md`
- `docs/roadmap/BACKLOG_LEDGER.md`

## Key decisions

- Request construction delegates to existing `build_creative_code_patch_build_request(...)` and revalidates through `validate_creative_code_patch_build_request(...)`; this PR does not duplicate PR-2 request logic.
- The admission artifact separates prepare-only executed effects from the existing PR-2 request authority.
- `prepare-builder` writes only existing builder prepare artifacts: `request.json`, `source_bundle.json`, `selected_variant.json`, and `state.json` under `patch_runs/<run-id>/`.
- `validate` and `summarize` re-check current `origin/main` binding to avoid stale-base false green reports.

## Risk & Impact

- [ ] User-facing change
- [ ] Data model/migration
- [x] Security-sensitive
- [ ] Performance-sensitive

Security-sensitive because this touches orchestration authority and local artifact admission boundaries. The implementation stays local-only and fail-closed.

## Premortem

Mode: `pr-premortem` on actual diff. Decision: proceed with changes; findings are closed in this PR surface.

Findings and closure:

- Authority drift from prepare-only to PR-2 generation/evaluation: closed by separate admission authority/executed-effects validation and no-generate/evaluate tests.
- Stale `origin/main` false green: closed by exact `origin/main` checks in build, validate, summarize, and prepare flows plus stale-base tests.
- Candidate patch accidentally produced during prepare: closed by builder prepare summary checks for no `candidate.patch`, no `result.json`, and false generated/evaluated flags.
- Partial run-dir cleanup trap: closed by fail-closed cleanup behavior plus injected prepare-failure and invalid-prepare-proof cleanup tests.
- Schema/contract drift: closed by closed JSON schemas and request-building delegation to existing PR-2 validator.

## Test Plan

- [x] Unit tests updated/added
- [x] Integration/slow tests (if applicable)
- [x] Manual verification steps

Local evidence:

- `python scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration/contracts --path docs/roadmap/BACKLOG_LEDGER.md --path tests` PASS.
- `python scripts/orchestration/check_agent_consistency.py` PASS.
- `python -m pytest -q tests/test_creative_spec_patch_admission.py` PASS: 15 passed after post-open bug-hunter fixes.
- `python -m pytest -q tests/test_creative_code_patch_builder.py tests/test_creative_code_specification.py tests/test_creative_specification_skeptic_review.py tests/test_creative_hypothesis_spec_bridge.py tests/test_creative_spec_learning_rollup.py tests/test_task_bootstrap.py tests/test_creative_spec_patch_admission.py` PASS.
- `make validate-changed` PASS after the latest mapping commit: selected `tests/test_creative_spec_patch_admission.py`, 15 passed.
- `pre-commit run --all-files` PASS after the latest mapping commit.
- Push hook PASS: mypy changed files, backend pre-push tests, full-repo Bandit, docker build test.
- CLI smoke: `python -m scripts.orchestration.creative_spec_patch_admission --help` PASS.
- `python scripts/orchestration/check_review_threads_disposition.py --pr-number 2080` PASS after resolving all 4 mapped CodeRabbit threads.
- `python scripts/ci/check_pr_merge_readiness.py --pr-number 2080 --repo Katsiarynakavaleuskaya/PulsePlate` PASS locally with `GITHUB_TOKEN` exported from `gh auth token`: review governance only, 0 unresolved threads, all actionable bot comments mapped.
- `python -m flake8 scripts/orchestration/creative_spec_patch_admission_contract.py` PASS after bug-hunter rerun import fix.

Experiment Runner oracle-only evidence:

- Zero-network attempt: rejected as `infra_flake` before oracle execution because local sandbox reported `Network-disabled sandbox requires unshare on PATH`.
- Accepted fallback: `artifacts/orchestration/experiments/results/er-creative-spec-patch-admission-oracle-result-network-fallback.json`, experiment `exp-df392704ff9d`, mode `oracle_only_governance_reviewer`, status `accepted`, failure_class `None`, 2/2 oracle commands executed, `mutated_paths=[]`, shared tree untouched.

## CI Gates

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage >= 97% on changed lines

Current-head GitHub CI is pending after `cfa7099d2`. No merge-readiness claim is made here.

## Split Justification

Required because this PR is >800 changed LoC under Tier 1 governance.

- Why this PR cannot be split safely: the Python validator/CLI, JSON schemas, docs contract, and focused tests form one closed admission contract; splitting would leave undocumented or untested authority surfaces.
- What invariant, contract, or rollout constraint requires one PR: prepare-only admission must be enforced consistently across schema, code, docs, and tests before it can be used as a patch-builder handoff.
- What follow-up PRs remain after this large change: no generation/evaluation follow-up is opened by this PR; later work must separately authorize any PR-2 generate/evaluate or promotion expansion.

## Security notes

- No secrets, provider calls, network calls, GitHub/Slack writes, product runtime calls, semantic-cache writes, or graph-truth writes.
- `candidate.patch` and `result.json` are explicitly forbidden in prepare proof.
- Dirty shared worktree and stale `origin/main` are fail-closed.
- Partial new run-dir cleanup now covers both prepare exceptions and post-prepare proof rejection, including forbidden `candidate.patch` output.

## Risks / rollback

Risk: an operator may misread a valid PR-2 request as permission to run generation. Mitigation: admission artifact and docs separate prepare-only executed authority from PR-2 request authority.

Rollback: revert commit `598ce1e94` to remove the admission CLI, contracts, schemas, tests, and governance docs updates. No migration or runtime toggle is involved.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] All 4 CodeRabbit review threads resolved after concrete disposition proof.
- [x] Post-open bug-hunter findings fixed in `1ea21520401f0e44cb00ee1c7287571f16a269a9`; bug-hunter rerun stale-import finding fixed in `52f400a7b8c7f92b4aee9fad7f8507f2682a613b`; mapping commits are `cfa7099d21aca46c366d7d4ac04f0e4c673a63c4`, `2c76793575da92360a8ad7750eb97b2bc3e91bd0`, `e0c28597eea46baefb2d010fbe6bdf695520ffa4`, and `73db9bdd2cd4271d968308a35e265f25ec653a78`.

### Fixed in Commit Mapping

- Canonical artifact: `docs/review/PR_2080_FIXED_MAPPING.md`.
- `pullrequestreview-4631302269` -> `1ea21520401f0e44cb00ee1c7287571f16a269a9`
- `discussion_r3524885014` -> `1ea21520401f0e44cb00ee1c7287571f16a269a9`
- `discussion_r3524885015` -> `f6b96ef4286f69ecce03a8db80af41abfcff19bc`
- `discussion_r3524885016` -> `1ea21520401f0e44cb00ee1c7287571f16a269a9`
- `discussion_r3524885018` -> `f6b96ef4286f69ecce03a8db80af41abfcff19bc`

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

This PR is ready for review, not declared merge-ready. Trivy ignore-policy expiry remains out of scope here and is expected to clear only after PR #2081 merges to `main`.

## Deferred / Follow-ups

- [x] Ledger item(s): `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-governed-creative-code-execution-lane`
- [ ] GitHub issue(s): None

## AGENTS.md or agent-instruction updates

Updated `scripts/AGENTS.md` with the new prepare-only creative spec patch admission boundary.

## Next best step

Post-open remaining pass: rerun `bug-hunter`, then `security-auditor -> Codex Security diff scan -> pulseplate-pr-review`, then handle any new bot/review findings with concrete fixes or dispositions. Trivy gate waits for PR #2081 in `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admits finalized creative-code specs into PR-2 `CreativeCodePatchBuildRequest`s and runs patch-builder in prepare-only mode. Adds a closed admission contract, strict schemas, and a CLI that validates authority and artifacts without enabling generation or evaluation.

- **New Features**
  - Closed admission contract and JSON schemas for finalized spec bundles.
  - CLI with `build-request`, `validate`, `prepare-only`, and `summarize`.
  - Prepare-only writes `request.json`, `source_bundle.json`, `selected_variant.json`, `state.json`; forbids `candidate.patch` and `result.json`.
  - Fail-closed and local-only; updated governance docs and `scripts/AGENTS.md`.

- **Bug Fixes**
  - Aligned schemas and validator with enforced proof; stronger negative cases and drift protections.
  - Cleanup of invalid/aborted prepare runs to remove partial run dirs.
  - Removed a stale import in the admission CLI.
  - Updated the fixed-mapping record and added a bug-hunter proof link.

<sup>Written for commit 73db9bdd2cd4271d968308a35e265f25ec653a78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a governed, prepare-only creative-spec patch admission CLI that writes deterministic admission and patch-builder request artifacts with clear status/summaries.
  * Introduced new orchestration contracts and strict JSON Schemas for admission and human approval validation.
* **Bug Fixes**
  * Strengthened base-commit matching, worktree cleanliness, artifact/ref binding consistency, and allowed-path enforcement.
  * Improved failure-closed behavior and cleanup to prevent partial or prohibited outputs.
* **Documentation**
  * Updated the roadmap/ledger, governance guidance, and added a PR review record for the new admission step.
* **Tests**
  * Added end-to-end tests covering success, validation failures, schema conformance, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





