### PR TITLE
fix(ci): stabilize legacy premium wrapper tests

### DIFF
--- a/docs/review/PR_2086_FIXED_MAPPING.md
+++ b/docs/review/PR_2086_FIXED_MAPPING.md
@@ -94,6 +94,7 @@ Artifact:
 - `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_route_family_bootstrap.py tests/test_legacy_premium_nutrition_registration_bootstrap.py` - PASS, `45 passed`.
 - `make validate-changed` - PASS.
 - `pre-commit run --all-files` - PASS.
+- `python3 scripts/ci/check_pr_size_governance.py --base-sha 0fea9394a78d75856a37acbd639746b4b00fdbbc --head-sha HEAD --body "$(gh pr view 2086 --json body --jq .body)"` - PASS.
 - Push hook - PASS, including backend pre-push tests, full-repo Bandit,
   pip-audit, and Docker build test skip/no files.
 

--- a/docs/review/PR_2086_FIXED_MAPPING.md
+++ b/docs/review/PR_2086_FIXED_MAPPING.md
@@ -18,13 +18,28 @@ the potentially stale `app_main._legacy_module` alias to the live runtime
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2086#pullrequestreview-4637062224 -> 03e4af380f7bef767e108b078007af641dacefcd
+Commit: 03e4af380f7bef767e108b078007af641dacefcd
+Evidence: `tests/test_route_family_bootstrap.py:20`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:21`, `tests/helpers/module_resolve.py:7`, `tests/helpers/module_resolve.py:17`
+Reason: The duplicated local `_runtime_legacy_module()` helpers were removed and both test files now reuse the existing shared runtime module resolver.
+
+Disposition: FIXED
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2086#pullrequestreview-4637102071 -> 03e4af380f7bef767e108b078007af641dacefcd
+Commit: 03e4af380f7bef767e108b078007af641dacefcd
+Evidence: `tests/test_route_family_bootstrap.py:20`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:21`, `tests/helpers/module_resolve.py:7`, `tests/helpers/module_resolve.py:17`
+Reason: CodeRabbit's duplicate-helper and type-precision feedback is addressed by reusing `resolve_legacy_app()`, whose shared helper returns `ModuleType`.
+
+Disposition: NOT-A-BUG
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2086#pullrequestreview-4637062224
+Evidence: `tests/helpers/module_resolve.py:7`, `tests/helpers/module_resolve.py:10`, `tests/helpers/module_resolve.py:14`
+Reason: Caching the imported `legacy_app` module would weaken the regression guard. The original `main` failure came from stale module identity under purge/reload order, so these tests must resolve the module at monkeypatch time.
 
 ## Implementation Evidence
 
 Disposition: FIXED
 Commit: e0da71dd3bb0f30a3b220f4d0d9c3a219c5810ca
-Evidence: `tests/test_route_family_bootstrap.py:132`, `tests/test_route_family_bootstrap.py:264`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:210`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:237`
+Evidence: `tests/test_route_family_bootstrap.py:20`, `tests/test_route_family_bootstrap.py:263`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:21`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:236`, `tests/helpers/module_resolve.py:17`
 Reason: Post-merge `main` CI showed that six wrapper delegation tests patched a stale legacy module alias under full-suite import/reload order. The fix resolves the live `legacy_app` module before patching the six delegate handlers while preserving object-identity and request-identity assertions.
 
 ## Main CI Failure Evidence

--- a/docs/review/PR_2086_FIXED_MAPPING.md
+++ b/docs/review/PR_2086_FIXED_MAPPING.md
@@ -35,6 +35,12 @@ Disposition: NOT-A-BUG
 Evidence: `tests/helpers/module_resolve.py:7`, `tests/helpers/module_resolve.py:10`, `tests/helpers/module_resolve.py:14`
 Reason: Caching the imported `legacy_app` module would weaken the regression guard. The original `main` failure came from stale module identity under purge/reload order, so these tests must resolve the module at monkeypatch time.
 
+Disposition: FIXED
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2086#pullrequestreview-4637212776 -> db6b9e1ccde83da40e3966e67365fc7917a5ff07
+Commit: db6b9e1ccde83da40e3966e67365fc7917a5ff07
+Evidence: `tests/test_route_family_bootstrap.py:120`, `tests/test_route_family_bootstrap.py:241`, `tests/test_route_family_bootstrap.py:413`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:198`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:214`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:386`
+Reason: Wrapper request/response fixture construction now uses `resolve_legacy_app()` too, so the tests no longer rely on `app_main._legacy_module` staying current for the runtime objects they pass into delegated wrappers.
+
 ## Implementation Evidence
 
 Disposition: FIXED

--- a/docs/review/PR_2086_FIXED_MAPPING.md
+++ b/docs/review/PR_2086_FIXED_MAPPING.md
@@ -1,0 +1,89 @@
+# PR 2086 - Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2086
+
+Branch: `codex/fix-main-premium-wrapper-route-tests`
+
+## Summary
+
+This PR fixes post-merge `main` CI failures in the legacy premium nutrition
+route-family wrapper delegation tests. It changes test monkeypatch targets from
+the potentially stale `app_main._legacy_module` alias to the live runtime
+`legacy_app` module that the wrappers import at call time.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Implementation Evidence
+
+Disposition: FIXED
+Commit: e0da71dd3bb0f30a3b220f4d0d9c3a219c5810ca
+Evidence: `tests/test_route_family_bootstrap.py:132`, `tests/test_route_family_bootstrap.py:264`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:210`, `tests/test_legacy_premium_nutrition_registration_bootstrap.py:237`
+Reason: Post-merge `main` CI showed that six wrapper delegation tests patched a stale legacy module alias under full-suite import/reload order. The fix resolves the live `legacy_app` module before patching the six delegate handlers while preserving object-identity and request-identity assertions.
+
+## Main CI Failure Evidence
+
+- `main` CI run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/28796797871
+- Failed job: `test-main (3.11, 60)` / job `85389472234`.
+- Failed job: `test-main (3.12, 90)` / job `85389472322`.
+- Failure class: six failures in `tests/test_route_family_bootstrap.py` where
+  `assert response is expected` failed because real legacy responses were
+  returned instead of monkeypatched fake delegates.
+
+## Role-Agent Evidence
+
+- Lane packet: `artifacts/orchestration/task_packets/8dcf55324443.json`
+- Pre-open role order completed:
+  `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor`.
+- Security-auditor verdict: no production files changed; no auth, tier,
+  API-key, OpenAPI, or route-registration behavior changed; no skip, xfail,
+  nosec, type-ignore, pragma weakening, or fail-open pattern introduced.
+
+## Premortem Evidence
+
+- Artifact:
+  `artifacts/orchestration/premortem/fix-main-premium-wrapper-route-tests-premortem.md`
+- Decision: `proceed with changes`; patch the live runtime module and require
+  current-head CI as the heavy matrix signal.
+
+## Experiment Runner Evidence
+
+Packet:
+`artifacts/orchestration/experiments/artifacts/orchestration/experiments/fix-main-premium-wrapper-route-tests-oracle-packet.json`
+
+Artifact:
+`artifacts/orchestration/experiments/results/artifacts/orchestration/experiments/results/fix-main-premium-wrapper-route-tests-oracle-result.json`
+- Experiment id: `exp-1287ead84df4`
+- Mode: `oracle_only_governance_reviewer`
+- Result: `accepted`
+- Contribution kind: `oracle_review`
+- `coauthor_required=true`
+- Commit carrying required trailer:
+  `e0da71dd3bb0f30a3b220f4d0d9c3a219c5810ca`
+- Oracle commands passed:
+  - `python3 -m pytest -q tests/test_route_family_bootstrap.py tests/test_legacy_premium_nutrition_registration_bootstrap.py -k "wrapper_delegates"`
+  - `python3 -m pytest -q tests/test_route_family_bootstrap.py tests/test_legacy_premium_nutrition_registration_bootstrap.py`
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` - PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
+- `git diff --check` - PASS.
+- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_route_family_bootstrap.py tests/test_legacy_premium_nutrition_registration_bootstrap.py -k 'wrapper_delegates'` - PASS, `12 passed`.
+- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_route_family_bootstrap.py tests/test_legacy_premium_nutrition_registration_bootstrap.py` - PASS, `45 passed`.
+- `make validate-changed` - PASS.
+- `pre-commit run --all-files` - PASS.
+- Push hook - PASS, including backend pre-push tests, full-repo Bandit,
+  pip-audit, and Docker build test skip/no files.
+
+## Merge Readiness
+
+Not claimed here. Requires current-head GitHub CI on PR #2086, strict
+merge-readiness wrapper, bot/review disposition pass, and post-open role/security
+review chain.

--- a/tests/test_legacy_premium_nutrition_registration_bootstrap.py
+++ b/tests/test_legacy_premium_nutrition_registration_bootstrap.py
@@ -195,7 +195,8 @@ def test_legacy_premium_nutrition_route_members_encode_api_key_exception() -> No
 
 
 def _who_targets_response() -> app_main._legacy_module.WHOTargetsResponse:
-    return app_main._legacy_module.WHOTargetsResponse(
+    legacy_module = resolve_legacy_app()
+    return legacy_module.WHOTargetsResponse(
         kcal_daily=1900,
         macros={"protein_g": 95, "fat_g": 63, "carbs_g": 238, "fiber_g": 28},
         water_ml=2200,
@@ -203,14 +204,15 @@ def _who_targets_response() -> app_main._legacy_module.WHOTargetsResponse:
         activity_weekly={"minutes": 150},
         calculation_date="2026-07-06",
         warnings=[],
-        ui_labels=app_main._legacy_module.build_who_targets_ui_labels("en"),
+        ui_labels=legacy_module.build_who_targets_ui_labels("en"),
     )
 
 
 def test_legacy_premium_plate_wrapper_delegates_to_legacy_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.PlateRequest(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.PlateRequest(
         sex="female",
         age=34,
         height_cm=168,
@@ -218,7 +220,7 @@ def test_legacy_premium_plate_wrapper_delegates_to_legacy_app(
         activity="light",
         goal="maintain",
     )
-    expected = app_main._legacy_module.PlateResponse(
+    expected = legacy_module.PlateResponse(
         kcal=1900,
         macros={"protein_g": 95, "fat_g": 63, "carbs_g": 238},
         portions={"vegetables": 0.5, "protein": 0.25, "grains": 0.25},
@@ -244,14 +246,15 @@ def test_legacy_premium_plate_wrapper_delegates_to_legacy_app(
 def test_legacy_premium_api_bmr_wrapper_delegates_to_legacy_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.BMRRequest(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.BMRRequest(
         weight_kg=70,
         height_cm=175,
         age=35,
         sex="male",
         activity="moderate",
     )
-    expected = app_main._legacy_module.BMRResponse(
+    expected = legacy_module.BMRResponse(
         bmr={"mifflin": 1650.0},
         tdee={"mifflin": 2557.5},
         activity_level="moderate",
@@ -282,14 +285,15 @@ def test_legacy_premium_api_bmr_wrapper_delegates_to_legacy_app(
 def test_legacy_premium_bmr_wrapper_delegates_to_legacy_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.BMRRequestLegacy(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.BMRRequestLegacy(
         weight_kg=70,
         height_cm=175,
         age=35,
         sex="male",
         activity="moderate",
     )
-    expected = app_main._legacy_module.BMRResponse(
+    expected = legacy_module.BMRResponse(
         bmr={"mifflin": 1650.0},
         tdee={"mifflin": 2557.5},
         activity_level="moderate",
@@ -320,7 +324,8 @@ def test_legacy_premium_bmr_wrapper_delegates_to_legacy_app(
 def test_legacy_premium_targets_wrapper_delegates_to_legacy_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.WHOTargetsRequest(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.WHOTargetsRequest(
         sex="female",
         age=34,
         height_cm=168,
@@ -378,9 +383,10 @@ def test_legacy_premium_api_targets_wrapper_delegates_to_legacy_app(
 def test_legacy_premium_gaps_wrapper_delegates_to_legacy_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.NutrientGapsRequest(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.NutrientGapsRequest(
         consumed_nutrients={"iron_mg": 10.0},
-        user_profile=app_main._legacy_module.WHOTargetsRequest(
+        user_profile=legacy_module.WHOTargetsRequest(
             sex="female",
             age=34,
             height_cm=168,
@@ -388,7 +394,7 @@ def test_legacy_premium_gaps_wrapper_delegates_to_legacy_app(
             activity="light",
         ),
     )
-    expected = app_main._legacy_module.NutrientGapsResponse(
+    expected = legacy_module.NutrientGapsResponse(
         gaps={"iron_mg": {"status": "low", "delta": -8.0}},
         food_recommendations=["lentils"],
         adherence_score=0.85,

--- a/tests/test_legacy_premium_nutrition_registration_bootstrap.py
+++ b/tests/test_legacy_premium_nutrition_registration_bootstrap.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 from collections import Counter
 from collections.abc import Callable
 
@@ -19,6 +18,7 @@ from app.effective_routes import (
     route_methods,
     route_path,
 )
+from tests.helpers.module_resolve import resolve_legacy_app
 
 _EXPECTED_ROUTE_SPECS = app_main._LEGACY_PREMIUM_NUTRITION_ROUTE_SPECS
 _EXPECTED_ROUTE_KEYS = {
@@ -207,10 +207,6 @@ def _who_targets_response() -> app_main._legacy_module.WHOTargetsResponse:
     )
 
 
-def _runtime_legacy_module() -> object:
-    return importlib.import_module("legacy_app")
-
-
 def test_legacy_premium_plate_wrapper_delegates_to_legacy_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -237,7 +233,7 @@ def test_legacy_premium_plate_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "api_premium_plate", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "api_premium_plate", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_premium_plate(req))
 
@@ -275,7 +271,7 @@ def test_legacy_premium_api_bmr_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "api_premium_bmr", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "api_premium_bmr", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_premium_bmr(req))
 
@@ -313,7 +309,7 @@ def test_legacy_premium_bmr_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "premium_bmr_legacy", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "premium_bmr_legacy", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.premium_bmr_legacy(req))
 
@@ -341,7 +337,7 @@ def test_legacy_premium_targets_wrapper_delegates_to_legacy_app(
         return expected
 
     monkeypatch.setattr(
-        _runtime_legacy_module(),
+        resolve_legacy_app(),
         "premium_targets_legacy",
         _fake_legacy_handler,
     )
@@ -371,7 +367,7 @@ def test_legacy_premium_api_targets_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "api_who_targets", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "api_who_targets", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_who_targets(payload))
 
@@ -405,7 +401,7 @@ def test_legacy_premium_gaps_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "api_nutrient_gaps", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "api_nutrient_gaps", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_nutrient_gaps(req))
 

--- a/tests/test_legacy_premium_nutrition_registration_bootstrap.py
+++ b/tests/test_legacy_premium_nutrition_registration_bootstrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 from collections import Counter
 from collections.abc import Callable
 
@@ -206,6 +207,10 @@ def _who_targets_response() -> app_main._legacy_module.WHOTargetsResponse:
     )
 
 
+def _runtime_legacy_module() -> object:
+    return importlib.import_module("legacy_app")
+
+
 def test_legacy_premium_plate_wrapper_delegates_to_legacy_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -232,7 +237,7 @@ def test_legacy_premium_plate_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "api_premium_plate", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "api_premium_plate", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_premium_plate(req))
 
@@ -270,7 +275,7 @@ def test_legacy_premium_api_bmr_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "api_premium_bmr", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "api_premium_bmr", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_premium_bmr(req))
 
@@ -308,7 +313,7 @@ def test_legacy_premium_bmr_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "premium_bmr_legacy", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "premium_bmr_legacy", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.premium_bmr_legacy(req))
 
@@ -336,7 +341,7 @@ def test_legacy_premium_targets_wrapper_delegates_to_legacy_app(
         return expected
 
     monkeypatch.setattr(
-        app_main._legacy_module,
+        _runtime_legacy_module(),
         "premium_targets_legacy",
         _fake_legacy_handler,
     )
@@ -366,7 +371,7 @@ def test_legacy_premium_api_targets_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "api_who_targets", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "api_who_targets", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_who_targets(payload))
 
@@ -400,7 +405,7 @@ def test_legacy_premium_gaps_wrapper_delegates_to_legacy_app(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "api_nutrient_gaps", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "api_nutrient_gaps", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_nutrient_gaps(req))
 

--- a/tests/test_route_family_bootstrap.py
+++ b/tests/test_route_family_bootstrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 from collections.abc import Sequence
 
 import pytest
@@ -126,6 +127,10 @@ def _who_targets_response() -> app_main._legacy_module.WHOTargetsResponse:
         warnings=[],
         ui_labels=app_main._legacy_module.build_who_targets_ui_labels("en"),
     )
+
+
+def _runtime_legacy_module() -> object:
+    return importlib.import_module("legacy_app")
 
 
 def _matching_routes(app: FastAPI, member: RouteMemberContract) -> list[object]:
@@ -259,7 +264,7 @@ def test_legacy_premium_plate_wrapper_delegates_inside_route_family_ci_suite(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "api_premium_plate", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "api_premium_plate", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_premium_plate(req))
 
@@ -297,7 +302,7 @@ def test_legacy_premium_api_bmr_wrapper_delegates_inside_route_family_ci_suite(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "api_premium_bmr", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "api_premium_bmr", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_premium_bmr(req))
 
@@ -335,7 +340,7 @@ def test_legacy_premium_bmr_wrapper_delegates_inside_route_family_ci_suite(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "premium_bmr_legacy", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "premium_bmr_legacy", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.premium_bmr_legacy(req))
 
@@ -363,7 +368,7 @@ def test_legacy_premium_targets_wrapper_delegates_inside_route_family_ci_suite(
         return expected
 
     monkeypatch.setattr(
-        app_main._legacy_module,
+        _runtime_legacy_module(),
         "premium_targets_legacy",
         _fake_legacy_handler,
     )
@@ -393,7 +398,7 @@ def test_legacy_premium_api_targets_wrapper_delegates_inside_route_family_ci_sui
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "api_who_targets", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "api_who_targets", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_who_targets(payload))
 
@@ -427,7 +432,7 @@ def test_legacy_premium_gaps_wrapper_delegates_inside_route_family_ci_suite(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(app_main._legacy_module, "api_nutrient_gaps", _fake_legacy_handler)
+    monkeypatch.setattr(_runtime_legacy_module(), "api_nutrient_gaps", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_nutrient_gaps(req))
 

--- a/tests/test_route_family_bootstrap.py
+++ b/tests/test_route_family_bootstrap.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 from collections.abc import Sequence
 
 import pytest
@@ -18,6 +17,7 @@ from app.bootstrap.route_family import (
     same_callable_by_module_and_qualname,
 )
 from app.routers import legacy_premium_nutrition
+from tests.helpers.module_resolve import resolve_legacy_app
 
 
 async def _api_key_dependency() -> str:
@@ -127,10 +127,6 @@ def _who_targets_response() -> app_main._legacy_module.WHOTargetsResponse:
         warnings=[],
         ui_labels=app_main._legacy_module.build_who_targets_ui_labels("en"),
     )
-
-
-def _runtime_legacy_module() -> object:
-    return importlib.import_module("legacy_app")
 
 
 def _matching_routes(app: FastAPI, member: RouteMemberContract) -> list[object]:
@@ -264,7 +260,7 @@ def test_legacy_premium_plate_wrapper_delegates_inside_route_family_ci_suite(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "api_premium_plate", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "api_premium_plate", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_premium_plate(req))
 
@@ -302,7 +298,7 @@ def test_legacy_premium_api_bmr_wrapper_delegates_inside_route_family_ci_suite(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "api_premium_bmr", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "api_premium_bmr", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_premium_bmr(req))
 
@@ -340,7 +336,7 @@ def test_legacy_premium_bmr_wrapper_delegates_inside_route_family_ci_suite(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "premium_bmr_legacy", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "premium_bmr_legacy", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.premium_bmr_legacy(req))
 
@@ -368,7 +364,7 @@ def test_legacy_premium_targets_wrapper_delegates_inside_route_family_ci_suite(
         return expected
 
     monkeypatch.setattr(
-        _runtime_legacy_module(),
+        resolve_legacy_app(),
         "premium_targets_legacy",
         _fake_legacy_handler,
     )
@@ -398,7 +394,7 @@ def test_legacy_premium_api_targets_wrapper_delegates_inside_route_family_ci_sui
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "api_who_targets", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "api_who_targets", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_who_targets(payload))
 
@@ -432,7 +428,7 @@ def test_legacy_premium_gaps_wrapper_delegates_inside_route_family_ci_suite(
         captured["request"] = received
         return expected
 
-    monkeypatch.setattr(_runtime_legacy_module(), "api_nutrient_gaps", _fake_legacy_handler)
+    monkeypatch.setattr(resolve_legacy_app(), "api_nutrient_gaps", _fake_legacy_handler)
 
     response = asyncio.run(legacy_premium_nutrition.api_nutrient_gaps(req))
 

--- a/tests/test_route_family_bootstrap.py
+++ b/tests/test_route_family_bootstrap.py
@@ -117,7 +117,8 @@ def _ensure(
 
 
 def _who_targets_response() -> app_main._legacy_module.WHOTargetsResponse:
-    return app_main._legacy_module.WHOTargetsResponse(
+    legacy_module = resolve_legacy_app()
+    return legacy_module.WHOTargetsResponse(
         kcal_daily=1900,
         macros={"protein_g": 95, "fat_g": 63, "carbs_g": 238, "fiber_g": 28},
         water_ml=2200,
@@ -125,7 +126,7 @@ def _who_targets_response() -> app_main._legacy_module.WHOTargetsResponse:
         activity_weekly={"minutes": 150},
         calculation_date="2026-07-06",
         warnings=[],
-        ui_labels=app_main._legacy_module.build_who_targets_ui_labels("en"),
+        ui_labels=legacy_module.build_who_targets_ui_labels("en"),
     )
 
 
@@ -237,7 +238,8 @@ def test_static_route_family_registration_is_idempotent() -> None:
 def test_legacy_premium_plate_wrapper_delegates_inside_route_family_ci_suite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.PlateRequest(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.PlateRequest(
         sex="female",
         age=34,
         height_cm=168,
@@ -245,7 +247,7 @@ def test_legacy_premium_plate_wrapper_delegates_inside_route_family_ci_suite(
         activity="light",
         goal="maintain",
     )
-    expected = app_main._legacy_module.PlateResponse(
+    expected = legacy_module.PlateResponse(
         kcal=1900,
         macros={"protein_g": 95, "fat_g": 63, "carbs_g": 238},
         portions={"vegetables": 0.5, "protein": 0.25, "grains": 0.25},
@@ -271,14 +273,15 @@ def test_legacy_premium_plate_wrapper_delegates_inside_route_family_ci_suite(
 def test_legacy_premium_api_bmr_wrapper_delegates_inside_route_family_ci_suite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.BMRRequest(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.BMRRequest(
         weight_kg=70,
         height_cm=175,
         age=35,
         sex="male",
         activity="moderate",
     )
-    expected = app_main._legacy_module.BMRResponse(
+    expected = legacy_module.BMRResponse(
         bmr={"mifflin": 1650.0},
         tdee={"mifflin": 2557.5},
         activity_level="moderate",
@@ -309,14 +312,15 @@ def test_legacy_premium_api_bmr_wrapper_delegates_inside_route_family_ci_suite(
 def test_legacy_premium_bmr_wrapper_delegates_inside_route_family_ci_suite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.BMRRequestLegacy(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.BMRRequestLegacy(
         weight_kg=70,
         height_cm=175,
         age=35,
         sex="male",
         activity="moderate",
     )
-    expected = app_main._legacy_module.BMRResponse(
+    expected = legacy_module.BMRResponse(
         bmr={"mifflin": 1650.0},
         tdee={"mifflin": 2557.5},
         activity_level="moderate",
@@ -347,7 +351,8 @@ def test_legacy_premium_bmr_wrapper_delegates_inside_route_family_ci_suite(
 def test_legacy_premium_targets_wrapper_delegates_inside_route_family_ci_suite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.WHOTargetsRequest(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.WHOTargetsRequest(
         sex="female",
         age=34,
         height_cm=168,
@@ -405,9 +410,10 @@ def test_legacy_premium_api_targets_wrapper_delegates_inside_route_family_ci_sui
 def test_legacy_premium_gaps_wrapper_delegates_inside_route_family_ci_suite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    req = app_main._legacy_module.NutrientGapsRequest(
+    legacy_module = resolve_legacy_app()
+    req = legacy_module.NutrientGapsRequest(
         consumed_nutrients={"iron_mg": 10.0},
-        user_profile=app_main._legacy_module.WHOTargetsRequest(
+        user_profile=legacy_module.WHOTargetsRequest(
             sex="female",
             age=34,
             height_cm=168,
@@ -415,7 +421,7 @@ def test_legacy_premium_gaps_wrapper_delegates_inside_route_family_ci_suite(
             activity="light",
         ),
     )
-    expected = app_main._legacy_module.NutrientGapsResponse(
+    expected = legacy_module.NutrientGapsResponse(
         gaps={"iron_mg": {"status": "low", "delta": -8.0}},
         food_recommendations=["lentils"],
         adherence_score=0.85,


### PR DESCRIPTION
## Goal
Fix post-merge `main` CI failures in the legacy premium nutrition route-family wrapper delegation tests without changing production route behavior.

## Business reason
`main` is red after PR #2084 because the heavy `test-main` matrix exposed a full-suite import/reload ordering problem in tests. This PR restores backend CI signal so the legacy route-extraction train can continue from a stable main.

## Scope
- Update legacy premium wrapper delegation tests in `tests/test_route_family_bootstrap.py` to patch the live runtime `legacy_app` module through the shared runtime resolver.
- Apply the same shared resolver pattern in `tests/test_legacy_premium_nutrition_registration_bootstrap.py` so the duplicate wrapper coverage stays aligned.
- Keep identity assertions and request/payload capture assertions unchanged.

## Out of scope
- No production code changes.
- No formula, payload, entitlement, API-key, OpenAPI, route-registration, or canonical PRO behavior changes.
- No skips, xfails, coverage weakening, suppressions, or allowlists.

## Failure Evidence
- `main` CI run `28796797871` failed after merge commit `0fea9394a78d75856a37acbd639746b4b00fdbbc`.
- Failed jobs: `test-main (3.11, 60)` job `85389472234`, `test-main (3.12, 90)` job `85389472322`.
- Raw failure class: six `tests/test_route_family_bootstrap.py` wrapper tests asserted `response is expected`, but real `PlateResponse` / `BMRResponse` / `WHOTargetsResponse` / `NutrientGapsResponse` objects were returned.

## Root Cause
The tests patched `app_main._legacy_module`, while `app/routers/legacy_premium_nutrition.py` imports delegates from `legacy_app` at call time. In full-suite CI order, prior module reload/purge behavior can make `app_main._legacy_module` stale, so the monkeypatch misses the actual handler used by the wrapper.

## Key Decisions
- Reuse `tests.helpers.module_resolve.resolve_legacy_app()`, which resolves `legacy_app` at monkeypatch time, before patching delegate handlers.
- Keep the wrapper tests direct and explicit instead of parameterizing during a main-red hotfix.
- Leave production wrappers unchanged because the failure is test-isolation evidence, not runtime behavior evidence.

## Tests
- `python3 scripts/orchestration/check_preflight.py` - PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_route_family_bootstrap.py tests/test_legacy_premium_nutrition_registration_bootstrap.py -k 'wrapper_delegates'` - PASS, `12 passed`.
- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/test_route_family_bootstrap.py tests/test_legacy_premium_nutrition_registration_bootstrap.py` - PASS, `45 passed`.
- `make validate-changed` - PASS; no Python/cross-surface files selected because this branch tracks `origin/main` and the focused pytest commands above cover the changed tests directly.
- `pre-commit run --all-files` - PASS.
- Push hook - PASS, including backend pre-push tests, full-repo Bandit, pip-audit, and Docker build test skip/no files.

## Role Evidence
- Lane packet: `artifacts/orchestration/task_packets/8dcf55324443.json`.
- Pre-open role order completed: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor`.
- Security-auditor verdict: no production files changed; no auth/tier/API-key/OpenAPI/route-registration behavior changed; no skip/xfail/nosec/type-ignore/pragma weakening introduced.

## Premortem Evidence
- Artifact: `artifacts/orchestration/premortem/fix-main-premium-wrapper-route-tests-premortem.md`.
- Decision: proceed with changes; fix must patch live runtime module and rely on current-head CI for heavy matrix signal.

## Experiment Runner Evidence
Packet: `artifacts/orchestration/experiments/artifacts/orchestration/experiments/fix-main-premium-wrapper-route-tests-oracle-packet.json`
Artifact: `artifacts/orchestration/experiments/results/artifacts/orchestration/experiments/results/fix-main-premium-wrapper-route-tests-oracle-result.json`
- Experiment id: `exp-1287ead84df4`.
- Mode: `oracle_only_governance_reviewer`.
- Status: accepted; both oracle pytest commands passed; `mutated_paths=[]`; shared tree untouched.
- Commit trailer required and present: `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

## Security Notes
- Test-only diff.
- No route/auth/dependency code changed.
- No manual Codex Security diff scan launched before PR open because this is not a material security diff; post-open security review remains required by lane governance.

## Risks / Rollback
Rollback is a straight revert of this PR; tests return to the prior stale-module patch target and `main` can fail again under full-suite import/reload order. Main residual risk is that isolated local tests cannot fully reproduce the heavy matrix order; current-head GitHub CI is required before any readiness claim.

## Lane Start Provenance
Packet: `artifacts/orchestration/task_packets/8dcf55324443.json`
Starter: `scripts/orchestration/start_pr_lane.sh`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2086_FIXED_MAPPING.md`.

## Merge Readiness
Not claimed. Requires current-head GitHub CI on this PR, strict merge-readiness wrapper, bot/review disposition pass, and post-open role/security review chain.

## Bot Review Dispositions
- Sourcery duplicate-helper feedback: FIXED in `03e4af380f7bef767e108b078007af641dacefcd`.
- CodeRabbit duplicate-helper/type-precision feedback: FIXED in `03e4af380f7bef767e108b078007af641dacefcd`.
- CodeRabbit runtime fixture-construction feedback: FIXED in `db6b9e1ccde83da40e3966e67365fc7917a5ff07`.
- Sourcery caching suggestion: NOT-A-BUG in `docs/review/PR_2086_FIXED_MAPPING.md`; runtime resolve is intentional for stale-module regression coverage.

## Deferred / Follow-ups
None.

## AGENTS.md / process updates
No AGENTS.md changes.

## Next best step
Open PR non-draft, add PR-numbered fixed-mapping artifact, then wait for current-head CI with focus on `test-main (3.11, 60)` and `test-main (3.12, 90)`.

## Summary by Sourcery

Стабилизировать устаревшие тесты делегирования обёртки премиального питания, патчащих живой модуль `legacy_app` вместо потенциально устаревшей ссылки на модуль `legacy`.

Tests:
- Обновить тесты делегирования обёртки в `test_route_family_bootstrap.py`, чтобы разрешать и monkeypatch-модуль времени выполнения `legacy_app` через `importlib`.
- Согласовать дублирующее покрытие обёртки в `test_legacy_premium_nutrition_registration_bootstrap.py` с тем же шаблоном патчинга выполняемого модуля `legacy_app`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize legacy premium nutrition wrapper delegation tests by patching the live legacy_app module instead of a potentially stale legacy module reference.

Tests:
- Update wrapper delegation tests in test_route_family_bootstrap.py to resolve and monkeypatch the runtime legacy_app module via importlib.
- Align duplicate wrapper coverage in test_legacy_premium_nutrition_registration_bootstrap.py with the same runtime legacy_app patching pattern.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes legacy premium nutrition wrapper tests by resolving and patching the live `legacy_app` at runtime and building fixtures from it. Fixes `main` CI flakiness with no production changes.

- **Bug Fixes**
  - Updated tests in `tests/test_route_family_bootstrap.py` and `tests/test_legacy_premium_nutrition_registration_bootstrap.py` to use `tests.helpers.module_resolve.resolve_legacy_app()` for delegate monkeypatching.
  - Constructed request/response fixtures from the runtime `legacy_app` (e.g., Plate, BMR, WHO Targets, Nutrient Gaps) to keep type identity consistent, including `_who_targets_response()` helpers.
  - Removed per-file helpers and avoided stale `app_main._legacy_module` references under full-suite import/reload order.

- **Docs**
  - Added `docs/review/PR_2086_FIXED_MAPPING.md` with fixed-in-commit mapping and updated notes covering fixture feedback.

<sup>Written for commit 09b446c55f3fada78c2144d16ec71e063a988aa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated legacy premium nutrition and route-family wrapper delegation tests to monkeypatch handlers on the runtime-resolved legacy module rather than a static bootstrap reference.
  * Scope includes premium plate, premium BMR, legacy premium targets, who targets, and nutrient gap flows, with existing assertions preserved.
* **Documentation**
  * Added a review write-up documenting the CI wrapper-delegation fix and including validation/merge-readiness notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



