### PR TITLE
test(ai): stabilize knowledge promotion error branch

### DIFF
--- a/docs/review/PR_2087_FIXED_MAPPING.md
+++ b/docs/review/PR_2087_FIXED_MAPPING.md
@@ -18,16 +18,22 @@ unchanged.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2087#pullrequestreview-4639030521 -> d680f2fed01bb9e82c55caa9eaa3e5f9b4835fe2
+Commit: d680f2fed01bb9e82c55caa9eaa3e5f9b4835fe2
+Evidence: `tests/test_remaining_modules.py`
+Reason: The store-error test now uses a module-object monkeypatch and `float("inf")` timeout sentinel, addressing Sourcery's determinism and refactor-resilience comments without changing production behavior.
 
 ## Implementation Evidence
 
 Disposition: FIXED
-Commit: 6d9d0022f5c0252cd59fe58691ecde9b074580cf
+Commit: 6d9d0022f5c0252cd59fe58691ecde9b074580cf,
+d680f2fed01bb9e82c55caa9eaa3e5f9b4835fe2
 Evidence: `tests/test_remaining_modules.py`
-Reason: The store-error test now raises `KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS`
-for that test only, so it exercises the intended `RuntimeError("boom")` branch
-instead of racing the timeout branch under the Python 3.12 CI shard.
+Reason: The store-error test now overrides `KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS`
+for that test only, using a timeout sentinel so it exercises the intended
+`RuntimeError("boom")` branch instead of racing the timeout branch under the
+Python 3.12 CI shard.
 
 ## Main CI Failure Evidence
 

--- a/docs/review/PR_2087_FIXED_MAPPING.md
+++ b/docs/review/PR_2087_FIXED_MAPPING.md
@@ -1,0 +1,70 @@
+# PR 2087 - Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2087
+
+Branch: `codex/fix-main-knowledge-promotion-timeout-test`
+
+## Summary
+
+This PR fixes the post-merge `main` CI failure in the knowledge-promotion
+store-error regression test. The test now isolates the intended store-error
+branch from the timeout branch, while production fail-soft behavior remains
+unchanged.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Implementation Evidence
+
+Disposition: FIXED
+Commit: 6d9d0022f5c0252cd59fe58691ecde9b074580cf
+Evidence: `tests/test_remaining_modules.py`
+Reason: The store-error test now raises `KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS`
+for that test only, so it exercises the intended `RuntimeError("boom")` branch
+instead of racing the timeout branch under the Python 3.12 CI shard.
+
+## Main CI Failure Evidence
+
+- `main` CI run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/28804293563
+- Failed job: `test-main (3.12, 90)` / job `85415810365`.
+- Failure:
+  `tests/test_remaining_modules.py::TestInsightApplicationServiceFastLane::test_maybe_promote_knowledge_candidates_logs_and_swallows_store_errors`
+  expected `Knowledge promotion failed` but observed
+  `Knowledge promotion timed out; response path continues without persistence`.
+
+## Role-Agent Notes
+
+- Lane packet: `artifacts/orchestration/task_packets/f63b2263dd01.json`
+- Role order requested:
+  `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor`.
+- Timed-out coordinator attempts were closed instead of left running:
+  `019f38d3-6468-7bd0-b349-187d10fcfc88`,
+  `019f38da-1e29-7781-92e3-0385c92fd74c`.
+
+## Experiment Runner Evidence
+
+Not applicable: runner was attempted but the local macOS sandbox rejected oracle
+execution because `unshare` is unavailable, so no accepted runner result shaped
+this commit.
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py --path tests/test_remaining_modules.py --path app/services/insight_application_service.py` - PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
+- `.venv/bin/python -m pytest -q tests/test_remaining_modules.py::TestInsightApplicationServiceFastLane::test_maybe_promote_knowledge_candidates_logs_and_swallows_store_errors` - PASS.
+- `.venv/bin/python -m pytest -q tests/test_remaining_modules.py -k 'maybe_promote_knowledge_candidates'` - PASS, `4 passed`.
+- `make validate-changed` - PASS.
+- `pre-commit run --all-files` - PASS.
+- Push hook - PASS, including backend pre-push tests, full-repo Bandit,
+  pip-audit, and Docker build test skip/no files.
+
+## Merge Readiness
+
+Not claimed here. Requires current-head GitHub CI, strict merge-readiness
+wrapper, and final bot/review disposition pass.

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -1368,6 +1368,12 @@ class TestInsightApplicationServiceFastLane:
                 del candidates
                 raise RuntimeError("boom")
 
+        # Isolate the store-error branch; timeout branches are covered below.
+        monkeypatch.setattr(
+            "app.services.insight_application_service.KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS",
+            5.0,
+            raising=True,
+        )
         monkeypatch.setattr(
             "app.services.insight_application_service.logger.warning",
             lambda *args, **kwargs: warnings.append((args, kwargs)),

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -1358,7 +1358,7 @@ class TestInsightApplicationServiceFastLane:
     ) -> None:
         """Store failures must not break the user response path."""
 
-        from app.services.insight_application_service import _maybe_promote_knowledge_candidates
+        from app.services import insight_application_service
         from core.knowledge.contracts import KnowledgeFactCandidate
 
         warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -1370,18 +1370,20 @@ class TestInsightApplicationServiceFastLane:
 
         # Isolate the store-error branch; timeout branches are covered below.
         monkeypatch.setattr(
-            "app.services.insight_application_service.KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS",
-            5.0,
+            insight_application_service,
+            "KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS",
+            float("inf"),
             raising=True,
         )
         monkeypatch.setattr(
-            "app.services.insight_application_service.logger.warning",
+            insight_application_service.logger,
+            "warning",
             lambda *args, **kwargs: warnings.append((args, kwargs)),
             raising=True,
         )
 
         asyncio.run(
-            _maybe_promote_knowledge_candidates(
+            insight_application_service._maybe_promote_knowledge_candidates(
                 knowledge_store=_BrokenStore(),
                 candidates=[cast(KnowledgeFactCandidate, SimpleNamespace(fact_key="fact-1"))],
                 verification_bundle=self._verification_bundle(),


### PR DESCRIPTION
## Summary
Fix the post-merge `main` CI failure introduced after PR #2086 landed by making the knowledge-promotion store-error regression test deterministic under the Python 3.12 `test-main` shard.

Failing evidence from `main` run `28804293563`, job `85415810365`:
`tests/test_remaining_modules.py::TestInsightApplicationServiceFastLane::test_maybe_promote_knowledge_candidates_logs_and_swallows_store_errors` expected `Knowledge promotion failed` but received `Knowledge promotion timed out; response path continues without persistence`.

## Scope
- Update only `tests/test_remaining_modules.py`.
- In the store-error test, set `KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS` high enough to isolate the intended `RuntimeError("boom")` branch.
- Keep the existing async and sync timeout tests as the timeout-branch contract.

## Out of scope
- No production changes to `app/services/insight_application_service.py`.
- No change to knowledge-promotion timeout policy, response-path fail-soft behavior, logging text, AI runtime behavior, or semantic-cache policy.
- No workflow, OpenAPI, auth, billing, frontend, iOS, or route changes.

## Key decisions
- This is a test isolation fix, not a runtime behavior change. Production still distinguishes timeout vs store exception and keeps both fail-soft.
- The original test was intended to validate store exceptions but could race the bounded timeout under overloaded Python 3.12 CI scheduling.
- Changing production timeout or running the sync store in the response path would widen runtime behavior to satisfy a test, which is the wrong tradeoff here.

## Tests
- `python3 scripts/orchestration/check_preflight.py --path tests/test_remaining_modules.py --path app/services/insight_application_service.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `.venv/bin/python -m pytest -q tests/test_remaining_modules.py::TestInsightApplicationServiceFastLane::test_maybe_promote_knowledge_candidates_logs_and_swallows_store_errors`
- `.venv/bin/python -m pytest -q tests/test_remaining_modules.py -k 'maybe_promote_knowledge_candidates'`
- `make validate-changed`
- `pre-commit run --all-files`

## Security notes
Test-only diff. No auth, tier, API-key, quota, route, provider, persistence, or sandbox runtime behavior changes.

## Risks / rollback
Risk is limited to test intent drift. Rollback is reverting this commit, but that reopens the Python 3.12 CI race where the store-error test can hit timeout logging first.

## Lane Start Provenance
Packet: artifacts/orchestration/task_packets/f63b2263dd01.json
Starter: scripts/orchestration/start_pr_lane.sh
Host/Codex preflight is not authoritative lane provenance; repo bootstrap is the lane authority.

## Experiment Runner Evidence
Not applicable: runner was attempted but the local macOS sandbox rejected oracle execution because `unshare` is unavailable, so no accepted runner result shaped this commit.

## Discussion Thread Pass
- [x] Discussion-thread pass completed

### Fixed in Commit Mapping
- [x] Fixed in commit mapping completed
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2087#pullrequestreview-4639030521 -> d680f2fed01bb9e82c55caa9eaa3e5f9b4835fe2

## Merge Readiness
- Local narrow bundle passed on branch head.
- GitHub current-head CI is required after PR open before any merge-readiness claim.

## Summary by Sourcery

Стабилизировать тест `knowledge-promotion` для ошибок хранилища, изолировав ветку `store-exception` от поведения тайм-аута в CI на Python 3.12.

Bug Fixes:
- Предотвратить недетерминированные сбои регрессионного теста `knowledge-promotion store-error` под Python 3.12, гарантируя, что он проверяет целевую ветку `RuntimeError`, а не ветку тайм-аута.

Tests:
- Скорректировать конфигурацию тайм-аута в тесте `knowledge-promotion store-error`, чтобы надёжно нацеливать его на ветку `store-exception`, оставив существующие тесты, ориентированные на тайм-аут, ответственными за проверку поведения при тайм-ауте.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize the knowledge-promotion store-error test by isolating the store-exception branch from timeout behavior in Python 3.12 CI.

Bug Fixes:
- Prevent nondeterministic failures in the knowledge-promotion store-error regression test under Python 3.12 by ensuring it exercises the intended RuntimeError branch rather than the timeout path.

Tests:
- Adjust the knowledge-promotion timeout configuration in the store-error test to reliably target the store-exception branch, leaving existing timeout-focused tests responsible for validating timeout behavior.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the knowledge-promotion store-error test by forcing the store-exception path with an infinite timeout and module-level monkeypatching; also adds a small review mapping doc. No production changes.

- **Bug Fixes**
  - In `tests/test_remaining_modules.py`, patch `insight_application_service.KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS` to `float("inf")` and stub `insight_application_service.logger.warning` to capture warnings, ensuring the store-error branch is exercised.
  - Import and call `_maybe_promote_knowledge_candidates` via the `app.services.insight_application_service` module to make patches resilient and avoid Python 3.12 timeout races in CI.

<sup>Written for commit b888edab3cfc1747c4df2856c5115c3b0b22e6d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for error-handling by making the knowledge-promotion store-error scenario deterministic.
  * Updated the test to reliably exercise the intended failure path without interference from timeout behavior.
* **Documentation**
  * Added a review note describing the rationale and verification steps for the CI-related fix to the store-error test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
