### PR TITLE
fix(orchestration): accept partial-failure promotion sentinel

### DIFF
--- a/docs/orchestration/contracts/creative_code_artifact_inventory_report.v1.schema.json
+++ b/docs/orchestration/contracts/creative_code_artifact_inventory_report.v1.schema.json
@@ -303,7 +303,7 @@
           "anyOf": [{ "enum": ["open", "partial_failure"] }, { "type": "null" }]
         },
         "pull_request_number": {
-          "anyOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
+          "anyOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }]
         },
         "head_branch": { "$ref": "#/$defs/experiment_branch_or_null" },
         "blockers": { "$ref": "#/$defs/reason_list" }

--- a/scripts/orchestration/creative_code_artifact_inventory.py
+++ b/scripts/orchestration/creative_code_artifact_inventory.py
@@ -1086,7 +1086,7 @@ def _validate_promotion_entry(entry: Any) -> dict[str, Any]:
     if entry["pull_request_number"] is not None and (
         not isinstance(entry["pull_request_number"], int)
         or isinstance(entry["pull_request_number"], bool)
-        or entry["pull_request_number"] < 1
+        or entry["pull_request_number"] < 0
     ):
         raise CreativeCodeArtifactInventoryError("promotion_artifact.pull_request_number invalid.")
     if entry["head_branch"] is not None and not EXPERIMENT_BRANCH_RE.fullmatch(

--- a/tests/test_creative_code_artifact_inventory.py
+++ b/tests/test_creative_code_artifact_inventory.py
@@ -552,10 +552,31 @@ def test_completed_promotion_receipt_blocks_duplicate_promotion_and_allows_clean
     assert "promotion_receipt_exists" in blockers
 
 
+def test_partial_failure_promotion_receipt_with_zero_pr_number_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo, run_id, result = _make_patch_run(monkeypatch, tmp_path, accepted=True)
+    receipt = _write_promotion_receipt(repo, result=result, partial_failure="pr creation failed")
+    receipt["pull_request_number"] = 0
+    receipt["pull_request_url"] = ""
+    _write_json(_promotion_dir(repo, "promotion-test") / inventory_cli.RECEIPT_FILE, receipt)
+
+    report = _report(monkeypatch, repo, origin_main=result["base_commit_sha"])
+
+    assert report["promotion_artifacts"][0]["state"] == "partial_failure"
+    assert report["promotion_artifacts"][0]["pull_request_number"] == 0
+    assert report["patch_runs"][0]["promotion_linkage"] == "partial_failure"
+    assert "promotion_partial_failure" in report["promotion_artifacts"][0]["blockers"]
+    ok, blockers = inventory_cli.assert_ready_for_promotion(run_id)
+    assert ok is False
+    assert "promotion_partial_failure" in blockers
+
+
 @pytest.mark.parametrize(
     ("field", "value", "message"),
     [
-        ("pull_request_number", 0, "promotion_artifact.pull_request_number invalid"),
+        ("pull_request_number", -1, "promotion_artifact.pull_request_number invalid"),
         ("head_branch", "feature/not-experiment", "promotion_artifact.head_branch invalid"),
     ],
 )


### PR DESCRIPTION
### Motivation
- The inventory validator and JSON schema started rejecting `pull_request_number=0`, which is a valid sentinel used by the PR-3 promotion flow to record partial failures after a branch was created; this caused inventory reporting to fail-closed instead of reporting a `promotion_partial_failure` blocker.

### Description
- Relax `promotion_artifact.pull_request_number` runtime validation to accept `0` while still rejecting negative, non-integer, and boolean values in `scripts/orchestration/creative_code_artifact_inventory.py`.
- Align the canonical report JSON schema by changing the `pull_request_number` minimum to `0` in `docs/orchestration/contracts/creative_code_artifact_inventory_report.v1.schema.json`.
- Add a focused regression test `test_partial_failure_promotion_receipt_with_zero_pr_number_is_reported` to `tests/test_creative_code_artifact_inventory.py` that verifies partial-failure receipts with `pull_request_number=0` are accepted and produce the expected `promotion_partial_failure` blocker.
- Keep the invalid-field regression case to continue rejecting negative PR numbers instead of the valid `0` sentinel.

### Testing
- `python3 scripts/orchestration/check_preflight.py` — pass.
- `python3 scripts/orchestration/check_agent_consistency.py` — pass.
- `python3 -m compileall -q scripts/orchestration/creative_code_artifact_inventory.py tests/test_creative_code_artifact_inventory.py` — pass.
- JSON parse of `docs/orchestration/contracts/creative_code_artifact_inventory_report.v1.schema.json` — pass.
- Inline runtime validation script exercising the inventory report with a `pull_request_number=0` promotion artifact — pass.
- `python3 -m pytest -q tests/test_creative_code_artifact_inventory.py` — blocked due to missing `pytest` in the environment.
- `make validate-changed` — blocked due to missing repo-shared `.venv` for local hook execution.
- `pre-commit run --all-files` — blocked due to `pre-commit` not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e3ba0cc04832ca97cb4ea9d3c111a)

## Summary by Sourcery

Разрешить обработку квитанций промоушена с `pull_request_number=0` как частичных ошибок вместо недействительных артефактов.

Исправления ошибок:
- Ослабить проверку `promotion_artifact.pull_request_number`, чтобы принимать значение 0, при этом по‑прежнему отклоняя недопустимые значения, такие как отрицательные числа и нецелые значения.

Документация:
- Обновить JSON‑схему отчёта об инвентаризации артефактов творческого кода, чтобы разрешить значения `pull_request_number` равные 0.

Тесты:
- Добавить регрессионный тест, проверяющий, что квитанции промоушена с частичным отказом и `pull_request_number=0` принимаются и отражаются с блокирующим статусом `promotion_partial_failure`.
- Скорректировать существующее регрессионное покрытие недопустимых полей, чтобы по‑прежнему отклонять отрицательные значения `pull_request_number`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow promotion receipts with pull_request_number=0 to be treated as partial failures instead of invalid artifacts.

Bug Fixes:
- Relax promotion_artifact.pull_request_number validation to accept 0 while still rejecting invalid values such as negatives and non-integers.

Documentation:
- Update the creative code artifact inventory report JSON schema to allow pull_request_number values of 0.

Tests:
- Add a regression test ensuring partial-failure promotion receipts with pull_request_number=0 are accepted and reported with a promotion_partial_failure blocker.
- Adjust existing invalid-field regression coverage to continue rejecting negative pull_request_number values.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `pull_request_number=0` as a sentinel for partial-failure promotion receipts. Prevents fail-closed inventory and correctly reports the `promotion_partial_failure` blocker.

- **Bug Fixes**
  - Relax runtime validation to accept `0` while still rejecting negatives, non-integers, and booleans.
  - Update the report JSON schema to set `pull_request_number` minimum to `0`.
  - Add a regression test to confirm `0` is accepted and triggers `promotion_partial_failure`; keep a test rejecting negative values.

<sup>Written for commit c05d76f9f0cfee12e0b5d7781f52c71e819cbabe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

