### PR TITLE
chore(deps): bump data-profile pyarrow to 25.0.0

### DIFF
--- a/docs/review/PR_PYARROW_25_FIXED_MAPPING.md
+++ b/docs/review/PR_PYARROW_25_FIXED_MAPPING.md
@@ -1,0 +1,58 @@
+# PR - Pyarrow 25 Fixed in Commit Mapping
+
+Branch: `codex/deps-pyarrow-25-data-profile`
+
+## Summary
+
+Controlled replacement for Dependabot PR #2106. Pins the offline/manual data-build
+lockfile to `pyarrow==25.0.0` while preserving the policy floor
+`pyarrow>=20.0.0,<26.0.0` in `requirements-data.in`.
+
+## Lane Start Provenance
+
+- Packet: pending local bootstrap before PR open
+- Required role order:
+  `agent-coordinator -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+- [ ] Post-open `qa-engineer-agent` pass completed
+- [ ] Post-open `bug-hunter` pass completed
+- [ ] Post-open `security-auditor` pass completed
+- [ ] `pulseplate-pr-review` completed
+- [ ] Codex Security diff scan explicitly unavailable or completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments yet
+
+## Replacement Findings
+
+Disposition: FIXED
+Commit: pending
+Evidence: `requirements-data.txt` pins `pyarrow==25.0.0`; `requirements-data.in`
+keeps `pyarrow>=20.0.0,<26.0.0`.
+Reason: Supersedes Dependabot #2106 with a current-main, user-owned data-profile
+lane that preserves the 20.0.0 minimum floor.
+
+## Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/ci/check_python_dependency_surfaces.py`
+- PASS: `python3 verify_requirements.py`
+- PASS: focused dependency/supply-chain pytest bundle
+- PASS: `PULSEPLATE_PYTHON_INDEX_URL=https://packages.pulseplate.app/root/pulseplate/+simple/
+  python3 scripts/ci/check_private_python_proxy_health.py --requirements-file
+  requirements-data.txt --project pyarrow --python-version 3.11
+  --python-version 3.12 --python-version 3.13 --max-bytes 5000000`
+  - Output: `project name=pyarrow status=200 expected=25.0.0 bytes=383305 reason=ok`
+- PASS: `pre-commit run --all-files`
+
+## Merge Readiness
+
+- [ ] Current-head required CI is green
+- [ ] Post-open role chain is complete
+- [ ] No unresolved/actionable review comments remain
+- [ ] Strict merge-readiness check passes

--- a/requirements-data.in
+++ b/requirements-data.in
@@ -9,4 +9,4 @@ pandas
 
 # Keep Parquet writer support explicit for local data-build lanes while preserving
 # runtime/Docker/CI-lite absence unless a future PR documents canonical ownership.
-pyarrow>=20.0.0,<25.0.0
+pyarrow>=20.0.0,<26.0.0

--- a/requirements-data.txt
+++ b/requirements-data.txt
@@ -10,7 +10,7 @@ numpy==2.4.6
     #   pandas
 pandas==3.0.3
     # via -r requirements-data.in
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via -r requirements-data.in
 python-dateutil==2.9.0.post0
     # via


### PR DESCRIPTION
## Summary

- Supersedes Dependabot #2106 with a controlled data-profile lane on current `main`.
- Pins `requirements-data.txt` to `pyarrow==25.0.0`.
- Preserves the policy floor `pyarrow>=20.0.0,<26.0.0` in `requirements-data.in`.
- Keeps `pyarrow` out of runtime/Docker/CI-lite/aggregate surfaces.

## Scope

- `requirements-data.in`
- `requirements-data.txt`
- `docs/review/PR_PYARROW_25_FIXED_MAPPING.md`

## Out of scope

- Runtime, Docker, CI-lite, or aggregate lock surfaces
- pgvector / testing-deps Dependabot lanes
- Dependabot config changes

## Tests

- [x] `python3 scripts/orchestration/check_preflight.py`
- [x] `python3 scripts/ci/check_python_dependency_surfaces.py`
- [x] `python3 verify_requirements.py`
- [x] Focused dependency/supply-chain pytest bundle
- [x] Private proxy probe for `pyarrow==25.0.0` (3.11/3.12/3.13)
- [x] `pre-commit run --all-files`
- [ ] Current-head GitHub CI

## Lane Start Provenance

- Branch: `codex/deps-pyarrow-25-data-profile`
- Replacement for: Dependabot #2106

## Experiment Runner Evidence

Not applicable: lockfile-only data-profile bump with offline oracle validation already captured in the mapping artifact.

## Deferred / Follow-ups

- Close #2106 after this PR is open.
- pgvector 0.5 lane remains separate (Dependabot #2105).
- Close #2103 after confirming #2107 supersession comment is sufficient.

## Discussion Thread Pass

- [ ] Discussion-thread pass completed
- [ ] Fixed in commit mapping completed

### Fixed in Commit Mapping

See `docs/review/PR_PYARROW_25_FIXED_MAPPING.md`.

## Merge Readiness

- [ ] Current-head required CI is green
- [ ] Post-open role chain complete
- [ ] No unresolved actionable bot comments
- [ ] Strict merge-readiness check passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pyarrow` to 25.0.0 for the data-profile build, keeping the `>=20.0.0,<26.0.0` policy range. No runtime, Docker, or CI-lite impact; supersedes Dependabot #2106.

- **Dependencies**
  - Pin `pyarrow==25.0.0` in `requirements-data.txt`.
  - Keep `pyarrow>=20.0.0,<26.0.0` in `requirements-data.in`.
  - Add `docs/review/PR_PYARROW_25_FIXED_MAPPING.md` with validation notes.

<sup>Written for commit 28712b9a1dfd766ac8f113d9af6b759b518ee629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

