### PR TITLE
fix(ios): pin Ruby 3.4-compatible CFPropertyList

### DIFF
--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -28,6 +28,10 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 - `ecfa35461db561ff3d5d898a845277d04a2f7455` - pin the exact compatibility
   bridge, conservatively reconcile its lock entry, and add fail-closed graph
   guards.
+- `c9c2159c3631d7a8481a9c14b39982a50f7f995d` - make the Phase-2 body and
+  mapping evidence parser-safe and complete the post-open role checkboxes.
+- `4677103c9a2f825508b6531e26e2fd82984dba0f` - reconcile the mandatory
+  security-auditor status and record the sealed security-scan closure.
 
 ## Discussion Thread Pass
 
@@ -38,7 +42,7 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 - [x] Experiment Runner oracle-only evidence accepted.
 - [x] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
 - [x] Codex Security diff scan completed for the material diff.
-- [ ] `pulseplate-pr-review` completed.
+- [x] `pulseplate-pr-review` completed.
 - [ ] All current review threads dispositioned and resolved.
 - [ ] Current-head CI completed.
 - [ ] Strict authenticated merge readiness and mandatory wait window completed.
@@ -46,6 +50,9 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 ## Fixed in Commit Mapping
 
 - No actionable review comments
+
+The artifact-level discussion-thread and fixed-mapping checkboxes are complete;
+merge-readiness and current-head CI remain separate pending gates.
 
 ## Experiment Runner Evidence
 
@@ -70,7 +77,8 @@ tests passing, no shared-tree mutation, and contribution kind `oracle_review`.
 - PASS: sealed Codex Security scan `07492320-eaa5-45f8-b238-2532b7e6a35c`
   reviewed all four diff rows through discovery, validation, and attack-path
   closure; zero reportable findings survived final policy adjustment.
-- PENDING: `pulseplate-pr-review`.
+- PASS: `pulseplate-pr-review` found no deterministic correctness, security,
+  release, or governance finding on the final four-file diff.
 
 ## Risks / Rollback
 

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -1,0 +1,76 @@
+# PR #2115 Fixed in Commit Mapping SoT
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115
+
+Branch: `codex/cfpropertylist-ruby34-compat`
+
+## Summary
+
+Pin the bounded `CFPropertyList 3.0.8` compatibility bridge required for the
+Ruby 3.4.10 release-toolchain migration while preserving the rest of the
+Fastlane/xcodeproj gem graph and all App Store workflow behavior.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/cfpropertylist_ruby34_compat.json`
+  (local-only, gitignored).
+- Pre-open role order executed:
+  `agent-coordinator -> app-store-release-agent -> security-auditor -> marketing-strategist -> qa-engineer-agent`.
+- The actual-diff premortem closed the missing `nkf` compatibility-anchor risk
+  before PR open.
+- Experiment Runner artifact:
+  `artifacts/orchestration/experiments/results/cfpropertylist-ruby34-compat-oracle-result.json`
+  (local-only, gitignored); accepted, 33 focused tests passed, shared tree
+  untouched, contribution kind `oracle_review`.
+
+## Implementation Commits
+
+- `ecfa35461db561ff3d5d898a845277d04a2f7455` - pin the exact compatibility
+  bridge, conservatively reconcile its lock entry, and add fail-closed graph
+  guards.
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed.
+- [ ] Fixed in commit mapping completed.
+- [x] Pre-open packet role order completed.
+- [x] Actual-diff premortem completed with no open blocker.
+- [x] Experiment Runner oracle-only evidence accepted.
+- [ ] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
+- [ ] Codex Security diff scan completed for the material diff.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] All current review threads dispositioned and resolved.
+- [ ] Current-head CI completed.
+- [ ] Strict authenticated merge readiness and mandatory wait window completed.
+
+## Fixed in Commit Mapping
+
+No actionable review comments.
+
+## Validation Evidence
+
+- PASS: orchestration preflight and agent consistency.
+- PASS: 89 focused compatibility/toolchain/App Store tests.
+- PASS: `bundle _2.4.22_ check --gemfile ios/Gemfile`.
+- PASS: `make validate-changed`.
+- PASS: `pre-commit run --all-files`.
+- PASS: pre-push pip-audit, focused backend tests, and full-repo Bandit.
+- PENDING: canonical current-head GitHub CI and strict merge readiness.
+
+## Security Review
+
+- PENDING: mandatory post-open security-auditor.
+- PENDING: one sealed Codex Security diff scan for the material diff.
+- PENDING: `pulseplate-pr-review`.
+
+## Risks / Rollback
+
+If Ruby 3.4.10 CI still exposes a compatibility regression, revert this PR as
+one unit and keep PR #2113 plus App Store upload workflows blocked until a
+supported graph is restored. Do not bypass the compatibility guard or broaden
+the gem update as an emergency workaround.
+
+## Deferred / Follow-ups
+
+PR #2113 remains the owner of the Ruby 3.4.10 workflow migration and is blocked
+until this prerequisite is merged and rebased.

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -37,7 +37,7 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 - [x] Actual-diff premortem completed with no open blocker.
 - [x] Experiment Runner oracle-only evidence accepted.
 - [x] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
-- [ ] Codex Security diff scan completed for the material diff.
+- [x] Codex Security diff scan completed for the material diff.
 - [ ] `pulseplate-pr-review` completed.
 - [ ] All current review threads dispositioned and resolved.
 - [ ] Current-head CI completed.
@@ -66,8 +66,10 @@ tests passing, no shared-tree mutation, and contribution kind `oracle_review`.
 
 ## Security Review
 
-- PENDING: mandatory post-open security-auditor.
-- PENDING: one sealed Codex Security diff scan for the material diff.
+- PASS: mandatory post-open security-auditor found no security actionable.
+- PASS: sealed Codex Security scan `07492320-eaa5-45f8-b238-2532b7e6a35c`
+  reviewed all four diff rows through discovery, validation, and attack-path
+  closure; zero reportable findings survived final policy adjustment.
 - PENDING: `pulseplate-pr-review`.
 
 ## Risks / Rollback

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -55,6 +55,12 @@ Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:38-39` and the post-comment evid
 Reason: Discussion/mapping closure is complete, while merge-readiness and current-head CI stay separate pending gates.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571067367 -> 66c89fe9c0c02badc0a2a6060b7a3607c7b853e4
 
+Disposition: FIXED
+Commit: ba3b3295cb7f78a2d9eea52a62e966d3c6cd6144
+Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:38-46` records the completed discussion/mapping/review-thread closure while retaining separate pending CI and merge-readiness gates.
+Reason: The review-level CodeRabbit summary requested the same artifact-level checkbox closure as its inline thread; the post-review governance commit preserves the final parser-safe state.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#pullrequestreview-4685195469 -> ba3b3295cb7f78a2d9eea52a62e966d3c6cd6144
+
 Disposition: NOT-A-BUG
 Evidence: `git merge-base --is-ancestor ecfa35461 HEAD` exits zero, and every `origin/main..HEAD` commit contains the canonical Experiment Runner co-author trailer.
 Reason: The reviewer inspected a GitHub synthetic merge commit; the public PR branch preserves attribution on the implementation and governance commits.
@@ -65,6 +71,16 @@ Commit: 4677103c9a2f825508b6531e26e2fd82984dba0f
 Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:97-100`
 Reason: Security Review now records the completed security-auditor and sealed diff-scan closure consistently with the checked role-chain status.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571109952 -> 4677103c9a2f825508b6531e26e2fd82984dba0f
+
+Disposition: NOT-A-BUG
+Evidence: On the public branch head `ba3b3295cb7f78a2d9eea52a62e966d3c6cd6144`, `git merge-base --is-ancestor ecfa35461db561ff3d5d898a845277d04a2f7455 HEAD` exits zero and every commit in `origin/main..HEAD` contains `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+Reason: The reviewer evaluated GitHub's synthetic merge commit `e719f874...`, not the public PR branch history used by the repository attribution contract; the accepted oracle contribution and canonical trailer are preserved on every branch commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571404141
+
+Disposition: NOT-A-BUG
+Evidence: On the public branch head `ba3b3295cb7f78a2d9eea52a62e966d3c6cd6144`, `git merge-base --is-ancestor 66c89fe9c0c02badc0a2a6060b7a3607c7b853e4 HEAD` exits zero.
+Reason: The mapped FIXED proof is reachable from the actual PR branch head; the non-reachability assertion is an artifact of reviewing GitHub's synthetic merge commit `e719f874...` as a standalone commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571404148
 
 ## Experiment Runner Evidence
 

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -31,12 +31,12 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed.
-- [ ] Fixed in commit mapping completed.
+- [x] Discussion-thread pass completed.
+- [x] Fixed in commit mapping completed.
 - [x] Pre-open packet role order completed.
 - [x] Actual-diff premortem completed with no open blocker.
 - [x] Experiment Runner oracle-only evidence accepted.
-- [ ] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
+- [x] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
 - [ ] Codex Security diff scan completed for the material diff.
 - [ ] `pulseplate-pr-review` completed.
 - [ ] All current review threads dispositioned and resolved.
@@ -45,7 +45,14 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 
 ## Fixed in Commit Mapping
 
-No actionable review comments.
+- No actionable review comments
+
+## Experiment Runner Evidence
+
+Artifact: artifacts/orchestration/experiments/results/cfpropertylist-ruby34-compat-oracle-result.json
+
+The artifact is local-only and gitignored. It was accepted with 33 focused
+tests passing, no shared-tree mutation, and contribution kind `oracle_review`.
 
 ## Validation Evidence
 

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -50,10 +50,10 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: 66c89fe9c13a3ce7bc33815044740db0bfcb1b89
+Commit: 66c89fe9c0c02badc0a2a6060b7a3607c7b853e4
 Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:38-39` and the post-comment evidence commit preserve both completed artifact-level checkboxes.
 Reason: Discussion/mapping closure is complete, while merge-readiness and current-head CI stay separate pending gates.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571067367 -> 66c89fe9c13a3ce7bc33815044740db0bfcb1b89
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571067367 -> 66c89fe9c0c02badc0a2a6060b7a3607c7b853e4
 
 Disposition: NOT-A-BUG
 Evidence: `git merge-base --is-ancestor ecfa35461 HEAD` exits zero, and every `origin/main..HEAD` commit contains the canonical Experiment Runner co-author trailer.

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -82,6 +82,16 @@ Evidence: On the public branch head `ba3b3295cb7f78a2d9eea52a62e966d3c6cd6144`, 
 Reason: The mapped FIXED proof is reachable from the actual PR branch head; the non-reachability assertion is an artifact of reviewing GitHub's synthetic merge commit `e719f874...` as a standalone commit.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571404148
 
+Disposition: NOT-A-BUG
+Evidence: GitHub PR #2115 reports public `headRefOid=474cde8926581c829517f537ecb986bec31e400b`; in that branch history, `git merge-base --is-ancestor 66c89fe9c0c02badc0a2a6060b7a3607c7b853e4 474cde8926581c829517f537ecb986bec31e400b` exits zero, as do the checks for the other mapped FIXED commits.
+Reason: The reviewed `5a03d460...` object is GitHub's synthetic merge commit in a shallow reviewer checkout, not the PR branch head. Missing shallow ancestry is not evidence that the public branch lost its mapped commits.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571484039
+
+Disposition: NOT-A-BUG
+Evidence: GitHub PR #2115 reports public `headRefOid=474cde8926581c829517f537ecb986bec31e400b`; every commit in `origin/main..474cde8926581c829517f537ecb986bec31e400b`, including that head, contains `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+Reason: The reviewed `5a03d460...` object is GitHub's synthetic merge commit and is not the public branch head governed by the attribution contract; the required public attribution is present throughout the branch history.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571484042
+
 ## Experiment Runner Evidence
 
 Artifact: artifacts/orchestration/experiments/results/cfpropertylist-ruby34-compat-oracle-result.json

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -49,10 +49,22 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 66c89fe9c13a3ce7bc33815044740db0bfcb1b89
+Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:38-39` and the post-comment evidence commit preserve both completed artifact-level checkboxes.
+Reason: Discussion/mapping closure is complete, while merge-readiness and current-head CI stay separate pending gates.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571067367 -> 66c89fe9c13a3ce7bc33815044740db0bfcb1b89
 
-The artifact-level discussion-thread and fixed-mapping checkboxes are complete;
-merge-readiness and current-head CI remain separate pending gates.
+Disposition: NOT-A-BUG
+Evidence: `git merge-base --is-ancestor ecfa35461 HEAD` exits zero, and every `origin/main..HEAD` commit contains the canonical Experiment Runner co-author trailer.
+Reason: The reviewer inspected a GitHub synthetic merge commit; the public PR branch preserves attribution on the implementation and governance commits.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571109947
+
+Disposition: FIXED
+Commit: 4677103c9a2f825508b6531e26e2fd82984dba0f
+Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:97-100`
+Reason: Security Review now records the completed security-auditor and sealed diff-scan closure consistently with the checked role-chain status.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571109952 -> 4677103c9a2f825508b6531e26e2fd82984dba0f
 
 ## Experiment Runner Evidence
 

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -68,7 +68,7 @@ Reason: The reviewer inspected a GitHub synthetic merge commit; the public PR br
 
 Disposition: FIXED
 Commit: 4677103c9a2f825508b6531e26e2fd82984dba0f
-Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:97-100`
+Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:114-119`
 Reason: Security Review now records the completed security-auditor and sealed diff-scan closure consistently with the checked role-chain status.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571109952 -> 4677103c9a2f825508b6531e26e2fd82984dba0f
 
@@ -107,7 +107,7 @@ tests passing, no shared-tree mutation, and contribution kind `oracle_review`.
 - PASS: `make validate-changed`.
 - PASS: `pre-commit run --all-files`.
 - PASS: pre-push pip-audit, focused backend tests, and full-repo Bandit.
-- PENDING: canonical current-head GitHub CI and strict merge readiness.
+- PASS: canonical current-head GitHub CI and strict authenticated merge readiness.
 
 ## Security Review
 

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -68,7 +68,7 @@ Reason: The reviewer inspected a GitHub synthetic merge commit; the public PR br
 
 Disposition: FIXED
 Commit: 4677103c9a2f825508b6531e26e2fd82984dba0f
-Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:114-119`
+Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:124-131`
 Reason: Security Review now records the completed security-auditor and sealed diff-scan closure consistently with the checked role-chain status.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571109952 -> 4677103c9a2f825508b6531e26e2fd82984dba0f
 
@@ -91,6 +91,18 @@ Disposition: NOT-A-BUG
 Evidence: GitHub PR #2115 reports public `headRefOid=474cde8926581c829517f537ecb986bec31e400b`; every commit in `origin/main..474cde8926581c829517f537ecb986bec31e400b`, including that head, contains `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
 Reason: The reviewed `5a03d460...` object is GitHub's synthetic merge commit and is not the public branch head governed by the attribution contract; the required public attribution is present throughout the branch history.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571484042
+
+Disposition: FIXED
+Commit: b16879c45e584d91b4f0799cc210784bf9c237a6
+Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:114-122`
+Reason: Validation Evidence now records terminal current-head CI and strict authenticated merge readiness consistently with the completed Discussion Thread Pass.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571762472 -> b16879c45e584d91b4f0799cc210784bf9c237a6
+
+Disposition: FIXED
+Commit: b16879c45e584d91b4f0799cc210784bf9c237a6
+Evidence: `docs/review/PR_2115_FIXED_MAPPING.md:124-131`
+Reason: The security-auditor disposition now points to the actual Security Review closure instead of the Experiment Runner section.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2115#discussion_r3571762480 -> b16879c45e584d91b4f0799cc210784bf9c237a6
 
 ## Experiment Runner Evidence
 

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -43,7 +43,7 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 - [x] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
 - [x] Codex Security diff scan completed for the material diff.
 - [x] `pulseplate-pr-review` completed.
-- [ ] All current review threads dispositioned and resolved.
+- [x] All current review threads dispositioned and resolved.
 - [ ] Current-head CI completed.
 - [ ] Strict authenticated merge readiness and mandatory wait window completed.
 

--- a/docs/review/PR_2115_FIXED_MAPPING.md
+++ b/docs/review/PR_2115_FIXED_MAPPING.md
@@ -44,8 +44,8 @@ Fastlane/xcodeproj gem graph and all App Store workflow behavior.
 - [x] Codex Security diff scan completed for the material diff.
 - [x] `pulseplate-pr-review` completed.
 - [x] All current review threads dispositioned and resolved.
-- [ ] Current-head CI completed.
-- [ ] Strict authenticated merge readiness and mandatory wait window completed.
+- [x] Current-head CI completed.
+- [x] Strict authenticated merge readiness and mandatory wait window completed.
 
 ## Fixed in Commit Mapping
 

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
 
+# Ruby 3.4 compatibility: keep xcodeproj's CFPropertyList < 4 graph on 3.0.8.
+gem "CFPropertyList", "= 3.0.8"
 gem "fastlane", "= 2.237.0"
 gem "public_suffix", "< 7"

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
+    CFPropertyList (3.0.8)
     abbrev (0.1.2)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
@@ -236,6 +236,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  CFPropertyList (= 3.0.8)
   fastlane (= 2.237.0)
   public_suffix (< 7)
 

--- a/tests/test_cfpropertylist_ruby_compatibility_guard.py
+++ b/tests/test_cfpropertylist_ruby_compatibility_guard.py
@@ -1,0 +1,24 @@
+"""Guard the Ruby 3.4-compatible CFPropertyList resolver contract."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cfpropertylist_is_exactly_pinned_without_widening_fastlane_graph() -> None:
+    gemfile = (REPO_ROOT / "ios" / "Gemfile").read_text(encoding="utf-8")
+    lockfile = (REPO_ROOT / "ios" / "Gemfile.lock").read_text(encoding="utf-8")
+
+    assert gemfile.splitlines()[0] == 'source "https://rubygems.org"'
+    assert gemfile.count('gem "CFPropertyList", "= 3.0.8"') == 1
+    assert "    CFPropertyList (3.0.8)" in lockfile
+    assert "  CFPropertyList (= 3.0.8)" in lockfile
+
+    assert 'gem "fastlane", "= 2.237.0"' in gemfile
+    assert "    fastlane (2.237.0)" in lockfile
+    assert "      CFPropertyList (>= 2.3, < 5.0.0)" in lockfile
+    assert "      nkf (~> 0.2)" in lockfile
+    assert "    nkf (0.2.0)" in lockfile
+    assert "    xcodeproj (1.27.0)" in lockfile
+    assert "      CFPropertyList (>= 2.3.3, < 4.0)" in lockfile
+    assert lockfile.endswith("BUNDLED WITH\n   2.4.22\n")


### PR DESCRIPTION
## Goal

Restore a Ruby 3.4-compatible Fastlane dependency graph by pinning the smallest supported `CFPropertyList` bridge before PR #2113 moves the release workflows to Ruby 3.4.10.

## Business reason

Current-head macOS validation for PR #2113 proved that `CFPropertyList 3.0.9` rejects Ruby 3.4 (`required ruby version < 3.2`). This prerequisite keeps the App Store release control plane supportable without widening into a Fastlane, xcodeproj, or gem-graph refresh.

## Scope

- Pin `CFPropertyList = 3.0.8` in `ios/Gemfile`.
- Conservatively resolve only `CFPropertyList 3.0.9 -> 3.0.8` in `ios/Gemfile.lock`.
- Add a fail-closed compatibility guard for the exact bridge and its current Fastlane/xcodeproj/nkf anchors.

## Out of scope

- No Ruby workflow or setup-action changes; those remain in PR #2113.
- No Fastlane, xcodeproj, Excon, JWT, Faraday, Google gem, Bundler, or platform updates.
- No Fastfile, App Store upload, metadata, asset, backend, OpenAPI, Python dependency, Docker, or deploy changes.
- No broad `bundle update`.

## Key decisions

- `CFPropertyList 4.x` is not usable with the current xcodeproj constraint `< 4.0`; `3.0.8` is the bounded bridge that does not declare the incompatible Ruby `< 3.2` ceiling added in `3.0.9`.
- The guard freezes `nkf (~> 0.2)` and locked `nkf 0.2.0`, because the current Fastlane graph supplies the Ruby 3.4-compatible encoding path needed by this bridge.
- The official RubyGems SHA-256 for `CFPropertyList 3.0.8` was verified as `2c99d0d980536d3d7ab252f7bd59ac8be50fbdd1ff487c98c949bb66bb114261`; no OSV/GitHub Advisory entry was found for this version.

## Tests

- ordered pre-open role dispatch (`agent-coordinator -> app-store-release-agent -> security-auditor -> marketing-strategist -> qa-engineer-agent`) — pass
- actual-diff premortem — pass after adding the nkf compatibility anchors
- 89 focused compatibility/toolchain/App Store tests — pass
- `bundle _2.4.22_ check --gemfile ios/Gemfile` — pass
- Experiment Runner oracle-only 33-test bundle — accepted; no shared-tree mutation
- `make validate-changed` — pass
- `pre-commit run --all-files` — pass
- pre-push pip-audit, focused backend tests, and full-repo Bandit — pass
- current-head GitHub CI — pass on `657fb39786624f0c4972d0806608e157b5fe3b49`
- App Store no-auth `validate-assets` — pass; `upload-assets` and `upload-app-privacy` skipped on the PR event

## Security notes

This changes a privileged App Store dependency surface, but adds no source, credentials, permissions, upload trigger, or runtime authority. The lock graph and Bundler version remain otherwise unchanged, and the exact gem artifact digest was checked against RubyGems metadata.

## Risks / rollback

If Ruby 3.4.10 CI still exposes a compatibility regression, revert this PR as one unit and keep PR #2113 plus App Store upload workflows blocked until a supported graph is restored. Do not bypass the compatibility guard or broaden the gem update as an emergency workaround.

## Experiment Runner Evidence

Artifact: artifacts/orchestration/experiments/results/cfpropertylist-ruby34-compat-oracle-result.json

The artifact is local-only and gitignored.

The accepted oracle-only result ran 33 focused compatibility and release-toolchain tests in an isolated checkout, recorded `mutated_paths=[]`, `shared_tree_untouched=true`, contribution kind `oracle_review`, and required the canonical Experiment Runner co-author trailer present on commit `ecfa35461`.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` pass completed
- [x] Codex Security diff scan completed for the material diff
- [x] `pulseplate-pr-review` completed
- [x] All current actionable review findings have an evidence-backed disposition

### Fixed in Commit Mapping

- `FIXED` — `discussion_r3571067367` -> `66c89fe9c0c02badc0a2a6060b7a3607c7b853e4`.
- `FIXED` — CodeRabbit review `pullrequestreview-4685195469` -> `ba3b3295cb7f78a2d9eea52a62e966d3c6cd6144`.
- `NOT-A-BUG` — `discussion_r3571109947`: the reviewer inspected a synthetic merge commit; the public branch preserves the Experiment Runner trailer on every commit.
- `FIXED` — `discussion_r3571109952` -> `4677103c9a2f825508b6531e26e2fd82984dba0f`.
- `NOT-A-BUG` — `discussion_r3571404141`: `ecfa35461...` is reachable from the public branch head and every branch commit preserves the canonical trailer.
- `NOT-A-BUG` — `discussion_r3571404148`: `66c89fe9...` is reachable from the public branch head; the contrary result used GitHub's synthetic merge commit.
- `NOT-A-BUG` — `discussion_r3571484039`: all mapped FIXED commits are reachable from public PR head `474cde892...`; the contrary result used a shallow synthetic merge checkout.
- `NOT-A-BUG` — `discussion_r3571484042`: every public branch commit through `474cde892...` preserves the canonical Experiment Runner trailer; the reviewed synthetic commit is not the PR head.
- `FIXED` — `discussion_r3571762472` -> `b16879c45e584d91b4f0799cc210784bf9c237a6`: validation status now matches completed readiness.
- `FIXED` — `discussion_r3571762480` -> `b16879c45e584d91b4f0799cc210784bf9c237a6`: security disposition now points to the actual Security Review lines.

The canonical evidence and full Reason/Evidence text are in `docs/review/PR_2115_FIXED_MAPPING.md`.

## Merge Readiness

- [x] Local narrow validation bundle passed; the current head adds only the canonical mapping artifact and passed commit hooks.
- [x] Canonical current-head required checks are terminal green.
- [x] Mandatory review cycle and strict authenticated merge-readiness gate passed.

## Deferred / Follow-ups

PR #2113 remains the owner of the Ruby 3.4.10 workflow migration and is blocked until this prerequisite is merged and rebased.

## AGENTS.md updates

None. Existing iOS release, security, workflow, and merge-governance instructions already cover this pattern.
