### PR TITLE
fix(orchestration): add strict macOS backend for Experiment Runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,7 @@
 !requirements-docker-runtime.in
 !requirements-docker-runtime.txt
 !requirements-dev.txt
+!requirements-lock.txt
 !constraints.txt
 
 # CI installer surfaces copied by Dockerfile

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -45,6 +45,23 @@ PRODUCTION_DOMAIN=example.com STAGING_FALLBACK_DOMAIN=staging.example.com \
 - Run containers: `make docker-run`, `make docker-run-dev`
 - Stop containers: `make docker-stop`
 
+## Experiment Runner image
+
+- `deploy/experiment-runner/Containerfile` is a local evidence image, not a
+  production or devcontainer image.
+- Keep its Python base tag pinned by OCI digest, install only locked
+  `runtime-dev` requirements through BuildKit secrets, and keep the final user
+  non-root.
+- Image builds may use the approved private proxy. Experiment runs must use a
+  prebuilt immutable `name@sha256:<digest>` reference and must not install
+  dependencies or pull images after the strict backend probe.
+- Post-build admission must inspect image history/config for private-proxy
+  secret names and values. Apple runs use the exact inspected
+  `name@sha256:<digest>`; Docker runs use the verified local digest with
+  `--pull never` and re-check the name-to-digest binding before execution.
+- Do not add Compose services, runtime sockets, host home/keychain mounts,
+  `SYS_ADMIN`, or other broad capabilities for this image.
+
 ## Conventions
 - Keep staging and production configs in sync with documented env vars.
 - Avoid changes that alter runtime ports without updating clients and docs.

--- a/deploy/experiment-runner/Containerfile
+++ b/deploy/experiment-runner/Containerfile
@@ -1,0 +1,85 @@
+# syntax=docker/dockerfile:1.7
+
+ARG PYTHON_BASE="python:3.13.13-slim-bookworm@sha256:355bfa66770995d7e9a0da4b3473b44d0cb451f6b56f5615ad9c39e3c4eca03f"
+
+FROM ${PYTHON_BASE} AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_PYTHON_VERSION_WARNING=1 \
+    PULSEPLATE_DOCKER_SINGLE_PASS_LOCKED_INSTALL=1 \
+    PULSEPLATE_DOCKER_PIP_LAYER_CACHE=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && python -m venv /opt/venv
+
+COPY requirements-lock.txt constraints.txt /build/
+COPY scripts/ci/check_python_startup_hooks.py \
+     scripts/ci/emergency_python_wheels.json \
+     scripts/ci/install_locked_python_requirements.py \
+     /build/scripts/ci/
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=secret,id=pp_py_index,required=true \
+    --mount=type=secret,id=pp_py_host,required=false \
+    --mount=type=secret,id=pp_netrc,required=false \
+    set -eu; \
+    index_url="$(cat /run/secrets/pp_py_index)"; \
+    trusted_host=""; \
+    if [ -f /run/secrets/pp_py_host ]; then \
+      trusted_host="$(cat /run/secrets/pp_py_host)"; \
+    fi; \
+    if [ -f /run/secrets/pp_netrc ]; then \
+      install -m 0600 /run/secrets/pp_netrc /root/.netrc; \
+    fi; \
+    trap 'rm -f /root/.netrc' EXIT; \
+    if [ -n "${trusted_host}" ]; then \
+      /opt/venv/bin/python /build/scripts/ci/install_locked_python_requirements.py \
+        --python-executable /opt/venv/bin/python \
+        --requirements-file /build/requirements-lock.txt \
+        --constraints-file /build/constraints.txt \
+        --guard-script /build/scripts/ci/check_python_startup_hooks.py \
+        --emergency-wheel-manifest /build/scripts/ci/emergency_python_wheels.json \
+        --install-mode direct-proxy \
+        --require-virtualenv \
+        --index-url "${index_url}" \
+        --trusted-host "${trusted_host}"; \
+    else \
+      /opt/venv/bin/python /build/scripts/ci/install_locked_python_requirements.py \
+        --python-executable /opt/venv/bin/python \
+        --requirements-file /build/requirements-lock.txt \
+        --constraints-file /build/constraints.txt \
+        --guard-script /build/scripts/ci/check_python_startup_hooks.py \
+        --emergency-wheel-manifest /build/scripts/ci/emergency_python_wheels.json \
+        --install-mode direct-proxy \
+        --require-virtualenv \
+        --index-url "${index_url}"; \
+    fi; \
+    /opt/venv/bin/pip uninstall -y setuptools wheel
+
+FROM ${PYTHON_BASE} AS runner
+
+LABEL org.opencontainers.image.title="PulsePlate Experiment Runner" \
+      org.opencontainers.image.description="Strict local oracle execution image" \
+      org.opencontainers.image.source="https://github.com/Katsiarynakavaleuskaya/PulsePlate"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates git libgnutls30 libssl3 make openssl util-linux \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --uid 65532 --user-group --no-create-home runner \
+    && mkdir -p /repo/artifacts/orchestration/experiments/results \
+    && chown -R 65532:65532 /repo
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV HOME=/tmp \
+    PATH="/opt/venv/bin:/usr/bin:/bin" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+USER 65532:65532
+WORKDIR /repo
+
+CMD ["/opt/venv/bin/python", "--version"]

--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -329,6 +329,10 @@ PR-1/PR-2/PR-3 gates admit later artifacts.
   Container first, then Docker `--network none`, with selection completed
   before the run. A backend may not silently fall back, add broad capabilities,
   or change the packet network budget after execution starts.
+- The strict dispatcher rejects non-zero `network_budget` before backend
+  selection. Native Linux `unshare` remains available through the existing
+  Runner, but is not a strict dispatcher backend until filesystem containment
+  reaches parity with the container mount contract.
 - Strict backend capability artifacts and result `execution_backend` provenance
   are evidence only. They do not change promotion or merge-readiness authority.
 

--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -324,6 +324,13 @@ PR-1/PR-2/PR-3 gates admit later artifacts.
 - No plaintext secret persistence.
 - External or retrieved content remains untrusted.
 - Any non-zero provider or network budget is `review-required`, not `auto-safe`.
+- On macOS, strict `network_budget=0` execution must use the capability-probed
+  dispatcher documented in `EXPERIMENT_RUNNER_MACOS_RUNBOOK.md`: Apple
+  Container first, then Docker `--network none`, with selection completed
+  before the run. A backend may not silently fall back, add broad capabilities,
+  or change the packet network budget after execution starts.
+- Strict backend capability artifacts and result `execution_backend` provenance
+  are evidence only. They do not change promotion or merge-readiness authority.
 
 ### Human review gate
 
@@ -471,11 +478,15 @@ Every rejected run must map to one primary failure class.
 | `guard_failure` | Tests, policy guards, or safety checks failed | discard candidate |
 | `policy_violation` | Forbidden surface changed or disallowed action attempted | stop cycle and escalate |
 | `unchanged_result` | Candidate produced no meaningful improvement | discard candidate |
+| `capability_mismatch` | Host/runtime cannot prove the packet's required isolation | stop without retry or downgrade |
 | `infra_flake` | Transient execution issue without code signal | retry within retry budget only |
 
 Rule:
 
 - A policy violation is not retryable as an automatic success path.
+- A capability mismatch is deterministic and non-retryable. Select another
+  already-probed strict backend in a new explicit invocation; never retry with
+  network access or weaker isolation.
 
 ---
 

--- a/docs/orchestration/EXPERIMENT_RUNNER_MACOS_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_MACOS_RUNBOOK.md
@@ -13,7 +13,9 @@ selection happens once, before the experiment:
 2. Docker with `--network none` when the Apple probe is not strict;
 3. `capability_mismatch` when neither backend proves the required controls.
 
-There is no mid-run fallback and no retry with a weaker network mode.
+There is no mid-run fallback and no retry with a weaker network mode. The
+strict dispatcher accepts only packets whose `network_budget` is exactly zero;
+a non-zero value produces `capability_mismatch` before any runtime probe.
 
 ## Host prerequisites
 
@@ -140,6 +142,7 @@ or substitute an image after preflight.
 - `apple_kernel_not_configured`;
 - `image_missing`, `image_digest_drift`;
 - `guest_unshare_unavailable`, `guest_platform_mismatch`;
+- `strict_network_budget_required`, `filesystem_isolation_unavailable`;
 - `network_gateway_unavailable`, `network_isolation_failed`,
   `mount_contract_failed`;
 - `result_volume_failed`, `container_cleanup_failed`;
@@ -148,6 +151,8 @@ or substitute an image after preflight.
 After the experiment starts, any runtime failure remains on the selected
 backend and is reported without trying Docker, Apple Container, or a networked
 mode. `infra_flake` remains reserved for genuinely transient execution errors.
+Loss of `unshare` after a passed preflight is still a non-retryable
+`capability_mismatch`.
 
 ## Validation and rollback
 
@@ -158,4 +163,7 @@ provenance, and no host path or secret.
 
 Rollback is a revert of the dispatcher, result-contract extension, capability
 schema, and dedicated Containerfile, followed by deleting the local OCI image.
-The native Linux `unshare` path remains unchanged throughout.
+The existing direct native Linux Runner path remains unchanged. The strict
+dispatcher can report its network capability, but does not admit native Linux
+execution until an equivalent read-only filesystem/private-temp containment
+contract exists; it returns `filesystem_isolation_unavailable` instead.

--- a/docs/orchestration/EXPERIMENT_RUNNER_MACOS_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_MACOS_RUNBOOK.md
@@ -1,0 +1,161 @@
+# Experiment Runner strict macOS backend
+
+Status: local development evidence only. This backend does not grant PR,
+promotion, merge, release, GitHub App, or Slack authority.
+
+## Purpose
+
+The macOS dispatcher preserves the canonical `network_budget=0` contract by
+running the existing Linux Experiment Runner in an isolated OCI guest. Backend
+selection happens once, before the experiment:
+
+1. Apple `container` on Apple silicon;
+2. Docker with `--network none` when the Apple probe is not strict;
+3. `capability_mismatch` when neither backend proves the required controls.
+
+There is no mid-run fallback and no retry with a weaker network mode.
+
+## Host prerequisites
+
+- Apple silicon and supported macOS for Apple Container 1.1.0;
+- official signed Apple package installed;
+- `container system start` completed;
+- recommended kernel configured when requested by the runtime;
+- Docker Desktop is an optional fallback, not a co-required runtime;
+- approved private Python proxy is available only during image build.
+
+Do not add `CAP_SYS_ADMIN`, mount a runtime socket, or change
+`network_budget` to a non-zero value to make a probe pass.
+
+## Build the immutable runner image
+
+The dedicated image uses the pinned multi-architecture digest for
+`python:3.13.13-slim-bookworm`, a locked `runtime-dev` environment, and a
+non-root final user. Proxy values enter BuildKit as secrets and are not build
+arguments or runtime environment variables.
+
+```bash
+python3 scripts/orchestration/experiment_runner_dispatch.py build-image \
+  --backend apple-container \
+  --tag pulseplate/experiment-runner:mac-local
+```
+
+The command returns a sanitized `name@sha256:<digest>` reference. Preserve that
+exact reference for `probe` and `run`; mutable tags are rejected by `run`.
+
+Docker fallback build:
+
+```bash
+python3 scripts/orchestration/experiment_runner_dispatch.py build-image \
+  --backend docker \
+  --tag pulseplate/experiment-runner:docker-local
+```
+
+## Probe
+
+```bash
+python3 scripts/orchestration/experiment_runner_dispatch.py probe \
+  --backend auto \
+  --image pulseplate/experiment-runner:mac-local@sha256:<digest> \
+  --output mac-strict-capability.json
+```
+
+The local artifact is written under
+`artifacts/orchestration/experiments/capabilities/` and is gitignored. It
+contains coarse platform/runtime classes, the image digest, boolean probes,
+deterministic blocker codes, and `authority: evidence_only`. It never contains
+hostnames, usernames, home paths, tokens, or raw subprocess output.
+
+Strict Apple execution requires all of the following:
+
+- an internal Apple network and `--no-dns`;
+- guest `unshare --net --map-root-user` without added capabilities;
+- a runtime-inspected gateway, never a hard-coded host address;
+- a real host TCP listener that is reachable in the outer Apple guest as a
+  positive control, while DNS and direct-IP outbound are blocked;
+- a separate inner-namespace canary proving that the same host listener, DNS,
+  and direct-IP outbound are all blocked by guest `unshare`;
+- repository, packet, patch, and root filesystem read-only;
+- no host-writable result bind: the untrusted runner writes only to a private
+  named result volume;
+- private bounded tmpfs mounted with
+  `type=tmpfs,destination=/tmp,size=1G,mode=1777`; the current PulsePlate Git
+  object store is larger than 600 MiB, so smaller tmpfs profiles cannot hold
+  the Runner's required no-hardlinks temporary clone;
+- forced deletion of uniquely named runner/canary containers before volume and
+  network cleanup.
+
+Docker requires the same guest and mount controls, with whole-container
+`--network none` and a bounded `/tmp` tmpfs. Its outer and inner canaries both
+must fail to reach the real listener, DNS, and direct IP. The listener is
+separately proven reachable from the host so a closed local port cannot create
+a false positive.
+
+The untrusted runner never mounts the runtime socket. After its PID 1 exits, a
+separate trusted collector mounts the private result volume read-only inside a
+fresh network namespace. The collector opens only the canonical result with
+`O_NOFOLLOW`, verifies a regular bounded file via `fstat`, and emits base64 to
+the dispatcher. The volume is then deleted.
+
+## Run
+
+Oracle-only governance evidence:
+
+```bash
+python3 scripts/orchestration/experiment_runner_dispatch.py run \
+  --backend auto \
+  --packet artifacts/orchestration/experiments/packets/<packet>.json \
+  --image pulseplate/experiment-runner:mac-local@sha256:<digest> \
+  --output <result>.json
+```
+
+Candidate mode additionally passes a repository-local patch:
+
+```bash
+python3 scripts/orchestration/experiment_runner_dispatch.py run \
+  --backend auto \
+  --packet <packet>.json \
+  --candidate-patch <candidate>.patch \
+  --image pulseplate/experiment-runner:mac-local@sha256:<digest> \
+  --output <result>.json
+```
+
+The dispatcher creates a self-contained temporary clone, applies the tracked
+working-tree diff for oracle-only freshness, and mounts that snapshot read-only.
+It never exposes a host worktree `.git/worktrees/...` path to the guest. New
+results contain optional `execution_backend` provenance; old v1 results remain
+valid without it.
+
+Apple Container is invoked with the already inspected exact
+`name@sha256:<digest>` reference. Docker is invoked with the inspected local
+digest identity and `--pull never`; the dispatcher re-inspects the original
+name-to-digest binding immediately before execution. Neither backend may pull
+or substitute an image after preflight.
+
+## Failure handling
+
+`capability_mismatch` is non-retryable environment evidence. Common blockers:
+
+- `runtime_cli_missing`, `runtime_stopped`, `runtime_not_ready`;
+- `apple_kernel_not_configured`;
+- `image_missing`, `image_digest_drift`;
+- `guest_unshare_unavailable`, `guest_platform_mismatch`;
+- `network_gateway_unavailable`, `network_isolation_failed`,
+  `mount_contract_failed`;
+- `result_volume_failed`, `container_cleanup_failed`;
+- `probe_execution_failed`.
+
+After the experiment starts, any runtime failure remains on the selected
+backend and is reported without trying Docker, Apple Container, or a networked
+mode. `infra_flake` remains reserved for genuinely transient execution errors.
+
+## Validation and rollback
+
+Before using local evidence in a PR lane, verify image history/config contains
+no proxy credential and scan the immutable image with Trivy. A successful run
+must show `network_budget=0`, `shared_tree_untouched: true`, populated backend
+provenance, and no host path or secret.
+
+Rollback is a revert of the dispatcher, result-contract extension, capability
+schema, and dedicated Containerfile, followed by deleting the local OCI image.
+The native Linux `unshare` path remains unchanged throughout.

--- a/docs/orchestration/contracts/experiment_runner_backend_capability.v1.schema.json
+++ b/docs/orchestration/contracts/experiment_runner_backend_capability.v1.schema.json
@@ -117,6 +117,8 @@
           "image_digest_drift",
           "guest_platform_mismatch",
           "guest_unshare_unavailable",
+          "filesystem_isolation_unavailable",
+          "strict_network_budget_required",
           "network_isolation_failed",
           "network_gateway_unavailable",
           "mount_contract_failed",
@@ -128,5 +130,27 @@
     },
     "strict_isolation": {"type": "boolean"},
     "sanitized": {"const": true}
-  }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"backend": {"const": "native-linux"}}},
+      "then": {"properties": {"isolation_method": {"const": "linux_unshare"}}}
+    },
+    {
+      "if": {"properties": {"backend": {"const": "apple-container"}}},
+      "then": {
+        "properties": {
+          "isolation_method": {"const": "apple_internal_no_dns_plus_linux_unshare"}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"backend": {"const": "docker"}}},
+      "then": {
+        "properties": {
+          "isolation_method": {"const": "docker_network_none_plus_linux_unshare"}
+        }
+      }
+    }
+  ]
 }

--- a/docs/orchestration/contracts/experiment_runner_backend_capability.v1.schema.json
+++ b/docs/orchestration/contracts/experiment_runner_backend_capability.v1.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.dev/schemas/experiment_runner_backend_capability.v1.schema.json",
+  "title": "Experiment Runner Backend Capability v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_type",
+    "authority",
+    "backend",
+    "host_platform",
+    "guest_platform",
+    "runtime_version",
+    "image_digest",
+    "isolation_method",
+    "probe_results",
+    "blocking_reasons",
+    "strict_isolation",
+    "sanitized"
+  ],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "artifact_type": {"const": "experiment_runner_backend_capability.v1"},
+    "authority": {"const": "evidence_only"},
+    "backend": {
+      "enum": ["apple-container", "docker", "native-linux"]
+    },
+    "host_platform": {
+      "enum": [
+        "macos_arm64",
+        "macos_amd64",
+        "macos_unsupported",
+        "linux_arm64",
+        "linux_amd64",
+        "linux_unsupported",
+        "unsupported"
+      ]
+    },
+    "guest_platform": {
+      "enum": ["linux_arm64", "linux_amd64", "linux_unsupported"]
+    },
+    "runtime_version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[A-Za-z0-9._+-]+$"
+    },
+    "image_digest": {
+      "oneOf": [
+        {"type": "null"},
+        {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      ]
+    },
+    "isolation_method": {
+      "enum": [
+        "linux_unshare",
+        "apple_internal_no_dns_plus_linux_unshare",
+        "docker_network_none_plus_linux_unshare"
+      ]
+    },
+    "probe_results": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runtime_available",
+        "image_digest_verified",
+        "guest_platform_supported",
+        "host_listener_ready",
+        "outer_host_control",
+        "outer_dns_blocked",
+        "outer_direct_ip_blocked",
+        "inner_host_blocked",
+        "inner_dns_blocked",
+        "inner_direct_ip_blocked",
+        "unshare_without_broad_capabilities",
+        "source_read_only",
+        "input_read_only",
+        "root_read_only",
+        "result_volume_writable",
+        "private_tmpfs",
+        "cleanup_completed"
+      ],
+      "properties": {
+        "runtime_available": {"type": ["boolean", "null"]},
+        "image_digest_verified": {"type": ["boolean", "null"]},
+        "guest_platform_supported": {"type": ["boolean", "null"]},
+        "host_listener_ready": {"type": ["boolean", "null"]},
+        "outer_host_control": {"type": ["boolean", "null"]},
+        "outer_dns_blocked": {"type": ["boolean", "null"]},
+        "outer_direct_ip_blocked": {"type": ["boolean", "null"]},
+        "inner_host_blocked": {"type": ["boolean", "null"]},
+        "inner_dns_blocked": {"type": ["boolean", "null"]},
+        "inner_direct_ip_blocked": {"type": ["boolean", "null"]},
+        "unshare_without_broad_capabilities": {"type": ["boolean", "null"]},
+        "source_read_only": {"type": ["boolean", "null"]},
+        "input_read_only": {"type": ["boolean", "null"]},
+        "root_read_only": {"type": ["boolean", "null"]},
+        "result_volume_writable": {"type": ["boolean", "null"]},
+        "private_tmpfs": {"type": ["boolean", "null"]},
+        "cleanup_completed": {"type": ["boolean", "null"]}
+      }
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "unsupported_host",
+          "unsupported_arch",
+          "runtime_cli_missing",
+          "runtime_stopped",
+          "apple_kernel_not_configured",
+          "runtime_not_ready",
+          "image_required",
+          "image_missing",
+          "image_digest_drift",
+          "guest_platform_mismatch",
+          "guest_unshare_unavailable",
+          "network_isolation_failed",
+          "network_gateway_unavailable",
+          "mount_contract_failed",
+          "result_volume_failed",
+          "container_cleanup_failed",
+          "probe_execution_failed"
+        ]
+      }
+    },
+    "strict_isolation": {"type": "boolean"},
+    "sanitized": {"const": true}
+  }
+}

--- a/docs/review/PR_2116_FIXED_MAPPING.md
+++ b/docs/review/PR_2116_FIXED_MAPPING.md
@@ -35,6 +35,8 @@ Starter: `scripts/orchestration/start_pr_lane.sh`
   cleanup, and post-probe capability false-green paths.
 - `0684d9b43` - bind the positive-control canary to an exact host address and
   remove the wildcard-listener security finding.
+- `c5cd8d870` - bound the Docker result handoff, validate untrusted results
+  before transformation, and classify lost runtime CLI as capability drift.
 
 ## Discussion Thread Pass
 
@@ -86,6 +88,35 @@ Evidence: CodeRabbit's current-head review at `cfd6d3e3a` has an empty review bo
 Reason: The current-head external review contains no actionable finding.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#pullrequestreview-4688294693
 
+Disposition: NOT-A-BUG
+Evidence: `scripts/orchestration/experiment_runner.py:27-29`, `scripts/orchestration/task_bootstrap.py:16-18`, and other repo-owned operator CLIs use the same bounded repo-root bootstrap so canonical direct-script invocation works from a clean checkout; preflight, agent consistency, Ruff, MyPy, and pre-commit accept the pattern.
+Reason: This dispatcher is a repo-local operator CLI, not an installed production package, and its approved interface intentionally supports `python3 scripts/orchestration/experiment_runner_dispatch.py`; changing only this command surface to module-only execution would create inconsistent operator semantics without a repo-wide migration contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784622
+
+Disposition: FIXED
+Commit: c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+Evidence: `_create_result_volume` now creates Docker's named handoff as a local-driver tmpfs with `size=2m,mode=0700`; `test_docker_volume_is_bounded_tmpfs` binds the quota to `MAX_RESULT_BYTES` and asserts the exact bounded argv.
+Reason: Untrusted candidate output can no longer grow the Docker handoff beyond the collector's configured maximum before validation.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784626 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+
+Disposition: FIXED
+Commit: c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+Evidence: `_sanitize_result` now runs the strict result-v1 validator before iterating `oracle_results`, converts invalid shapes to stable `result_validation_failed`, and `test_sanitize_result_rejects_malformed_oracle_before_transform` covers a null oracle entry.
+Reason: Malformed untrusted output now produces a structured failure path instead of an uncaught `TypeError`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784628 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+
+Disposition: FIXED
+Commit: c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+Evidence: `_invoke_container_runner` raises `PreRunCapabilityError("runtime_cli_missing")` when the already-selected runtime disappears, and `test_missing_runtime_after_probe_is_pre_run_capability_drift` covers the classification.
+Reason: Runtime disappearance before candidate execution is deterministic capability drift and does not consume retry budget as `infra_flake`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784645 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+
+Disposition: FIXED
+Commit: c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+Evidence: All three valid findings in the grouped review are fixed and tested above; the direct-script bootstrap finding is dispositioned separately with repo-native evidence.
+Reason: The grouped CodeRabbit review is fully accounted for by the four thread-level dispositions.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#pullrequestreview-4688335453 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+
 ## Experiment Runner Evidence
 
 Artifact: `artifacts/orchestration/experiments/results/mac-strict-oracle-current-head.json`
@@ -100,7 +131,7 @@ Artifact: `artifacts/orchestration/experiments/results/mac-strict-oracle-current
 ## Validation Evidence
 
 - PASS: orchestration preflight and agent consistency.
-- PASS: 188 focused Runner, dispatcher, sandbox, and review-pattern tests.
+- PASS: 191 focused Runner, dispatcher, sandbox, and review-pattern tests.
 - PASS: focused Ruff and MyPy.
 - PASS: `make validate-changed`.
 - PASS: `pre-commit run --all-files`.

--- a/docs/review/PR_2116_FIXED_MAPPING.md
+++ b/docs/review/PR_2116_FIXED_MAPPING.md
@@ -94,28 +94,28 @@ Reason: This dispatcher is a repo-local operator CLI, not an installed productio
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784622
 
 Disposition: FIXED
-Commit: c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+Commit: c5cd8d870a31e3ab8834a14e7c192540b9956188
 Evidence: `_create_result_volume` now creates Docker's named handoff as a local-driver tmpfs with `size=2m,mode=0700`; `test_docker_volume_is_bounded_tmpfs` binds the quota to `MAX_RESULT_BYTES` and asserts the exact bounded argv.
 Reason: Untrusted candidate output can no longer grow the Docker handoff beyond the collector's configured maximum before validation.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784626 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784626 -> c5cd8d870a31e3ab8834a14e7c192540b9956188
 
 Disposition: FIXED
-Commit: c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+Commit: c5cd8d870a31e3ab8834a14e7c192540b9956188
 Evidence: `_sanitize_result` now runs the strict result-v1 validator before iterating `oracle_results`, converts invalid shapes to stable `result_validation_failed`, and `test_sanitize_result_rejects_malformed_oracle_before_transform` covers a null oracle entry.
 Reason: Malformed untrusted output now produces a structured failure path instead of an uncaught `TypeError`.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784628 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784628 -> c5cd8d870a31e3ab8834a14e7c192540b9956188
 
 Disposition: FIXED
-Commit: c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+Commit: c5cd8d870a31e3ab8834a14e7c192540b9956188
 Evidence: `_invoke_container_runner` raises `PreRunCapabilityError("runtime_cli_missing")` when the already-selected runtime disappears, and `test_missing_runtime_after_probe_is_pre_run_capability_drift` covers the classification.
 Reason: Runtime disappearance before candidate execution is deterministic capability drift and does not consume retry budget as `infra_flake`.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784645 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784645 -> c5cd8d870a31e3ab8834a14e7c192540b9956188
 
 Disposition: FIXED
-Commit: c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+Commit: c5cd8d870a31e3ab8834a14e7c192540b9956188
 Evidence: All three valid findings in the grouped review are fixed and tested above; the direct-script bootstrap finding is dispositioned separately with repo-native evidence.
 Reason: The grouped CodeRabbit review is fully accounted for by the four thread-level dispositions.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#pullrequestreview-4688335453 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#pullrequestreview-4688335453 -> c5cd8d870a31e3ab8834a14e7c192540b9956188
 
 ## Experiment Runner Evidence
 

--- a/docs/review/PR_2116_FIXED_MAPPING.md
+++ b/docs/review/PR_2116_FIXED_MAPPING.md
@@ -1,0 +1,131 @@
+# PR #2116 Fixed in Commit Mapping SoT
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116
+
+Branch: `codex/experiment-runner-mac-strict-backend`
+
+## Summary
+
+Add a strict, evidence-only Apple Container execution backend for the local
+PulsePlate Experiment Runner while preserving `network_budget=0`, immutable
+image identity, fail-closed capability classification, and result-v1
+compatibility.
+
+## Lane Start Provenance
+
+Packet: `artifacts/orchestration/task_packets/pr2116-post-open.json`
+Starter: `scripts/orchestration/start_pr_lane.sh`
+
+- The packet and role outputs are retained locally under the gitignored
+  `artifacts/orchestration/` control plane.
+- The coordinator-owned post-open order
+  `qa-engineer-agent -> bug-hunter -> security-auditor` completed before the
+  final ordinary `pulseplate-pr-review` pass.
+
+## Implementation Commits
+
+- `788450377` - add strict backend dispatch and capability probing.
+- `0687a408d` - add the immutable non-root Runner image.
+- `0451069be` - cover backend selection, mounts, redaction, and compatibility.
+- `81d20e42b` - document strict macOS operations and authority boundaries.
+- `dbae5283d` - make dispatcher result typing strict.
+- `939104f5c` - classify pre-run capability drift as non-retryable.
+- `affdb0e17` - guarantee resource cleanup on Runner failures.
+- `b2915e00a` - close provenance, network-budget, filesystem-containment,
+  cleanup, and post-probe capability false-green paths.
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed.
+- [x] Fixed in commit mapping completed.
+- [x] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
+- [x] Ordinary `pulseplate-pr-review` completed on current head.
+- [ ] Canonical current-head CI completed.
+- [ ] Strict authenticated merge readiness and mandatory wait window completed.
+
+## Fixed in Commit Mapping
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/orchestration/experiment_runner_dispatch.py:619-637` binds an ephemeral OS-assigned port, accepts no input, and emits only a fixed canary response; Apple VM gateway reachability is the required positive control and the listener is context-managed.
+Reason: Wildcard binding is necessary for the local Apple VM gateway probe and does not expose a product or persistent service.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3572512959
+
+Disposition: FIXED
+Commit: b2915e00a0c01060586decc71a89ed7dbbe82e00
+Evidence: `scripts/orchestration/experiment_contract.py:886-909`, the capability schema `allOf` mapping, and `tests/test_experiment_runner_dispatch.py:415-447` reject mismatched and impossible backend provenance.
+Reason: Backend name, isolation method, guest support, preflight state, result status, and capability failure class now form one coherent contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3572747164 -> b2915e00a0c01060586decc71a89ed7dbbe82e00
+
+Disposition: FIXED
+Commit: b2915e00a0c01060586decc71a89ed7dbbe82e00
+Evidence: `scripts/orchestration/experiment_runner_dispatch.py` no longer imports `stat`; full local Ruff, flake8-bearing CI lint, and pre-commit validation cover the module.
+Reason: The collector imports `stat` only inside its isolated source string, so the unused host-module import was removed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3572747168 -> b2915e00a0c01060586decc71a89ed7dbbe82e00
+
+Disposition: FIXED
+Commit: b2915e00a0c01060586decc71a89ed7dbbe82e00
+Evidence: `_inspect_image` and `_cleanup_container` now use one common bounded argv; parametrized cleanup tests prove Apple and Docker force deletion still runs after graceful-stop errors.
+Reason: The redundant branches were removed without changing backend-specific deletion behavior.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#pullrequestreview-4687150927 -> b2915e00a0c01060586decc71a89ed7dbbe82e00
+
+Disposition: NOT-A-BUG
+Evidence: Repo-required Black, Ruff, MyPy, pre-commit, focused tests, and current-head diff coverage are the canonical gates; the external docstring-per-function metric is not a PulsePlate contract.
+Reason: Adding boilerplate docstrings to internal bounded helpers would expand this security-sensitive diff without improving an enforced interface or invariant.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#issuecomment-4960413001
+
+Disposition: NOT-A-BUG
+Evidence: Sourcery posted no code finding and states only that its external weekly character quota was exhausted; repo-native and current-head gates remain authoritative.
+Reason: An external service quota is not a defect in this PR.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#pullrequestreview-4686868398
+
+## Experiment Runner Evidence
+
+Artifact: `artifacts/orchestration/experiments/results/mac-strict-oracle-current-head.json`
+
+- Local-only, gitignored evidence at current source diff: `accepted`,
+  `failure_class: null`, `shared_tree_untouched: true`, two oracle return codes
+  `0`, `network_budget=0`, Apple Container 1.1.0, and immutable image digest
+  `sha256:cefe9cfa20a89e2b24b4041c50d02f9bc202664d44e81470f962d5b72f063e13`.
+- Candidate-mode evidence is also accepted with the same strict provenance and
+  remains local-only.
+
+## Validation Evidence
+
+- PASS: orchestration preflight and agent consistency.
+- PASS: 187 focused Runner, dispatcher, sandbox, and review-pattern tests.
+- PASS: focused Ruff and MyPy.
+- PASS: `make validate-changed`.
+- PASS: `pre-commit run --all-files`.
+- PASS: pre-push MyPy, pip-audit, backend tests, full-repo Bandit, and
+  Containerfile build test.
+- PASS: real Apple capability probe, oracle-only run, and candidate run.
+- PENDING: canonical current-head GitHub CI and strict authenticated merge
+  readiness.
+
+Full local `make verify` was not run because repository policy prohibits that
+machine-heavy invocation without a one-time human override.
+
+## Security Review
+
+- PASS: repo-native `security-auditor`, Bandit, Trivy, GitHub CodeQL workflow,
+  immutable-image history/config inspection, negative-network canaries, and
+  mount-write controls produced no unresolved actionable defect at this head.
+- The separate Codex Security plugin workflow was canceled by the operator
+  after repeated platform safety-filter aborts. No incomplete or draft scan
+  output is used as evidence, and the workflow must not be restarted for this
+  PR.
+
+## Risks / Rollback
+
+Apple runtime or image drift, cleanup failure, unsupported filesystem
+containment, and any ambiguous network state fail closed. Rollback is one PR
+revert plus deletion of the local OCI image; no backend, OpenAPI, web, iOS,
+database, GitHub App, or Slack rollback is required.
+
+## Deferred / Follow-ups
+
+- Apple Container remains opt-in local tooling.
+- Native Linux remains on the existing direct Runner path until strict
+  filesystem containment reaches parity.
+- Public distribution, GitHub App, Slack, OCW/OSW, semantic cache, generic
+  extraction, automatic promotion, merge, and deploy remain outside scope.

--- a/docs/review/PR_2116_FIXED_MAPPING.md
+++ b/docs/review/PR_2116_FIXED_MAPPING.md
@@ -33,6 +33,8 @@ Starter: `scripts/orchestration/start_pr_lane.sh`
 - `affdb0e17` - guarantee resource cleanup on Runner failures.
 - `b2915e00a` - close provenance, network-budget, filesystem-containment,
   cleanup, and post-probe capability false-green paths.
+- `0684d9b43` - bind the positive-control canary to an exact host address and
+  remove the wildcard-listener security finding.
 
 ## Discussion Thread Pass
 
@@ -45,10 +47,11 @@ Starter: `scripts/orchestration/start_pr_lane.sh`
 
 ## Fixed in Commit Mapping
 
-Disposition: NOT-A-BUG
-Evidence: `scripts/orchestration/experiment_runner_dispatch.py:619-637` binds an ephemeral OS-assigned port, accepts no input, and emits only a fixed canary response; Apple VM gateway reachability is the required positive control and the listener is context-managed.
-Reason: Wildcard binding is necessary for the local Apple VM gateway probe and does not expose a product or persistent service.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3572512959
+Disposition: FIXED
+Commit: 0684d9b43
+Evidence: `scripts/orchestration/experiment_runner_dispatch.py` now resolves and binds one exact non-loopback host IPv4 address, never persists that address, and uses it only for the context-managed fixed-response positive control; `tests/test_experiment_runner_dispatch.py::test_host_bind_address_is_exact_non_loopback_ipv4` covers the selection contract and a real Apple probe returned `strict_isolation: true`.
+Reason: The wildcard listener was eliminated while preserving the Apple VM host-reachability control required to prove that guest `unshare` actually removes connectivity.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3572512959 -> 0684d9b43
 
 Disposition: FIXED
 Commit: b2915e00a0c01060586decc71a89ed7dbbe82e00
@@ -97,7 +100,7 @@ Artifact: `artifacts/orchestration/experiments/results/mac-strict-oracle-current
 ## Validation Evidence
 
 - PASS: orchestration preflight and agent consistency.
-- PASS: 187 focused Runner, dispatcher, sandbox, and review-pattern tests.
+- PASS: 188 focused Runner, dispatcher, sandbox, and review-pattern tests.
 - PASS: focused Ruff and MyPy.
 - PASS: `make validate-changed`.
 - PASS: `pre-commit run --all-files`.
@@ -112,9 +115,11 @@ machine-heavy invocation without a one-time human override.
 
 ## Security Review
 
-- PASS: repo-native `security-auditor`, Bandit, Trivy, GitHub CodeQL workflow,
+- PASS: repo-native `security-auditor`, Bandit, Trivy,
   immutable-image history/config inspection, negative-network canaries, and
   mount-write controls produced no unresolved actionable defect at this head.
+- PENDING: GitHub CodeQL confirmation of the exact-address canary fix on the
+  new current head.
 - The separate Codex Security plugin workflow was canceled by the operator
   after repeated platform safety-filter aborts. No incomplete or draft scan
   output is used as evidence, and the workflow must not be restarted for this

--- a/docs/review/PR_2116_FIXED_MAPPING.md
+++ b/docs/review/PR_2116_FIXED_MAPPING.md
@@ -36,7 +36,7 @@ Starter: `scripts/orchestration/start_pr_lane.sh`
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed.
+- [x] Discussion-thread pass completed.
 - [x] Fixed in commit mapping completed.
 - [x] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
 - [x] Ordinary `pulseplate-pr-review` completed on current head.
@@ -77,6 +77,11 @@ Disposition: NOT-A-BUG
 Evidence: Sourcery posted no code finding and states only that its external weekly character quota was exhausted; repo-native and current-head gates remain authoritative.
 Reason: An external service quota is not a defect in this PR.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#pullrequestreview-4686868398
+
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit's current-head review at `cfd6d3e3a` has an empty review body and created no unresolved discussion thread.
+Reason: The current-head external review contains no actionable finding.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#pullrequestreview-4688294693
 
 ## Experiment Runner Evidence
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -10857,6 +10857,30 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Immutable oracle mutation is rejected fail-closed
     - Runner outputs candidate result artifacts, not autonomous merge-ready commits
 
+<a id="ledger-p1-experiment-runner-macos-strict-backend"></a>
+- [ ] P1: Strict macOS backend for Experiment Runner
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (restore canonical zero-network oracle evidence on the operator Mac)
+  - Target PR: `codex/experiment-runner-mac-strict-backend`
+  - Status: In progress; Apple Container remains opt-in until real Mac evidence and current-head CI complete.
+  - Dependencies:
+    - [P1: PR3 experiment runner MVP for bounded candidate loops](#ledger-p1-agent-experiment-runner)
+  - Reason (EN): The native runner correctly requires `network_budget=0`, but macOS cannot provide the Linux `unshare` primitive directly. Add one fail-closed dispatcher that proves Apple Container isolation first, proves Docker `--network none` only as a fallback, and returns non-retryable `capability_mismatch` instead of weakening network policy.
+  - Links:
+    - `docs/orchestration/EXPERIMENT_RUNNER_MACOS_RUNBOOK.md`
+    - `docs/orchestration/contracts/experiment_runner_backend_capability.v1.schema.json`
+    - `scripts/orchestration/experiment_runner_dispatch.py`
+    - `deploy/experiment-runner/Containerfile`
+    - `tests/test_experiment_runner_dispatch.py`
+  - DoD:
+    - Apple and Docker backend selection completes before an experiment and never falls back mid-run
+    - Apple proves internal/no-DNS networking plus guest unshare without broad capabilities; Docker proves network-none plus the same negative canaries
+    - Repository/input/root mounts are read-only, no host-writable result bind reaches the untrusted runner, the private result volume is collected read-only after PID 1 exits, and private tmpfs is bounded
+    - Every dispatched run requires immutable image identity and records sanitized backend provenance
+    - Existing Linux native behavior and legacy result v1 artifacts remain compatible
+    - Real candidate and oracle-only Mac runs pass with `network_budget=0`, `shared_tree_untouched: true`, image scan evidence, and no secret/host-path leakage
+    - Local narrow gates, post-open review chain, current-head CI, review dispositions, and strict merge-readiness complete before closure
+
 <a id="ledger-p2-experiment-runner-pr-evidence-hard-gate"></a>
 - [x] P2: Promote Experiment Runner PR evidence from advisory to hard gate
   - Owner: @katsiaryna_kavaleuskaya

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -110,6 +110,22 @@
   reviewed allowlist, forbidden-surface tests, identity checks, and rollback
   notes.
 - Result artifacts stay local under `artifacts/orchestration/experiments/results/` and are evidence only, not merge-ready or promotion-ready output.
+- `experiment_runner_dispatch.py` is the strict local backend boundary for
+  macOS Experiment Runner execution. It may probe, build the dedicated local
+  image, create a self-contained temporary repository snapshot, and execute the
+  existing runner only after one backend passes capability checks. `auto`
+  precedence is Apple Container then Docker; backend selection is final before
+  oracle execution. The dispatcher must never change `network_budget`, retry
+  with network access, add broad Linux capabilities, mount host home/keychain/
+  agent/runtime sockets, persist raw runtime output, or treat capability/result
+  artifacts as readiness or promotion authority. Missing strict isolation is
+  `capability_mismatch`, not `infra_flake`.
+- Container-backed dispatch must not expose a host-writable result bind to the
+  untrusted runner. Use a private named volume, force-delete the uniquely named
+  runner after PID 1 exits, and extract the bounded regular result through a
+  separate read-only trusted collector inside guest `unshare`; delete the
+  volume on every path. Apple gateway canaries must use runtime network inspect,
+  never a hard-coded host address.
 - PR-2 creative-code patch-builder artifacts stay local under
   `artifacts/orchestration/creative_code/patch_runs/`. The builder CLI
   `creative_code_patch_builder.py` is not role dispatch, PR lifecycle

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -120,6 +120,10 @@
   agent/runtime sockets, persist raw runtime output, or treat capability/result
   artifacts as readiness or promotion authority. Missing strict isolation is
   `capability_mismatch`, not `infra_flake`.
+- Strict dispatch requires `network_budget=0` and container-equivalent
+  filesystem containment. The existing native Linux Runner remains compatible,
+  but `native-linux` capability probing must report
+  `filesystem_isolation_unavailable` until that containment is implemented.
 - Container-backed dispatch must not expose a host-writable result bind to the
   untrusted runner. Use a private named volume, force-delete the uniquely named
   runner after PID 1 exits, and extract the bounded regular result through a

--- a/scripts/orchestration/experiment_contract.py
+++ b/scripts/orchestration/experiment_contract.py
@@ -51,8 +51,27 @@ FAILURE_CLASSES: tuple[str, ...] = (
     "guard_failure",
     "policy_violation",
     "unchanged_result",
+    "capability_mismatch",
     "infra_flake",
 )
+
+EXECUTION_BACKEND_NAMES: tuple[str, ...] = (
+    "native-linux",
+    "apple-container",
+    "docker",
+)
+EXECUTION_BACKEND_PREFLIGHT_STATUSES: tuple[str, ...] = ("passed", "failed")
+EXECUTION_BACKEND_GUEST_PLATFORMS: tuple[str, ...] = (
+    "linux_arm64",
+    "linux_amd64",
+    "linux_unsupported",
+)
+EXECUTION_BACKEND_NETWORK_ISOLATION: tuple[str, ...] = (
+    "linux_unshare",
+    "apple_internal_no_dns_plus_linux_unshare",
+    "docker_network_none_plus_linux_unshare",
+)
+IMAGE_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 DEFAULT_STOP_CONDITION = (
     "Stop on timeout, OOM, metric regression, guard failure, policy violation, or unchanged result."
@@ -822,6 +841,46 @@ def validate_experiment_result(result: dict[str, Any]) -> dict[str, Any]:
         status=status,
     )
 
+    execution_backend_raw = result.get("execution_backend")
+    execution_backend: dict[str, str] | None = None
+    if execution_backend_raw is not None:
+        if not isinstance(execution_backend_raw, dict):
+            raise ValueError("Experiment result execution_backend must be an object.")
+        expected_backend_keys = {
+            "name",
+            "guest_platform",
+            "runtime_version",
+            "image_digest",
+            "network_isolation",
+            "preflight_status",
+        }
+        if set(execution_backend_raw) != expected_backend_keys:
+            raise ValueError(
+                "Experiment result execution_backend must contain exactly: "
+                + ", ".join(sorted(expected_backend_keys))
+            )
+        execution_backend = {
+            key: str(execution_backend_raw[key]).strip() for key in expected_backend_keys
+        }
+        if execution_backend["name"] not in EXECUTION_BACKEND_NAMES:
+            raise ValueError("Experiment result execution_backend.name is unsupported.")
+        if execution_backend["guest_platform"] not in EXECUTION_BACKEND_GUEST_PLATFORMS:
+            raise ValueError("Experiment result execution_backend.guest_platform is unsupported.")
+        if not execution_backend["runtime_version"]:
+            raise ValueError(
+                "Experiment result execution_backend.runtime_version must be non-empty."
+            )
+        if not IMAGE_DIGEST_RE.fullmatch(execution_backend["image_digest"]):
+            raise ValueError(
+                "Experiment result execution_backend.image_digest must be a sha256 digest."
+            )
+        if execution_backend["network_isolation"] not in EXECUTION_BACKEND_NETWORK_ISOLATION:
+            raise ValueError(
+                "Experiment result execution_backend.network_isolation is unsupported."
+            )
+        if execution_backend["preflight_status"] not in EXECUTION_BACKEND_PREFLIGHT_STATUSES:
+            raise ValueError("Experiment result execution_backend.preflight_status is unsupported.")
+
     candidate_patch = str(result.get("candidate_patch", "")).strip()
     if not candidate_patch:
         raise ValueError("Experiment result must include a non-empty candidate_patch.")
@@ -853,4 +912,6 @@ def validate_experiment_result(result: dict[str, Any]) -> dict[str, Any]:
     normalized["coauthor_required"] = coauthor_required
     normalized["coauthor_reason"] = coauthor_reason
     normalized["candidate_patch"] = candidate_patch
+    if execution_backend is not None:
+        normalized["execution_backend"] = execution_backend
     return normalized

--- a/scripts/orchestration/experiment_contract.py
+++ b/scripts/orchestration/experiment_contract.py
@@ -71,6 +71,11 @@ EXECUTION_BACKEND_NETWORK_ISOLATION: tuple[str, ...] = (
     "apple_internal_no_dns_plus_linux_unshare",
     "docker_network_none_plus_linux_unshare",
 )
+EXECUTION_BACKEND_ISOLATION_BY_NAME: dict[str, str] = {
+    "native-linux": "linux_unshare",
+    "apple-container": "apple_internal_no_dns_plus_linux_unshare",
+    "docker": "docker_network_none_plus_linux_unshare",
+}
 IMAGE_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 DEFAULT_STOP_CONDITION = (
@@ -878,8 +883,30 @@ def validate_experiment_result(result: dict[str, Any]) -> dict[str, Any]:
             raise ValueError(
                 "Experiment result execution_backend.network_isolation is unsupported."
             )
+        expected_isolation = EXECUTION_BACKEND_ISOLATION_BY_NAME[execution_backend["name"]]
+        if execution_backend["network_isolation"] != expected_isolation:
+            raise ValueError(
+                "Experiment result execution_backend.network_isolation is inconsistent "
+                "with execution_backend.name."
+            )
         if execution_backend["preflight_status"] not in EXECUTION_BACKEND_PREFLIGHT_STATUSES:
             raise ValueError("Experiment result execution_backend.preflight_status is unsupported.")
+        preflight_passed = execution_backend["preflight_status"] == "passed"
+        if status == "accepted" and (
+            not preflight_passed or execution_backend["guest_platform"] == "linux_unsupported"
+        ):
+            raise ValueError(
+                "Accepted experiment results require a passed backend preflight and a "
+                "supported guest platform."
+            )
+        if not preflight_passed and (
+            status != "rejected" or failure_class != "capability_mismatch"
+        ):
+            raise ValueError(
+                "Failed backend preflight requires a rejected capability_mismatch result."
+            )
+        if failure_class == "capability_mismatch" and preflight_passed:
+            raise ValueError("Capability mismatch results require a failed backend preflight.")
 
     candidate_patch = str(result.get("candidate_patch", "")).strip()
     if not candidate_patch:

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -71,6 +71,10 @@ class InfraFlakeError(ExperimentRunnerError):
     """Patch/apply/oracle execution failed for runner reasons, not code signal."""
 
 
+class CapabilityMismatchError(ExperimentRunnerError):
+    """Required execution isolation disappeared or is unsupported."""
+
+
 def _result_payload(
     *,
     experiment_id: str,
@@ -514,7 +518,7 @@ def _classify_oracle_failure(result: sandbox.SandboxResult) -> str:
             "not found",
         )
     ):
-        return "infra_flake"
+        return "capability_mismatch"
     if any(pattern.search(combined_output) for pattern in OOM_PATTERNS):
         return "oom"
     return "guard_failure"
@@ -567,6 +571,14 @@ def _run_oracles(
                     allowlist={("sandbox.exec", "local://sandbox")},
                 )
             except Exception as exc:
+                message = str(exc).lower()
+                if disable_network and (
+                    "unshare" in message or "network-disabled sandbox" in message
+                ):
+                    raise CapabilityMismatchError(
+                        f"Unable to enforce zero-network oracle isolation for "
+                        f"{oracle['command']!r}: {exc}"
+                    ) from exc
                 raise InfraFlakeError(
                     f"Unable to execute oracle {oracle['command']!r}: {exc}"
                 ) from exc
@@ -743,6 +755,19 @@ def evaluate_candidate(packet: dict[str, Any], candidate_patch_path: Path) -> di
             budget_observations=budget_observations,
             shared_tree_untouched=shared_status_before is not None,
         )
+    except CapabilityMismatchError as exc:
+        budget_observations["runner_error"] = str(exc)
+        result = _result_payload(
+            experiment_id=packet["experiment_id"],
+            runner_mode=packet.get("runner_mode", DEFAULT_RUNNER_MODE),
+            candidate_patch=candidate_patch_ref,
+            status="rejected",
+            failure_class="capability_mismatch",
+            mutated_paths=[],
+            oracle_results=[],
+            budget_observations=budget_observations,
+            shared_tree_untouched=shared_status_before is not None,
+        )
     except InfraFlakeError as exc:
         budget_observations["runner_error"] = str(exc)
         result = _result_payload(
@@ -879,6 +904,19 @@ def evaluate_oracle_only_governance_reviewer(
             candidate_patch=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
             status="rejected",
             failure_class="policy_violation",
+            mutated_paths=[],
+            oracle_results=[],
+            budget_observations=budget_observations,
+            shared_tree_untouched=shared_status_before is not None,
+        )
+    except CapabilityMismatchError as exc:
+        budget_observations["runner_error"] = str(exc)
+        result = _result_payload(
+            experiment_id=packet["experiment_id"],
+            runner_mode=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+            candidate_patch=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+            status="rejected",
+            failure_class="capability_mismatch",
             mutated_paths=[],
             oracle_results=[],
             budget_observations=budget_observations,

--- a/scripts/orchestration/experiment_runner_dispatch.py
+++ b/scripts/orchestration/experiment_runner_dispatch.py
@@ -24,7 +24,7 @@ import subprocess  # nosec B404: bounded absolute runtime/git argv only (remove-
 import sys
 import tempfile
 import threading
-from typing import Any, Iterator
+from typing import Any, cast, Iterator
 import uuid
 
 DISPATCH_REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -1097,9 +1097,10 @@ def _require_repo_local_file(raw: str, *, suffix: str) -> Path:
     candidate = Path(raw)
     if candidate.is_absolute():
         raise ValueError("Input paths must be repository-relative.")
-    resolved = (REPO_ROOT / candidate).resolve(strict=True)
+    repo_root = Path(REPO_ROOT).resolve()
+    resolved = (repo_root / candidate).resolve(strict=True)
     try:
-        resolved.relative_to(REPO_ROOT.resolve())
+        resolved.relative_to(repo_root)
     except ValueError as exc:
         raise ValueError("Input paths must stay inside the repository.") from exc
     if not resolved.is_file() or resolved.suffix != suffix:
@@ -1197,7 +1198,7 @@ def _capability_mismatch_result(
             passed=False,
         ),
     }
-    return validate_experiment_result(result)
+    return cast(dict[str, Any], validate_experiment_result(result))
 
 
 def _infra_flake_result(
@@ -1235,7 +1236,7 @@ def _infra_flake_result(
         "coauthor_reason": "",
         "execution_backend": _execution_backend_payload(probe, passed=True),
     }
-    return validate_experiment_result(_redact_result_value(result))
+    return cast(dict[str, Any], validate_experiment_result(_redact_result_value(result)))
 
 
 _SECRET_TEXT_PATTERNS = (
@@ -1280,7 +1281,7 @@ def _sanitize_result(result: dict[str, Any], probe: BackendProbe) -> dict[str, A
         oracle["cwd"] = "/workspace"
         oracle_results.append(oracle)
     sanitized["oracle_results"] = oracle_results
-    return validate_experiment_result(sanitized)
+    return cast(dict[str, Any], validate_experiment_result(sanitized))
 
 
 def _collect_result_volume(

--- a/scripts/orchestration/experiment_runner_dispatch.py
+++ b/scripts/orchestration/experiment_runner_dispatch.py
@@ -57,7 +57,7 @@ CONTAINER_REPO = "/repo"
 CONTAINER_INPUT = "/repo/.experiment-runner-input"
 CONTAINER_RESULT_DIR = "/repo/artifacts/orchestration/experiments/results"
 CONTAINER_PRIVATE_TMP = Path("/", "tmp").as_posix()
-RESULT_VOLUME_SIZE = "64M"
+RESULT_VOLUME_SIZE = "2M"
 MAX_RESULT_BYTES = 2 * 1024 * 1024
 IMAGE_REF_RE = re.compile(
     r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._:/-]{0,254})@(?P<digest>sha256:[0-9a-f]{64})$"
@@ -568,7 +568,20 @@ def _create_result_volume(cli: str, backend: str) -> str:
     argv = (
         [cli, "volume", "create", "-s", RESULT_VOLUME_SIZE, name]
         if backend == "apple-container"
-        else [cli, "volume", "create", name]
+        else [
+            cli,
+            "volume",
+            "create",
+            "--driver",
+            "local",
+            "--opt",
+            "type=tmpfs",
+            "--opt",
+            "device=tmpfs",
+            "--opt",
+            f"o=size={RESULT_VOLUME_SIZE.lower()},mode=0700",
+            name,
+        ]
     )
     if _run(argv, cwd=REPO_ROOT).returncode != 0:
         raise DispatchError("result_volume_failed")
@@ -1383,7 +1396,11 @@ def _redact_result_value(value: Any) -> Any:
 
 
 def _sanitize_result(result: dict[str, Any], probe: BackendProbe) -> dict[str, Any]:
-    sanitized = _redact_result_value(dict(result))
+    try:
+        validated = _validated_experiment_result(result)
+    except (TypeError, ValueError) as exc:
+        raise DispatchError("result_validation_failed") from exc
+    sanitized = _redact_result_value(validated)
     if not isinstance(sanitized, dict):
         raise DispatchError("result_redaction_failed")
     sanitized["execution_backend"] = _execution_backend_payload(probe, passed=True)
@@ -1464,7 +1481,7 @@ def _invoke_container_runner(
     cli_name = "container" if probe.backend == "apple-container" else "docker"
     cli = _resolve_cli(cli_name)
     if cli is None:
-        raise DispatchError("runtime_cli_missing")
+        raise PreRunCapabilityError("runtime_cli_missing")
     with tempfile.TemporaryDirectory(prefix="pp-er-run-") as raw_temp:
         temp_root = Path(raw_temp)
         snapshot = temp_root / "repo"

--- a/scripts/orchestration/experiment_runner_dispatch.py
+++ b/scripts/orchestration/experiment_runner_dispatch.py
@@ -1,0 +1,1646 @@
+#!/usr/bin/env python3
+"""Strict execution-backend dispatcher for the PulsePlate Experiment Runner.
+
+The dispatcher is deliberately a local evidence tool.  It selects one backend
+before an experiment starts, proves the backend's isolation properties, and
+never retries an experiment with a weaker backend or network policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+from contextlib import contextmanager
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import socket
+import stat
+import subprocess  # nosec B404: bounded absolute runtime/git argv only (remove-by: 2026-10-31, ref: ledger-p1-experiment-runner-macos-strict-backend)
+import sys
+import tempfile
+import threading
+from typing import Any, Iterator
+import uuid
+
+DISPATCH_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(DISPATCH_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(DISPATCH_REPO_ROOT))
+
+from scripts.orchestration.context_pack import REPO_ROOT
+from scripts.orchestration.experiment_contract import (
+    IMAGE_DIGEST_RE,
+    ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+    validate_experiment_packet,
+    validate_experiment_result,
+)
+
+CAPABILITY_SCHEMA_VERSION = "1.0"
+CAPABILITY_ARTIFACT_TYPE = "experiment_runner_backend_capability.v1"
+CAPABILITY_ARTIFACT_DIR = REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "capabilities"
+RESULT_ARTIFACT_DIR = REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "results"
+CONTAINERFILE = REPO_ROOT / "deploy" / "experiment-runner" / "Containerfile"
+
+BACKENDS = ("auto", "apple-container", "docker", "native-linux")
+CONTAINER_BACKENDS = ("apple-container", "docker")
+CPU_LIMIT = "2"
+MEMORY_LIMIT = "4g"
+TMPFS_SIZE = "1g"
+APPLE_TMPFS_SIZE = "1G"
+CANARY_BIND_ADDRESS = "0.0.0.0"  # nosec B104: ephemeral fixed-response Apple VM canary requires the host gateway redirect (remove-by: 2026-10-31, ref: ledger-p1-experiment-runner-macos-strict-backend)
+CONTAINER_PYTHON = "/opt/venv/bin/python"
+CONTAINER_UNSHARE = "/usr/bin/unshare"
+CONTAINER_REPO = "/repo"
+CONTAINER_INPUT = "/repo/.experiment-runner-input"
+CONTAINER_RESULT_DIR = "/repo/artifacts/orchestration/experiments/results"
+CONTAINER_PRIVATE_TMP = Path("/", "tmp").as_posix()
+RESULT_VOLUME_SIZE = "64M"
+MAX_RESULT_BYTES = 2 * 1024 * 1024
+IMAGE_REF_RE = re.compile(
+    r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._:/-]{0,254})@(?P<digest>sha256:[0-9a-f]{64})$"
+)
+TAG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,254}$")
+VERSION_RE = re.compile(r"(?<![0-9])([0-9]+\.[0-9]+\.[0-9]+)(?![0-9])")
+BLOCKER_CODES = frozenset(
+    {
+        "unsupported_host",
+        "unsupported_arch",
+        "runtime_cli_missing",
+        "runtime_stopped",
+        "apple_kernel_not_configured",
+        "runtime_not_ready",
+        "image_required",
+        "image_missing",
+        "image_digest_drift",
+        "guest_platform_mismatch",
+        "guest_unshare_unavailable",
+        "network_isolation_failed",
+        "network_gateway_unavailable",
+        "mount_contract_failed",
+        "result_volume_failed",
+        "container_cleanup_failed",
+        "probe_execution_failed",
+    }
+)
+
+PROBE_RESULT_KEYS = (
+    "runtime_available",
+    "image_digest_verified",
+    "guest_platform_supported",
+    "host_listener_ready",
+    "outer_host_control",
+    "outer_dns_blocked",
+    "outer_direct_ip_blocked",
+    "inner_host_blocked",
+    "inner_dns_blocked",
+    "inner_direct_ip_blocked",
+    "unshare_without_broad_capabilities",
+    "source_read_only",
+    "input_read_only",
+    "root_read_only",
+    "result_volume_writable",
+    "private_tmpfs",
+    "cleanup_completed",
+)
+HOST_PLATFORM_CLASSES = frozenset(
+    {
+        "macos_arm64",
+        "macos_amd64",
+        "macos_unsupported",
+        "linux_arm64",
+        "linux_amd64",
+        "linux_unsupported",
+        "unsupported",
+    }
+)
+GUEST_PLATFORM_CLASSES = frozenset({"linux_arm64", "linux_amd64", "linux_unsupported"})
+REQUIRED_PROBE_KEYS = {
+    "apple-container": PROBE_RESULT_KEYS,
+    "docker": tuple(key for key in PROBE_RESULT_KEYS if key != "outer_host_control"),
+    "native-linux": (
+        "runtime_available",
+        "guest_platform_supported",
+        "host_listener_ready",
+        "inner_host_blocked",
+        "inner_dns_blocked",
+        "inner_direct_ip_blocked",
+        "unshare_without_broad_capabilities",
+        "cleanup_completed",
+    ),
+}
+
+
+def _canary_code(host: str, port: int) -> str:
+    return rf"""
+import json, os, platform, socket
+
+def blocked_write(path):
+    try:
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("blocked")
+    except OSError:
+        return True
+    return False
+
+def blocked_connect(host, port):
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return False
+    except OSError:
+        return True
+
+host = {host!r}
+port = {port}
+output_path = "/repo/artifacts/orchestration/experiments/results/probe-write.json"
+tmp_path = "/tmp/probe-write"
+output_writable = False
+private_tmpfs = False
+try:
+    with open(output_path, "w", encoding="utf-8") as handle:
+        handle.write("{{}}")
+    os.unlink(output_path)
+    output_writable = True
+except OSError:
+    pass
+try:
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        handle.write("ok")
+    os.unlink(tmp_path)
+    private_tmpfs = True
+except OSError:
+    pass
+payload = {{
+    "guest_platform_supported": platform.system() == "Linux" and platform.machine() in {{"aarch64", "arm64", "x86_64", "amd64"}},
+    "host_reachable": not blocked_connect(host, port),
+    "dns_blocked": blocked_connect("example.com", 443),
+    "direct_ip_blocked": blocked_connect("1.1.1.1", 443),
+    "source_read_only": blocked_write("/repo/probe-source-write"),
+    "input_read_only": blocked_write("/repo/.experiment-runner-input/probe-input-write"),
+    "root_read_only": blocked_write("/probe-root-write"),
+    "result_volume_writable": output_writable,
+    "private_tmpfs": private_tmpfs,
+}}
+print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+""".strip()
+
+
+_COLLECTOR_CODE = rf"""
+import base64, json, os, stat
+path = os.environ["RESULT_PATH"]
+flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+fd = os.open(path, flags)
+try:
+    info = os.fstat(fd)
+    if not stat.S_ISREG(info.st_mode) or info.st_size > {MAX_RESULT_BYTES}:
+        raise SystemExit(71)
+    payload = os.read(fd, {MAX_RESULT_BYTES} + 1)
+    if len(payload) != info.st_size or len(payload) > {MAX_RESULT_BYTES}:
+        raise SystemExit(72)
+finally:
+    os.close(fd)
+print(json.dumps({{"payload_b64": base64.b64encode(payload).decode("ascii")}}, separators=(",", ":")))
+""".strip()
+
+
+class DispatchError(RuntimeError):
+    """Stable dispatcher failure without raw host/runtime output."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class ImageReference:
+    name: str
+    digest: str
+
+    def runtime_ref(self, backend: str) -> str:
+        if backend == "apple-container":
+            return f"{self.name}@{self.digest}"
+        return self.digest
+
+
+@dataclass(frozen=True)
+class BackendProbe:
+    backend: str
+    host_platform: str
+    guest_platform: str
+    runtime_version: str
+    image_digest: str | None
+    isolation_method: str
+    probe_results: dict[str, bool | None]
+    blocking_reasons: tuple[str, ...]
+
+    @property
+    def strict(self) -> bool:
+        return not self.blocking_reasons and all(
+            self.probe_results.get(key) is True for key in REQUIRED_PROBE_KEYS[self.backend]
+        )
+
+    def to_artifact(self) -> dict[str, Any]:
+        payload = {
+            "schema_version": CAPABILITY_SCHEMA_VERSION,
+            "artifact_type": CAPABILITY_ARTIFACT_TYPE,
+            "authority": "evidence_only",
+            "backend": self.backend,
+            "host_platform": self.host_platform,
+            "guest_platform": self.guest_platform,
+            "runtime_version": self.runtime_version,
+            "image_digest": self.image_digest,
+            "isolation_method": self.isolation_method,
+            "probe_results": dict(sorted(self.probe_results.items())),
+            "blocking_reasons": list(self.blocking_reasons),
+            "strict_isolation": self.strict,
+            "sanitized": True,
+        }
+        return validate_capability_artifact(payload)
+
+
+def _host_platform_class() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if machine in {"aarch64", "arm64"}:
+        normalized_machine = "arm64"
+    elif machine in {"x86_64", "amd64"}:
+        normalized_machine = "amd64"
+    else:
+        normalized_machine = "unsupported"
+    if system == "darwin":
+        system = "macos"
+    elif system != "linux":
+        return "unsupported"
+    return f"{system}_{normalized_machine}"
+
+
+def _guest_platform_class() -> str:
+    machine = platform.machine().lower()
+    if machine in {"aarch64", "arm64"}:
+        normalized_machine = "arm64"
+    elif machine in {"x86_64", "amd64"}:
+        normalized_machine = "amd64"
+    else:
+        normalized_machine = "unsupported"
+    return f"linux_{normalized_machine}"
+
+
+def _isolation_method(backend: str) -> str:
+    return {
+        "native-linux": "linux_unshare",
+        "apple-container": "apple_internal_no_dns_plus_linux_unshare",
+        "docker": "docker_network_none_plus_linux_unshare",
+    }[backend]
+
+
+def _safe_env() -> dict[str, str]:
+    allowed = ("HOME", "LANG", "LC_ALL", "LC_CTYPE", "PATH", "TMPDIR")
+    return {key: os.environ[key] for key in allowed if os.environ.get(key)}
+
+
+def _run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    timeout: int = 30,
+    input_text: str | None = None,
+    secret_env_keys: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
+    if not argv or not Path(argv[0]).is_absolute():
+        raise DispatchError("runtime_cli_missing")
+    try:
+        child_env = _safe_env()
+        child_env.update({key: os.environ[key] for key in secret_env_keys if os.environ.get(key)})
+        return subprocess.run(  # nosec B603: argv begins with resolved absolute executable, no shell (remove-by: 2026-10-31, ref: ledger-p1-experiment-runner-macos-strict-backend)
+            argv,
+            cwd=str(cwd),
+            env=child_env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+            input=input_text,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise DispatchError("probe_execution_failed") from exc
+
+
+def _resolve_cli(name: str) -> str | None:
+    discovered = shutil.which(name)
+    if discovered is None:
+        return None
+    resolved = Path(discovered).expanduser().resolve(strict=True)
+    if not resolved.is_file() or not os.access(resolved, os.X_OK):
+        return None
+    return str(resolved)
+
+
+def _runtime_version(cli: str) -> str:
+    result = _run([cli, "--version"], cwd=REPO_ROOT)
+    if result.returncode != 0:
+        return "unavailable"
+    match = VERSION_RE.search(result.stdout or result.stderr)
+    return match.group(1) if match else "unknown"
+
+
+def parse_image_reference(raw: str) -> ImageReference:
+    match = IMAGE_REF_RE.fullmatch(raw.strip())
+    if match is None:
+        raise ValueError("--image must use immutable name@sha256:<64 lowercase hex> syntax.")
+    return ImageReference(name=match.group("name"), digest=match.group("digest"))
+
+
+def _primary_image_digest(payload: Any) -> str:
+    record = payload[0] if isinstance(payload, list) and payload else payload
+    if not isinstance(record, dict):
+        raise DispatchError("image_missing")
+    configuration = record.get("configuration")
+    if isinstance(configuration, dict):
+        descriptor = configuration.get("descriptor")
+        if isinstance(descriptor, dict):
+            digest = descriptor.get("digest")
+            if isinstance(digest, str) and IMAGE_DIGEST_RE.fullmatch(digest):
+                return digest
+    for key in ("Id", "id"):
+        digest = record.get(key)
+        if isinstance(digest, str):
+            normalized = digest if digest.startswith("sha256:") else f"sha256:{digest}"
+            if IMAGE_DIGEST_RE.fullmatch(normalized):
+                return normalized
+    raise DispatchError("image_missing")
+
+
+def _inspect_image(cli: str, backend: str, image: ImageReference) -> str:
+    argv = (
+        [cli, "image", "inspect", image.name]
+        if backend == "docker"
+        else [cli, "image", "inspect", image.name]
+    )
+    result = _run(argv, cwd=REPO_ROOT)
+    if result.returncode != 0:
+        raise DispatchError("image_missing")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise DispatchError("image_missing") from exc
+    if image.digest != _primary_image_digest(payload):
+        raise DispatchError("image_digest_drift")
+    return image.digest
+
+
+def _base_probe_results(backend: str) -> dict[str, bool | None]:
+    results: dict[str, bool | None] = {key: None for key in PROBE_RESULT_KEYS}
+    for key in REQUIRED_PROBE_KEYS[backend]:
+        results[key] = False
+    return results
+
+
+def _failed_probe(
+    backend: str,
+    reason: str,
+    *,
+    runtime_version: str = "unavailable",
+    image_digest: str | None = None,
+    results: dict[str, bool | None] | None = None,
+) -> BackendProbe:
+    if reason not in BLOCKER_CODES:
+        raise ValueError(f"Unsupported blocker code: {reason}")
+    return BackendProbe(
+        backend=backend,
+        host_platform=_host_platform_class(),
+        guest_platform=_guest_platform_class(),
+        runtime_version=runtime_version,
+        image_digest=image_digest,
+        isolation_method=_isolation_method(backend),
+        probe_results=results or _base_probe_results(backend),
+        blocking_reasons=(reason,),
+    )
+
+
+def _docker_mount(source: Path, target: str, *, readonly: bool) -> str:
+    suffix = ",readonly" if readonly else ""
+    return f"type=bind,source={source},target={target}{suffix}"
+
+
+def _apple_mount(source: Path, target: str, *, readonly: bool) -> str:
+    suffix = ",readonly" if readonly else ""
+    return f"source={source},target={target}{suffix}"
+
+
+def _volume_mount(volume: str, target: str, *, readonly: bool) -> str:
+    suffix = ",readonly" if readonly else ""
+    return f"type=volume,source={volume},target={target}{suffix}"
+
+
+def _container_run_argv(
+    *,
+    cli: str,
+    backend: str,
+    image_ref: str,
+    container_name: str,
+    result_volume: str,
+    command: list[str],
+    repository: Path | None = None,
+    input_dir: Path | None = None,
+    apple_network: str | None = None,
+    user: str = "65532:65532",
+    result_readonly: bool = False,
+    extra_env: tuple[str, ...] = (),
+) -> list[str]:
+    if backend == "docker":
+        argv = [
+            cli,
+            "run",
+            "--name",
+            container_name,
+            "--pull",
+            "never",
+            "--network",
+            "none",
+            "--read-only",
+            "--user",
+            user,
+            "--cpus",
+            CPU_LIMIT,
+            "--memory",
+            MEMORY_LIMIT,
+            "--tmpfs",
+            f"{CONTAINER_PRIVATE_TMP}:rw,noexec,nosuid,size={TMPFS_SIZE}",
+        ]
+        if repository is not None and input_dir is not None:
+            argv.extend(
+                [
+                    "--mount",
+                    _docker_mount(repository, CONTAINER_REPO, readonly=True),
+                    "--mount",
+                    _docker_mount(input_dir, CONTAINER_INPUT, readonly=True),
+                ]
+            )
+    elif backend == "apple-container" and apple_network:
+        argv = [
+            cli,
+            "run",
+            "--name",
+            container_name,
+            "--network",
+            apple_network,
+            "--no-dns",
+            "--read-only",
+            "--user",
+            user,
+            "--cpus",
+            CPU_LIMIT,
+            "--memory",
+            MEMORY_LIMIT,
+            "--mount",
+            (
+                "type=tmpfs,"
+                f"destination={CONTAINER_PRIVATE_TMP},"
+                f"size={APPLE_TMPFS_SIZE},mode=1777"
+            ),
+        ]
+        if repository is not None and input_dir is not None:
+            argv.extend(
+                [
+                    "--mount",
+                    _apple_mount(repository, CONTAINER_REPO, readonly=True),
+                    "--mount",
+                    _apple_mount(input_dir, CONTAINER_INPUT, readonly=True),
+                ]
+            )
+    else:
+        raise DispatchError("probe_execution_failed")
+    argv.extend(
+        [
+            "--mount",
+            _volume_mount(result_volume, CONTAINER_RESULT_DIR, readonly=result_readonly),
+            "--env",
+            f"VENV_PYTHON={CONTAINER_PYTHON}",
+            "--env",
+            f"PYTHONPATH={CONTAINER_REPO}",
+        ]
+    )
+    for entry in extra_env:
+        argv.extend(["--env", entry])
+    argv.extend([image_ref, *command])
+    return argv
+
+
+def _cleanup_container(cli: str, backend: str, name: str) -> bool:
+    stop_args = (
+        [cli, "stop", "--time", "1", name]
+        if backend == "apple-container"
+        else [
+            cli,
+            "stop",
+            "--time",
+            "1",
+            name,
+        ]
+    )
+    _run(stop_args, cwd=REPO_ROOT)
+    delete_args = (
+        [cli, "delete", "--force", name]
+        if backend == "apple-container"
+        else [cli, "rm", "--force", name]
+    )
+    return _run(delete_args, cwd=REPO_ROOT).returncode == 0
+
+
+def _create_result_volume(cli: str, backend: str) -> str:
+    name = f"pp-er-result-{uuid.uuid4().hex[:12]}"
+    argv = (
+        [cli, "volume", "create", "-s", RESULT_VOLUME_SIZE, name]
+        if backend == "apple-container"
+        else [cli, "volume", "create", name]
+    )
+    if _run(argv, cwd=REPO_ROOT).returncode != 0:
+        raise DispatchError("result_volume_failed")
+    return name
+
+
+def _delete_result_volume(cli: str, backend: str, name: str) -> bool:
+    argv = (
+        [cli, "volume", "delete", name]
+        if backend == "apple-container"
+        else [cli, "volume", "rm", "--force", name]
+    )
+    return _run(argv, cwd=REPO_ROOT).returncode == 0
+
+
+def _initialize_result_volume(
+    *,
+    cli: str,
+    backend: str,
+    image_ref: str,
+    volume: str,
+    apple_network: str | None,
+) -> bool:
+    name = f"pp-er-init-{uuid.uuid4().hex[:12]}"
+    completed_ok = False
+    cleanup_ok = False
+    try:
+        argv = _container_run_argv(
+            cli=cli,
+            backend=backend,
+            image_ref=image_ref,
+            container_name=name,
+            result_volume=volume,
+            apple_network=apple_network,
+            user="0:0",
+            command=["/usr/bin/chown", "65532:65532", CONTAINER_RESULT_DIR],
+        )
+        completed = _run(argv, cwd=REPO_ROOT, timeout=30)
+        completed_ok = completed.returncode == 0
+    finally:
+        cleanup_ok = _cleanup_container(cli, backend, name)
+    return completed_ok and cleanup_ok
+
+
+@contextmanager
+def _host_listener() -> Iterator[tuple[int, bool]]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind((CANARY_BIND_ADDRESS, 0))
+    listener.listen(8)
+    listener.settimeout(0.2)
+    stop = threading.Event()
+
+    def serve() -> None:
+        while not stop.is_set():
+            try:
+                connection, _address = listener.accept()
+            except (TimeoutError, OSError):
+                if stop.is_set():
+                    return
+                continue
+            with connection:
+                connection.sendall(b"pulseplate-strict-canary")
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    port = int(listener.getsockname()[1])
+    ready = False
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=1):
+            ready = True
+        yield port, ready
+    finally:
+        stop.set()
+        listener.close()
+        thread.join(timeout=1)
+
+
+def _find_gateway(value: Any) -> str | None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if str(key).lower() in {
+                "gateway",
+                "gatewayaddress",
+                "gateway_address",
+                "ipv4gateway",
+            }:
+                candidate = str(nested).strip()
+                if re.fullmatch(r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}", candidate):
+                    return candidate
+            found = _find_gateway(nested)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for nested in value:
+            found = _find_gateway(nested)
+            if found:
+                return found
+    return None
+
+
+def _discover_gateway(cli: str, backend: str, apple_network: str | None) -> str:
+    argv = (
+        [cli, "network", "inspect", apple_network]
+        if backend == "apple-container" and apple_network
+        else [cli, "network", "inspect", "bridge"]
+    )
+    completed = _run(argv, cwd=REPO_ROOT)
+    if completed.returncode != 0:
+        raise DispatchError("network_gateway_unavailable")
+    try:
+        gateway = _find_gateway(json.loads(completed.stdout))
+    except json.JSONDecodeError as exc:
+        raise DispatchError("network_gateway_unavailable") from exc
+    if gateway is None:
+        raise DispatchError("network_gateway_unavailable")
+    return gateway
+
+
+def _parse_canary(completed: subprocess.CompletedProcess[str]) -> dict[str, bool]:
+    if completed.returncode != 0:
+        raise DispatchError("probe_execution_failed")
+    try:
+        payload = json.loads(completed.stdout.strip().splitlines()[-1])
+    except (IndexError, json.JSONDecodeError) as exc:
+        raise DispatchError("probe_execution_failed") from exc
+    if not isinstance(payload, dict) or not all(
+        isinstance(value, bool) for value in payload.values()
+    ):
+        raise DispatchError("probe_execution_failed")
+    return payload
+
+
+def _runtime_readiness_reason(cli: str, backend: str) -> str | None:
+    argv = (
+        [cli, "info", "--format", "{{.ServerVersion}}"]
+        if backend == "docker"
+        else [cli, "system", "status"]
+    )
+    result = _run(argv, cwd=REPO_ROOT)
+    if result.returncode == 0:
+        return None
+    if backend == "docker":
+        return "runtime_stopped"
+    diagnostic = f"{result.stdout}\n{result.stderr}".lower()
+    if "kernel" in diagnostic:
+        return "apple_kernel_not_configured"
+    return "runtime_not_ready"
+
+
+def _create_apple_network(cli: str) -> str:
+    name = f"pp-er-{uuid.uuid4().hex[:12]}"
+    result = _run([cli, "network", "create", "--internal", name], cwd=REPO_ROOT)
+    if result.returncode != 0:
+        raise DispatchError("network_isolation_failed")
+    return name
+
+
+def _delete_apple_network(cli: str, name: str) -> bool:
+    return _run([cli, "network", "delete", name], cwd=REPO_ROOT).returncode == 0
+
+
+def _run_container_canary(
+    cli: str,
+    backend: str,
+    image: ImageReference,
+) -> dict[str, bool | None]:
+    with tempfile.TemporaryDirectory(prefix="pp-er-probe-") as raw_temp:
+        root = Path(raw_temp)
+        repository = root / "repo"
+        input_dir = root / "input"
+        for directory in (repository, input_dir):
+            directory.mkdir()
+        (repository / CONTAINER_INPUT.removeprefix(f"{CONTAINER_REPO}/")).mkdir()
+        (repository / CONTAINER_RESULT_DIR.removeprefix(f"{CONTAINER_REPO}/")).mkdir(parents=True)
+        (repository / "probe-source").write_text("source", encoding="utf-8")
+        (input_dir / "probe-input").write_text("input", encoding="utf-8")
+        apple_network: str | None = None
+        volume: str | None = None
+        cleanup_completed = True
+        try:
+            if backend == "apple-container":
+                apple_network = _create_apple_network(cli)
+            gateway = _discover_gateway(cli, backend, apple_network)
+            volume = _create_result_volume(cli, backend)
+            runtime_ref = image.runtime_ref(backend)
+            if not _initialize_result_volume(
+                cli=cli,
+                backend=backend,
+                image_ref=runtime_ref,
+                volume=volume,
+                apple_network=apple_network,
+            ):
+                raise DispatchError("result_volume_failed")
+            results = _base_probe_results(backend)
+            results["runtime_available"] = True
+            results["image_digest_verified"] = True
+            with _host_listener() as (port, listener_ready):
+                results["host_listener_ready"] = listener_ready
+                outer_name = f"pp-er-outer-{uuid.uuid4().hex[:12]}"
+                inner_name = f"pp-er-inner-{uuid.uuid4().hex[:12]}"
+                code = _canary_code(gateway, port)
+                try:
+                    outer = _run(
+                        _container_run_argv(
+                            cli=cli,
+                            backend=backend,
+                            image_ref=runtime_ref,
+                            container_name=outer_name,
+                            result_volume=volume,
+                            repository=repository,
+                            input_dir=input_dir,
+                            apple_network=apple_network,
+                            command=[CONTAINER_PYTHON, "-c", code],
+                        ),
+                        cwd=REPO_ROOT,
+                        timeout=45,
+                    )
+                    outer_payload = _parse_canary(outer)
+                finally:
+                    cleanup_completed = (
+                        _cleanup_container(cli, backend, outer_name) and cleanup_completed
+                    )
+                try:
+                    inner = _run(
+                        _container_run_argv(
+                            cli=cli,
+                            backend=backend,
+                            image_ref=runtime_ref,
+                            container_name=inner_name,
+                            result_volume=volume,
+                            repository=repository,
+                            input_dir=input_dir,
+                            apple_network=apple_network,
+                            command=[
+                                CONTAINER_UNSHARE,
+                                "--net",
+                                "--map-root-user",
+                                CONTAINER_PYTHON,
+                                "-c",
+                                code,
+                            ],
+                        ),
+                        cwd=REPO_ROOT,
+                        timeout=45,
+                    )
+                    inner_payload = _parse_canary(inner)
+                    results["unshare_without_broad_capabilities"] = True
+                finally:
+                    cleanup_completed = (
+                        _cleanup_container(cli, backend, inner_name) and cleanup_completed
+                    )
+            results["guest_platform_supported"] = outer_payload["guest_platform_supported"]
+            results["outer_host_control"] = (
+                outer_payload["host_reachable"] if backend == "apple-container" else None
+            )
+            results["outer_dns_blocked"] = outer_payload["dns_blocked"]
+            results["outer_direct_ip_blocked"] = outer_payload["direct_ip_blocked"]
+            results["inner_host_blocked"] = not inner_payload["host_reachable"]
+            results["inner_dns_blocked"] = inner_payload["dns_blocked"]
+            results["inner_direct_ip_blocked"] = inner_payload["direct_ip_blocked"]
+            for key in (
+                "source_read_only",
+                "input_read_only",
+                "root_read_only",
+                "result_volume_writable",
+                "private_tmpfs",
+            ):
+                results[key] = inner_payload[key]
+        finally:
+            if volume is not None:
+                cleanup_completed = (
+                    _delete_result_volume(cli, backend, volume) and cleanup_completed
+                )
+            if apple_network is not None:
+                cleanup_completed = _delete_apple_network(cli, apple_network) and cleanup_completed
+        results["cleanup_completed"] = cleanup_completed
+        return results
+
+
+def probe_backend(backend: str, image: ImageReference | None = None) -> BackendProbe:
+    if backend == "native-linux":
+        if image is None:
+            return _failed_probe(backend, "image_required")
+        if platform.system() != "Linux":
+            return _failed_probe(backend, "unsupported_host", image_digest=image.digest)
+        if platform.machine().lower() not in {"arm64", "aarch64", "x86_64", "amd64"}:
+            return _failed_probe(backend, "unsupported_arch", image_digest=image.digest)
+        unshare = _resolve_cli("unshare")
+        if unshare is None:
+            return _failed_probe(backend, "runtime_cli_missing", image_digest=image.digest)
+        results = _base_probe_results(backend)
+        results["runtime_available"] = True
+        with _host_listener() as (port, ready):
+            results["host_listener_ready"] = ready
+            completed = _run(
+                [
+                    unshare,
+                    "--net",
+                    "--map-root-user",
+                    sys.executable,
+                    "-c",
+                    _canary_code("127.0.0.1", port),
+                ],
+                cwd=REPO_ROOT,
+            )
+        if completed.returncode != 0:
+            return _failed_probe(
+                backend,
+                "guest_unshare_unavailable",
+                runtime_version=platform.release(),
+                image_digest=image.digest,
+                results=results,
+            )
+        inner = _parse_canary(completed)
+        results["guest_platform_supported"] = inner["guest_platform_supported"]
+        results["inner_host_blocked"] = not inner["host_reachable"]
+        results["inner_dns_blocked"] = inner["dns_blocked"]
+        results["inner_direct_ip_blocked"] = inner["direct_ip_blocked"]
+        results["unshare_without_broad_capabilities"] = True
+        results["cleanup_completed"] = True
+        native_blockers = (
+            ()
+            if all(results[key] is True for key in REQUIRED_PROBE_KEYS[backend])
+            else ("network_isolation_failed",)
+        )
+        return BackendProbe(
+            backend=backend,
+            host_platform=_host_platform_class(),
+            guest_platform=_guest_platform_class(),
+            runtime_version=platform.release(),
+            image_digest=image.digest,
+            isolation_method=_isolation_method(backend),
+            probe_results=results,
+            blocking_reasons=native_blockers,
+        )
+
+    expected_cli = "container" if backend == "apple-container" else "docker"
+    if backend == "apple-container":
+        if platform.system() != "Darwin":
+            return _failed_probe(
+                backend, "unsupported_host", image_digest=image.digest if image else None
+            )
+        if platform.machine().lower() not in {"arm64", "aarch64"}:
+            return _failed_probe(
+                backend, "unsupported_arch", image_digest=image.digest if image else None
+            )
+    cli = _resolve_cli(expected_cli)
+    if cli is None:
+        return _failed_probe(
+            backend, "runtime_cli_missing", image_digest=image.digest if image else None
+        )
+    version = _runtime_version(cli)
+    readiness_reason = _runtime_readiness_reason(cli, backend)
+    if readiness_reason is not None:
+        return _failed_probe(
+            backend,
+            readiness_reason,
+            runtime_version=version,
+            image_digest=image.digest if image else None,
+        )
+    if image is None:
+        results = _base_probe_results(backend)
+        results["runtime_available"] = True
+        return _failed_probe(backend, "image_required", runtime_version=version, results=results)
+    try:
+        _inspect_image(cli, backend, image)
+        results = _run_container_canary(cli, backend, image)
+    except DispatchError as exc:
+        reason = str(exc)
+        if reason not in BLOCKER_CODES:
+            reason = "probe_execution_failed"
+        return _failed_probe(
+            backend,
+            reason,
+            runtime_version=version,
+            image_digest=image.digest,
+        )
+    container_blockers: list[str] = []
+    if results["guest_platform_supported"] is not True:
+        container_blockers.append("guest_platform_mismatch")
+    if results["unshare_without_broad_capabilities"] is not True:
+        container_blockers.append("guest_unshare_unavailable")
+    network_keys: tuple[str, ...] = (
+        "host_listener_ready",
+        "outer_dns_blocked",
+        "outer_direct_ip_blocked",
+        "inner_host_blocked",
+        "inner_dns_blocked",
+        "inner_direct_ip_blocked",
+    )
+    if backend == "apple-container":
+        network_keys = (*network_keys, "outer_host_control")
+    if not all(results[key] is True for key in network_keys):
+        container_blockers.append("network_isolation_failed")
+    if not all(
+        results[key] is True
+        for key in (
+            "source_read_only",
+            "input_read_only",
+            "root_read_only",
+            "result_volume_writable",
+            "private_tmpfs",
+        )
+    ):
+        container_blockers.append("mount_contract_failed")
+    if results["cleanup_completed"] is not True:
+        container_blockers.append("container_cleanup_failed")
+    return BackendProbe(
+        backend=backend,
+        host_platform=_host_platform_class(),
+        guest_platform=_guest_platform_class(),
+        runtime_version=version,
+        image_digest=image.digest,
+        isolation_method=_isolation_method(backend),
+        probe_results=results,
+        blocking_reasons=tuple(sorted(set(container_blockers))),
+    )
+
+
+def select_backend(
+    requested: str, image: ImageReference
+) -> tuple[BackendProbe | None, list[BackendProbe]]:
+    if requested != "auto":
+        probe = probe_backend(requested, image)
+        return (probe if probe.strict else None), [probe]
+    candidates = (
+        ("native-linux",) if platform.system() == "Linux" else ("apple-container", "docker")
+    )
+    attempts: list[BackendProbe] = []
+    for backend in candidates:
+        probe = probe_backend(backend, image)
+        attempts.append(probe)
+        if probe.strict:
+            return probe, attempts
+    return None, attempts
+
+
+def validate_capability_artifact(payload: dict[str, Any]) -> dict[str, Any]:
+    expected = {
+        "schema_version",
+        "artifact_type",
+        "authority",
+        "backend",
+        "host_platform",
+        "guest_platform",
+        "runtime_version",
+        "image_digest",
+        "isolation_method",
+        "probe_results",
+        "blocking_reasons",
+        "strict_isolation",
+        "sanitized",
+    }
+    if set(payload) != expected:
+        raise ValueError("Capability artifact has unexpected or missing fields.")
+    if payload["schema_version"] != CAPABILITY_SCHEMA_VERSION:
+        raise ValueError("Capability artifact schema_version is unsupported.")
+    if payload["artifact_type"] != CAPABILITY_ARTIFACT_TYPE:
+        raise ValueError("Capability artifact type is unsupported.")
+    if payload["authority"] != "evidence_only" or payload["sanitized"] is not True:
+        raise ValueError("Capability artifact must remain sanitized evidence_only output.")
+    if payload["backend"] not in BACKENDS[1:]:
+        raise ValueError("Capability artifact backend is unsupported.")
+    backend = str(payload["backend"])
+    if payload["host_platform"] not in HOST_PLATFORM_CLASSES:
+        raise ValueError("Capability artifact host_platform is unsupported.")
+    if payload["guest_platform"] not in GUEST_PLATFORM_CLASSES:
+        raise ValueError("Capability artifact guest_platform is unsupported.")
+    runtime_version = payload["runtime_version"]
+    if not isinstance(runtime_version, str) or not re.fullmatch(
+        r"[A-Za-z0-9._+-]{1,64}", runtime_version
+    ):
+        raise ValueError("Capability artifact runtime_version is invalid.")
+    if payload["isolation_method"] != _isolation_method(backend):
+        raise ValueError("Capability artifact isolation_method is inconsistent.")
+    digest = payload["image_digest"]
+    if digest is not None and not IMAGE_DIGEST_RE.fullmatch(str(digest)):
+        raise ValueError("Capability artifact image_digest is invalid.")
+    reasons = payload["blocking_reasons"]
+    if not isinstance(reasons, list) or reasons != sorted(set(reasons)):
+        raise ValueError("Capability artifact blocking_reasons must be sorted and unique.")
+    if any(reason not in BLOCKER_CODES for reason in reasons):
+        raise ValueError("Capability artifact blocker code is unsupported.")
+    probe_results = payload["probe_results"]
+    if set(probe_results) != set(PROBE_RESULT_KEYS) or not all(
+        isinstance(value, bool) or value is None for value in probe_results.values()
+    ):
+        raise ValueError(
+            "Capability artifact probe_results must contain the exact boolean/null contract."
+        )
+    strict = not reasons and all(probe_results[key] is True for key in REQUIRED_PROBE_KEYS[backend])
+    if payload["strict_isolation"] is not strict:
+        raise ValueError("Capability artifact strict_isolation is inconsistent.")
+    return dict(payload)
+
+
+def _reject_symlink_components(path: Path) -> None:
+    absolute = path.absolute()
+    for component in reversed((absolute, *absolute.parents)):
+        if component.exists() or component.is_symlink():
+            if component.is_symlink():
+                raise ValueError("Artifact paths must not contain symlinked components.")
+
+
+def _resolve_local_output(raw: str, *, root: Path, suffix: str = ".json") -> Path:
+    candidate = Path(raw)
+    if candidate.is_absolute() or candidate.name != raw or not raw.endswith(suffix):
+        raise ValueError(f"Output must be a local {suffix} filename without path separators.")
+    _reject_symlink_components(root)
+    root.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_components(root)
+    resolved = (root / candidate).resolve()
+    if resolved.parent != root.resolve() or resolved.is_symlink():
+        raise ValueError("Output path escaped the canonical local artifact directory.")
+    return resolved
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    _reject_symlink_components(path.parent)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _reject_symlink_components(path.parent)
+    if path.is_symlink():
+        raise ValueError("Refusing to write through a symlinked artifact path.")
+    fd, raw_temp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(raw_temp)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _require_repo_local_file(raw: str, *, suffix: str) -> Path:
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        raise ValueError("Input paths must be repository-relative.")
+    resolved = (REPO_ROOT / candidate).resolve(strict=True)
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError as exc:
+        raise ValueError("Input paths must stay inside the repository.") from exc
+    if not resolved.is_file() or resolved.suffix != suffix:
+        raise ValueError(f"Input must be an existing repository-local {suffix} file.")
+    return resolved
+
+
+def _git_binary() -> str:
+    git = _resolve_cli("git")
+    if git is None:
+        raise DispatchError("runtime_cli_missing")
+    return git
+
+
+def _git(
+    args: list[str], *, cwd: Path, input_text: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    result = _run([_git_binary(), *args], cwd=cwd, input_text=input_text)
+    if result.returncode != 0:
+        raise DispatchError("probe_execution_failed")
+    return result
+
+
+def _create_snapshot(root: Path, destination: Path) -> str:
+    before = _git(["status", "--short", "--untracked-files=no"], cwd=root).stdout
+    _git(["clone", "--quiet", "--no-hardlinks", str(root), str(destination)], cwd=root)
+    head = _git(["rev-parse", "HEAD"], cwd=root).stdout.strip()
+    _git(["checkout", "--quiet", "--detach", head], cwd=destination)
+    tracked_diff = _git(["diff", "--binary", "HEAD"], cwd=root).stdout
+    if tracked_diff:
+        _git(["apply", "--index", "--binary", "-"], cwd=destination, input_text=tracked_diff)
+    after = _git(["status", "--short", "--untracked-files=no"], cwd=root).stdout
+    if before != after:
+        raise DispatchError("probe_execution_failed")
+    return tracked_diff
+
+
+def _execution_backend_payload(probe: BackendProbe, *, passed: bool) -> dict[str, str]:
+    if probe.image_digest is None:
+        raise ValueError("Execution backend provenance requires an image digest.")
+    return {
+        "name": probe.backend,
+        "guest_platform": probe.guest_platform,
+        "runtime_version": probe.runtime_version,
+        "image_digest": probe.image_digest,
+        "network_isolation": probe.isolation_method,
+        "preflight_status": "passed" if passed else "failed",
+    }
+
+
+def _capability_mismatch_result(
+    packet: dict[str, Any],
+    image: ImageReference,
+    probe: BackendProbe,
+) -> dict[str, Any]:
+    experiment_id = packet["experiment_id"]
+    runner_mode = packet["runner_mode"]
+    candidate_patch = (
+        ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE
+        if runner_mode == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE
+        else "candidate.patch"
+    )
+    result = {
+        "schema_version": "1.0",
+        "experiment_id": experiment_id,
+        "runner_mode": runner_mode,
+        "candidate_patch": candidate_patch,
+        "status": "rejected",
+        "failure_class": "capability_mismatch",
+        "mutated_paths": [],
+        "oracle_results": [],
+        "budget_observations": {
+            "configured_budgets": dict(packet["budgets"]),
+            "oracle_commands_executed": 0,
+            "attempts": 0,
+            "retries_consumed": 0,
+            "runner_error": probe.blocking_reasons[0],
+        },
+        "shared_tree_untouched": True,
+        "promotion_ready": False,
+        "contribution_kind": "none",
+        "coauthor_required": False,
+        "coauthor_reason": "",
+        "execution_backend": _execution_backend_payload(
+            BackendProbe(
+                backend=probe.backend,
+                host_platform=probe.host_platform,
+                guest_platform=probe.guest_platform,
+                runtime_version=probe.runtime_version,
+                image_digest=image.digest,
+                isolation_method=probe.isolation_method,
+                probe_results=probe.probe_results,
+                blocking_reasons=probe.blocking_reasons,
+            ),
+            passed=False,
+        ),
+    }
+    return validate_experiment_result(result)
+
+
+def _infra_flake_result(
+    packet: dict[str, Any],
+    image: ImageReference,
+    probe: BackendProbe,
+    error_code: str,
+) -> dict[str, Any]:
+    runner_mode = packet["runner_mode"]
+    candidate_patch = (
+        ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE
+        if runner_mode == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE
+        else "candidate.patch"
+    )
+    result = {
+        "schema_version": "1.0",
+        "experiment_id": packet["experiment_id"],
+        "runner_mode": runner_mode,
+        "candidate_patch": candidate_patch,
+        "status": "rejected",
+        "failure_class": "infra_flake",
+        "mutated_paths": [],
+        "oracle_results": [],
+        "budget_observations": {
+            "configured_budgets": dict(packet["budgets"]),
+            "oracle_commands_executed": 0,
+            "attempts": 1,
+            "retries_consumed": 0,
+            "runner_error": error_code,
+        },
+        "shared_tree_untouched": True,
+        "promotion_ready": False,
+        "contribution_kind": "none",
+        "coauthor_required": False,
+        "coauthor_reason": "",
+        "execution_backend": _execution_backend_payload(probe, passed=True),
+    }
+    return validate_experiment_result(_redact_result_value(result))
+
+
+_SECRET_TEXT_PATTERNS = (
+    re.compile(r"(?i)(token|secret|password|api[_-]?key)\s*[:=]\s*[^\s,;]+"),
+    re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,})\b"),
+)
+
+
+def _redact_result_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _redact_result_value(nested) for key, nested in value.items()}
+    if isinstance(value, list):
+        return [_redact_result_value(nested) for nested in value]
+    if not isinstance(value, str):
+        return value
+    redacted = value
+    path_replacements = (
+        (str(REPO_ROOT), "<repo>"),
+        (str(Path.home()), "<home>"),
+        (tempfile.gettempdir(), "<tmp>"),
+    )
+    for raw, replacement in path_replacements:
+        if raw and len(raw) > 1:
+            redacted = redacted.replace(raw, replacement)
+    for key, secret in os.environ.items():
+        if any(token in key.upper() for token in ("TOKEN", "SECRET", "PASSWORD", "SALT", "KEY")):
+            if len(secret) >= 6:
+                redacted = redacted.replace(secret, "<redacted>")
+    for pattern in _SECRET_TEXT_PATTERNS:
+        redacted = pattern.sub("<redacted>", redacted)
+    return redacted
+
+
+def _sanitize_result(result: dict[str, Any], probe: BackendProbe) -> dict[str, Any]:
+    sanitized = _redact_result_value(dict(result))
+    if not isinstance(sanitized, dict):
+        raise DispatchError("result_redaction_failed")
+    sanitized["execution_backend"] = _execution_backend_payload(probe, passed=True)
+    oracle_results = []
+    for raw_oracle in sanitized.get("oracle_results", []):
+        oracle = dict(raw_oracle)
+        oracle["cwd"] = "/workspace"
+        oracle_results.append(oracle)
+    sanitized["oracle_results"] = oracle_results
+    return validate_experiment_result(sanitized)
+
+
+def _collect_result_volume(
+    *,
+    cli: str,
+    backend: str,
+    image_ref: str,
+    volume: str,
+    output_name: str,
+    apple_network: str | None,
+) -> dict[str, Any]:
+    collector = f"pp-er-collector-{uuid.uuid4().hex[:12]}"
+    try:
+        completed = _run(
+            _container_run_argv(
+                cli=cli,
+                backend=backend,
+                image_ref=image_ref,
+                container_name=collector,
+                result_volume=volume,
+                result_readonly=True,
+                apple_network=apple_network,
+                extra_env=(f"RESULT_PATH={CONTAINER_RESULT_DIR}/{output_name}",),
+                command=[
+                    CONTAINER_UNSHARE,
+                    "--net",
+                    "--map-root-user",
+                    CONTAINER_PYTHON,
+                    "-c",
+                    _COLLECTOR_CODE,
+                ],
+            ),
+            cwd=REPO_ROOT,
+            timeout=30,
+        )
+        if completed.returncode != 0:
+            raise DispatchError("result_extraction_failed")
+        try:
+            envelope = json.loads(completed.stdout.strip().splitlines()[-1])
+            encoded = envelope["payload_b64"]
+            payload_bytes = base64.b64decode(encoded, validate=True)
+            payload = json.loads(payload_bytes.decode("utf-8"))
+        except (
+            IndexError,
+            KeyError,
+            TypeError,
+            ValueError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+        ) as exc:
+            raise DispatchError("result_extraction_failed") from exc
+        if len(payload_bytes) > MAX_RESULT_BYTES or not isinstance(payload, dict):
+            raise DispatchError("result_extraction_failed")
+        return payload
+    finally:
+        if not _cleanup_container(cli, backend, collector):
+            raise DispatchError("container_cleanup_failed")
+
+
+def _invoke_container_runner(
+    *,
+    probe: BackendProbe,
+    image: ImageReference,
+    packet_path: Path,
+    candidate_patch: Path | None,
+    output_name: str,
+) -> dict[str, Any]:
+    cli_name = "container" if probe.backend == "apple-container" else "docker"
+    cli = _resolve_cli(cli_name)
+    if cli is None:
+        raise DispatchError("runtime_cli_missing")
+    with tempfile.TemporaryDirectory(prefix="pp-er-run-") as raw_temp:
+        temp_root = Path(raw_temp)
+        snapshot = temp_root / "repo"
+        input_dir = temp_root / "input"
+        input_dir.mkdir()
+        _create_snapshot(REPO_ROOT, snapshot)
+        (snapshot / CONTAINER_INPUT.removeprefix(f"{CONTAINER_REPO}/")).mkdir()
+        (snapshot / CONTAINER_RESULT_DIR.removeprefix(f"{CONTAINER_REPO}/")).mkdir(
+            parents=True, exist_ok=True
+        )
+        shutil.copyfile(packet_path, input_dir / "packet.json")
+        if candidate_patch is not None:
+            shutil.copyfile(candidate_patch, input_dir / "candidate.patch")
+        command = [
+            CONTAINER_PYTHON,
+            f"{CONTAINER_REPO}/scripts/orchestration/experiment_runner.py",
+            "--packet",
+            f"{CONTAINER_INPUT}/packet.json",
+            "--output",
+            output_name,
+        ]
+        if candidate_patch is not None:
+            command.extend(["--candidate-patch", f"{CONTAINER_INPUT}/candidate.patch"])
+        apple_network: str | None = None
+        volume: str | None = None
+        runner_name = f"pp-er-runner-{uuid.uuid4().hex[:12]}"
+        cleanup_completed = True
+        try:
+            if probe.backend == "apple-container":
+                apple_network = _create_apple_network(cli)
+            _inspect_image(cli, probe.backend, image)
+            runtime_ref = image.runtime_ref(probe.backend)
+            volume = _create_result_volume(cli, probe.backend)
+            if not _initialize_result_volume(
+                cli=cli,
+                backend=probe.backend,
+                image_ref=runtime_ref,
+                volume=volume,
+                apple_network=apple_network,
+            ):
+                raise DispatchError("result_volume_failed")
+            packet = validate_experiment_packet(json.loads(packet_path.read_text(encoding="utf-8")))
+            timeout = int(packet["budgets"]["wall_clock_seconds"]) + 60
+            try:
+                completed = _run(
+                    _container_run_argv(
+                        cli=cli,
+                        backend=probe.backend,
+                        image_ref=runtime_ref,
+                        container_name=runner_name,
+                        result_volume=volume,
+                        repository=snapshot,
+                        input_dir=input_dir,
+                        command=command,
+                        apple_network=apple_network,
+                    ),
+                    cwd=REPO_ROOT,
+                    timeout=timeout,
+                )
+            finally:
+                cleanup_completed = (
+                    _cleanup_container(cli, probe.backend, runner_name) and cleanup_completed
+                )
+            if not cleanup_completed:
+                raise DispatchError("container_cleanup_failed")
+            if completed.returncode not in {0, 1}:
+                raise DispatchError("runner_execution_failed")
+            payload = _collect_result_volume(
+                cli=cli,
+                backend=probe.backend,
+                image_ref=runtime_ref,
+                volume=volume,
+                output_name=output_name,
+                apple_network=apple_network,
+            )
+        finally:
+            if volume is not None:
+                cleanup_completed = (
+                    _delete_result_volume(cli, probe.backend, volume) and cleanup_completed
+                )
+            if apple_network is not None:
+                cleanup_completed = _delete_apple_network(cli, apple_network) and cleanup_completed
+        if not cleanup_completed:
+            raise DispatchError("container_cleanup_failed")
+        return _sanitize_result(payload, probe)
+
+
+def _invoke_native_runner(
+    *,
+    probe: BackendProbe,
+    packet_path: Path,
+    candidate_patch: Path | None,
+    output_name: str,
+) -> dict[str, Any]:
+    from scripts.orchestration import experiment_runner
+
+    packet = validate_experiment_packet(json.loads(packet_path.read_text(encoding="utf-8")))
+    if candidate_patch is None:
+        result = experiment_runner.evaluate_oracle_only_governance_reviewer(packet)
+    else:
+        result = experiment_runner.evaluate_candidate(packet, candidate_patch)
+    return _sanitize_result(result, probe)
+
+
+def _build_image(backend: str, tag: str) -> dict[str, str]:
+    if not TAG_RE.fullmatch(tag) or "@" in tag:
+        raise ValueError("--tag must be a bounded mutable local image tag without a digest.")
+    cli_name = "container" if backend == "apple-container" else "docker"
+    cli = _resolve_cli(cli_name)
+    if cli is None:
+        raise DispatchError("runtime_cli_missing")
+    readiness_reason = _runtime_readiness_reason(cli, backend)
+    if readiness_reason is not None:
+        raise DispatchError(readiness_reason)
+    argv = [cli, "build", "--file", str(CONTAINERFILE), "--tag", tag]
+    for env_name, secret_id in (
+        ("PULSEPLATE_PYTHON_INDEX_URL", "pp_py_index"),
+        ("PULSEPLATE_PYTHON_TRUSTED_HOST", "pp_py_host"),
+        ("PULSEPLATE_PYTHON_NETRC", "pp_netrc"),
+    ):
+        if os.environ.get(env_name):
+            argv.extend(["--secret", f"id={secret_id},env={env_name}"])
+    argv.append(str(REPO_ROOT))
+    secret_env_keys = tuple(
+        env_name
+        for env_name in (
+            "PULSEPLATE_PYTHON_INDEX_URL",
+            "PULSEPLATE_PYTHON_TRUSTED_HOST",
+            "PULSEPLATE_PYTHON_NETRC",
+        )
+        if os.environ.get(env_name)
+    )
+    completed = _run(
+        argv,
+        cwd=REPO_ROOT,
+        timeout=1800,
+        secret_env_keys=secret_env_keys,
+    )
+    if completed.returncode != 0:
+        raise DispatchError("probe_execution_failed")
+    inspect = _run([cli, "image", "inspect", tag], cwd=REPO_ROOT)
+    if inspect.returncode != 0:
+        raise DispatchError("image_missing")
+    try:
+        digest = _primary_image_digest(json.loads(inspect.stdout))
+    except json.JSONDecodeError as exc:
+        raise DispatchError("image_missing") from exc
+    history = ""
+    if backend == "docker":
+        history_result = _run(
+            [cli, "history", "--no-trunc", "--format", "{{json .CreatedBy}}", tag],
+            cwd=REPO_ROOT,
+        )
+        if history_result.returncode != 0:
+            raise DispatchError("image_hygiene_failed")
+        history = history_result.stdout
+    immutable_ref = f"{tag}@{digest}"
+    if backend == "apple-container":
+        registered = _run(
+            [cli, "image", "tag", tag, immutable_ref],
+            cwd=REPO_ROOT,
+        )
+        if registered.returncode != 0:
+            raise DispatchError("image_digest_drift")
+        immutable_inspect = _run(
+            [cli, "image", "inspect", immutable_ref],
+            cwd=REPO_ROOT,
+        )
+        if immutable_inspect.returncode != 0:
+            raise DispatchError("image_digest_drift")
+        try:
+            if _primary_image_digest(json.loads(immutable_inspect.stdout)) != digest:
+                raise DispatchError("image_digest_drift")
+        except json.JSONDecodeError as exc:
+            raise DispatchError("image_digest_drift") from exc
+        inspect = immutable_inspect
+    image_metadata = f"{inspect.stdout}\n{history}"
+    forbidden_names = secret_env_keys
+    forbidden_values = tuple(
+        os.environ[key] for key in secret_env_keys if len(os.environ.get(key, "")) >= 6
+    )
+    if any(name in image_metadata for name in forbidden_names) or any(
+        value in image_metadata for value in forbidden_values
+    ):
+        raise DispatchError("image_hygiene_failed")
+    return {"backend": backend, "image": immutable_ref, "sanitized": "true"}
+
+
+def _read_packet(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Unable to read a valid experiment packet JSON.") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Experiment packet must be a JSON object.")
+    return payload
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="experiment_runner_dispatch",
+        description="Select and execute a strict Experiment Runner backend without downgrade.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    probe = subparsers.add_parser("probe")
+    probe.add_argument("--backend", choices=BACKENDS, default="auto")
+    probe.add_argument("--image", required=True)
+    probe.add_argument("--output", required=True)
+    build = subparsers.add_parser("build-image")
+    build.add_argument("--backend", choices=CONTAINER_BACKENDS, required=True)
+    build.add_argument("--tag", required=True)
+    run = subparsers.add_parser("run")
+    run.add_argument("--backend", choices=BACKENDS, default="auto")
+    run.add_argument("--packet", required=True)
+    run.add_argument("--candidate-patch", default=None)
+    run.add_argument("--image", required=True)
+    run.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = _parse_args(argv)
+        if args.command == "probe":
+            image = parse_image_reference(args.image)
+            if args.backend == "auto":
+                selected, attempts = select_backend("auto", image)
+                probe = selected or attempts[-1]
+            else:
+                probe = probe_backend(args.backend, image)
+            output = _resolve_local_output(args.output, root=CAPABILITY_ARTIFACT_DIR)
+            _atomic_write_json(output, probe.to_artifact())
+            print(
+                json.dumps(
+                    {"artifact": output.name, "strict_isolation": probe.strict}, sort_keys=True
+                )
+            )
+            return 0 if probe.strict else 2
+        if args.command == "build-image":
+            print(json.dumps(_build_image(args.backend, args.tag), sort_keys=True))
+            return 0
+
+        image = parse_image_reference(args.image)
+        packet_path = _require_repo_local_file(args.packet, suffix=".json")
+        candidate_patch = (
+            _require_repo_local_file(args.candidate_patch, suffix=".patch")
+            if args.candidate_patch
+            else None
+        )
+        output_path = _resolve_local_output(args.output, root=RESULT_ARTIFACT_DIR)
+        packet = validate_experiment_packet(_read_packet(packet_path))
+        if packet["runner_mode"] == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+            if candidate_patch is not None:
+                raise ValueError("Oracle-only packets must not include --candidate-patch.")
+        elif candidate_patch is None:
+            raise ValueError("Candidate-patch packets require --candidate-patch.")
+        selected, attempts = select_backend(args.backend, image)
+        if selected is None:
+            result = _capability_mismatch_result(packet, image, attempts[-1])
+        else:
+            try:
+                if selected.backend == "native-linux":
+                    result = _invoke_native_runner(
+                        probe=selected,
+                        packet_path=packet_path,
+                        candidate_patch=candidate_patch,
+                        output_name=output_path.name,
+                    )
+                else:
+                    result = _invoke_container_runner(
+                        probe=selected,
+                        image=image,
+                        packet_path=packet_path,
+                        candidate_patch=candidate_patch,
+                        output_name=output_path.name,
+                    )
+            except DispatchError as exc:
+                result = _infra_flake_result(packet, image, selected, exc.code)
+            except (OSError, ValueError):
+                result = _infra_flake_result(packet, image, selected, "result_validation_failed")
+        _atomic_write_json(output_path, result)
+        print(
+            json.dumps({"artifact": output_path.name, "status": result["status"]}, sort_keys=True)
+        )
+        return 0 if result["status"] == "accepted" else 1
+    except (DispatchError, OSError, ValueError) as exc:
+        print(f"experiment_runner_dispatch: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/experiment_runner_dispatch.py
+++ b/scripts/orchestration/experiment_runner_dispatch.py
@@ -12,6 +12,7 @@ import argparse
 import base64
 from contextlib import contextmanager
 from dataclasses import dataclass
+import ipaddress
 import json
 import os
 from pathlib import Path
@@ -50,7 +51,6 @@ CPU_LIMIT = "2"
 MEMORY_LIMIT = "4g"
 TMPFS_SIZE = "1g"
 APPLE_TMPFS_SIZE = "1G"
-CANARY_BIND_ADDRESS = "0.0.0.0"  # nosec B104: ephemeral fixed-response Apple VM canary requires the host gateway redirect (remove-by: 2026-10-31, ref: ledger-p1-experiment-runner-macos-strict-backend)
 CONTAINER_PYTHON = "/opt/venv/bin/python"
 CONTAINER_UNSHARE = "/usr/bin/unshare"
 CONTAINER_REPO = "/repo"
@@ -616,11 +616,55 @@ def _initialize_result_volume(
     return completed_ok and cleanup_ok
 
 
+def _address_is_bindable(address: str) -> bool:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        probe.bind((address, 0))
+    except OSError:
+        return False
+    finally:
+        probe.close()
+    return True
+
+
+def _discover_host_bind_address() -> str:
+    """Return one exact non-loopback IPv4 address without persisting host identity."""
+
+    try:
+        records = socket.getaddrinfo(
+            socket.gethostname(),
+            None,
+            family=socket.AF_INET,
+            type=socket.SOCK_STREAM,
+        )
+    except OSError as exc:
+        raise DispatchError("host_listener_unavailable") from exc
+
+    candidates: list[str] = []
+    for _family, _kind, _proto, _canonical, sockaddr in records:
+        candidate = str(sockaddr[0])
+        address = ipaddress.ip_address(candidate)
+        if (
+            address.is_loopback
+            or address.is_unspecified
+            or address.is_multicast
+            or address.is_link_local
+            or candidate in candidates
+        ):
+            continue
+        candidates.append(candidate)
+    for candidate in candidates:
+        if _address_is_bindable(candidate):
+            return candidate
+    raise DispatchError("host_listener_unavailable")
+
+
 @contextmanager
-def _host_listener() -> Iterator[tuple[int, bool]]:
+def _host_listener() -> Iterator[tuple[str, int, bool]]:
+    bind_address = _discover_host_bind_address()
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    listener.bind((CANARY_BIND_ADDRESS, 0))
+    listener.bind((bind_address, 0))
     listener.listen(8)
     listener.settimeout(0.2)
     stop = threading.Event()
@@ -641,9 +685,9 @@ def _host_listener() -> Iterator[tuple[int, bool]]:
     port = int(listener.getsockname()[1])
     ready = False
     try:
-        with socket.create_connection(("127.0.0.1", port), timeout=1):
+        with socket.create_connection((bind_address, port), timeout=1):
             ready = True
-        yield port, ready
+        yield bind_address, port, ready
     finally:
         stop.set()
         listener.close()
@@ -788,11 +832,12 @@ def _run_container_canary(
             results = _base_probe_results(backend)
             results["runtime_available"] = True
             results["image_digest_verified"] = True
-            with _host_listener() as (port, listener_ready):
+            with _host_listener() as (host_address, port, listener_ready):
                 results["host_listener_ready"] = listener_ready
                 outer_name = f"pp-er-outer-{uuid.uuid4().hex[:12]}"
                 inner_name = f"pp-er-inner-{uuid.uuid4().hex[:12]}"
-                code = _canary_code(gateway, port)
+                canary_address = host_address if backend == "apple-container" else gateway
+                code = _canary_code(canary_address, port)
                 try:
                     outer = _run(
                         _container_run_argv(
@@ -895,7 +940,7 @@ def probe_backend(backend: str, image: ImageReference | None = None) -> BackendP
             return _failed_probe(backend, "runtime_cli_missing", image_digest=image.digest)
         results = _base_probe_results(backend)
         results["runtime_available"] = True
-        with _host_listener() as (port, ready):
+        with _host_listener() as (_host_address, port, ready):
             results["host_listener_ready"] = ready
             completed = _run(
                 [

--- a/scripts/orchestration/experiment_runner_dispatch.py
+++ b/scripts/orchestration/experiment_runner_dispatch.py
@@ -214,6 +214,10 @@ class DispatchError(RuntimeError):
         super().__init__(code)
 
 
+class PreRunCapabilityError(DispatchError):
+    """Deterministic backend drift detected after selection but before execution."""
+
+
 @dataclass(frozen=True)
 class ImageReference:
     name: str
@@ -416,6 +420,21 @@ def _failed_probe(
         image_digest=image_digest,
         isolation_method=_isolation_method(backend),
         probe_results=results or _base_probe_results(backend),
+        blocking_reasons=(reason,),
+    )
+
+
+def _probe_with_blocker(probe: BackendProbe, reason: str) -> BackendProbe:
+    if reason not in BLOCKER_CODES:
+        raise ValueError(f"Unsupported blocker code: {reason}")
+    return BackendProbe(
+        backend=probe.backend,
+        host_platform=probe.host_platform,
+        guest_platform=probe.guest_platform,
+        runtime_version=probe.runtime_version,
+        image_digest=probe.image_digest,
+        isolation_method=probe.isolation_method,
+        probe_results=probe.probe_results,
         blocking_reasons=(reason,),
     )
 
@@ -1381,19 +1400,22 @@ def _invoke_container_runner(
         runner_name = f"pp-er-runner-{uuid.uuid4().hex[:12]}"
         cleanup_completed = True
         try:
-            if probe.backend == "apple-container":
-                apple_network = _create_apple_network(cli)
-            _inspect_image(cli, probe.backend, image)
-            runtime_ref = image.runtime_ref(probe.backend)
-            volume = _create_result_volume(cli, probe.backend)
-            if not _initialize_result_volume(
-                cli=cli,
-                backend=probe.backend,
-                image_ref=runtime_ref,
-                volume=volume,
-                apple_network=apple_network,
-            ):
-                raise DispatchError("result_volume_failed")
+            try:
+                if probe.backend == "apple-container":
+                    apple_network = _create_apple_network(cli)
+                _inspect_image(cli, probe.backend, image)
+                runtime_ref = image.runtime_ref(probe.backend)
+                volume = _create_result_volume(cli, probe.backend)
+                if not _initialize_result_volume(
+                    cli=cli,
+                    backend=probe.backend,
+                    image_ref=runtime_ref,
+                    volume=volume,
+                    apple_network=apple_network,
+                ):
+                    raise DispatchError("result_volume_failed")
+            except DispatchError as exc:
+                raise PreRunCapabilityError(exc.code) from exc
             packet = validate_experiment_packet(json.loads(packet_path.read_text(encoding="utf-8")))
             timeout = int(packet["budgets"]["wall_clock_seconds"]) + 60
             try:
@@ -1629,6 +1651,12 @@ def main(argv: list[str] | None = None) -> int:
                         candidate_patch=candidate_patch,
                         output_name=output_path.name,
                     )
+            except PreRunCapabilityError as exc:
+                result = _capability_mismatch_result(
+                    packet,
+                    image,
+                    _probe_with_blocker(selected, exc.code),
+                )
             except DispatchError as exc:
                 result = _infra_flake_result(packet, image, selected, exc.code)
             except (OSError, ValueError):

--- a/scripts/orchestration/experiment_runner_dispatch.py
+++ b/scripts/orchestration/experiment_runner_dispatch.py
@@ -19,7 +19,6 @@ import platform
 import re
 import shutil
 import socket
-import stat
 import subprocess  # nosec B404: bounded absolute runtime/git argv only (remove-by: 2026-10-31, ref: ledger-p1-experiment-runner-macos-strict-backend)
 import sys
 import tempfile
@@ -78,6 +77,8 @@ BLOCKER_CODES = frozenset(
         "image_digest_drift",
         "guest_platform_mismatch",
         "guest_unshare_unavailable",
+        "filesystem_isolation_unavailable",
+        "strict_network_budget_required",
         "network_isolation_failed",
         "network_gateway_unavailable",
         "mount_contract_failed",
@@ -378,11 +379,8 @@ def _primary_image_digest(payload: Any) -> str:
 
 
 def _inspect_image(cli: str, backend: str, image: ImageReference) -> str:
-    argv = (
-        [cli, "image", "inspect", image.name]
-        if backend == "docker"
-        else [cli, "image", "inspect", image.name]
-    )
+    del backend
+    argv = [cli, "image", "inspect", image.name]
     result = _run(argv, cwd=REPO_ROOT)
     if result.returncode != 0:
         raise DispatchError("image_missing")
@@ -549,21 +547,11 @@ def _container_run_argv(
 
 
 def _cleanup_container(cli: str, backend: str, name: str) -> bool:
-    stop_args = (
-        [cli, "stop", "--time", "1", name]
-        if backend == "apple-container"
-        else [
-            cli,
-            "stop",
-            "--time",
-            "1",
-            name,
-        ]
-    )
+    stop_args = [cli, "stop", "--time", "1", name]
     try:
         _run(stop_args, cwd=REPO_ROOT)
     except DispatchError:
-        return False
+        pass
     delete_args = (
         [cli, "delete", "--force", name]
         if backend == "apple-container"
@@ -935,11 +923,9 @@ def probe_backend(backend: str, image: ImageReference | None = None) -> BackendP
         results["inner_direct_ip_blocked"] = inner["direct_ip_blocked"]
         results["unshare_without_broad_capabilities"] = True
         results["cleanup_completed"] = True
-        native_blockers = (
-            ()
-            if all(results[key] is True for key in REQUIRED_PROBE_KEYS[backend])
-            else ("network_isolation_failed",)
-        )
+        native_blockers = ["filesystem_isolation_unavailable"]
+        if not all(results[key] is True for key in REQUIRED_PROBE_KEYS[backend]):
+            native_blockers.append("network_isolation_failed")
         return BackendProbe(
             backend=backend,
             host_platform=_host_platform_class(),
@@ -948,7 +934,7 @@ def probe_backend(backend: str, image: ImageReference | None = None) -> BackendP
             image_digest=image.digest,
             isolation_method=_isolation_method(backend),
             probe_results=results,
-            blocking_reasons=native_blockers,
+            blocking_reasons=tuple(sorted(native_blockers)),
         )
 
     expected_cli = "container" if backend == "apple-container" else "docker"
@@ -1050,6 +1036,24 @@ def select_backend(
         if probe.strict:
             return probe, attempts
     return None, attempts
+
+
+def _strict_network_budget_probe(requested: str, image: ImageReference) -> BackendProbe:
+    """Build a deterministic fail-closed probe without contacting a runtime."""
+
+    if requested != "auto":
+        backend = requested
+    elif platform.system() == "Darwin":
+        backend = "apple-container"
+    elif platform.system() == "Linux":
+        backend = "native-linux"
+    else:
+        backend = "docker"
+    return _failed_probe(
+        backend,
+        "strict_network_budget_required",
+        image_digest=image.digest,
+    )
 
 
 def validate_capability_artifact(payload: dict[str, Any]) -> dict[str, Any]:
@@ -1517,23 +1521,6 @@ def _invoke_container_runner(
         return _sanitize_result(payload, probe)
 
 
-def _invoke_native_runner(
-    *,
-    probe: BackendProbe,
-    packet_path: Path,
-    candidate_patch: Path | None,
-    output_name: str,
-) -> dict[str, Any]:
-    from scripts.orchestration import experiment_runner
-
-    packet = validate_experiment_packet(json.loads(packet_path.read_text(encoding="utf-8")))
-    if candidate_patch is None:
-        result = experiment_runner.evaluate_oracle_only_governance_reviewer(packet)
-    else:
-        result = experiment_runner.evaluate_candidate(packet, candidate_patch)
-    return _sanitize_result(result, probe)
-
-
 def _build_image(backend: str, tag: str) -> dict[str, str]:
     if not TAG_RE.fullmatch(tag) or "@" in tag:
         raise ValueError("--tag must be a bounded mutable local image tag without a digest.")
@@ -1686,26 +1673,31 @@ def main(argv: list[str] | None = None) -> int:
                 raise ValueError("Oracle-only packets must not include --candidate-patch.")
         elif candidate_patch is None:
             raise ValueError("Candidate-patch packets require --candidate-patch.")
+        if int(packet["budgets"]["network_budget"]) != 0:
+            probe = _strict_network_budget_probe(args.backend, image)
+            result = _capability_mismatch_result(packet, image, probe)
+            _atomic_write_json(output_path, result)
+            print(
+                json.dumps(
+                    {"artifact": output_path.name, "status": result["status"]},
+                    sort_keys=True,
+                )
+            )
+            return 1
         selected, attempts = select_backend(args.backend, image)
         if selected is None:
             result = _capability_mismatch_result(packet, image, attempts[-1])
         else:
             try:
-                if selected.backend == "native-linux":
-                    result = _invoke_native_runner(
-                        probe=selected,
-                        packet_path=packet_path,
-                        candidate_patch=candidate_patch,
-                        output_name=output_path.name,
-                    )
-                else:
-                    result = _invoke_container_runner(
-                        probe=selected,
-                        image=image,
-                        packet_path=packet_path,
-                        candidate_patch=candidate_patch,
-                        output_name=output_path.name,
-                    )
+                if selected.backend not in CONTAINER_BACKENDS:
+                    raise PreRunCapabilityError("filesystem_isolation_unavailable")
+                result = _invoke_container_runner(
+                    probe=selected,
+                    image=image,
+                    packet_path=packet_path,
+                    candidate_patch=candidate_patch,
+                    output_name=output_path.name,
+                )
             except PreRunCapabilityError as exc:
                 result = _capability_mismatch_result(
                     packet,

--- a/scripts/orchestration/experiment_runner_dispatch.py
+++ b/scripts/orchestration/experiment_runner_dispatch.py
@@ -24,7 +24,7 @@ import subprocess  # nosec B404: bounded absolute runtime/git argv only (remove-
 import sys
 import tempfile
 import threading
-from typing import Any, cast, Iterator
+from typing import Any, Iterator
 import uuid
 
 DISPATCH_REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -560,13 +560,19 @@ def _cleanup_container(cli: str, backend: str, name: str) -> bool:
             name,
         ]
     )
-    _run(stop_args, cwd=REPO_ROOT)
+    try:
+        _run(stop_args, cwd=REPO_ROOT)
+    except DispatchError:
+        return False
     delete_args = (
         [cli, "delete", "--force", name]
         if backend == "apple-container"
         else [cli, "rm", "--force", name]
     )
-    return _run(delete_args, cwd=REPO_ROOT).returncode == 0
+    try:
+        return _run(delete_args, cwd=REPO_ROOT).returncode == 0
+    except DispatchError:
+        return False
 
 
 def _create_result_volume(cli: str, backend: str) -> str:
@@ -587,7 +593,10 @@ def _delete_result_volume(cli: str, backend: str, name: str) -> bool:
         if backend == "apple-container"
         else [cli, "volume", "rm", "--force", name]
     )
-    return _run(argv, cwd=REPO_ROOT).returncode == 0
+    try:
+        return _run(argv, cwd=REPO_ROOT).returncode == 0
+    except DispatchError:
+        return False
 
 
 def _initialize_result_volume(
@@ -734,7 +743,26 @@ def _create_apple_network(cli: str) -> str:
 
 
 def _delete_apple_network(cli: str, name: str) -> bool:
-    return _run([cli, "network", "delete", name], cwd=REPO_ROOT).returncode == 0
+    try:
+        return _run([cli, "network", "delete", name], cwd=REPO_ROOT).returncode == 0
+    except DispatchError:
+        return False
+
+
+def _cleanup_container_resources(
+    *,
+    cli: str,
+    backend: str,
+    volume: str | None,
+    apple_network: str | None,
+    prior_cleanup_ok: bool,
+) -> bool:
+    cleanup_ok = prior_cleanup_ok
+    if volume is not None:
+        cleanup_ok = _delete_result_volume(cli, backend, volume) and cleanup_ok
+    if apple_network is not None:
+        cleanup_ok = _delete_apple_network(cli, apple_network) and cleanup_ok
+    return cleanup_ok
 
 
 def _run_container_canary(
@@ -844,13 +872,24 @@ def _run_container_canary(
                 "private_tmpfs",
             ):
                 results[key] = inner_payload[key]
-        finally:
-            if volume is not None:
-                cleanup_completed = (
-                    _delete_result_volume(cli, backend, volume) and cleanup_completed
-                )
-            if apple_network is not None:
-                cleanup_completed = _delete_apple_network(cli, apple_network) and cleanup_completed
+        except BaseException as exc:
+            cleanup_completed = _cleanup_container_resources(
+                cli=cli,
+                backend=backend,
+                volume=volume,
+                apple_network=apple_network,
+                prior_cleanup_ok=cleanup_completed,
+            )
+            if not cleanup_completed:
+                raise DispatchError("container_cleanup_failed") from exc
+            raise
+        cleanup_completed = _cleanup_container_resources(
+            cli=cli,
+            backend=backend,
+            volume=volume,
+            apple_network=apple_network,
+            prior_cleanup_ok=cleanup_completed,
+        )
         results["cleanup_completed"] = cleanup_completed
         return results
 
@@ -1170,6 +1209,11 @@ def _execution_backend_payload(probe: BackendProbe, *, passed: bool) -> dict[str
     }
 
 
+def _validated_experiment_result(result: dict[str, Any]) -> dict[str, Any]:
+    validated: dict[str, Any] = validate_experiment_result(result)
+    return validated
+
+
 def _capability_mismatch_result(
     packet: dict[str, Any],
     image: ImageReference,
@@ -1217,7 +1261,7 @@ def _capability_mismatch_result(
             passed=False,
         ),
     }
-    return cast(dict[str, Any], validate_experiment_result(result))
+    return _validated_experiment_result(result)
 
 
 def _infra_flake_result(
@@ -1255,7 +1299,7 @@ def _infra_flake_result(
         "coauthor_reason": "",
         "execution_backend": _execution_backend_payload(probe, passed=True),
     }
-    return cast(dict[str, Any], validate_experiment_result(_redact_result_value(result)))
+    return _validated_experiment_result(_redact_result_value(result))
 
 
 _SECRET_TEXT_PATTERNS = (
@@ -1300,7 +1344,7 @@ def _sanitize_result(result: dict[str, Any], probe: BackendProbe) -> dict[str, A
         oracle["cwd"] = "/workspace"
         oracle_results.append(oracle)
     sanitized["oracle_results"] = oracle_results
-    return cast(dict[str, Any], validate_experiment_result(sanitized))
+    return _validated_experiment_result(sanitized)
 
 
 def _collect_result_volume(
@@ -1450,13 +1494,24 @@ def _invoke_container_runner(
                 output_name=output_name,
                 apple_network=apple_network,
             )
-        finally:
-            if volume is not None:
-                cleanup_completed = (
-                    _delete_result_volume(cli, probe.backend, volume) and cleanup_completed
-                )
-            if apple_network is not None:
-                cleanup_completed = _delete_apple_network(cli, apple_network) and cleanup_completed
+        except BaseException as exc:
+            cleanup_completed = _cleanup_container_resources(
+                cli=cli,
+                backend=probe.backend,
+                volume=volume,
+                apple_network=apple_network,
+                prior_cleanup_ok=cleanup_completed,
+            )
+            if not cleanup_completed:
+                raise DispatchError("container_cleanup_failed") from exc
+            raise
+        cleanup_completed = _cleanup_container_resources(
+            cli=cli,
+            backend=probe.backend,
+            volume=volume,
+            apple_network=apple_network,
+            prior_cleanup_ok=cleanup_completed,
+        )
         if not cleanup_completed:
             raise DispatchError("container_cleanup_failed")
         return _sanitize_result(payload, probe)

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -1218,7 +1218,7 @@ def test_classify_oracle_failure_matches_only_standalone_oom_markers() -> None:
     assert experiment_runner._classify_oracle_failure(oom_result) == "oom"
 
 
-def test_classify_oracle_failure_maps_unshare_setup_to_infra_flake() -> None:
+def test_classify_oracle_failure_maps_unshare_setup_to_capability_mismatch() -> None:
     result = SandboxResult(
         argv=("unshare", "--net", "python3"),
         returncode=1,
@@ -1229,7 +1229,43 @@ def test_classify_oracle_failure_maps_unshare_setup_to_infra_flake() -> None:
         cwd="/tmp",
     )
 
-    assert experiment_runner._classify_oracle_failure(result) == "infra_flake"
+    assert experiment_runner._classify_oracle_failure(result) == "capability_mismatch"
+
+
+def test_evaluate_candidate_does_not_retry_lost_unshare_capability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    patch_path = _write_patch(
+        repo,
+        "core/rag/allowed.py",
+        "def candidate_value() -> int:\n    return 2\n",
+        tmp_path / "lost-unshare.patch",
+    )
+    packet = _validate_packet(
+        _base_packet(
+            mutable_path="core/rag/allowed.py",
+            oracle_command='python3 -c "print(1)"',
+            network_budget=0,
+        )
+    )
+    attempts = {"count": 0}
+
+    def _missing_unshare(*_args: object, **_kwargs: object) -> SandboxResult:
+        attempts["count"] += 1
+        raise RuntimeError("Network-disabled sandbox requires unshare on PATH.")
+
+    monkeypatch.setattr(experiment_runner.sandbox, "run_local_sandbox", _missing_unshare)
+
+    result = experiment_runner.evaluate_candidate(packet, patch_path)
+
+    assert result["status"] == "rejected"
+    assert result["failure_class"] == "capability_mismatch"
+    assert result["budget_observations"]["attempts"] == 1
+    assert result["budget_observations"]["retries_consumed"] == 0
+    assert attempts["count"] == 1
 
 
 def test_evaluate_candidate_allows_first_oracle_on_one_second_budget(

--- a/tests/test_experiment_runner_dispatch.py
+++ b/tests/test_experiment_runner_dispatch.py
@@ -638,3 +638,94 @@ def test_container_cleanup_forces_stop_before_delete(monkeypatch: pytest.MonkeyP
     assert dispatch._cleanup_container("/usr/local/bin/container", "apple-container", "run-id")
     assert calls[0][1:4] == ["stop", "--time", "1"]
     assert calls[1][1:3] == ["delete", "--force"]
+
+
+def test_probe_cleanup_failure_overrides_original_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dispatch, "_create_apple_network", lambda _cli: "probe-network")
+    monkeypatch.setattr(
+        dispatch,
+        "_discover_gateway",
+        lambda *_args: (_ for _ in ()).throw(dispatch.DispatchError("network_gateway_unavailable")),
+    )
+    monkeypatch.setattr(dispatch, "_delete_apple_network", lambda *_args: False)
+
+    with pytest.raises(dispatch.DispatchError, match="container_cleanup_failed") as caught:
+        dispatch._run_container_canary("/usr/local/bin/container", "apple-container", _image())
+
+    assert isinstance(caught.value.__cause__, dispatch.DispatchError)
+    assert caught.value.__cause__.code == "network_gateway_unavailable"
+
+
+def test_pre_run_cleanup_failure_overrides_capability_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(_packet()), encoding="utf-8")
+    monkeypatch.setattr(dispatch, "_resolve_cli", lambda _name: "/usr/local/bin/container")
+    monkeypatch.setattr(
+        dispatch,
+        "_create_snapshot",
+        lambda _root, destination: destination.mkdir() or "",
+    )
+    monkeypatch.setattr(dispatch, "_create_apple_network", lambda _cli: "run-network")
+    monkeypatch.setattr(
+        dispatch,
+        "_inspect_image",
+        lambda *_args: (_ for _ in ()).throw(dispatch.DispatchError("image_digest_drift")),
+    )
+    monkeypatch.setattr(dispatch, "_delete_apple_network", lambda *_args: False)
+
+    with pytest.raises(dispatch.DispatchError, match="container_cleanup_failed") as caught:
+        dispatch._invoke_container_runner(
+            probe=_probe("apple-container", strict=True),
+            image=_image(),
+            packet_path=packet_path,
+            candidate_patch=None,
+            output_name="result.json",
+        )
+
+    assert isinstance(caught.value.__cause__, dispatch.PreRunCapabilityError)
+    assert caught.value.__cause__.code == "image_digest_drift"
+
+
+def test_post_start_cleanup_failure_overrides_execution_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(_packet()), encoding="utf-8")
+    monkeypatch.setattr(dispatch, "_resolve_cli", lambda _name: "/usr/local/bin/container")
+    monkeypatch.setattr(
+        dispatch,
+        "_create_snapshot",
+        lambda _root, destination: destination.mkdir() or "",
+    )
+    monkeypatch.setattr(dispatch, "_create_apple_network", lambda _cli: "run-network")
+    monkeypatch.setattr(dispatch, "_inspect_image", lambda *_args: _DIGEST)
+    monkeypatch.setattr(dispatch, "_create_result_volume", lambda *_args: "result-volume")
+    monkeypatch.setattr(dispatch, "_initialize_result_volume", lambda **_kwargs: True)
+    monkeypatch.setattr(
+        dispatch,
+        "_run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            dispatch.DispatchError("runner_execution_failed")
+        ),
+    )
+    monkeypatch.setattr(dispatch, "_cleanup_container", lambda *_args: True)
+    monkeypatch.setattr(dispatch, "_delete_result_volume", lambda *_args: False)
+    monkeypatch.setattr(dispatch, "_delete_apple_network", lambda *_args: True)
+
+    with pytest.raises(dispatch.DispatchError, match="container_cleanup_failed") as caught:
+        dispatch._invoke_container_runner(
+            probe=_probe("apple-container", strict=True),
+            image=_image(),
+            packet_path=packet_path,
+            candidate_patch=None,
+            output_name="result.json",
+        )
+
+    assert isinstance(caught.value.__cause__, dispatch.DispatchError)
+    assert caught.value.__cause__.code == "runner_execution_failed"

--- a/tests/test_experiment_runner_dispatch.py
+++ b/tests/test_experiment_runner_dispatch.py
@@ -599,13 +599,42 @@ def test_capability_validator_matches_platform_and_isolation_schema() -> None:
 def test_host_listener_marks_successful_positive_control_ready(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(dispatch, "_discover_host_bind_address", lambda: "127.0.0.1")
     monkeypatch.setattr(
         dispatch.socket, "create_connection", lambda *_args, **_kwargs: nullcontext()
     )
 
-    with dispatch._host_listener() as (port, ready):
+    with dispatch._host_listener() as (address, port, ready):
+        assert address == "127.0.0.1"
         assert port > 0
         assert ready is True
+
+
+def test_host_bind_address_is_exact_non_loopback_ipv4(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dispatch.socket, "gethostname", lambda: "local-host")
+    monkeypatch.setattr(
+        dispatch.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (dispatch.socket.AF_INET, dispatch.socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+            (
+                dispatch.socket.AF_INET,
+                dispatch.socket.SOCK_STREAM,
+                6,
+                "",
+                ("192.168.100.100", 0),
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        dispatch,
+        "_address_is_bindable",
+        lambda address: address == "192.168.100.100",
+    )
+
+    assert dispatch._discover_host_bind_address() == "192.168.100.100"
 
 
 def test_probe_cli_requires_immutable_image() -> None:

--- a/tests/test_experiment_runner_dispatch.py
+++ b/tests/test_experiment_runner_dispatch.py
@@ -7,6 +7,7 @@ import json
 import os
 from pathlib import Path
 import subprocess
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -582,6 +583,47 @@ def test_post_preflight_failure_is_validated_infra_flake() -> None:
     assert result["failure_class"] == "infra_flake"
     assert result["budget_observations"]["runner_error"] == "runner_execution_failed"
     assert result["budget_observations"]["configured_budgets"]["network_budget"] == 0
+
+
+def test_pre_run_image_drift_is_non_retryable_capability_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(_packet()), encoding="utf-8")
+    output_path = tmp_path / "result.json"
+    probe = _probe("apple-container", strict=True)
+    written: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        dispatch,
+        "_parse_args",
+        lambda _argv: SimpleNamespace(
+            command="run",
+            backend="apple-container",
+            packet="packet.json",
+            candidate_patch=None,
+            image=f"pulseplate/experiment-runner:local@{_DIGEST}",
+            output="result.json",
+        ),
+    )
+    monkeypatch.setattr(dispatch, "_require_repo_local_file", lambda *_args, **_kwargs: packet_path)
+    monkeypatch.setattr(dispatch, "_resolve_local_output", lambda *_args, **_kwargs: output_path)
+    monkeypatch.setattr(dispatch, "select_backend", lambda *_args: (probe, [probe]))
+
+    def fail_before_start(**_kwargs: object) -> dict[str, Any]:
+        raise dispatch.PreRunCapabilityError("image_digest_drift")
+
+    monkeypatch.setattr(dispatch, "_invoke_container_runner", fail_before_start)
+    monkeypatch.setattr(
+        dispatch, "_atomic_write_json", lambda _path, payload: written.update(payload)
+    )
+
+    assert dispatch.main([]) == 1
+    assert written["failure_class"] == "capability_mismatch"
+    assert written["budget_observations"]["runner_error"] == "image_digest_drift"
+    assert written["budget_observations"]["attempts"] == 0
+    assert written["budget_observations"]["configured_budgets"]["network_budget"] == 0
 
 
 def test_container_cleanup_forces_stop_before_delete(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_experiment_runner_dispatch.py
+++ b/tests/test_experiment_runner_dispatch.py
@@ -1,0 +1,598 @@
+"""Deterministic security and compatibility tests for strict runner dispatch."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+import json
+import os
+from pathlib import Path
+import subprocess
+from typing import Any
+
+import pytest
+
+from scripts.orchestration import experiment_contract
+from scripts.orchestration import experiment_runner_dispatch as dispatch
+
+_DIGEST = "sha256:" + "a" * 64
+_OTHER_DIGEST = "sha256:" + "b" * 64
+
+
+def _run_isolated_git(
+    git: str,
+    *args: str,
+    cwd: Path,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_COMMON_DIR"):
+        env.pop(key, None)
+    return subprocess.run(
+        [git, *args],
+        cwd=cwd,
+        check=True,
+        capture_output=capture_output,
+        text=True,
+        env=env,
+    )
+
+
+def _image() -> dispatch.ImageReference:
+    return dispatch.ImageReference(name="pulseplate/experiment-runner:local", digest=_DIGEST)
+
+
+def _results(backend: str, value: bool = True) -> dict[str, bool | None]:
+    results = dispatch._base_probe_results(backend)
+    for key in dispatch.REQUIRED_PROBE_KEYS[backend]:
+        results[key] = value
+    return results
+
+
+def _probe(
+    backend: str,
+    *,
+    strict: bool,
+    reason: str = "runtime_cli_missing",
+) -> dispatch.BackendProbe:
+    return dispatch.BackendProbe(
+        backend=backend,
+        host_platform="macos_arm64",
+        guest_platform="linux_arm64",
+        runtime_version="1.1.0" if backend == "apple-container" else "29.6.1",
+        image_digest=_DIGEST,
+        isolation_method=dispatch._isolation_method(backend),
+        probe_results=_results(backend, strict),
+        blocking_reasons=() if strict else (reason,),
+    )
+
+
+def _packet(*, network_budget: int = 0) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "experiment_id": "strict-mac-test",
+        "runner_mode": "oracle_only_governance_reviewer",
+        "decision_question": "Verify strict Mac execution",
+        "task_class": "Infrastructure",
+        "mutable_candidate_surface": ["scripts/orchestration/experiment_runner.py"],
+        "immutable_oracles": [{"command": "git --version", "expected_signal": "pass"}],
+        "budgets": {
+            "wall_clock_seconds": 30,
+            "retry_budget": 1,
+            "max_changed_files": 1,
+            "network_budget": network_budget,
+            "benchmark_budget": 1,
+            "test_budget": 1,
+            "stop_condition": "Stop on any failure.",
+        },
+        "metrics": {
+            "primary": "strict_isolation",
+            "secondary": [],
+            "baseline_reference": "current-main",
+            "acceptance_threshold": "strict_improvement",
+        },
+        "negative_controls": [
+            "network remains unavailable",
+            "shared worktree remains unchanged",
+        ],
+        "promotion_target": "audit_artifact",
+    }
+
+
+def _legacy_result() -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "experiment_id": "legacy-result",
+        "runner_mode": "candidate_patch",
+        "candidate_patch": "candidate.patch",
+        "status": "accepted",
+        "failure_class": None,
+        "mutated_paths": ["core/rag/allowed.py"],
+        "oracle_results": [],
+        "budget_observations": {},
+        "shared_tree_untouched": True,
+        "promotion_ready": False,
+        "contribution_kind": "none",
+        "coauthor_required": False,
+        "coauthor_reason": "",
+    }
+
+
+def test_image_reference_requires_immutable_digest() -> None:
+    assert dispatch.parse_image_reference(f"runner:local@{_DIGEST}").digest == _DIGEST
+
+    with pytest.raises(ValueError, match="immutable"):
+        dispatch.parse_image_reference("runner:latest")
+    with pytest.raises(ValueError, match="immutable"):
+        dispatch.parse_image_reference(f"runner:local@sha256:{'A' * 64}")
+
+
+def test_auto_prefers_strict_apple_without_probing_docker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(dispatch.platform, "system", lambda: "Darwin")
+
+    def fake_probe(backend: str, _image: dispatch.ImageReference) -> dispatch.BackendProbe:
+        calls.append(backend)
+        return _probe(backend, strict=True)
+
+    monkeypatch.setattr(dispatch, "probe_backend", fake_probe)
+
+    selected, attempts = dispatch.select_backend("auto", _image())
+
+    assert selected is not None and selected.backend == "apple-container"
+    assert [attempt.backend for attempt in attempts] == ["apple-container"]
+    assert calls == ["apple-container"]
+
+
+def test_auto_uses_docker_only_after_apple_preflight_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(dispatch.platform, "system", lambda: "Darwin")
+
+    def fake_probe(backend: str, _image: dispatch.ImageReference) -> dispatch.BackendProbe:
+        calls.append(backend)
+        return _probe(backend, strict=backend == "docker")
+
+    monkeypatch.setattr(dispatch, "probe_backend", fake_probe)
+
+    selected, _attempts = dispatch.select_backend("auto", _image())
+
+    assert selected is not None and selected.backend == "docker"
+    assert calls == ["apple-container", "docker"]
+
+
+def test_explicit_backend_never_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_probe(backend: str, _image: dispatch.ImageReference) -> dispatch.BackendProbe:
+        calls.append(backend)
+        return _probe(backend, strict=False)
+
+    monkeypatch.setattr(dispatch, "probe_backend", fake_probe)
+
+    selected, attempts = dispatch.select_backend("apple-container", _image())
+
+    assert selected is None
+    assert [probe.backend for probe in attempts] == ["apple-container"]
+    assert calls == ["apple-container"]
+
+
+@pytest.mark.parametrize("backend", ["apple-container", "docker"])
+def test_container_argv_enforces_exact_mount_and_network_contract(
+    tmp_path: Path,
+    backend: str,
+) -> None:
+    cli = "/usr/local/bin/container" if backend == "apple-container" else "/usr/local/bin/docker"
+    argv = dispatch._container_run_argv(
+        cli=cli,
+        backend=backend,
+        image_ref=_DIGEST,
+        container_name="pp-er-test",
+        result_volume="pp-er-result-test",
+        repository=tmp_path / "repo",
+        input_dir=tmp_path / "input",
+        apple_network="strict-network" if backend == "apple-container" else None,
+        command=[dispatch.CONTAINER_PYTHON, "--version"],
+    )
+    joined = " ".join(argv)
+
+    assert "--read-only" in argv
+    assert "65532:65532" in argv
+    assert dispatch.CONTAINER_REPO in joined
+    assert dispatch.CONTAINER_INPUT in joined
+    assert "pp-er-result-test" in joined
+    assert dispatch.CONTAINER_RESULT_DIR in joined
+    assert "$HOME" not in joined
+    assert "SSH_AUTH_SOCK" not in joined
+    assert "docker.sock" not in joined
+    assert "--cap-add" not in argv
+    assert "SYS_ADMIN" not in argv
+    if backend == "docker":
+        assert argv[argv.index("--network") + 1] == "none"
+        assert argv[argv.index("--pull") + 1] == "never"
+        assert any(value.startswith("/tmp:rw,noexec,nosuid,size=") for value in argv)
+    else:
+        assert "--no-dns" in argv
+        assert "type=tmpfs,destination=/tmp,size=1G,mode=1777" in argv
+        assert "--tmpfs" not in argv
+
+
+def test_subprocess_rejects_non_absolute_binary(tmp_path: Path) -> None:
+    with pytest.raises(dispatch.DispatchError, match="runtime_cli_missing"):
+        dispatch._run(["docker", "info"], cwd=tmp_path)
+
+
+def test_apple_probe_rejects_unsupported_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dispatch.platform, "system", lambda: "Linux")
+
+    probe = dispatch.probe_backend("apple-container", _image())
+
+    assert probe.blocking_reasons == ("unsupported_host",)
+    assert probe.strict is False
+
+
+def test_probe_missing_cli_is_capability_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dispatch.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(dispatch.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(dispatch, "_resolve_cli", lambda _name: None)
+
+    probe = dispatch.probe_backend("apple-container", _image())
+
+    assert probe.blocking_reasons == ("runtime_cli_missing",)
+
+
+def test_probe_distinguishes_apple_kernel_setup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dispatch.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(dispatch.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(dispatch, "_resolve_cli", lambda _name: "/usr/local/bin/container")
+    monkeypatch.setattr(dispatch, "_runtime_version", lambda _cli: "1.1.0")
+    monkeypatch.setattr(
+        dispatch,
+        "_runtime_readiness_reason",
+        lambda _cli, _backend: "apple_kernel_not_configured",
+    )
+
+    probe = dispatch.probe_backend("apple-container", _image())
+
+    assert probe.blocking_reasons == ("apple_kernel_not_configured",)
+
+
+def test_image_digest_drift_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        dispatch,
+        "_run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps([{"Id": _OTHER_DIGEST}]), stderr=""
+        ),
+    )
+
+    with pytest.raises(dispatch.DispatchError, match="image_digest_drift"):
+        dispatch._inspect_image("/usr/local/bin/docker", "docker", _image())
+
+
+def test_capability_artifact_is_strict_and_sanitized() -> None:
+    artifact = _probe("apple-container", strict=True).to_artifact()
+    serialized = json.dumps(artifact)
+
+    assert artifact["authority"] == "evidence_only"
+    assert artifact["sanitized"] is True
+    assert artifact["strict_isolation"] is True
+    assert "username" not in serialized
+    assert "hostname" not in serialized
+    assert "/Users/" not in serialized
+    assert "TOKEN" not in serialized
+    assert "stdout" not in serialized
+    assert "stderr" not in serialized
+
+
+def test_capability_artifact_rejects_extra_fields() -> None:
+    artifact = _probe("docker", strict=True).to_artifact()
+    artifact["raw_output"] = "secret"
+
+    with pytest.raises(ValueError, match="unexpected"):
+        dispatch.validate_capability_artifact(artifact)
+
+
+def test_snapshot_applies_tracked_diff_and_leaves_source_unchanged(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    git = dispatch._resolve_cli("git")
+    assert git is not None
+    _run_isolated_git(git, "init", "--quiet", cwd=source)
+    _run_isolated_git(git, "config", "user.email", "test@example.invalid", cwd=source)
+    _run_isolated_git(git, "config", "user.name", "Test", cwd=source)
+    tracked = source / "tracked.txt"
+    tracked.write_text("before\n", encoding="utf-8")
+    _run_isolated_git(git, "add", "tracked.txt", cwd=source)
+    _run_isolated_git(git, "commit", "--quiet", "-m", "init", cwd=source)
+    tracked.write_text("after\n", encoding="utf-8")
+    before_status = _run_isolated_git(
+        git, "status", "--short", cwd=source, capture_output=True
+    ).stdout
+
+    snapshot = tmp_path / "snapshot"
+    tracked_diff = dispatch._create_snapshot(source, snapshot)
+
+    assert tracked_diff
+    assert (snapshot / "tracked.txt").read_text(encoding="utf-8") == "after\n"
+    assert (snapshot / ".git").is_dir()
+    assert "gitdir:" not in (snapshot / ".git" / "HEAD").read_text(encoding="utf-8")
+    after_status = _run_isolated_git(
+        git, "status", "--short", cwd=source, capture_output=True
+    ).stdout
+    assert after_status == before_status
+
+
+def test_snapshot_preserves_staged_new_file_as_tracked(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    git = dispatch._resolve_cli("git")
+    assert git is not None
+    _run_isolated_git(git, "init", "--quiet", cwd=source)
+    _run_isolated_git(git, "config", "user.email", "test@example.invalid", cwd=source)
+    _run_isolated_git(git, "config", "user.name", "Test", cwd=source)
+    (source / "base.txt").write_text("base\n", encoding="utf-8")
+    _run_isolated_git(git, "add", "base.txt", cwd=source)
+    _run_isolated_git(git, "commit", "--quiet", "-m", "init", cwd=source)
+    added = source / "added.txt"
+    added.write_text("new\n", encoding="utf-8")
+    _run_isolated_git(git, "add", "added.txt", cwd=source)
+    before_status = _run_isolated_git(
+        git, "status", "--short", cwd=source, capture_output=True
+    ).stdout
+
+    snapshot = tmp_path / "snapshot"
+    dispatch._create_snapshot(source, snapshot)
+
+    tracked = _run_isolated_git(
+        git, "ls-files", "--error-unmatch", "added.txt", cwd=snapshot, capture_output=True
+    ).stdout
+    assert tracked.strip() == "added.txt"
+    assert added.read_text(encoding="utf-8") == "new\n"
+    after_status = _run_isolated_git(
+        git, "status", "--short", cwd=source, capture_output=True
+    ).stdout
+    assert after_status == before_status
+
+
+def test_repo_local_input_rejects_absolute_and_traversal(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="repository-relative"):
+        dispatch._require_repo_local_file(str(tmp_path / "packet.json"), suffix=".json")
+    with pytest.raises((FileNotFoundError, ValueError)):
+        dispatch._require_repo_local_file("../packet.json", suffix=".json")
+
+
+def test_legacy_result_v1_remains_valid_without_backend_provenance() -> None:
+    validated = experiment_contract.validate_experiment_result(_legacy_result())
+
+    assert "execution_backend" not in validated
+
+
+def test_result_v1_accepts_strict_backend_provenance() -> None:
+    result = _legacy_result()
+    result["execution_backend"] = dispatch._execution_backend_payload(
+        _probe("docker", strict=True), passed=True
+    )
+
+    validated = experiment_contract.validate_experiment_result(result)
+
+    assert validated["execution_backend"]["network_isolation"] == (
+        "docker_network_none_plus_linux_unshare"
+    )
+
+
+def test_capability_mismatch_is_non_retryable_and_preserves_zero_network() -> None:
+    packet = _packet(network_budget=0)
+    probe = _probe("apple-container", strict=False)
+
+    result = dispatch._capability_mismatch_result(packet, _image(), probe)
+
+    assert result["failure_class"] == "capability_mismatch"
+    assert result["budget_observations"]["attempts"] == 0
+    assert result["budget_observations"]["retries_consumed"] == 0
+    assert result["budget_observations"]["configured_budgets"]["network_budget"] == 0
+    assert result["execution_backend"]["preflight_status"] == "failed"
+
+
+def test_result_backend_rejects_mutable_or_invalid_digest() -> None:
+    result = _legacy_result()
+    result["execution_backend"] = {
+        **dispatch._execution_backend_payload(_probe("docker", strict=True), passed=True),
+        "image_digest": "runner:latest",
+    }
+
+    with pytest.raises(ValueError, match="sha256"):
+        experiment_contract.validate_experiment_result(result)
+
+
+def test_backend_specific_runtime_refs_prevent_apple_digest_pull() -> None:
+    image = _image()
+
+    assert image.runtime_ref("apple-container") == f"{image.name}@{image.digest}"
+    assert image.runtime_ref("docker") == image.digest
+
+
+def test_apple_build_registers_exact_local_digest_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    digest = "sha256:" + "a" * 64
+    tag = "pulseplate/experiment-runner:test"
+    immutable_ref = f"{tag}@{digest}"
+    inspect_payload = json.dumps([{"configuration": {"descriptor": {"digest": digest}}}])
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        stdout = inspect_payload if argv[1:3] == ["image", "inspect"] else ""
+        return subprocess.CompletedProcess(argv, 0, stdout, "")
+
+    for name in (
+        "PULSEPLATE_PYTHON_INDEX_URL",
+        "PULSEPLATE_PYTHON_TRUSTED_HOST",
+        "PULSEPLATE_PYTHON_NETRC",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(dispatch, "_resolve_cli", lambda _name: "/usr/local/bin/container")
+    monkeypatch.setattr(dispatch, "_runtime_readiness_reason", lambda _cli, _backend: None)
+    monkeypatch.setattr(dispatch, "_run", fake_run)
+
+    result = dispatch._build_image("apple-container", tag)
+
+    assert result["image"] == immutable_ref
+    assert [
+        "/usr/local/bin/container",
+        "image",
+        "tag",
+        tag,
+        immutable_ref,
+    ] in calls
+    assert [
+        "/usr/local/bin/container",
+        "image",
+        "inspect",
+        immutable_ref,
+    ] in calls
+
+
+def test_backend_probe_uses_explicit_not_applicable_values() -> None:
+    docker = _probe("docker", strict=True)
+    native = _probe("native-linux", strict=True)
+
+    assert docker.probe_results["outer_host_control"] is None
+    assert native.probe_results["source_read_only"] is None
+    assert docker.strict is True
+    assert native.strict is True
+    dispatch.validate_capability_artifact(native.to_artifact())
+
+
+def test_gateway_is_discovered_from_runtime_metadata() -> None:
+    payload = [{"status": {"ipv4Gateway": "192.168.64.1"}}]
+
+    assert dispatch._find_gateway(payload) == "192.168.64.1"
+
+
+def test_apple_volume_uses_supported_bounded_size_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(dispatch.uuid, "uuid4", lambda: type("U", (), {"hex": "a" * 32})())
+    monkeypatch.setattr(dispatch, "_run", fake_run)
+
+    dispatch._create_result_volume("/usr/local/bin/container", "apple-container")
+
+    assert calls == [
+        [
+            "/usr/local/bin/container",
+            "volume",
+            "create",
+            "-s",
+            dispatch.RESULT_VOLUME_SIZE,
+            "pp-er-result-aaaaaaaaaaaa",
+        ]
+    ]
+
+
+def test_capability_validator_matches_platform_and_isolation_schema() -> None:
+    artifact = _probe("apple-container", strict=True).to_artifact()
+
+    invalid_host = {**artifact, "host_platform": "windows_amd64"}
+    with pytest.raises(ValueError, match="host_platform"):
+        dispatch.validate_capability_artifact(invalid_host)
+
+    invalid_isolation = {**artifact, "isolation_method": "linux_unshare"}
+    with pytest.raises(ValueError, match="isolation_method"):
+        dispatch.validate_capability_artifact(invalid_isolation)
+
+
+def test_host_listener_marks_successful_positive_control_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        dispatch.socket, "create_connection", lambda *_args, **_kwargs: nullcontext()
+    )
+
+    with dispatch._host_listener() as (port, ready):
+        assert port > 0
+        assert ready is True
+
+
+def test_probe_cli_requires_immutable_image() -> None:
+    with pytest.raises(SystemExit):
+        dispatch._parse_args(["probe", "--backend", "auto", "--output", "probe.json"])
+
+
+def test_artifact_root_rejects_symlinked_components(tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    linked = tmp_path / "linked"
+    linked.symlink_to(real, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlinked components"):
+        dispatch._resolve_local_output("result.json", root=linked)
+
+
+def test_recursive_result_redaction_removes_paths_and_secret_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEST_API_TOKEN", "aaaaaaaa")
+    payload = {
+        "nested": [
+            f"failure at {dispatch.REPO_ROOT}/file.py",
+            "fixture=aaaaaaaa",
+        ]
+    }
+
+    redacted = dispatch._redact_result_value(payload)
+    serialized = json.dumps(redacted)
+
+    assert str(dispatch.REPO_ROOT) not in serialized
+    assert "aaaaaaaa" not in serialized
+    assert "<redacted>" in serialized
+
+
+def test_collector_is_nofollow_regular_file_and_size_bounded() -> None:
+    assert "O_NOFOLLOW" in dispatch._COLLECTOR_CODE
+    assert "S_ISREG" in dispatch._COLLECTOR_CODE
+    assert str(dispatch.MAX_RESULT_BYTES) in dispatch._COLLECTOR_CODE
+
+
+def test_post_preflight_failure_is_validated_infra_flake() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = dispatch._infra_flake_result(
+        packet,
+        _image(),
+        _probe("apple-container", strict=True),
+        "runner_execution_failed",
+    )
+
+    assert result["failure_class"] == "infra_flake"
+    assert result["budget_observations"]["runner_error"] == "runner_execution_failed"
+    assert result["budget_observations"]["configured_budgets"]["network_budget"] == 0
+
+
+def test_container_cleanup_forces_stop_before_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(dispatch, "_run", fake_run)
+
+    assert dispatch._cleanup_container("/usr/local/bin/container", "apple-container", "run-id")
+    assert calls[0][1:4] == ["stop", "--time", "1"]
+    assert calls[1][1:3] == ["delete", "--force"]

--- a/tests/test_experiment_runner_dispatch.py
+++ b/tests/test_experiment_runner_dispatch.py
@@ -567,6 +567,39 @@ def test_apple_volume_uses_supported_bounded_size_flag(
     ]
 
 
+def test_docker_volume_is_bounded_tmpfs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(dispatch.uuid, "uuid4", lambda: type("U", (), {"hex": "b" * 32})())
+    monkeypatch.setattr(dispatch, "_run", fake_run)
+
+    dispatch._create_result_volume("/usr/local/bin/docker", "docker")
+
+    assert dispatch.RESULT_VOLUME_SIZE.lower() == f"{dispatch.MAX_RESULT_BYTES // (1024 * 1024)}m"
+    assert calls == [
+        [
+            "/usr/local/bin/docker",
+            "volume",
+            "create",
+            "--driver",
+            "local",
+            "--opt",
+            "type=tmpfs",
+            "--opt",
+            "device=tmpfs",
+            "--opt",
+            f"o=size={dispatch.RESULT_VOLUME_SIZE.lower()},mode=0700",
+            "pp-er-result-bbbbbbbbbbbb",
+        ]
+    ]
+
+
 def test_capability_validator_matches_platform_and_isolation_schema() -> None:
     artifact = _probe("apple-container", strict=True).to_artifact()
 
@@ -669,6 +702,14 @@ def test_recursive_result_redaction_removes_paths_and_secret_values(
     assert str(dispatch.REPO_ROOT) not in serialized
     assert "aaaaaaaa" not in serialized
     assert "<redacted>" in serialized
+
+
+def test_sanitize_result_rejects_malformed_oracle_before_transform() -> None:
+    result = _legacy_result()
+    result["oracle_results"] = [None]
+
+    with pytest.raises(dispatch.DispatchError, match="result_validation_failed"):
+        dispatch._sanitize_result(result, _probe("apple-container", strict=True))
 
 
 def test_collector_is_nofollow_regular_file_and_size_bounded() -> None:
@@ -841,6 +882,22 @@ def test_pre_run_cleanup_failure_overrides_capability_drift(
 
     assert isinstance(caught.value.__cause__, dispatch.PreRunCapabilityError)
     assert caught.value.__cause__.code == "image_digest_drift"
+
+
+def test_missing_runtime_after_probe_is_pre_run_capability_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(dispatch, "_resolve_cli", lambda _name: None)
+
+    with pytest.raises(dispatch.PreRunCapabilityError, match="runtime_cli_missing"):
+        dispatch._invoke_container_runner(
+            probe=_probe("apple-container", strict=True),
+            image=_image(),
+            packet_path=tmp_path / "packet.json",
+            candidate_patch=None,
+            output_name="result.json",
+        )
 
 
 def test_post_start_cleanup_failure_overrides_execution_exception(

--- a/tests/test_experiment_runner_dispatch.py
+++ b/tests/test_experiment_runner_dispatch.py
@@ -183,6 +183,27 @@ def test_explicit_backend_never_falls_back(
     assert calls == ["apple-container"]
 
 
+def test_native_linux_is_not_strict_without_filesystem_containment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dispatch.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        dispatch,
+        "probe_backend",
+        lambda backend, _image: _probe(
+            backend,
+            strict=False,
+            reason="filesystem_isolation_unavailable",
+        ),
+    )
+
+    selected, attempts = dispatch.select_backend("auto", _image())
+
+    assert selected is None
+    assert [probe.backend for probe in attempts] == ["native-linux"]
+    assert attempts[0].blocking_reasons == ("filesystem_isolation_unavailable",)
+
+
 @pytest.mark.parametrize("backend", ["apple-container", "docker"])
 def test_container_argv_enforces_exact_mount_and_network_contract(
     tmp_path: Path,
@@ -391,6 +412,41 @@ def test_result_v1_accepts_strict_backend_provenance() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        (
+            {"network_isolation": "linux_unshare"},
+            "network_isolation is inconsistent",
+        ),
+        ({"preflight_status": "failed"}, "Accepted experiment results require"),
+        ({"guest_platform": "linux_unsupported"}, "Accepted experiment results require"),
+    ],
+)
+def test_result_v1_rejects_impossible_backend_provenance(
+    updates: dict[str, str],
+    message: str,
+) -> None:
+    result = _legacy_result()
+    provenance = dispatch._execution_backend_payload(_probe("docker", strict=True), passed=True)
+    result["execution_backend"] = {**provenance, **updates}
+
+    with pytest.raises(ValueError, match=message):
+        experiment_contract.validate_experiment_result(result)
+
+
+def test_capability_mismatch_requires_failed_preflight() -> None:
+    result = _legacy_result()
+    result["status"] = "rejected"
+    result["failure_class"] = "capability_mismatch"
+    result["execution_backend"] = dispatch._execution_backend_payload(
+        _probe("docker", strict=True), passed=True
+    )
+
+    with pytest.raises(ValueError, match="failed backend preflight"):
+        experiment_contract.validate_experiment_result(result)
+
+
 def test_capability_mismatch_is_non_retryable_and_preserves_zero_network() -> None:
     packet = _packet(network_budget=0)
     probe = _probe("apple-container", strict=False)
@@ -466,12 +522,16 @@ def test_apple_build_registers_exact_local_digest_reference(
 
 def test_backend_probe_uses_explicit_not_applicable_values() -> None:
     docker = _probe("docker", strict=True)
-    native = _probe("native-linux", strict=True)
+    native = _probe(
+        "native-linux",
+        strict=False,
+        reason="filesystem_isolation_unavailable",
+    )
 
     assert docker.probe_results["outer_host_control"] is None
     assert native.probe_results["source_read_only"] is None
     assert docker.strict is True
-    assert native.strict is True
+    assert native.strict is False
     dispatch.validate_capability_artifact(native.to_artifact())
 
 
@@ -517,6 +577,23 @@ def test_capability_validator_matches_platform_and_isolation_schema() -> None:
     invalid_isolation = {**artifact, "isolation_method": "linux_unshare"}
     with pytest.raises(ValueError, match="isolation_method"):
         dispatch.validate_capability_artifact(invalid_isolation)
+
+    schema_path = (
+        dispatch.REPO_ROOT
+        / "docs/orchestration/contracts/experiment_runner_backend_capability.v1.schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    mapped_backends = {
+        rule["if"]["properties"]["backend"]["const"]: rule["then"]["properties"][
+            "isolation_method"
+        ]["const"]
+        for rule in schema["allOf"]
+    }
+    assert mapped_backends == {
+        "native-linux": "linux_unshare",
+        "apple-container": "apple_internal_no_dns_plus_linux_unshare",
+        "docker": "docker_network_none_plus_linux_unshare",
+    }
 
 
 def test_host_listener_marks_successful_positive_control_ready(
@@ -626,18 +703,64 @@ def test_pre_run_image_drift_is_non_retryable_capability_mismatch(
     assert written["budget_observations"]["configured_budgets"]["network_budget"] == 0
 
 
-def test_container_cleanup_forces_stop_before_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("backend", ["apple-container", "docker"])
+def test_container_cleanup_forces_delete_after_stop_error(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
     calls: list[list[str]] = []
 
     def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         calls.append(argv)
+        if argv[1] == "stop":
+            raise dispatch.DispatchError("probe_execution_failed")
         return subprocess.CompletedProcess(argv, 0, "", "")
 
     monkeypatch.setattr(dispatch, "_run", fake_run)
 
-    assert dispatch._cleanup_container("/usr/local/bin/container", "apple-container", "run-id")
+    assert dispatch._cleanup_container("/usr/local/bin/runtime", backend, "run-id")
     assert calls[0][1:4] == ["stop", "--time", "1"]
-    assert calls[1][1:3] == ["delete", "--force"]
+    expected_delete = "delete" if backend == "apple-container" else "rm"
+    assert calls[1][1:3] == [expected_delete, "--force"]
+
+
+def test_nonzero_network_budget_fails_before_backend_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(_packet(network_budget=1)), encoding="utf-8")
+    output_path = tmp_path / "result.json"
+    written: dict[str, Any] = {}
+    monkeypatch.setattr(dispatch.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        dispatch,
+        "_parse_args",
+        lambda _argv: SimpleNamespace(
+            command="run",
+            backend="auto",
+            packet="packet.json",
+            candidate_patch=None,
+            image=f"pulseplate/experiment-runner:local@{_DIGEST}",
+            output="result.json",
+        ),
+    )
+    monkeypatch.setattr(dispatch, "_require_repo_local_file", lambda *_args, **_kwargs: packet_path)
+    monkeypatch.setattr(dispatch, "_resolve_local_output", lambda *_args, **_kwargs: output_path)
+    monkeypatch.setattr(
+        dispatch,
+        "select_backend",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("backend probe must not run")),
+    )
+    monkeypatch.setattr(
+        dispatch, "_atomic_write_json", lambda _path, payload: written.update(payload)
+    )
+
+    assert dispatch.main([]) == 1
+    assert written["failure_class"] == "capability_mismatch"
+    assert written["budget_observations"]["configured_budgets"]["network_budget"] == 1
+    assert written["budget_observations"]["runner_error"] == ("strict_network_budget_required")
+    assert written["execution_backend"]["preflight_status"] == "failed"
 
 
 def test_probe_cleanup_failure_overrides_original_exception(


### PR DESCRIPTION
## Summary

Adds a strict, evidence-only macOS execution backend for the PulsePlate Experiment Runner while preserving the existing direct native Linux Runner path and `network_budget=0`.

- [x] I reviewed docs/ENGINEERING_LESSONS.md and followed repo policies.
- [x] Change type: Bug fix
- [x] Related PR: #2112 is adjacent and independent; this PR does not change its creative-code surfaces.

## Goal

Make Experiment Runner oracle-only and candidate runs work safely on the operator Mac without changing network_budget=0 or silently retrying with weaker isolation.

## Business reason

The current macOS host cannot execute the Linux-only unshare backend directly. A strict Apple Container path restores deterministic local evidence for PulsePlate development without turning Experiment Runner into a public product or moving the wider dev stack away from Docker Compose.

## Scope

- Add probe, build-image, and run dispatcher commands.
- Select Apple Container first, Docker network-none second, and fail closed with capability_mismatch.
- Require immutable name@sha256 image references.
- Add sanitized capability and execution-backend provenance.
- Preserve the direct native Linux Runner and result-v1 compatibility; strict dispatch fails closed on native Linux until filesystem containment reaches parity.
- Add an immutable non-root runner image and focused deterministic tests.
- Document the Mac operations and evidence-only authority.

## Out of scope

- No backend, OpenAPI, web, iOS, or runtime product contract changes.
- No GitHub App, Slack, public distribution, OCW/OSW, semantic cache, or generic external runner extraction.
- No Docker Compose, devcontainer, or production-image migration.
- No automatic promotion, merge, or deploy authority.

## Files changed

14 tracked files including the post-open fixed-mapping artifact:

- dispatcher and result contract
- strict capability schema
- immutable runner Containerfile and scoped deploy policy
- deterministic dispatcher/security tests
- macOS runbook, protocol, scoped agent policy, and backlog entry

## Key decisions

- Backend selection happens once before execution; no mid-run fallback.
- Strict dispatch rejects non-zero `network_budget` before probing a runtime.
- Apple uses host-only/internal networking plus no DNS and mandatory guest unshare.
- Docker fallback uses whole-container network none plus a negative network canary.
- Runtime mounts are allowlisted; source/input/root are read-only, result volume is the only writable evidence surface, and tmpfs is private.
- Worktree input is cloned into a self-contained snapshot so host .git/worktrees paths are not exposed.
- The short-lived Apple host canary binds a random port on one exact non-loopback host IPv4 address, never persists that address, and emits only a fixed response.

## Risk and impact

- [ ] User-facing change
- [ ] Data model or migration
- [x] Security-sensitive local tooling
- [x] Performance-sensitive local tooling

## Test plan and local evidence

- [x] Unit and deterministic security tests added.
- [x] check_preflight.py passed.
- [x] check_agent_consistency.py passed.
- [x] Focused dispatcher, runner, sandbox, nosec, absolute-binary, and review-pattern tests passed.
- [x] make validate-changed passed on the committed branch diff.
- [x] pre-commit run --all-files passed after the final change.
- [x] Pre-push MyPy, pip-audit, backend tests, full-repo Bandit, and Docker build test passed.
- [x] Real Apple capability probe returned strict_isolation=true.
- [x] Trivy reported zero HIGH/CRITICAL findings with ignore-unfixed, matching repository policy.
- [x] Image history/config inspection found no proxy credential names or values.
- [x] One oracle-only run and one candidate run were accepted with network_budget=0, failure_class=null, shared_tree_untouched=true, exact backend provenance, and no host paths or secrets.

Local evidence is intentionally gitignored under artifacts/orchestration. The validated image is:

pulseplate/experiment-runner:mac-strict@sha256:cefe9cfa20a89e2b24b4041c50d02f9bc202664d44e81470f962d5b72f063e13

Full local make verify was not run because repository policy forbids that machine-heavy command by default.

## CI gates

- [ ] Current-head PR tests green.
- [ ] Diff coverage at least 97 percent.
- [ ] Applicable security and governance checks green.

## Split justification

This is larger than 800 changed lines because the strict backend is one vertical security boundary: executable dispatcher, schema, immutable image, negative-network and mount tests, and operator contract must land together. Splitting them would temporarily ship an executable backend without its enforceable image, contract, or regression proof. Product runtime and externalization remain explicitly excluded.

## Security notes

- No shell execution and all external binaries resolve to absolute paths.
- No broad Linux capabilities, Docker socket, home directory, Keychain, SSH agent, or provider/GitHub/Slack credentials are mounted.
- Image build authority is separate from experiment execution authority.
- Result collection occurs only after the untrusted runner container is forcibly removed and validates file type, size, and symlink state.
- Apple and Docker result handoff volumes are capped at 2 MiB; Docker uses a quota-bounded local-driver tmpfs.
- Capability mismatch is non-retryable; transient infra failures remain separate.
- network_budget=0 is never changed or downgraded.

## Risks and rollback

Risks include Apple runtime drift, immutable digest drift, VM startup overhead, and false capability classification. Every ambiguity fails closed.

Rollback is to revert the dispatcher, image, contract, tests, and docs commits and remove the local OCI image. The existing direct native Linux Runner remains unchanged throughout.

## Deferred and follow-ups

- Marketplace, hosted control plane, public GitHub App, and generic runner extraction remain outside this lane.
- Apple Container remains opt-in until sufficient local-run evidence is accumulated.
- No automatic merge is requested.

## Lane Start Provenance

Packet: `artifacts/orchestration/task_packets/pr2116-post-open.json`
Starter: `scripts/orchestration/start_pr_lane.sh`

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/mac-strict-oracle-current-head.json`

The artifact is local-only and gitignored. It records an accepted Apple
Container 1.1.0 oracle-only run with two successful oracles,
`network_budget=0`, `failure_class: null`, and
`shared_tree_untouched: true`.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Mandatory post-open role/review pass completed.
- [x] All actionable review comments have evidence-backed dispositions.

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3572512959 -> 0684d9b43
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3572747164 -> b2915e00a0c01060586decc71a89ed7dbbe82e00
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3572747168 -> b2915e00a0c01060586decc71a89ed7dbbe82e00
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784622
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784626 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784628 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#discussion_r3573784645 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2116#pullrequestreview-4688335453 -> c5cd8d870a31cc704e1a01931fb6d13f952b2bee

Canonical proof and review-level dispositions: `docs/review/PR_2116_FIXED_MAPPING.md`.

## Merge Readiness

- [ ] All required checks are green on the latest commit.
- [ ] Diff coverage is at least 97 percent.
- [x] No unresolved review threads remain.
- [x] No actionable bot comments remain.
- [x] Fixed mapping artifact and PR body mirror are current.
- [ ] Mandatory wait window completed.
- [ ] Strict authenticated merge-readiness check passed.

## Next best step

Wait for terminal current-head CI, perform the mandatory review wait-window pass, and run strict authenticated merge readiness. Do not restart the operator-canceled Codex Security plugin workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a strict, evidence‑only macOS backend for the Experiment Runner that prefers Apple Container, falls back to Docker with `--network none`, and fails closed when isolation isn’t proven. Rejects non‑zero `network_budget` up front, proves capability before run, treats lost `unshare` as non‑retryable `capability_mismatch`, and keeps native Linux behavior unchanged with `network_budget=0`.

- **New Features**
  - One-time dispatcher selects a backend; returns `capability_mismatch` for missing strict isolation or pre‑run drift; no mid‑run fallback or retry.
  - Immutable non‑root runner image; digest‑locked `name@sha256`; typed capability schema and backend provenance; rejects incoherent provenance.
  - Hard isolation: read‑only inputs, private tmpfs, snapshotting; only the results volume is writable; guaranteed cleanup of containers, mounts, and temp snapshots on errors. Apple host canary binds to one exact non‑loopback IPv4 address.
  - Deterministic tests for selection/isolation and cleanup; macOS runbook and protocol updates; `.dockerignore` now admits `requirements-lock.txt`.

- **Migration**
  - macOS: install and start Apple Container 1.1+; Docker Desktop is an optional fallback.
  - Use immutable `name@sha256` images; strict dispatcher rejects non‑zero `network_budget`; no mid‑run fallback.
  - No changes required on Linux.

<sup>Written for commit 5949e05dfe18341e647de541f90222846a2c9c56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a strict macOS Experiment Runner with fail-closed, capability-based backend selection and enforced `network_budget=0` isolation.
  * Introduced immutable image digest enforcement plus sanitized capability/provenance artifact validation.
  * Hardened the experiment runner image build/runtime (non-root execution, locked dependencies, tightened environment).
* **Documentation**
  * Added macOS strict backend runbook and updated experimentation protocol/security guidance.
  * Added backend capability contract schema and an experimentation backlog item.
* **Tests**
  * Added deterministic dispatcher and runner tests covering selection, contract validation, redaction, cleanup, and non-retryable `capability_mismatch` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
