### PR TITLE
fix(ci): refresh Docker source artifact review window

### DIFF
--- a/scripts/ci/docker_source_artifacts.json
+++ b/scripts/ci/docker_source_artifacts.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-06-29",
-  "review_by": "2026-07-13",
+  "generated_at": "2026-07-14",
+  "review_by": "2026-07-28",
   "reason": "Emergency Docker source-artifact pin for SQLite runtime remediation. This makes the upstream fetch explicit in CI/local preparation instead of performing hidden live downloads inside Docker builds.",
   "artifacts": [
     {

--- a/tests/test_docker_workflow_build_path_contract.py
+++ b/tests/test_docker_workflow_build_path_contract.py
@@ -312,7 +312,8 @@ def test_docker_source_artifact_manifest_pins_sqlite_source() -> None:
     )
     artifacts = manifest["artifacts"]
     assert manifest["schema_version"] == 1
-    assert manifest["review_by"] == "2026-07-13"
+    assert manifest["generated_at"] == "2026-07-14"
+    assert manifest["review_by"] == "2026-07-28"
     assert len(artifacts) == 1
 
     artifact = artifacts[0]


### PR DESCRIPTION
## Summary

- Refreshes the bounded review window for the existing attested SQLite source artifact from 2026-07-13 to 2026-07-28.
- Records the refresh date as 2026-07-14 and pins both dates in the deterministic contract test.
- Preserves the exact artifact identity, filename, URL, SHA3-256 digest, fetch reason, workflows, and Docker build inputs.

## Goal

Restore current-main Docker build eligibility without changing the pinned source artifact or widening runtime/deploy behavior.

## Business reason

The expired review window blocks the canonical Docker build gate for PR #2119 and other current-main consumers even though the retained source archive still matches the attested digest. This narrow prerequisite restores release throughput while preserving fail-closed source-integrity policy.

## Scope

- Update `generated_at` to `2026-07-14`.
- Update `review_by` to `2026-07-28`, preserving the established 14-day review cadence.
- Pin the exact dates in `tests/test_docker_workflow_build_path_contract.py`.

## Out of scope

- No artifact version, filename, URL, or digest change.
- No Dockerfile, workflow, Caddy, dependency, runtime, provider, API, OpenAPI, DB, feature-flag, semantic-cache, Evidence Graph, Bayes, Markov, or OCW change.
- No claim that cached digest verification proves live upstream availability.
- No change to PR #2117; its Caddy hunks do not refresh this manifest.

## Files changed

- `scripts/ci/docker_source_artifacts.json`
- `tests/test_docker_workflow_build_path_contract.py`

## Key decisions

- Keep the artifact payload byte-equivalent to `origin/main`.
- Refresh only the expiring review metadata and exact contract assertions.
- Keep this prerequisite separate from PR #2119 and the Caddy PR.
- Use Experiment Runner only as an oracle-only governance reviewer under strict Apple Container isolation.

## Lane Start Provenance

Packet: `artifacts/orchestration/task_packets/0172e0315d75.json`

Local coordinator and role evidence is gitignored and is not product truth.

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/docker-source-manifest-review-20260714-strict-result.json`

The strict oracle-only run was accepted through Apple Container (`linux_arm64`, image digest `sha256:cefe9cfa20a89e2b24b4041c50d02f9bc202664d44e81470f962d5b72f063e13`) with network isolation `apple_internal_no_dns_plus_linux_unshare`, no mutated paths, shared tree untouched, and `18 passed`.

## Tests / validation

- `python3 scripts/orchestration/check_preflight.py` — PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` — PASS.
- `.venv/bin/python -m pytest -q tests/test_docker_workflow_build_path_contract.py` — PASS (`18 passed`).
- `make validate-changed` — PASS.
- `pre-commit run --all-files` — PASS.
- Pre-push Black, Ruff, MyPy, pip-audit, backend tests, Bandit, and Docker build hooks — PASS.
- Cached archive SHA3-256 recomputation matched the manifest digest.

Local full `make verify` was not run per repository machine-budget policy. A fresh upstream HTTPS fetch could not be proven locally because host DNS resolution failed; clean-runner CI remains the availability proof.

## Security notes

- The attested artifact array is unchanged.
- The cache verifier still requires the exact SHA3-256 digest and fails closed.
- No network, secret, workflow, deploy, or runtime authority is added.
- Apple Container evidence is local, sanitized, and has no merge authority.

## Risks / rollback

Risk is limited to extending the existing review window for the unchanged pinned artifact. Rollback is a revert of this PR; no migration, cache invalidation, client rollback, or feature flag is required.

## Deferred / follow-ups

- If live upstream availability fails in current-head CI, investigate it as a new source-availability defect; do not weaken integrity checks.
- After this prerequisite merges, rebase/revalidate PR #2119 on current `main`.
- PR #2117 may touch the same test file in separate hunks; rebase and rerun the focused oracle if it merges first.

## Discussion Thread Pass

- [ ] Discussion-thread pass completed
- [ ] Fixed in commit mapping completed
- [ ] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` completed.
- [ ] Codex Security final material-diff scan completed.

### Fixed in Commit Mapping

Canonical artifact will be added as `docs/review/PR_<N>_FIXED_MAPPING.md` after GitHub assigns the PR number.

- No actionable review comments have been dispositioned yet.

## Merge Readiness

- [ ] Current-head required CI is terminal PASS.
- [ ] Diff coverage is at least 97%.
- [ ] CodeRabbit, Sourcery, and Cubic have no actionable findings.
- [ ] Strict authenticated merge-readiness passes.
- [ ] Mandatory review wait-window has elapsed.
- [ ] Human merge authorization is recorded.

## Summary by Sourcery

Обновить метаданные окна одобренного ревью для закреплённого артефакта исходников Docker-образа SQLite, чтобы восстановить соответствие текущей основной ветки требованиям к Docker-сборке, при этом не изменяя содержимое артефакта.

Enhancements:
- Обновить метаданные манифеста артефакта исходников Docker, чтобы использовать новую дату generated-at и расширенную дату review-by для существующего архива исходников SQLite.
- Скорректировать контрактный тест пути сборки в Docker workflow, чтобы он проверял обновлённые даты generated-at и review-by для закреплённого артефакта SQLite.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refresh the approved-review window metadata for the pinned SQLite Docker source artifact to restore current-main Docker build eligibility while keeping the artifact payload unchanged.

Enhancements:
- Update the Docker source artifact manifest metadata to use a new generated-at date and extended review-by date for the existing SQLite source archive.
- Adjust the Docker workflow build path contract test to assert the refreshed generated-at and review-by dates for the pinned SQLite artifact.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the review window for the attested SQLite source artifact used by Docker builds to restore current-main build eligibility without changing the artifact or digest. Updates `generated_at` to 2026-07-14 and `review_by` to 2026-07-28, and pins these dates in the contract test.

<sup>Written for commit ba66c94938b02da01a7a2be263e8e3f76a897f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker source-artifact metadata with refreshed generation and review dates.

* **Tests**
  * Enhanced validation to confirm the artifact manifest’s generation date and updated review deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->