### PR TITLE
fix(orchestration): tolerate failed adaptive review quarantines

### DIFF
--- a/scripts/orchestration/creative_specification_skeptic_review.py
+++ b/scripts/orchestration/creative_specification_skeptic_review.py
@@ -10,6 +10,7 @@ import importlib
 import json
 import os
 from pathlib import Path
+import re
 import secrets
 import shutil
 import stat
@@ -65,6 +66,9 @@ from scripts.orchestration.creative_specification_skeptic_review_contract import
 SPEC_BRIDGE_ROOT: Path = creative_code_spec_pipeline.ARTIFACT_ROOT / "spec_bridge"
 ADAPTIVE_RESUME_FILENAME = "creative_adaptive_pr1_resume_binding.json"
 ADAPTIVE_INTAKE_FILENAME = "creative_adaptive_pr1_variant_intake.json"
+FAILED_REVIEWED_RUN_QUARANTINE_PATTERN = re.compile(
+    rf"^\.{re.escape(REVIEWED_RUN_DIRNAME)}\.[0-9a-f]{{16}}\.failed$"
+)
 ATTACHMENT_FILENAME = "skeptic_review_attachment.json"
 BUNDLE_FILENAME = "creative_code_specification_bundle.json"
 FINALIZE_RECEIPT_FILENAME = "finalize_receipt.json"
@@ -468,6 +472,7 @@ def _read_prepared_adaptive_resume(
             REVIEWED_RUN_DIRNAME,
         },
         label="adaptive resume",
+        allowed_quarantines=True,
     )
     candidate_path = bridge_dir / CANDIDATE_FILENAME
     intake_path = bridge_dir / ADAPTIVE_INTAKE_FILENAME
@@ -657,7 +662,19 @@ def _pending_skeptic_review_count(reviews: Sequence[Any]) -> int:
     )
 
 
-def _reject_unexpected_entries(path: Path, *, allowed: set[str], label: str) -> None:
+def _is_failed_reviewed_run_quarantine(child: Path) -> bool:
+    return (
+        child.is_dir() and FAILED_REVIEWED_RUN_QUARANTINE_PATTERN.fullmatch(child.name) is not None
+    )
+
+
+def _reject_unexpected_entries(
+    path: Path,
+    *,
+    allowed: set[str],
+    label: str,
+    allowed_quarantines: bool = False,
+) -> None:
     if path.exists() and not path.is_dir():
         raise CreativeSpecificationSkepticReviewCliError(f"{label} must be a directory.")
     if not path.exists():
@@ -667,7 +684,12 @@ def _reject_unexpected_entries(path: Path, *, allowed: set[str], label: str) -> 
         raise CreativeSpecificationSkepticReviewCliError(
             f"{label} contains symlink artifact(s): {', '.join(symlink_children)}."
         )
-    unexpected = sorted(child.name for child in path.iterdir() if child.name not in allowed)
+    unexpected = sorted(
+        child.name
+        for child in path.iterdir()
+        if child.name not in allowed
+        and not (allowed_quarantines and _is_failed_reviewed_run_quarantine(child))
+    )
     if unexpected:
         raise CreativeSpecificationSkepticReviewCliError(
             f"{label} contains unexpected artifact(s): {', '.join(unexpected)}."

--- a/tests/test_creative_specification_skeptic_review.py
+++ b/tests/test_creative_specification_skeptic_review.py
@@ -1786,3 +1786,36 @@ def test_reviewed_finalize_modules_do_not_import_mutation_surfaces() -> None:
             for imported in imports
             if imported in banned_exact or imported.startswith(banned_prefixes)
         ]
+
+
+def test_adaptive_resume_allows_retained_failed_reviewed_run_quarantine(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / review_cli.ADAPTIVE_RESUME_FILENAME).write_text("{}", encoding="utf-8")
+    (tmp_path / f".{review_cli.REVIEWED_RUN_DIRNAME}.0123456789abcdef.failed").mkdir()
+
+    review_cli._reject_unexpected_entries(
+        tmp_path,
+        allowed={review_cli.ADAPTIVE_RESUME_FILENAME},
+        label="adaptive resume",
+        allowed_quarantines=True,
+    )
+
+
+def test_adaptive_resume_rejects_non_directory_quarantine_name(tmp_path: Path) -> None:
+    (tmp_path / review_cli.ADAPTIVE_RESUME_FILENAME).write_text("{}", encoding="utf-8")
+    (tmp_path / f".{review_cli.REVIEWED_RUN_DIRNAME}.0123456789abcdef.failed").write_text(
+        "not a retained run directory",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        review_cli.CreativeSpecificationSkepticReviewCliError,
+        match=r"adaptive resume contains unexpected artifact\(s\)",
+    ):
+        review_cli._reject_unexpected_entries(
+            tmp_path,
+            allowed={review_cli.ADAPTIVE_RESUME_FILENAME},
+            label="adaptive resume",
+            allowed_quarantines=True,
+        )


### PR DESCRIPTION
### Motivation
- Adaptive attach now quarantines failed reviewed-run artifacts as hidden siblings named like `.spec_finalize_reviewed.<token>.failed`, which previously caused `_read_prepared_adaptive_resume()` to fail early when re-scanning the bridge directory. 
- The intent is to retain failure artifacts for forensics while allowing adaptive resume/retry to proceed when the quarantined entry is a bona fide retained directory. 
- Validation must remain strict for symlinks, non-directory lookalikes, and other unexpected entries to keep the loader fail-closed for real anomalies.

### Description
- Add a precise quarantine name pattern `FAILED_REVIEWED_RUN_QUARANTINE_PATTERN` and helper `_is_failed_reviewed_run_quarantine()` to detect retained `.spec_finalize_reviewed.<16 hex>.failed` directories. 
- Extend `_reject_unexpected_entries()` with an `allowed_quarantines: bool` flag and update its filtering logic to ignore matching retained quarantine **directories** when allowed. 
- Enable `allowed_quarantines=True` in the adaptive resume path (`_read_prepared_adaptive_resume`) so retries tolerate retained failed-reviewed-run directories. 
- Add two focused regression tests `test_adaptive_resume_allows_retained_failed_reviewed_run_quarantine` and `test_adaptive_resume_rejects_non_directory_quarantine_name` to verify allowed quarantines and to keep rejecting non-directory lookalikes.

### Testing
- `python3 scripts/orchestration/check_preflight.py` — PASS. 
- `python3 scripts/orchestration/check_agent_consistency.py` — PASS. 
- `PYENV_VERSION=3.13.13 python -m py_compile scripts/orchestration/creative_specification_skeptic_review.py tests/test_creative_specification_skeptic_review.py` — PASS. 
- Code formatting via `python -m black` reformatted the updated file (applied automatically). 
- Targeted `pytest` for the new tests was attempted but blocked in the local environment due to missing test dependencies (`ModuleNotFoundError: No module named 'fastapi'`), and broader local validation (`make validate-changed`, `pre-commit run --all-files`) was blocked by missing repo `.venv` and `pre-commit` tooling in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55ba2933e4832cba3d4d002223c613)

## Summary by Sourcery

Разрешить адаптивному возобновлению (adaptive resume) корректно работать при наличии сохранённых каталогов карантина неудачных проверенных запусков (failed reviewed-run), сохранив строгую проверку для других неожиданных артефактов.

Bug Fixes:
- Исправлена ошибка, из-за которой адаптивное возобновление завершалось сбоем при обнаружении сохранённых каталогов карантина неудачных проверенных запусков в каталоге bridge.

Enhancements:
- Добавлен явный шаблон и вспомогательная функция для идентификации каталогов карантина неудачных проверенных запусков и интегрировано разрешение таких карантинных каталогов в логику отклонения неожиданных элементов.

Tests:
- Добавлены регрессионные тесты, проверяющие, что адаптивное возобновление принимает сохранённые каталоги карантина неудачных проверенных запусков и отклоняет объекты, похожие на карантин, которые не являются каталогами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow adaptive resume to tolerate retained failed reviewed-run quarantine directories while keeping strict validation for other unexpected artifacts.

Bug Fixes:
- Fix adaptive resume failing when encountering retained failed reviewed-run quarantine directories in the bridge directory.

Enhancements:
- Add explicit pattern and helper for identifying failed reviewed-run quarantine directories and integrate quarantine allowance into unexpected-entry rejection logic.

Tests:
- Add regression tests ensuring adaptive resume accepts retained failed reviewed-run quarantine directories and rejects non-directory quarantine lookalikes.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adaptive resume now correctly permits valid quarantine directories from failed reviewed runs.
  * Unexpected artifacts that resemble quarantine entries but are not directories continue to be rejected with a clear error.

* **Tests**
  * Added coverage for accepted failed-run quarantines and invalid quarantine artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->