### PR TITLE
fix(ci): detect legacy_app.__dict__ namespace lookups in API-key ownership guard

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -1693,6 +1693,24 @@ def validate_api_key_dependency_ownership(
                     == "legacy_app"
                 )
 
+            def legacy_namespace_lookup_symbol(node: ast.AST) -> str | None:
+                if not isinstance(node, ast.Subscript):
+                    return None
+                if (
+                    _static_module_reference(
+                        node.value,
+                        module_aliases=module_aliases,
+                        import_module_aliases=import_module_aliases,
+                        static_string_bindings=static_string_bindings,
+                    )
+                    != "legacy_app.__dict__"
+                ):
+                    return None
+                symbol_name = _resolve_static_string(node.slice, static_string_bindings)
+                if symbol_name in CANONICAL_API_KEY_SYMBOLS:
+                    return symbol_name
+                return None
+
             for lookup_node in ast.walk(expression):
                 if (
                     isinstance(lookup_node, ast.Attribute)
@@ -1719,6 +1737,11 @@ def validate_api_key_dependency_ownership(
                 ):
                     errors.append(
                         f"{filename}: dynamic legacy API-key dependency lookup is forbidden: "
+                        f"{symbol_name}"
+                    )
+                elif (symbol_name := legacy_namespace_lookup_symbol(lookup_node)) is not None:
+                    errors.append(
+                        f"{filename}: legacy API-key dependency namespace lookup is forbidden: "
                         f"{symbol_name}"
                     )
 
@@ -1782,6 +1805,24 @@ def validate_api_key_dependency_ownership(
                 == "legacy_app"
             )
 
+        def legacy_namespace_lookup_symbol(node: ast.AST) -> str | None:
+            if not isinstance(node, ast.Subscript):
+                return None
+            if (
+                _static_module_reference(
+                    node.value,
+                    module_aliases=module_aliases,
+                    import_module_aliases=import_module_aliases,
+                    static_string_bindings=static_string_bindings,
+                )
+                != "legacy_app.__dict__"
+            ):
+                return None
+            symbol_name = _resolve_static_string(node.slice, static_string_bindings)
+            if symbol_name in CANONICAL_API_KEY_SYMBOLS:
+                return symbol_name
+            return None
+
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module == "legacy_app":
                 for alias in node.names:
@@ -1815,6 +1856,11 @@ def validate_api_key_dependency_ownership(
             ):
                 errors.append(
                     f"{filename}: dynamic legacy API-key dependency lookup is forbidden: "
+                    f"{symbol_name}"
+                )
+            elif (symbol_name := legacy_namespace_lookup_symbol(node)) is not None:
+                errors.append(
+                    f"{filename}: legacy API-key dependency namespace lookup is forbidden: "
                     f"{symbol_name}"
                 )
     return sorted(set(errors))

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -841,6 +841,20 @@ def test_api_key_ownership_guard_rejects_legacy_star_import() -> None:
     ) == ["app/main.py: canonical code must not use a legacy_app star import"]
 
 
+def test_api_key_ownership_guard_rejects_legacy_namespace_lookup() -> None:
+    legacy_source = (
+        "from app.routers.api_key import (\n    _get_api_key_dynamic,\n    get_api_key,\n)\n"
+    )
+
+    source = 'import legacy_app as legacy\ndependency = legacy.__dict__["get_api_key"]\n'
+
+    assert legacy_guard.validate_api_key_dependency_ownership(
+        legacy_source,
+        {"app/main.py": source},
+    ) == [
+        "app/main.py: legacy API-key dependency namespace lookup is forbidden: get_api_key"
+    ]
+
 def test_api_key_ownership_guard_allows_unrelated_star_import() -> None:
     legacy_source = (
         "from app.routers.api_key import (\n    _get_api_key_dynamic,\n    get_api_key,\n)\n"


### PR DESCRIPTION
### Motivation
- Harden legacy API-key ownership guard which could be bypassed by namespace lookups such as `legacy_app.__dict__["get_api_key"]` that were not detected by the narrowed AST scanner. 

### Description
- Add a `legacy_namespace_lookup_symbol` helper inside `validate_api_key_dependency_ownership` to detect `legacy_app.__dict__["..."]` subscripts during bounded expression scanning and the full reverse-dependency scan. 
- Emit a deterministic error `legacy API-key dependency namespace lookup is forbidden: <symbol>` when such namespace lookups reference canonical API-key symbols. 
- Add a focused regression test `test_api_key_ownership_guard_rejects_legacy_namespace_lookup` in `tests/test_legacy_growth_guard.py` to cover the new detection while preserving existing compatibility re-export and rebinding checks. 

### Testing
- Ran `python3 -m compileall -q scripts/ci/check_legacy_growth_guard.py tests/test_legacy_growth_guard.py` which succeeded and validated syntax. 
- Executed a PoC call to `validate_api_key_dependency_ownership(...)` that confirmed the namespace-lookup case now returns the expected error (`legacy API-key dependency namespace lookup is forbidden: get_api_key`). 
- Ran repository preflight and agent consistency checks via `python3 scripts/orchestration/check_preflight.py` and `python3 scripts/orchestration/check_agent_consistency.py` which reported the canonical SoT/agent checks passing. 
- `make validate-changed` and `pre-commit run --all-files` were blocked by the local environment (`no repo/.venv Python found` and `pre-commit: command not found` respectively) so the full local narrow bundle and CI parity were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55b8880f40832c9a40dbbbac68a81f)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the legacy API-key ownership guard to catch namespace lookups via `legacy_app.__dict__[...]`, closing a bypass that the AST scanner missed. Adds a clear error when canonical API-key symbols are accessed this way and tests to prevent regressions.

- **Bug Fixes**
  - Detect and block `legacy_app.__dict__["get_api_key"]` (and other canonical symbols) in both scanning paths of `validate_api_key_dependency_ownership`.
  - Emit deterministic error: legacy API-key dependency namespace lookup is forbidden: <symbol>.
  - Add regression test `test_api_key_ownership_guard_rejects_legacy_namespace_lookup`.

<sup>Written for commit 5105374e41d1d5cb65fc9e4e87ac6bbbb61531fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to detect and block unsupported legacy access patterns involving API-key dependencies.
  * Updated error messaging to more clearly identify namespace-based access violations.

* **Tests**
  * Added coverage to verify that prohibited legacy namespace access is consistently rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->