### PR TITLE
fix(ci): catch conditional API-key guard definitions

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -1593,12 +1593,37 @@ def validate_api_key_dependency_ownership(
     legacy_tree, parse_errors = _parse_source(legacy_source, filename=LEGACY_APP)
     errors.extend(parse_errors)
     if legacy_tree is not None:
-        locally_defined = {
-            node.name
-            for node in legacy_tree.body
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-            and node.name in CANONICAL_API_KEY_SYMBOLS
-        }
+        locally_defined: set[str] = set()
+
+        class _ModuleApiKeyDefinitionVisitor(ast.NodeVisitor):
+            def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+                if node.name in CANONICAL_API_KEY_SYMBOLS:
+                    locally_defined.add(node.name)
+                for decorator in node.decorator_list:
+                    self.visit(decorator)
+                for default in [*node.args.defaults, *node.args.kw_defaults]:
+                    if default is not None:
+                        self.visit(default)
+                if node.returns is not None:
+                    self.visit(node.returns)
+
+            def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+                self.visit_FunctionDef(node)
+
+            def visit_ClassDef(self, node: ast.ClassDef) -> None:
+                for decorator in node.decorator_list:
+                    self.visit(decorator)
+                for base in node.bases:
+                    self.visit(base)
+                for keyword in node.keywords:
+                    self.visit(keyword)
+
+            def visit_Lambda(self, node: ast.Lambda) -> None:
+                return
+
+        definition_visitor = _ModuleApiKeyDefinitionVisitor()
+        for statement in legacy_tree.body:
+            definition_visitor.visit(statement)
         for name in sorted(locally_defined):
             errors.append(f"{LEGACY_APP}: API-key dependency must not be defined locally: {name}")
 

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -759,6 +759,44 @@ def test_api_key_ownership_guard_allows_nested_local_function(
     assert legacy_guard.validate_api_key_dependency_ownership(legacy_source, {}) == []
 
 
+@pytest.mark.parametrize("keyword", ["def", "async def"])
+@pytest.mark.parametrize("symbol", ["get_api_key", "_get_api_key_dynamic"])
+@pytest.mark.parametrize(
+    "compound_template",
+    [
+        "if enabled:\n    {definition}",
+        "try:\n    {definition}\nexcept Exception:\n    pass",
+        "with context():\n    {definition}",
+        "for item in values:\n    {definition}",
+    ],
+    ids=["if", "try", "with", "for"],
+)
+def test_api_key_ownership_guard_rejects_module_compound_local_function(
+    keyword: str,
+    symbol: str,
+    compound_template: str,
+) -> None:
+    definition = f"{keyword} {symbol}():\n        return 'legacy'"
+    legacy_source = (
+        "from app.routers.api_key import (\n"
+        "    _get_api_key_dynamic,\n"
+        "    get_api_key,\n"
+        ")\n"
+        "enabled = True\n"
+        "values = [object()]\n"
+        "class context:\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, *args):\n"
+        "        return False\n"
+        f"{compound_template.format(definition=definition)}\n"
+    )
+
+    assert legacy_guard.validate_api_key_dependency_ownership(legacy_source, {}) == [
+        f"legacy_app.py: API-key dependency must not be defined locally: {symbol}"
+    ]
+
+
 def test_legacy_growth_guard_rejects_api_key_header_reintroduction() -> None:
     errors = legacy_guard.validate_legacy_growth("from app.routers.api_key import api_key_header\n")
 


### PR DESCRIPTION
### Motivation
- A recent change restricted the API-key ownership check to direct module body nodes and therefore missed module-level `if`/`try`/`with`/loop blocks that can still bind module-level `def`/`async def` names, weakening the CI guard.
- The guard must detect module-scope conditional `def`/`async def` definitions of `get_api_key` and `_get_api_key_dynamic` to prevent future malicious or accidental rebinding of canonical API-key exports. 

### Description
- Replace the simple module-body comprehension with a small AST `NodeVisitor` (`_ModuleApiKeyDefinitionVisitor`) that walks each top-level statement to find `FunctionDef`/`AsyncFunctionDef` occurrences even when nested inside module-level compound statements. 
- The visitor visits decorators, defaults, return annotations and other top-level expression fragments while avoiding false positives for nested local functions and lambdas.  
- Add a parametrized regression test in `tests/test_legacy_growth_guard.py` that asserts conditional module-scope `def`/`async def` inside `if`, `try`, `with`, and `for` blocks are rejected for both `get_api_key` and `_get_api_key_dynamic`, while preserving the existing nested-local-function allowance. 

### Testing
- `python3 scripts/orchestration/check_preflight.py` passed successfully.  
- `python3 scripts/orchestration/check_agent_consistency.py` passed successfully.  
- Direct guard reproduction using `from scripts.ci import check_legacy_growth_guard as legacy_guard` confirmed that conditional module-scope `def`/`async def` definitions are now rejected and nested local functions remain allowed.  
- `python3 -m py_compile scripts/ci/check_legacy_growth_guard.py tests/test_legacy_growth_guard.py` succeeded; attempts to run `pytest`/`make validate-changed` and `pre-commit run --all-files` were skipped due to the local environment missing `.venv`/`pytest`/`pre-commit` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55ba28f2b4832c8e4c460199e9e725)

## Summary by Sourcery

Усиление устаревшего механизма контроля владения API-ключом за счёт обнаружения канонических функций работы с API-ключом, определённых в условных блоках на уровне модуля, и сообщения о них как о нарушениях.

Bug Fixes:
- Обеспечить, чтобы определения `get_api_key` и `_get_api_key_dynamic` на уровне модуля внутри блоков `if`/`try`/`with`/`for` обнаруживались и отклонялись механизмом контроля владения API-ключом.

Enhancements:
- Заменить простой просмотр функций в теле модуля на обход AST с помощью посетителя, который проходит по верхнеуровневым операторам, чтобы находить канонические определения функций работы с API-ключом, избегая ложных срабатываний для вложенных локальных функций.

Tests:
- Добавить параметризованные регрессионные тесты, которые покрывают условные определения `def`/`async def` на уровне модуля внутри различных составных операторов и подтверждают, что такие определения отклоняются, в то время как вложенные локальные функции остаются разрешёнными.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the legacy API-key ownership guard by detecting canonical API-key functions defined in conditional module-level blocks and reporting them as violations.

Bug Fixes:
- Ensure module-scope conditional definitions of get_api_key and _get_api_key_dynamic inside if/try/with/for blocks are detected and rejected by the API-key ownership guard.

Enhancements:
- Replace the simple module-body function scan with an AST visitor that walks top-level statements to find canonical API-key function definitions while avoiding nested local function false positives.

Tests:
- Add parametrized regression tests that cover conditional module-scope def/async def definitions within various compound statements and confirm they are rejected while nested local functions remain allowed.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the CI API‑key guard by detecting module‑scope conditional definitions of `get_api_key` and `_get_api_key_dynamic` inside compound statements. Closes a gap that allowed rebinding under if/try/with/for.

- **Bug Fixes**
  - Replaced the simple module-body scan with a top-level AST visitor that finds `def`/`async def` in `if`/`try`/`with`/`for` blocks.
  - Avoids false positives for nested local functions and lambdas.
  - Added parameterized regression tests covering both symbols and all compound blocks.

<sup>Written for commit c22a6bd3064dd710749ed711c5f77c835157a60b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

