### PR TITLE
fix(ci): detect nested legacy api key imports

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -1681,6 +1681,16 @@ def validate_api_key_dependency_ownership(
         static_string_bindings: dict[str, str] = {}
         top_level_assignment_counts: Counter[str] = Counter()
 
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in {"importlib", "legacy_app"}:
+                        module_aliases.setdefault(alias.asname or alias.name, alias.name)
+            elif isinstance(node, ast.ImportFrom) and node.module == "importlib":
+                for alias in node.names:
+                    if alias.name == "import_module":
+                        import_module_aliases.add(alias.asname or alias.name)
+
         def record_bounded_lookups(expression: ast.AST) -> None:
             def expression_is_legacy_module(node: ast.AST) -> bool:
                 return (

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -888,6 +888,50 @@ def test_api_key_ownership_guard_rejects_dynamic_import_legacy_lookup(source: st
     ]
 
 
+@pytest.mark.parametrize(
+    ("source", "expected_error"),
+    [
+        (
+            "def injected_dependency():\n"
+            "    import legacy_app as legacy\n"
+            "    dependency = legacy.get_api_key\n"
+            "    return dependency\n",
+            "app/main.py: legacy API-key dependency attribute access is forbidden: get_api_key",
+        ),
+        (
+            "def injected_dependency():\n"
+            "    import importlib as il\n"
+            "    dependency = getattr(il.import_module(\"legacy_app\"), \"get_api_key\", None)\n"
+            "    return dependency\n",
+            "app/main.py: dynamic legacy API-key dependency lookup is forbidden: get_api_key",
+        ),
+        (
+            "def injected_dependency():\n"
+            "    from importlib import import_module as load_module\n"
+            "    dependency = getattr(load_module(\"legacy_app\"), \"_get_api_key_dynamic\", None)\n"
+            "    return dependency\n",
+            "app/main.py: dynamic legacy API-key dependency lookup is forbidden: "
+            "_get_api_key_dynamic",
+        ),
+    ],
+    ids=["nested-legacy-alias", "nested-importlib-alias", "nested-import-module-alias"],
+)
+def test_api_key_ownership_guard_rejects_nested_legacy_import_aliases(
+    source: str,
+    expected_error: str,
+) -> None:
+    legacy_source = (
+        "from app.routers.api_key import (\n"
+        "    _get_api_key_dynamic as _get_api_key_dynamic,\n"
+        "    get_api_key as get_api_key,\n"
+        ")\n"
+    )
+
+    assert legacy_guard.validate_api_key_dependency_ownership(
+        legacy_source,
+        {"app/main.py": source},
+    ) == [expected_error]
+
 def test_api_key_ownership_guard_accepts_direct_identity_preserving_reexports() -> None:
     legacy_source = (
         "from app.routers.api_key import (\n    _get_api_key_dynamic,\n    get_api_key,\n)\n"


### PR DESCRIPTION
### Motivation

- Prevent a CI/security-governance bypass where `legacy_app` and `importlib.import_module` imports nested inside functions/classes were not recorded, allowing forbidden legacy API-key lookups to evade the static guard.

### Description

- Restore full-AST alias discovery by walking `tree` and populating `module_aliases` and `import_module_aliases` from all `ast.Import` / `ast.ImportFrom` nodes before the bounded-lookup recording phase in `validate_api_key_dependency_ownership` in `scripts/ci/check_legacy_growth_guard.py`.
- Preserve the top-level bounded-record behavior but use the complete alias map for the final attribute/call checks so nested `import legacy_app as legacy` and nested `importlib.import_module(...)` forms are detected.
- Add regression coverage in `tests/test_legacy_growth_guard.py` that exercises three nested patterns (`nested-legacy-alias`, `nested-importlib-alias`, `nested-import-module-alias`) to assert the guard reports the expected forbidden lookups.
- Files changed: `scripts/ci/check_legacy_growth_guard.py`, `tests/test_legacy_growth_guard.py` (commit: `63728c7`).

### Testing

- Ran `python3 scripts/orchestration/check_preflight.py` and `python3 scripts/orchestration/check_agent_consistency.py`, both passed locally.
- Executed the guard locally with scripted checks and manual module import tests; `validate_api_key_dependency_ownership` now returns the expected error messages for nested legacy import patterns (manual invocation showed errors for the nested cases).
- Code-level checks succeeded: `python3 -m py_compile scripts/ci/check_legacy_growth_guard.py` and `PYENV_VERSION=3.13.13 python -m ruff check scripts/ci/check_legacy_growth_guard.py tests/test_legacy_growth_guard.py` completed with no findings, and `git diff --check` returned clean.
- Environment-limited checks not run here: `pytest` could not be executed because `pytest`/runtime deps (e.g. `fastapi`) and the repo `.venv`/`pre-commit` are not available in this environment; `make validate-changed` and `pre-commit run --all-files` were therefore not executed successfully locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55ba290970832cb16e6c55fc55bcb6)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the legacy API-key guard to detect nested `legacy_app` and `importlib.import_module` imports inside functions/classes. Closes a bypass where forbidden lookups evaded static checks.

- **Bug Fixes**
  - Walk the AST to build a complete alias map for `importlib`, `legacy_app`, and `import_module` from all imports, then use it during attribute/call checks; preserves top-level bounded recording.
  - Added regression tests for nested patterns: `nested-legacy-alias`, `nested-importlib-alias`, `nested-import-module-alias`.

<sup>Written for commit ff6557744c2f338c1a215654a6179fcbfef14dcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

