### PR TITLE
fix(security): preserve legacy registrar string constants

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -854,8 +854,6 @@ def _collect_binding_counts(tree: ast.Module) -> Counter[str]:
             counts[node.id] += 1
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             counts[node.name] += 1
-        elif isinstance(node, ast.arg):
-            counts[node.arg] += 1
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 counts[alias.asname or alias.name.split(".", maxsplit=1)[0]] += 1

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -2156,6 +2156,24 @@ def test_legacy_growth_guard_rejects_forbidden_runtime_registrar_star_imports(
     ]
 
 
+def test_legacy_growth_guard_rejects_dynamic_registrar_with_shadowed_parameter() -> None:
+    source = (
+        "from importlib import import_module\n"
+        'module_name = "app.bootstrap.http_stack"\n'
+        'registrar_name = "register_http_middleware_stack"\n'
+        "def harmless(registrar_name):\n"
+        "    return registrar_name\n"
+        "getattr(import_module(module_name), registrar_name)(app)\n"
+    )
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: forbidden legacy runtime registration: "
+        "runtime_registration:register_http_middleware_stack:app"
+    ]
+
+
 def test_legacy_growth_guard_rejects_aliased_add_middleware() -> None:
     source = "add = app.add_middleware\nregister = add\nregister(NewMiddleware)\n"
 


### PR DESCRIPTION
### Motivation
- Fix an AST binding-counting regression where function parameters were counted globally (via `ast.arg`), allowing a parameter name to shadow a module-level string constant and causing the legacy growth guard to miss forbidden runtime registrar calls.

### Description
- Stop counting function parameters in `_collect_binding_counts` inside `scripts/ci/check_legacy_growth_guard.py` so unrelated `def f(param): ...` declarations no longer suppress module-level static string bindings.
- Add a regression test `test_legacy_growth_guard_rejects_dynamic_registrar_with_shadowed_parameter` in `tests/test_legacy_growth_guard.py` that verifies `validate_legacy_growth` still flags a `getattr(import_module(...), registrar_name)(app)` call when `registrar_name` is also used as a function parameter.

### Testing
- Ran `python3 scripts/orchestration/check_preflight.py`, `python3 scripts/orchestration/check_agent_consistency.py`, `python3 -m py_compile scripts/ci/check_legacy_growth_guard.py tests/test_legacy_growth_guard.py`, and a focused `legacy_guard.validate_legacy_growth(...)` invocation which returned the expected forbidden-registrar error; these checks passed.
- Could not run `pytest`, `make validate-changed`, or `pre-commit run --all-files` in this environment because `pytest`, the repo `.venv`, and `pre-commit` are not installed here, so those commands were not executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55ba284164832ca85897c708f38f15)

## Summary by Sourcery

Исправлено устаревшее подсчитывание привязок growth guard, чтобы строковые константы регистраторов на уровне модуля продолжали соблюдаться, даже когда они переопределяются параметрами функций.

Bug Fixes:
- Обеспечить, чтобы устаревший growth guard корректно помечал запрещённые регистраторные вызовы во время выполнения, даже когда имя регистратора переиспользуется как параметр функции.

Tests:
- Добавлен регрессионный тест, охватывающий динамические вызовы регистратора, где строковая константа имени регистратора скрывается параметром функции, чтобы проверить, что guard по‑прежнему отклоняет такие вызовы.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix legacy growth guard binding counting so module-level registrar string constants remain enforced when shadowed by function parameters.

Bug Fixes:
- Ensure legacy growth guard correctly flags forbidden runtime registrar calls even when the registrar name is reused as a function parameter.

Tests:
- Add a regression test covering dynamic registrar calls where the registrar name string constant is shadowed by a function parameter to verify the guard still rejects them.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a security regression in the legacy growth guard where function parameter names could shadow module-level registrar string constants. This restores correct blocking of forbidden dynamic registrar calls.

- **Bug Fixes**
  - Stop counting `ast.arg` in `_collect_binding_counts` so params don’t mask module-level string constants.
  - Add a regression test to ensure `getattr(import_module(...), registrar_name)(app)` is still rejected when `registrar_name` is also a function parameter.

<sup>Written for commit cfbc41b04e72e3f8d8d5a2bccb48b2ae13e18294. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

