### PR TITLE
fix(guards): fail closed on dynamic getattr routes

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -380,25 +380,33 @@ def _getattr_app_call_action(
     router_aliases: frozenset[str],
     static_string_bindings: Mapping[str, str] | None = None,
 ) -> str | None:
-    method = _getattr_method_name(
-        func,
-        methods,
-        static_string_bindings=static_string_bindings,
-    )
-    if method is None or not isinstance(func, ast.Call) or not func.args:
+    if not isinstance(func, ast.Call) or not func.args:
         return None
     target = func.args[0]
+    target_prefix: str | None = None
     if isinstance(target, ast.Name) and target.id in app_aliases:
-        return method
-    if isinstance(target, ast.Name) and target.id in router_aliases:
-        return f"router.{method}"
-    if (
+        target_prefix = ""
+    elif isinstance(target, ast.Name) and target.id in router_aliases:
+        target_prefix = "router."
+    elif (
         isinstance(target, ast.Attribute)
         and target.attr == "router"
         and isinstance(target.value, ast.Name)
         and target.value.id in app_aliases
     ):
-        return f"router.{method}"
+        target_prefix = "router."
+    if target_prefix is None:
+        return None
+
+    method = _getattr_method_name(
+        func,
+        methods,
+        static_string_bindings=static_string_bindings,
+    )
+    if method is not None:
+        return f"{target_prefix}{method}"
+    if _is_unresolved_getattr_method(func, static_string_bindings=static_string_bindings):
+        return f"{target_prefix}dynamic"
     return None
 
 
@@ -1124,6 +1132,20 @@ def _getattr_method_name(
     if method in methods:
         return method
     return None
+
+
+def _is_unresolved_getattr_method(
+    func: ast.Call,
+    *,
+    static_string_bindings: Mapping[str, str] | None = None,
+) -> bool:
+    if not isinstance(func.func, ast.Name) or func.func.id != "getattr":
+        return False
+    if len(func.args) < 2:
+        return False
+    if _resolve_static_string(func.args[1], static_string_bindings or {}) is not None:
+        return False
+    return True
 
 
 def _assignment_target_names(node: ast.AST) -> tuple[str, ...]:

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -1995,6 +1995,21 @@ def test_legacy_growth_guard_rejects_add_middleware() -> None:
     ]
 
 
+def test_legacy_growth_guard_rejects_reassigned_getattr_route_method() -> None:
+    source = textwrap.dedent("""
+        method = "get"
+        method = "post"
+        getattr(app, method)("/api/v1/reassigned")(handler)
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:dynamic:/api/v1/reassigned"
+    ]
+
+
 def test_legacy_growth_guard_rejects_middleware_decorator() -> None:
     source = textwrap.dedent("""
         @app.middleware("http")


### PR DESCRIPTION
### Motivation
- Recent changes to static-string binding collection caused reassigned method-name variables to become unresolved and silently bypass legacy route-growth detection, creating a fail-open path for getattr-based route registrations.
- The intent of this change is to make the legacy guard fail-closed for unresolved `getattr(app, method)` cases so unexpected endpoints cannot be hidden by variable reassignment.

### Description
- Adjust `_getattr_app_call_action` to identify the call target (app vs router) before resolving the method and to return a `dynamic` registration fact when the method name cannot be statically resolved.
- Add `_is_unresolved_getattr_method(...)` to detect unresolved `getattr` method expressions and distinguish them from statically resolvable names.
- Preserve existing static resolution semantics so literal or single-binding `getattr` calls remain reported with concrete HTTP method names.
- Add a regression test `test_legacy_growth_guard_rejects_reassigned_getattr_route_method` to `tests/test_legacy_growth_guard.py` that asserts `method = "get"; method = "post"; getattr(app, method)(...)` is treated as `registration:dynamic:...` and rejected.

### Testing
- Ran `python3 scripts/ci/check_legacy_growth_guard.py` and observed the guard pass for normal input and report the reassigned-getattr case as an unexpected dynamic registration (passed).
- Verified behavior with a small Python harness calling `validate_legacy_growth(...)` which produced the expected `registration:dynamic:/api/v1/reassigned` result for the reassigned-getattr PoC and preserved concrete-method results for literal/single-binding getattr (passed).
- Performed static checks via `python3 -m py_compile scripts/ci/check_legacy_growth_guard.py tests/test_legacy_growth_guard.py` and executed `python3 scripts/orchestration/check_preflight.py` and `python3 scripts/orchestration/check_agent_consistency.py`, all of which passed in the environment used.
- `pytest`/`make validate-changed`/`pre-commit run --all-files` were not executed due to missing local test tooling (`pytest`, repository `.venv`, and `pre-commit` not available in the container).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55ba28fe68832ca98eee79fb3dedab)

## Summary by Sourcery

Ужесточить защиту роста устаревших маршрутов, чтобы рассматривать нерешённые регистрации маршрутов на основе `getattr` как динамические и отклонять их, предотвращая обход скрытыми конечными точками проверок.

Bug Fixes:
- Обеспечить, чтобы регистрации маршрутов на основе `getattr` с переопределёнными или нерешёнными переменными методов классифицировались как динамические и отклонялись, вместо того чтобы тихо обходить обнаружение роста устаревших маршрутов.

Enhancements:
- Ввести вспомогательную логику для обнаружения нерешённых выражений методов `getattr`, сохраняя существующее статическое разрешение для литеральных или однозначно связанных имён методов.

Tests:
- Добавить регрессионный тест, охватывающий переопределённые методы маршрутов через `getattr`, чтобы подтвердить, что они рассматриваются как динамические регистрации и отклоняются защитой роста устаревших маршрутов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the legacy route growth guard to treat unresolved getattr-based route registrations as dynamic and reject them, preventing hidden endpoints from bypassing checks.

Bug Fixes:
- Ensure getattr-based route registrations with reassigned or unresolved method variables are classified as dynamic and rejected instead of silently bypassing legacy route growth detection.

Enhancements:
- Introduce helper logic to detect unresolved getattr method expressions while preserving existing static resolution for literal or single-binding method names.

Tests:
- Add a regression test covering reassigned getattr route methods to confirm they are reported as dynamic registrations and rejected by the legacy growth guard.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the legacy route-growth guard fail-closed for dynamic `getattr` route registrations so reassigned method-name variables can’t hide new endpoints. Unresolved `getattr(app|router, method)` are now reported as `registration:dynamic` and rejected.

- **Bug Fixes**
  - Determine call target (app vs router) before method resolution and apply the `router.` prefix correctly.
  - Treat unresolved `getattr` method names as dynamic; reject them to close the bypass.
  - Preserve static behavior for literal or single-binding method names.
  - Add `_is_unresolved_getattr_method(...)` and a regression test for the reassigned `method` case.

<sup>Written for commit a635f9f5445f39487d15884bfdd504cba107fb22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

