### PR TITLE
fix(orchestration): preserve post-preflight capability_mismatch

### DIFF
--- a/scripts/orchestration/experiment_contract.py
+++ b/scripts/orchestration/experiment_contract.py
@@ -905,9 +905,8 @@ def validate_experiment_result(result: dict[str, Any]) -> dict[str, Any]:
             raise ValueError(
                 "Failed backend preflight requires a rejected capability_mismatch result."
             )
-        if failure_class == "capability_mismatch" and preflight_passed:
-            raise ValueError("Capability mismatch results require a failed backend preflight.")
-
+        # A backend can pass preflight and then lose a required primitive during
+        # runner execution; keep that non-retryable capability_mismatch intact.
     candidate_patch = str(result.get("candidate_patch", "")).strip()
     if not candidate_patch:
         raise ValueError("Experiment result must include a non-empty candidate_patch.")

--- a/tests/test_experiment_runner_dispatch.py
+++ b/tests/test_experiment_runner_dispatch.py
@@ -435,7 +435,7 @@ def test_result_v1_rejects_impossible_backend_provenance(
         experiment_contract.validate_experiment_result(result)
 
 
-def test_capability_mismatch_requires_failed_preflight() -> None:
+def test_capability_mismatch_allows_post_preflight_isolation_loss() -> None:
     result = _legacy_result()
     result["status"] = "rejected"
     result["failure_class"] = "capability_mismatch"
@@ -443,8 +443,10 @@ def test_capability_mismatch_requires_failed_preflight() -> None:
         _probe("docker", strict=True), passed=True
     )
 
-    with pytest.raises(ValueError, match="failed backend preflight"):
-        experiment_contract.validate_experiment_result(result)
+    validated = experiment_contract.validate_experiment_result(result)
+
+    assert validated["failure_class"] == "capability_mismatch"
+    assert validated["execution_backend"]["preflight_status"] == "passed"
 
 
 def test_capability_mismatch_is_non_retryable_and_preserves_zero_network() -> None:
@@ -716,6 +718,19 @@ def test_collector_is_nofollow_regular_file_and_size_bounded() -> None:
     assert "O_NOFOLLOW" in dispatch._COLLECTOR_CODE
     assert "S_ISREG" in dispatch._COLLECTOR_CODE
     assert str(dispatch.MAX_RESULT_BYTES) in dispatch._COLLECTOR_CODE
+
+
+def test_sanitize_result_preserves_post_preflight_capability_mismatch() -> None:
+    result = _legacy_result()
+    result["status"] = "rejected"
+    result["failure_class"] = "capability_mismatch"
+    result["budget_observations"] = {"runner_error": "zero-network unshare lost"}
+
+    sanitized = dispatch._sanitize_result(result, _probe("apple-container", strict=True))
+
+    assert sanitized["failure_class"] == "capability_mismatch"
+    assert sanitized["budget_observations"]["runner_error"] == "zero-network unshare lost"
+    assert sanitized["execution_backend"]["preflight_status"] == "passed"
 
 
 def test_post_preflight_failure_is_validated_infra_flake() -> None:


### PR DESCRIPTION
### Motivation
- Fix a classification regression where a runner-side loss of an isolation primitive after a passed backend preflight was being rewritten as a retryable `infra_flake` instead of preserving a non-retryable `capability_mismatch` result.

### Description
- Relax `validate_experiment_result` to allow `failure_class == "capability_mismatch"` even when `execution_backend.preflight_status == "passed"`, with a clarifying comment explaining post-preflight loss is possible.
- Add a unit test that asserts the validator accepts a post-preflight `capability_mismatch` with `preflight_status == "passed"`.
- Add a sanitizer regression test that verifies `_sanitize_result(...)` preserves a post-preflight `capability_mismatch` and the runner error after dispatcher provenance stamping.
- Files changed: `scripts/orchestration/experiment_contract.py` and `tests/test_experiment_runner_dispatch.py`.

### Testing
- Ran `python3 scripts/orchestration/check_preflight.py` and it completed successfully.
- Ran `python3 scripts/orchestration/check_agent_consistency.py` and it completed successfully.
- Verified syntax/compilation with `python3 -m py_compile` on the modified modules and test file and it succeeded.
- Performed a direct Python contract validation exercising a post-preflight `capability_mismatch` path and the validation accepted the result (success).
- Could not run `pytest` or the full local narrow bundle in this environment because `pytest`, `pre-commit`, and the repo `.venv` are not available here, so `pytest`-based execution and `make validate-changed` were not executed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55ba292158832cac2f0424a616475d)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves post‑preflight `capability_mismatch` results instead of rewriting them to `infra_flake`. Relaxes validation and adds tests to ensure runner-side isolation loss after a passed preflight remains non‑retryable.

- **Bug Fixes**
  - Allow `capability_mismatch` when `execution_backend.preflight_status == "passed"` in `validate_experiment_result` (with clarifying comment).
  - Ensure `_sanitize_result(...)` preserves post‑preflight `capability_mismatch` and `budget_observations.runner_error`.

<sup>Written for commit 5538147f5f8db9d7188b1612422b552775f3ce9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

