### PR TITLE
fix(orchestration): trust mounted repo for runner git commands via safe.directory

### DIFF
--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -59,6 +59,12 @@ OOM_PATTERNS: tuple[re.Pattern[str], ...] = (
 PYTHON_ORACLE_BINARIES = {"python", "python3"}
 
 
+def _safe_git_config_args_for(cwd: Path) -> list[str]:
+    """Return sanitized git config with cwd trusted for readonly container mounts."""
+
+    return [*_safe_git_config_args(), "-c", f"safe.directory={cwd}"]
+
+
 class ExperimentRunnerError(RuntimeError):
     """Base error for internal runner failures."""
 
@@ -243,7 +249,7 @@ def _run_git(
     """Run git with an absolute binary and stable text capture."""
 
     process = subprocess.run(  # nosec B603: absolute git binary with bounded argv is required for isolated checkouts (remove-by: 2026-07-31, ref: PR-1082)
-        [_resolve_git_binary(), *_safe_git_config_args(), *args],
+        [_resolve_git_binary(), *_safe_git_config_args_for(cwd), *args],
         cwd=str(cwd),
         env=_sanitized_git_env_without_parent_state(),
         capture_output=True,

--- a/tests/test_creative_code_patch_builder.py
+++ b/tests/test_creative_code_patch_builder.py
@@ -703,6 +703,8 @@ def test_experiment_runner_uses_sanitized_git_env(
     assert "diff.external=" in argv
     assert "core.fsmonitor=false" in argv
     assert f"core.hooksPath={os.devnull}" in argv
+    assert "-c" in argv
+    assert f"safe.directory={repo}" in argv
     env = captured["kwargs"]["env"]
     assert env["GIT_CONFIG_GLOBAL"] == os.devnull
     assert env["GIT_CONFIG_NOSYSTEM"] == "1"


### PR DESCRIPTION
### Motivation
- The experiment runner runs as a non-root UID and clones a host-mounted readonly repository, which Git rejects as "dubious ownership" unless the checkout path is trusted via `safe.directory`.

### Description
- Add `_safe_git_config_args_for(cwd: Path)` in `scripts/orchestration/experiment_runner.py` to append a per-invocation `-c safe.directory=<cwd>` to the sanitized git config args.  
- Use the new helper in `_run_git(...)` so every runner Git invocation trusts the repository root passed as `cwd`.  
- Extend `tests/test_creative_code_patch_builder.py::test_experiment_runner_uses_sanitized_git_env` to assert the `-c safe.directory=<repo>` override is present in the git argv.

### Testing
- Ran `python3 scripts/orchestration/check_preflight.py` and it passed.  
- Ran `python3 scripts/orchestration/check_agent_consistency.py` and it passed.  
- Verified Python byte-compile for the modified files with `python3 -m py_compile scripts/orchestration/experiment_runner.py tests/test_creative_code_patch_builder.py` and it passed.  
- `pytest -q tests/test_creative_code_patch_builder.py::test_experiment_runner_uses_sanitized_git_env tests/test_experiment_runner.py` was attempted but blocked by local environment issues (`pyenv` version mismatch and a missing `fastapi` dependency).  
- `make validate-changed` and `pre-commit run --all-files` were attempted but blocked by the missing repo `.venv` / `pre-commit` command in the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55ba27a30c832ca654584e83294bc9)

## Summary by Sourcery

Доверять Git-операциям запускателя экспериментов в репозиториях, смонтированных только для чтения, помечая рабочий каталог как безопасный Git‑каталог при каждом запуске.

Bug Fixes:
- Гарантировать, что команды git в запускателе экспериментов больше не завершаются с ошибкой «dubious ownership» при работе с смонтированными на хосте репозиториями только для чтения.

Tests:
- Расширить тесты окружения Git для запускателя экспериментов, чтобы проверять, что параметр safe.directory включён в аргументы команд git.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Trust the experiment runner's git operations against readonly mounted repositories by marking the working directory as a safe Git directory on each invocation.

Bug Fixes:
- Ensure git commands in the experiment runner no longer fail due to "dubious ownership" when operating on host-mounted readonly repositories.

Tests:
- Extend experiment runner git environment tests to verify the safe.directory override is included in the git command arguments.

</details>