### PR TITLE
fix(orchestration): fingerprint prepare artifact validation

### DIFF
--- a/scripts/orchestration/creative_code_spec_pipeline.py
+++ b/scripts/orchestration/creative_code_spec_pipeline.py
@@ -455,6 +455,18 @@ def _canonical_context_pack_json(value: Mapping[str, Any]) -> str:
     return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
 
 
+def _canonical_payload_matches(left: Any, right: Any) -> bool:
+    """Compare JSON artifacts by canonical bytes instead of Python equality."""
+
+    try:
+        return fingerprint_payload(left) == fingerprint_payload(right)
+    except ValueError as exc:
+        raise CreativeCodeSpecPipelineError(
+            "adaptive_source_lineage_mismatch: retained prepare artifact is not "
+            "deterministic JSON-compatible data"
+        ) from exc
+
+
 def _validate_historical_context_pack(
     value: Any,
     *,
@@ -819,7 +831,7 @@ def validate_default_prepare_artifact_snapshots(
                     "stable lineage is not canonical"
                 )
             continue
-        if retained_payload != expected_payload:
+        if not _canonical_payload_matches(retained_payload, expected_payload):
             raise CreativeCodeSpecPipelineError(
                 f"adaptive_source_lineage_mismatch: retained {filename} is not canonical"
             )
@@ -885,11 +897,11 @@ def validate_exact_prepare_artifacts(
     context_pack = _read_json_artifact(source_dir / "context_pack.json")
     normalized_packet = validate_source_candidate_packet(expected_packet)
     normalized_variants = [dict(row) for row in expected_variants]
-    if source_packet != normalized_packet:
+    if not _canonical_payload_matches(source_packet, normalized_packet):
         raise CreativeCodeSpecPipelineError(
             "adaptive_prepare_source_packet_mismatch: source_packet.json drifted"
         )
-    if variants != normalized_variants:
+    if not _canonical_payload_matches(variants, normalized_variants):
         raise CreativeCodeSpecPipelineError(
             "adaptive_prepare_variants_mismatch: variants.json drifted"
         )
@@ -897,12 +909,12 @@ def validate_exact_prepare_artifacts(
         source_packet=normalized_packet,
         variants=normalized_variants,
     )
-    if skeptic_reviews != expected_reviews:
+    if not _canonical_payload_matches(skeptic_reviews, expected_reviews):
         raise CreativeCodeSpecPipelineError(
             "adaptive_prepare_reviews_mismatch: skeptic_reviews.json drifted"
         )
     expected_context_pack = _context_pack_for_packet(normalized_packet)
-    if context_pack != expected_context_pack:
+    if not _canonical_payload_matches(context_pack, expected_context_pack):
         raise CreativeCodeSpecPipelineError(
             "adaptive_prepare_context_mismatch: context_pack.json drifted"
         )

--- a/tests/test_creative_code_specification.py
+++ b/tests/test_creative_code_specification.py
@@ -766,6 +766,27 @@ def test_retained_prepare_returns_defensive_snapshot_copies(
     assert historical == historical_before
 
 
+def test_retained_prepare_rejects_numeric_type_drift() -> None:
+    packet = _packet()
+    snapshots = creative_code_spec_pipeline.build_default_prepare_artifacts(packet)
+    assert snapshots["source_packet.json"]["variant_count"] == packet["variant_count"]
+    snapshots["source_packet.json"]["variant_count"] = float(packet["variant_count"])
+    expected_source = creative_code_spec_pipeline.build_default_prepare_artifacts(packet)[
+        "source_packet.json"
+    ]
+    assert snapshots["source_packet.json"] == expected_source
+
+    with pytest.raises(
+        CreativeCodeSpecPipelineError,
+        match="retained source_packet.json is not canonical",
+    ):
+        creative_code_spec_pipeline.validate_default_prepare_artifact_snapshots(
+            snapshots,
+            expected_packet=packet,
+            historical_context_char_counts=_historical_context_char_counts(packet),
+        )
+
+
 def test_retained_prepare_normalizes_size_derived_no_reduction_reason(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1065,6 +1086,22 @@ def test_prepare_exact_preserves_legacy_prepare_and_rejects_test_drift(
             expected_packet=packet,
             expected_variants=exact,
         )
+        exact_source_path = exact_dir / "source_packet.json"
+        exact_source_bytes = exact_source_path.read_bytes()
+        exact_source = json.loads(exact_source_bytes)
+        exact_source["variant_count"] = float(exact_source["variant_count"])
+        assert exact_source == packet
+        exact_source_path.write_text(json.dumps(exact_source), encoding="utf-8")
+        with pytest.raises(
+            CreativeCodeSpecPipelineError,
+            match="adaptive_prepare_source_packet_mismatch",
+        ):
+            creative_code_spec_pipeline.validate_exact_prepare_artifacts(
+                run_dir=exact_dir,
+                expected_packet=packet,
+                expected_variants=exact,
+            )
+        exact_source_path.write_bytes(exact_source_bytes)
         exact_context_path = exact_dir / "context_pack.json"
         exact_context_bytes = exact_context_path.read_bytes()
         historical_context = _historical_default_prepare_artifacts(monkeypatch, packet)[


### PR DESCRIPTION
### Motivation

- The PR-1 prepare artifact validators used direct Python equality for JSON payloads, which treats integers and equal-valued floats as equal (e.g. `3` == `3.0`), weakening provenance integrity checks.
- The change restores type-sensitive canonical comparison so tampered retained/exact prepare artifacts (numeric type drift and similar JSON encoding differences) fail closed.

### Description

- Added `_canonical_payload_matches(...)` to `scripts/orchestration/creative_code_spec_pipeline.py` that compares artifacts via existing `fingerprint_payload(...)` (canonical JSON bytes + SHA-256) and raises a `CreativeCodeSpecPipelineError` on non-deterministic JSON.
- Replaced Python `==` checks with `_canonical_payload_matches` in `validate_default_prepare_artifact_snapshots(...)` for retained sidecars and in `validate_exact_prepare_artifacts(...)` for `source_packet`, `variants`, `skeptic_reviews`, and `context_pack` comparisons so canonical fingerprints are enforced.
- Added regression tests in `tests/test_creative_code_specification.py` to assert numeric type drift (integer → float) is rejected for retained snapshots and for exact prepare replay.
- Commit message: `fix(orchestration): fingerprint prepare artifact validation` (changes in `scripts/orchestration/creative_code_spec_pipeline.py` and `tests/test_creative_code_specification.py`).

### Testing

- Ran `python3 -m py_compile scripts/orchestration/creative_code_spec_pipeline.py tests/test_creative_code_specification.py` with success to validate syntax.
- Executed local targeted PoCs that exercise `validate_default_prepare_artifact_snapshots(...)` and `validate_exact_prepare_artifacts(...)` demonstrating the numeric-type-drift cases now raise `CreativeCodeSpecPipelineError` (observed exception messages: retained/exact mismatches), and ran `python3 scripts/orchestration/check_preflight.py` and `python3 scripts/orchestration/check_agent_consistency.py` which passed.
- Ran `git diff --check` and basic repository checks with success and committed the fix.
- Environment-limited checks that could not be executed here: `make validate-changed` failed due to missing repo `.venv` Python, `python3 -m pytest ...` could not run because `pytest` is not available in system Python, and `pre-commit run --all-files` could not run because `pre-commit` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55ba29accc832c8823576be374250a)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces type-sensitive, canonical fingerprint comparison for prepare artifacts to catch numeric type drift and JSON encoding differences. This closes gaps where Python equality treated 3 and 3.0 as equal, improving provenance checks.

- **Bug Fixes**
  - Added `_canonical_payload_matches` using `fingerprint_payload(...)`; raises `CreativeCodeSpecPipelineError` on non-deterministic JSON.
  - Replaced `==` with canonical comparison in `validate_default_prepare_artifact_snapshots(...)` and `validate_exact_prepare_artifacts(...)` for `source_packet`, `variants`, `skeptic_reviews`, and `context_pack`.
  - Added tests to reject integer→float drift for retained snapshots and exact prepare runs.

<sup>Written for commit 1c1575ab2885b6db769ad86ca548c0d0cfea28f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

