### PR TITLE
fix(ci): preserve legacy app/router aliases on unknown rebinding

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -1711,7 +1711,16 @@ class _LexicalBindings:
 
     def bind(self, name: str, *, reference: str | None, string: str | None) -> None:
         if reference is None:
-            self.references.pop(name, None)
+            existing_reference = self.resolve_reference(name)
+            if existing_reference in {"pulseplate.app", _POSSIBLE_APP_REFERENCE}:
+                self.references[name] = _POSSIBLE_APP_REFERENCE
+            elif existing_reference in {
+                "pulseplate.app.router",
+                _POSSIBLE_ROUTER_REFERENCE,
+            }:
+                self.references[name] = _POSSIBLE_ROUTER_REFERENCE
+            else:
+                self.references.pop(name, None)
         else:
             self.references[name] = reference
         if string is None:

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -3196,6 +3196,28 @@ def test_legacy_growth_guard_rejects_new_route() -> None:
     ]
 
 
+def test_legacy_growth_guard_rejects_dynamic_app_rebinding_route() -> None:
+    source = textwrap.dedent("""
+        _existing_app = app
+
+        def _resolve_app():
+            return _existing_app
+
+        app = _resolve_app()
+
+        @app.get("/api/v1/hidden")
+        async def hidden():
+            return {"ok": True}
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "decorator:get:/api/v1/hidden -> hidden"
+    ]
+
+
 @pytest.mark.parametrize(
     ("path", "owner"),
     [


### PR DESCRIPTION
### Motivation
- The legacy-growth static analyzer could lose tracked `app`/`app.router` aliases when an assignment value could not be statically resolved, allowing runtime route registrations after dynamic rebinding to evade the CI guard. 
- The change aims to make the analyzer fail-closed for unresolved rebindings that may still reference the canonical FastAPI app/router. 

### Description
- Update `_LexicalBindings.bind` in `scripts/ci/check_legacy_growth_guard.py` to preserve known `pulseplate.app` and `pulseplate.app.router` references as `_POSSIBLE_APP_REFERENCE` and `_POSSIBLE_ROUTER_REFERENCE` when an assignment's `reference` is `None` but a previously-resolved reference exists. 
- Add a focused regression test `test_legacy_growth_guard_rejects_dynamic_app_rebinding_route` to `tests/test_legacy_growth_guard.py` that exercises `_existing_app = app; app = _resolve_app(); @app.get(...)` and asserts the legacy guard reports the unexpected route. 

### Testing
- `python3 scripts/orchestration/check_preflight.py --mode analyze --path scripts/ci/check_legacy_growth_guard.py --path tests/test_legacy_growth_guard.py` succeeded. 
- `python3 scripts/orchestration/check_agent_consistency.py` and executing `scripts/ci/check_legacy_growth_guard.py` smoke-validation calls (via `validate_legacy_growth(...)`) passed and showed the new regression is detected. 
- Static checks succeeded: `python3 -m py_compile scripts/ci/check_legacy_growth_guard.py tests/test_legacy_growth_guard.py` passed. 
- Local `pytest` / `make validate-changed` / `pre-commit run --all-files` were not completed in this environment due to a missing local `.venv`, missing `pytest`/`pre-commit`, and network/package fetch restrictions; these are noted as environment limitations and should be run in CI or a developer env to complete the narrow local bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a579dffd24c832c80e87723e6e736ea)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the CI legacy-growth analyzer to preserve `pulseplate.app` and `pulseplate.app.router` aliases when a variable is rebound to an unknown value. This blocks dynamic app rebindings from hiding new routes and ensures the guard flags them.

- **Bug Fixes**
  - Update `_LexicalBindings.bind` in `scripts/ci/check_legacy_growth_guard.py` to keep `_POSSIBLE_APP_REFERENCE`/`_POSSIBLE_ROUTER_REFERENCE` when `reference` is `None` but an existing app/router alias is known.
  - Add regression test `test_legacy_growth_guard_rejects_dynamic_app_rebinding_route` to confirm routes like `@app.get("/api/v1/hidden")` after `app = _resolve_app()` are reported.

<sup>Written for commit 25de4250ae32682145267fb83363a8e0de5929bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

