### PR TITLE
deps(data): upgrade PyArrow to 25.0.0 with Parquet compatibility proof

### DIFF
--- a/docs/review/PR_2146_FIXED_MAPPING.md
+++ b/docs/review/PR_2146_FIXED_MAPPING.md
@@ -1,0 +1,26 @@
+# PR 2146 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/05116ce4384e.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/pyarrow25-offline-data-oracle-result.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 17beb0e59ba6564f00fb7416f4426815cf6dd2ba
+Evidence: tests/test_python_supply_chain_controls.py:955 asserts the 25.0.0 floor, lines 958-961 enforce the <26.0.0 ceiling, and focused supply-chain pytest passed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2146#discussion_r3608655570 -> 17beb0e59ba6564f00fb7416f4426815cf6dd2ba
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"review_commit_ref":"17beb0e59ba6564f00fb7416f4426815cf6dd2ba","review_commit_ref_kind":"repository_commit","review_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2146#issuecomment-5012446561","reviewed_material_digest":"sha256:dbd27d0dd58f2ed5e9b56e3f46189c139480963cb46a984adcd881af620d4a8e","status":"completed"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:08438dae801c51ea63036dd3f1b317e387a706d0c3b664a0fe2afeea01ab9bf5","findings_sha256":"sha256:6d7cfc2a93762e5889bb940e12cf40df1058d85c3533aa9da409da9428b6b4c7","work_ledger_sha256":"sha256:a62f3ae913eae94e29e6c4c2876aea709167fb37cb9cc15d5e30b7f68ee95568"},"authority":"human_asserted_content_receipt","base_revision":"bf31be9b3d015414c0b11917ff940146b2c1f81a","coverage_completeness":"complete","findings_count":0,"head_revision":"17beb0e59ba6564f00fb7416f4426815cf6dd2ba","manifest_sha256":"sha256:1073c65a3061dd114d84099a0431facc2af4da515f0e01d3667cc6f03373444c","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"657538e9-efb7-4342-8799-60cb64a40e70","snapshot_digest":"codex-security-snapshot/v1:sha256:d5220767b096f97f4250ce7b3f53e8245f7cdd2447a9013fc5ebf1d313ab8690"},"material":{"base_ref_oid":"bf31be9b3d015414c0b11917ff940146b2c1f81a","digest":"sha256:dbd27d0dd58f2ed5e9b56e3f46189c139480963cb46a984adcd881af620d4a8e","material_head_sha":"17beb0e59ba6564f00fb7416f4426815cf6dd2ba","merge_base_sha":"bf31be9b3d015414c0b11917ff940146b2c1f81a","policy_version":"pulseplate.material-classification/v1"},"pr_number":2146,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/docs/review/PR_2146_FIXED_MAPPING.md
+++ b/docs/review/PR_2146_FIXED_MAPPING.md
@@ -19,6 +19,20 @@ Commit: 17beb0e59ba6564f00fb7416f4426815cf6dd2ba
 Evidence: tests/test_python_supply_chain_controls.py:955 asserts the 25.0.0 floor, lines 958-961 enforce the <26.0.0 ceiling, and focused supply-chain pytest passed.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2146#discussion_r3608655570 -> 17beb0e59ba6564f00fb7416f4426815cf6dd2ba
 
+Disposition: NOT-A-BUG
+Evidence: GitHub reports live PR head 626f6bacc418ad0f273f6fe002cd6ac46273f3fb; git merge-base --is-ancestor 17beb0e59ba6564f00fb7416f4426815cf6dd2ba 626f6bacc418ad0f273f6fe002cd6ac46273f3fb exits 0, while the Commit API cannot resolve reviewer ref 86950ac1cc9f2ca3025cc8357fd4f47fae2c8448.
+Reason: The cited 86950ac1cc9f2ca3025cc8357fd4f47fae2c8448 is an unavailable reviewer execution ref, not the live PR head; the material seal is reachable from the real head.
+Fingerprint: sha256:682837e66f6f8a599a1a678843685c1026b5201c66981709ba6ef2d283e65fcf
+Cause: unavailable_review_ref_ancestry
+Material-Digest: sha256:dbd27d0dd58f2ed5e9b56e3f46189c139480963cb46a984adcd881af620d4a8e
+Verified-Fix: 626f6bacc418ad0f273f6fe002cd6ac46273f3fb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2146#discussion_r3608971162
+
+Disposition: NOT-A-BUG
+Evidence: The sole actionable child is https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2146#discussion_r3608655570, fixed by 17beb0e59ba6564f00fb7416f4426815cf6dd2ba and mapped separately; tests/test_python_supply_chain_controls.py:968-987 intentionally enforces the fail-closed single literal call contract.
+Reason: The aggregate Sourcery wrapper adds no independent actionable; its general AST-flexibility suggestions conflict with this lane explicit-engine regression invariant.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2146#pullrequestreview-4728779576
+
 ## Review Material Seal
 <!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
 <!-- pragma: allowlist nextline secret -->

--- a/docs/review/PR_2146_FIXED_MAPPING.md
+++ b/docs/review/PR_2146_FIXED_MAPPING.md
@@ -20,12 +20,12 @@ Evidence: tests/test_python_supply_chain_controls.py:955 asserts the 25.0.0 floo
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2146#discussion_r3608655570 -> 17beb0e59ba6564f00fb7416f4426815cf6dd2ba
 
 Disposition: NOT-A-BUG
-Evidence: GitHub reports live PR head 626f6bacc418ad0f273f6fe002cd6ac46273f3fb; git merge-base --is-ancestor 17beb0e59ba6564f00fb7416f4426815cf6dd2ba 626f6bacc418ad0f273f6fe002cd6ac46273f3fb exits 0, while the Commit API cannot resolve reviewer ref 86950ac1cc9f2ca3025cc8357fd4f47fae2c8448.
+Evidence: GitHub reports live PR head 61b09cff15e2f4e80675eb08525566cc84b0e510; git merge-base --is-ancestor 17beb0e59ba6564f00fb7416f4426815cf6dd2ba 61b09cff15e2f4e80675eb08525566cc84b0e510 exits 0, while the Commit API cannot resolve reviewer ref 86950ac1cc9f2ca3025cc8357fd4f47fae2c8448.
 Reason: The cited 86950ac1cc9f2ca3025cc8357fd4f47fae2c8448 is an unavailable reviewer execution ref, not the live PR head; the material seal is reachable from the real head.
-Fingerprint: sha256:682837e66f6f8a599a1a678843685c1026b5201c66981709ba6ef2d283e65fcf
+Fingerprint: sha256:2092979535eca048a1efb6f07d09c024704a5f2963db8dddd365730f9ae0c3a4
 Cause: unavailable_review_ref_ancestry
 Material-Digest: sha256:dbd27d0dd58f2ed5e9b56e3f46189c139480963cb46a984adcd881af620d4a8e
-Verified-Fix: 626f6bacc418ad0f273f6fe002cd6ac46273f3fb
+Verified-Fix: 17beb0e59ba6564f00fb7416f4426815cf6dd2ba
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2146#discussion_r3608971162
 
 Disposition: NOT-A-BUG

--- a/requirements-data.in
+++ b/requirements-data.in
@@ -9,4 +9,4 @@ pandas
 
 # Keep Parquet writer support explicit for local data-build lanes while preserving
 # runtime/Docker/CI-lite absence unless a future PR documents canonical ownership.
-pyarrow>=20.0.0,<25.0.0
+pyarrow>=25.0.0,<26.0.0

--- a/requirements-data.txt
+++ b/requirements-data.txt
@@ -12,7 +12,7 @@ numpy==2.4.6
     #   pandas
 pandas==3.0.3
     # via -r requirements-data.in
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via -r requirements-data.in
 python-dateutil==2.9.0.post0
     # via

--- a/scripts/build_food_db.py
+++ b/scripts/build_food_db.py
@@ -226,7 +226,7 @@ class FoodDatabaseBuilder:
             data.append(row)
 
         df = pd.DataFrame(data)
-        df.to_parquet(self.food_parquet, index=False)
+        df.to_parquet(self.food_parquet, engine="pyarrow", index=False)
 
         logging.info(f"  ✅ Parquet saved: {self.food_parquet}")
         logging.info(f"  📊 Records: {len(df)}")

--- a/scripts/build_recipe_db.py
+++ b/scripts/build_recipe_db.py
@@ -116,7 +116,7 @@ def main():
         )
     out_df = pd.DataFrame(out_rows)
     OUT_PARQUET.parent.mkdir(parents=True, exist_ok=True)
-    out_df.to_parquet(OUT_PARQUET, index=False)
+    out_df.to_parquet(OUT_PARQUET, engine="pyarrow", index=False)
     con = sqlite3.connect(OUT_SQLITE)
     out_df.to_sql("recipes", con, if_exists="replace", index=False)
     con.execute("DROP TABLE IF EXISTS recipes_fts;")

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -955,6 +955,10 @@ def test_constraints_keep_dependency_security_floors_aligned() -> None:
     assert _requirement_package_versions(REPO_ROOT / "requirements-data.in", "pyarrow") == {
         "25.0.0"
     }
+    assert _requirement_package_specifiers(REPO_ROOT / "requirements-data.in", "pyarrow") == {
+        (">=", "25.0.0"),
+        ("<", "26.0.0"),
+    }
     data_lock_versions = _requirement_package_versions(
         REPO_ROOT / "requirements-data.txt", "pyarrow"
     )

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import re
@@ -13,7 +14,6 @@ import subprocess
 from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
-from packaging.version import Version
 import pytest
 import yaml
 
@@ -953,13 +953,34 @@ def test_constraints_keep_dependency_security_floors_aligned() -> None:
     ):
         assert not _requirement_package_versions(lock_surface, "pyarrow")
     assert _requirement_package_versions(REPO_ROOT / "requirements-data.in", "pyarrow") == {
-        "20.0.0"
+        "25.0.0"
     }
     data_lock_versions = _requirement_package_versions(
         REPO_ROOT / "requirements-data.txt", "pyarrow"
     )
-    assert data_lock_versions
-    assert all(Version(version) >= Version("20.0.0") for version in data_lock_versions)
+    assert data_lock_versions == {"25.0.0"}
+
+
+def test_offline_builders_require_explicit_pyarrow_parquet_engine() -> None:
+    for builder_path in (
+        REPO_ROOT / "scripts" / "build_food_db.py",
+        REPO_ROOT / "scripts" / "build_recipe_db.py",
+    ):
+        tree = ast.parse(builder_path.read_text(encoding="utf-8"), filename=str(builder_path))
+        parquet_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "to_parquet"
+        ]
+
+        assert len(parquet_calls) == 1, builder_path
+        keywords = {keyword.arg: keyword.value for keyword in parquet_calls[0].keywords}
+        assert isinstance(keywords.get("engine"), ast.Constant), builder_path
+        assert keywords["engine"].value == "pyarrow", builder_path
+        assert isinstance(keywords.get("index"), ast.Constant), builder_path
+        assert keywords["index"].value is False, builder_path
 
 
 def test_ci_security_job_runs_pip_audit_from_ci_lite_toolchain() -> None:


### PR DESCRIPTION
## Goal

Upgrade the governed offline data dependency profile from PyArrow 24 to exact PyArrow 25.0.0 and make both Parquet builders select the PyArrow engine explicitly.

Supersedes #2106. This is the coordinator-first governed replacement for closed PR #2110; that branch and its provenance are not reused.

## Business reason

Keep offline food/recipe data generation on a current, bounded Arrow release while preventing pandas `auto` engine fallback from silently changing the serializer. The narrow proof reduces supply-chain and Parquet-compatibility risk without moving PyArrow into production runtime surfaces.

## Scope

- Change the data-profile source range to `pyarrow>=25.0.0,<26.0.0`.
- Regenerate only `requirements-data.txt` through the governed Make/private-proxy path, producing `pyarrow==25.0.0` with all companion pins unchanged.
- Require `engine="pyarrow"` and `index=False` in the food and recipe offline builders.
- Extend the existing supply-chain test with exact source/lock assertions and a bounded AST contract for the two builder calls.
- Prove read compatibility for a PyArrow 24 synthetic baseline and the two tracked older-Arrow Parquet fixtures, plus a PyArrow 25 semantic round-trip.

## Out of scope

- Runtime, Docker, CI-lite, or aggregate dependency changes.
- Public API, OpenAPI, database schema, generated clients, builder APIs, paths, serialization contracts, or business logic.
- A permanent compatibility checker, new test file, dependency registry/workflow/docs, premortem document, or proxy byte-limit change.
- Regenerating or committing tracked Parquet data.
- pgvector #2105 and the independent #2144/#2145 lanes.

## Files changed

- `requirements-data.in`
- `requirements-data.txt`
- `scripts/build_food_db.py`
- `scripts/build_recipe_db.py`
- `tests/test_python_supply_chain_controls.py`

## Key decisions

- Use explicit `engine="pyarrow"`; pandas `auto` may fall back to `fastparquet`.
- Keep a bounded source range and an exact generated lock at 25.0.0.
- Leave `GRAPH_CHANGE_PACKAGES` unset because the normalized dependency graph is unchanged.
- Keep the implementation and deterministic guard in one coherent material commit.
- Start from `bf31be9b3d015414c0b11917ff940146b2c1f81a`, the current `origin/main` containing merge #2142. The operator override permitted the lane to start while post-merge main CI was non-terminal; it does not waive clean-base, PR CI, review, security, or merge-readiness gates.

## Tests

- [x] `python3 scripts/orchestration/check_preflight.py`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] Governed `UPGRADE_PACKAGES="pyarrow==25.0.0" LOCK_PROFILES="data" make requirements-locks`
- [x] Second `LOCK_PROFILES="data" make requirements-locks` was byte-idempotent (`requirements-data.txt` SHA-256 `1d6ccad5c345d99ef0e67fc85c6eea5350a1e4aed839e0aeb132beb393712792`)
- [x] Companion pins remained `numpy==2.4.6`, `pandas==3.0.3`, `python-dateutil==2.9.0.post0`, and `six==1.17.0`
- [x] Existing private-proxy checker found exact PyArrow 25 artifacts for Python 3.11, 3.12, and 3.13 without increasing `--max-bytes`
- [x] Governed wheelhouse install on macOS arm64 completed wheel-only and reported PyArrow 25.0.0 / pandas 3.0.3
- [x] PyArrow 25 read a synthetic PyArrow 24 baseline and tracked `data/food.parquet` / `data/recipes.parquet`
- [x] PyArrow 25 write/read canary preserved rows, columns, logical schema, Unicode, nulls, floats, JSON fields, and nested nutrition provenance after normalization
- [x] Tracked Parquet hashes were unchanged; no generated data or local artifacts entered the diff
- [x] Focused dependency/supply-chain pytest, including the complete dependency-surface suite
- [x] `python3 scripts/ci/check_python_dependency_surfaces.py`
- [x] `python3 scripts/verify_requirements.py`
- [x] `git diff --check`
- [x] `make validate-changed`
- [x] `pre-commit run --all-files`
- [x] Pre-push mypy, pip-audit, selected backend tests, full-repo Bandit, and Docker build hook
- [ ] Current-head GitHub lint/typecheck, relevant test-main shards, diff coverage at least 97%, dependency/security/governance checks, and strict merge readiness

Local full `make verify` was not run, per the repository machine-budget hard gate.

## Security notes

- PyArrow remains confined to the offline data profile; existing assertions continue to reject it from runtime, Docker, CI-lite, and aggregate locks.
- Lock resolution and installation used the governed private proxy with no public-index fallback and no source build.
- No credentials, package-index secrets, raw wheel metadata, or Parquet contents are included in this PR.
- The pre-open architecture and security role passes reported no actionable P0-P3 findings on the exact material diff.
- One final Codex Security diff scan (`657538e9-efb7-4342-8799-60cb64a40e70`) completed on frozen material head `17beb0e59ba6564f00fb7416f4426815cf6dd2ba`: 5/5 worklist receipts, complete coverage, and zero findings.
- The repo seal ingests the same completed scan through its canonical three-artifact projection (`findings`, `coverage`, and `work_ledger`); no second scan or material change was introduced.
- The exact-head Codex review and the single repo-native `pulseplate-pr-review` pass reported no material findings.

## Risks / rollback

- Compatibility risk: PyArrow 25 could interpret older logical/nested values differently. The v24/v19-era reads and v25 normalized round-trip fail this lane on row, column, schema, Unicode/null/float/JSON, or nested-provenance drift.
- Operational risk: a stale manually managed data environment may still have PyArrow 24. Offline builder operators must reinstall the exact `requirements-data.txt` profile before running builders.
- Supply-chain risk: missing exact wheels or proxy lag fails closed; there is no public fallback or sdist path.
- Rollback: atomically revert this PR and reinstall the prior data lock. No data migration, deploy rollback, API rollback, or client rollback is required.

## Lane start provenance

- Starter: `scripts/orchestration/start_pr_lane.sh`
- Packet: `artifacts/orchestration/task_packets/8efd99b68256.json`
- Pre-open dispatch executed in order: `agent-coordinator -> dev-operator -> architecture-specialist -> security-auditor`
- Task class / phase: `Infrastructure` / `pre_open`
- Plugin checklist: `codex-security`

## Premortem

Actual-diff premortem result: **PROCEED**. The bounded failure modes are stale manual environments, older-Parquet schema/semantic drift, implicit engine fallback, dependency-surface creep, and proxy/source-build fallback. They are closed by the exact lock/install proof, compatibility canaries, AST contract, containment assertions, and governed wheel-only installer. No scope expansion was required.

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/pyarrow25-offline-data-oracle-result.json`

The mandatory oracle-only Experiment Runner packet was accepted with all three deterministic oracles passing, `mutated_paths=[]`, and the shared tree untouched. It did not materially influence the implementation or commit decision, so no Experiment Runner co-author trailer is required. The current capability/no-DNS isolation probe passed against the same immutable runner image previously reviewed in #2116. A redundant current local Trivy rerun was killed by host memory pressure (exit 137); this PR does not claim a new Trivy pass from that attempt.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- Canonical artifact: [review governance evidence](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/f06e7c45b34e73fe2c5530e877ff0172f7fc1137/docs/review/PR_2146_FIXED_MAPPING.md).

## Merge Readiness

- [ ] Current-head required CI is terminal
- [ ] Diff coverage is at least 97%
- [ ] CodeRabbit, Sourcery, Cubic, post-open role chain, Codex Security, and PulsePlate PR review have no remaining actionables
- [ ] Canonical mapping/seal and mandatory review wait-window are complete
- [ ] Authenticated strict merge-readiness passes

Do not merge without an explicit operator action.

## Split justification

- Why this PR cannot be split safely: the source pin, generated lock, two explicit serializer call sites, and deterministic guard are one small executable contract.
- Invariant requiring one PR: the declared offline dependency and the engine actually used by both governed builders must change atomically.
- Follow-up PRs: none for this lane; unrelated dependency and legacy-route work remains separate.

## Deferred / Follow-ups

- #2105 / pgvector remains a separate dependency lane.
- #2144 and #2145 remain separate dependent lanes.
- No new deferred defect or backlog item was created by this PR.

## Next best step

Wait for the mapping-only current-head CI wave and final review window, then run authenticated strict merge readiness. Do not rerun bots, role agents, Codex review, or Codex Security unless a real material change invalidates the frozen receipt.

## Summary by Sourcery

Обновить зависимость PyArrow для офлайн‑данных и внедрить явные настройки сериализации Parquet в управляемых билдеров.

Улучшения:
- Зафиксировать профиль управляемых офлайн‑данных на PyArrow 25.0.0 с точной блокировкой в `requirements-data`.
- Обязать билдеры офлайн‑данных для продуктов питания и рецептов использовать `pandas.to_parquet` с `engine="pyarrow"` и отключённым индексом, обеспечивая это через тест на основе AST.

Тесты:
- Ужесточить тест контроля цепочки поставок, чтобы он проверял точные исходный и заблокированный варианты PyArrow 25.0.0, а также наличие явных аргументов `engine` и `index` для Parquet в офлайн‑билдерах.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the offline data PyArrow dependency and enforce explicit Parquet serialization settings in governed builders.

Enhancements:
- Pin the governed offline data profile to PyArrow 25.0.0 with an exact lock in requirements-data.
- Require the food and recipe offline builders to use pandas.to_parquet with engine="pyarrow" and index disabled, enforced via an AST-based test.

Tests:
- Tighten the supply-chain control test to assert the exact PyArrow 25.0.0 source and lock versions and to verify explicit Parquet engine and index arguments in the offline builders.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the offline data profile to `pyarrow` 25.0.0 and require `pandas.to_parquet` to use the `pyarrow` engine with `index=False` for consistent Parquet writes. Verified read compatibility with existing Parquet fixtures; runtime surfaces remain unchanged.

- **Dependencies**
  - Pin `requirements-data.in` to `pyarrow>=25.0.0,<26.0.0`; lock `requirements-data.txt` to `pyarrow==25.0.0`.
  - Tighten supply-chain tests to assert the floor, ceiling, and exact lock, and AST-guard `engine="pyarrow"` and `index=False` in both builders.

- **Migration**
  - Reinstall the offline data environment using `requirements-data.txt` before running builders.

<sup>Written for commit f06e7c45b34e73fe2c5530e877ff0172f7fc1137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->