### PR TITLE
fix(orchestration): resolve shared hook Python in linked worktrees

### DIFF
--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -372,6 +372,33 @@ This metrics section provides **quantitative targets**; the evaluation contract 
 
 ## Pre-push hygiene checklist (mandatory)
 
+### Linked-worktree hook Python resolution
+
+Checked-in hooks call `resolve_repo_python <repo_root>` from
+`scripts/hooks/repo_python.sh`. Resolution order is exact:
+
+1. a valid absolute regular executable `VENV_PYTHON`, otherwise `DEV_PYTHON`;
+   an invalid explicit override is terminal
+2. the current checkout `.venv`
+3. the primary checkout `.venv`, only after canonical Git common-dir,
+   primary top-level, and same-common-dir validation
+4. system `python3`, then `python`, in CI only
+5. local failure when none of the trusted candidates exists
+
+Linked worktrees may be nested, sibling, or outside the primary checkout.
+Directory naming is not evidence of ownership; bare, separate, or decoy `.git`
+layouts are rejected. If a commit stops with
+`ERROR: no repo/shared .venv Python found for local hook execution`, repeat the
+original commit command with an absolute override for that one recovery run.
+For example:
+
+```bash
+VENV_PYTHON="/absolute/path/to/primary/.venv/bin/python" git commit -m "same commit message"
+```
+
+Do not export the override permanently, disable the hook, or skip it. Repair
+the checkout/venv binding before the next normal commit.
+
 ## GitHub Full-Verify Parity
 
 Agents do not run full local `make verify` by default. If a human explicitly

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -381,13 +381,15 @@ Checked-in hooks call `resolve_repo_python <repo_root>` from
    an invalid explicit override is terminal
 2. the current checkout `.venv`
 3. the primary checkout `.venv`, only after canonical Git common-dir,
-   primary top-level, and same-common-dir validation
+   linked-worktree admin backlink, primary top-level, and same-common-dir
+   validation
 4. system `python3`, then `python`, in CI only
 5. local failure when none of the trusted candidates exists
 
 Linked worktrees may be nested, sibling, or outside the primary checkout.
-Directory naming is not evidence of ownership; bare, separate, or decoy `.git`
-layouts are rejected. If a commit stops with
+Directory naming is not evidence of ownership; the worktree `.git` pointer and
+admin `gitdir` backlink must identify each other. Bare, separate, or decoy
+`.git` layouts are rejected. If a commit stops with
 `ERROR: no repo/shared .venv Python found for local hook execution`, repeat the
 original commit command with an absolute override for that one recovery run.
 For example:

--- a/docs/PRE_COMMIT_HOOKS.md
+++ b/docs/PRE_COMMIT_HOOKS.md
@@ -23,6 +23,7 @@ git config core.hooksPath .githooks
 checkout. Некорректный явно заданный override — terminal error: resolver не
 переходит к следующему кандидату. Основной checkout определяется не по имени
 каталога: resolver канонизирует Git common dir, требует basename `.git` и
+проверяет обратную ссылку worktree admin `gitdir` на текущий checkout, а затем
 повторно проверяет в основном checkout те же canonical top-level и common dir.
 Поэтому linked worktree может находиться в любой вложенной, соседней или
 внешней директории, а bare/separate/подставная `.git` layout отклоняется.
@@ -63,8 +64,9 @@ The exact precedence is a valid absolute regular executable `VENV_PYTHON`
 checkout `.venv`. An invalid explicitly configured override is terminal; the
 resolver does not continue to another candidate. The primary checkout is not
 inferred from a directory name: the resolver canonicalizes Git's common dir,
-requires basename `.git`, and revalidates the same canonical top-level and
-common dir from the primary checkout. Linked worktrees may therefore live in
+requires basename `.git`, verifies the worktree admin `gitdir` backlink to the
+current checkout, and revalidates the same canonical top-level and common dir
+from the primary checkout. Linked worktrees may therefore live in
 nested, sibling, or arbitrary external directories, while bare, separate, and
 decoy `.git` layouts are rejected. Only CI may fall back to system
 `python3`/`python`; local execution fails closed without a trusted interpreter.

--- a/docs/PRE_COMMIT_HOOKS.md
+++ b/docs/PRE_COMMIT_HOOKS.md
@@ -17,12 +17,19 @@ git config core.hooksPath .githooks
 .githooks/pre-commit
 ```
 
-Checked-in hooks resolve Python through `scripts/hooks/repo_python.sh`.
-The resolver prefers the current checkout `.venv`, then the shared root
-`.venv` when running from `worktrees/...`. Local hook execution fails closed
-when no repo/shared `.venv` exists; CI may fall back to system Python. Keep
-Python tools behind the resolved interpreter (`python -m ...`) so local commits
-do not drift into an ambient environment missing locked deps such as FastAPI.
+Хуки из репозитория выбирают Python через `scripts/hooks/repo_python.sh`.
+Точный приоритет: корректный абсолютный исполняемый файл `VENV_PYTHON`
+(иначе `DEV_PYTHON`), `.venv` текущего checkout, затем `.venv` основного
+checkout. Некорректный явно заданный override — terminal error: resolver не
+переходит к следующему кандидату. Основной checkout определяется не по имени
+каталога: resolver канонизирует Git common dir, требует basename `.git` и
+повторно проверяет в основном checkout те же canonical top-level и common dir.
+Поэтому linked worktree может находиться в любой вложенной, соседней или
+внешней директории, а bare/separate/подставная `.git` layout отклоняется.
+Только CI может перейти к системному `python3`/`python`; локально отсутствие
+доверенного Python завершает hook с ошибкой. Запускайте Python-инструменты
+через выбранный interpreter (`python -m ...`), чтобы hook не использовал
+ambient environment без locked dependencies, например FastAPI.
 
 **Преимущества:**
 - 🎯 Все проверки в одном месте
@@ -51,11 +58,19 @@ git config core.hooksPath .githooks
 ```
 
 Checked-in hooks resolve Python through `scripts/hooks/repo_python.sh`.
-The resolver prefers the current checkout `.venv`, then the shared root
-`.venv` when running from `worktrees/...`. Local hook execution fails closed
-when no repo/shared `.venv` exists; CI may fall back to system Python. Keep
-Python tools behind the resolved interpreter (`python -m ...`) so local commits
-do not drift into an ambient environment missing locked deps such as FastAPI.
+The exact precedence is a valid absolute regular executable `VENV_PYTHON`
+(otherwise `DEV_PYTHON`), the current checkout `.venv`, then the primary
+checkout `.venv`. An invalid explicitly configured override is terminal; the
+resolver does not continue to another candidate. The primary checkout is not
+inferred from a directory name: the resolver canonicalizes Git's common dir,
+requires basename `.git`, and revalidates the same canonical top-level and
+common dir from the primary checkout. Linked worktrees may therefore live in
+nested, sibling, or arbitrary external directories, while bare, separate, and
+decoy `.git` layouts are rejected. Only CI may fall back to system
+`python3`/`python`; local execution fails closed without a trusted interpreter.
+Keep Python tools behind the resolved interpreter (`python -m ...`) so hooks
+cannot drift into an ambient environment missing locked dependencies such as
+FastAPI.
 
 **Advantages:**
 - 🎯 All checks in a single place

--- a/docs/review/PR_2147_FIXED_MAPPING.md
+++ b/docs/review/PR_2147_FIXED_MAPPING.md
@@ -3,10 +3,10 @@
 Review-Seal-Version: v1
 
 ## Lane Start Provenance
-Packet: `artifacts/orchestration/task_packets/a271825c41f0.json`
+Packet: `artifacts/orchestration/task_packets/72463acb54a2.json`
 
 ## Experiment Runner Evidence
-Artifact: `artifacts/orchestration/experiments/results/exp-b61cf0c617ea.json`
+Artifact: `artifacts/orchestration/experiments/results/exp-d5a8b5a40026.json`
 
 ## Discussion Thread Pass
 - [x] Discussion-thread pass completed
@@ -29,13 +29,88 @@ Commit: 8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d
 Evidence: scripts/hooks/repo_python.sh:98-111 and tests/test_pre_commit_hook_python_resolver.py:194 prove relative admin backlinks resolve from the canonical admin dir while preserving reciprocal ownership.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609034120 -> 8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d
 
+Disposition: FIXED
+Commit: 4aea27933d3334ecbd54004e9c15d952315ab4c9
+Evidence: scripts/hooks/repo_python.sh:26-41 and tests/test_pre_commit_hook_python_resolver.py:344-379 prove command-function lookup interposition cannot influence the clean resolver child.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609196759 -> 4aea27933d3334ecbd54004e9c15d952315ab4c9
+
+Disposition: FIXED
+Commit: 95ac71a97c2f14bfcfd0fe16c79005a300f3cece
+Evidence: scripts/hooks/repo_python.sh:26-41 and tests/test_pre_commit_hook_python_resolver.py:382-456 prove exported builtin-function interposition is stripped by the clean Bash boundary.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609255545 -> 95ac71a97c2f14bfcfd0fe16c79005a300f3cece
+
+Disposition: FIXED
+Commit: 1e5affdc3e9acbf424930d810d706a7ce8c132b2
+Evidence: scripts/hooks/repo_python.sh:29-41 pins the clean entrypoint to /usr/bin/env and /bin/bash; tests/test_pre_commit_hook_python_resolver.py:459-486 proves a caller-PATH fake Bash is not executed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609488111 -> 1e5affdc3e9acbf424930d810d706a7ce8c132b2
+
+Disposition: FIXED
+Commit: 1e5affdc3e9acbf424930d810d706a7ce8c132b2
+Evidence: scripts/hooks/repo_python.sh:29-41 fixes the clean child tool PATH; tests/test_pre_commit_hook_python_resolver.py:540-628 proves hostile caller-PATH env and git binaries are selected by the caller precondition but never executed by the resolver.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609488114 -> 1e5affdc3e9acbf424930d810d706a7ce8c132b2
+
+Disposition: FIXED
+Commit: 62341486e120759c5e7a7b5dff82845cbc3260a9
+Evidence: scripts/hooks/repo_python.sh:149-164 and tests/test_pre_commit_hook_python_resolver.py:249-286 prove an OS-gated Git Bash drive-absolute worktree backlink reaches the verified primary interpreter.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3610029524 -> 62341486e120759c5e7a7b5dff82845cbc3260a9
+
+Disposition: NOT-A-BUG
+Evidence: The regenerated Fixed in Commit Mapping preserves the original proof block and separately records the current forged copied/symlinked .git regression at tests/test_pre_commit_hook_python_resolver.py:937-969.
+Reason: The comment correctly identified a stale line-only citation in an interim seal; the final additive closeout preserves prior proof while current executable evidence remains covered by the final resolver test matrix.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609248527
+
+Disposition: NOT-A-BUG
+Evidence: The Review Material Seal below binds material head 6f5a14479bb04cde044f2c07156324814cded1ad and digest sha256:f0081ae7114e41b946921ef7e2f983cb7fcd45e4a5f4fa4eb7bbef2ecb02873c.
+Reason: The comment correctly identified an interim stale seal while material was still changing; the canonical one-closeout cycle replaces it atomically on the frozen final material.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609248528
+
+Disposition: NOT-A-BUG
+Evidence: The Review Material Seal below binds the live repository commit 6f5a14479bb04cde044f2c07156324814cded1ad and all FIXED proof SHAs are reachable from that head.
+Reason: The review execution displayed a synthetic squashed ref while the live PR retained its normal reachable commit graph; final exact-head closeout is machine-bound to the live full SHA.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609255544
+
+Disposition: NOT-A-BUG
+Evidence: The Review Material Seal below binds the live repository commit 6f5a14479bb04cde044f2c07156324814cded1ad and all FIXED proof SHAs are reachable from that head.
+Reason: This was an expected interim-seal warning during later hardening; the final atomic closeout removes the stale state without changing material code.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609488110
+
+Disposition: NOT-A-BUG
+Evidence: The Review Material Seal below binds exact frozen material head 6f5a14479bb04cde044f2c07156324814cded1ad and digest sha256:f0081ae7114e41b946921ef7e2f983cb7fcd45e4a5f4fa4eb7bbef2ecb02873c.
+Reason: The finding accurately described the superseded interim seal; it has no independent code defect once the required one-closeout artifact is regenerated for the final head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3610001915
+
+Disposition: NOT-A-BUG
+Evidence: The Review Material Seal below binds exact frozen material head 6f5a14479bb04cde044f2c07156324814cded1ad and all listed FIXED commits remain in its live PR ancestry.
+Reason: The stale-seal state was temporary and expected before material freeze; the canonical final closeout is the disposition evidence.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3610029523
+
+Disposition: NOT-A-BUG
+Evidence: The Review Material Seal below binds exact frozen material head 6f5a14479bb04cde044f2c07156324814cded1ad and all listed FIXED commits remain in its live PR ancestry.
+Reason: The reviewed ancestor correctly carried a stale interim seal because later material fixes were still landing; the final one-closeout artifact removes that transient state.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3610053235
+
+Disposition: NOT-A-BUG
+Evidence: Exact-head Codex review https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#pullrequestreview-4730308698 is machine-bound to 6f5a14479bb04cde044f2c07156324814cded1ad; the Review Material Seal below uses the same frozen head and digest.
+Reason: The synthetic squashed SHA mentioned by the review is not the live PR commit identity; the final canonical seal uses GitHub's trusted full review commit and closes the only exact-head finding.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3610090662
+
 Disposition: NOT-A-BUG
 Evidence: scripts/hooks/repo_python.sh:24-27 canonicalizes repo_root before identity comparisons; lines 55-71 and 119-129 keep the six-variable sanitized Git envelope identical, and tests/test_pre_commit_hook_python_resolver.py:128 covers a symlink alias.
 Reason: The first premise is false on the reviewed implementation, while extracting a helper is an optional refactor explicitly outside this micro-PR and would not change runtime correctness.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#pullrequestreview-4729010204
 
+Disposition: NOT-A-BUG
+Evidence: Its single inline actionable is dispositioned separately in this mapping with reachable FIXED proof and current code/test evidence.
+Reason: The review summary is a pointer to the inline finding and contains no independent actionable.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#pullrequestreview-4729012474
+
+Disposition: NOT-A-BUG
+Evidence: Both inline actionables are dispositioned separately in this mapping: the evidence citation is preserved with current regression coverage and the final seal is bound to the frozen exact material.
+Reason: The review summary is a pointer to the two inline findings and contains no independent actionable.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#pullrequestreview-4729349206
+
 ## Review Material Seal
 <!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
 <!-- pragma: allowlist nextline secret -->
-{"authority":"human_asserted_content_receipt","code_review":{"review_commit_ref":"8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d","review_commit_ref_kind":"repository_commit","review_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#issuecomment-5012865615","reviewed_material_digest":"sha256:17fd3d19ea85b094d263f9f6200075e2e406454e98787397f9b61b6992a35b3f","status":"completed"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:112fed270db41098a262c6bd51cd505b35379f1e495ced1b8cda7fae1369a86f","findings_sha256":"sha256:e06d33ed17eee7dff417d80dd4280631de499e6e431b0ab0197253b17f605b2c","work_ledger_sha256":"sha256:63119448f19b5116d14b3b2311caf4bf92d385e06552758dcc7c0d672d8e92cf"},"authority":"human_asserted_content_receipt","base_revision":"bf31be9b3d015414c0b11917ff940146b2c1f81a","coverage_completeness":"complete","findings_count":0,"head_revision":"8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d","manifest_sha256":"sha256:24c1515664f770d22eeba433c4a6ef1798f65aa81fa27cc00ba240832e9f3482","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"c412f317-c7ff-4fd6-bbbf-ba0ad80010bd","snapshot_digest":"codex-security-snapshot/v1:sha256:1d74df0bc5da366ec7aad16a4841552de3d91d1cb5319d4e849096130ccb54eb"},"material":{"base_ref_oid":"bf31be9b3d015414c0b11917ff940146b2c1f81a","digest":"sha256:17fd3d19ea85b094d263f9f6200075e2e406454e98787397f9b61b6992a35b3f","material_head_sha":"8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d","merge_base_sha":"bf31be9b3d015414c0b11917ff940146b2c1f81a","policy_version":"pulseplate.material-classification/v1"},"pr_number":2147,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+{"authority":"human_asserted_content_receipt","code_review":{"review_commit_ref":"6f5a14479bb04cde044f2c07156324814cded1ad","review_commit_ref_kind":"repository_commit","review_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#pullrequestreview-4730308698","reviewed_material_digest":"sha256:f0081ae7114e41b946921ef7e2f983cb7fcd45e4a5f4fa4eb7bbef2ecb02873c","status":"completed"},"codex_security":{"authority":"operator_outage_override","base_revision":"bf31be9b3d015414c0b11917ff940146b2c1f81a","created_at":"2026-07-19T07:42:02Z","error_code":"-32001","error_message":"Request timed out","head_revision":"6f5a14479bb04cde044f2c07156324814cded1ad","material_digest":"sha256:f0081ae7114e41b946921ef7e2f983cb7fcd45e4a5f4fa4eb7bbef2ecb02873c","operator_association":"OWNER","operator_login":"Katsiarynakavaleuskaya","operator_user_id":169792616,"outage_class":"codex_security_mcp_timeout","override_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#issuecomment-5014901578","scan_id":null,"status":"tooling_unavailable"},"material":{"base_ref_oid":"bf31be9b3d015414c0b11917ff940146b2c1f81a","digest":"sha256:f0081ae7114e41b946921ef7e2f983cb7fcd45e4a5f4fa4eb7bbef2ecb02873c","material_head_sha":"6f5a14479bb04cde044f2c07156324814cded1ad","merge_base_sha":"bf31be9b3d015414c0b11917ff940146b2c1f81a","policy_version":"pulseplate.material-classification/v1"},"pr_number":2147,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
 <!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/docs/review/PR_2147_FIXED_MAPPING.md
+++ b/docs/review/PR_2147_FIXED_MAPPING.md
@@ -1,0 +1,41 @@
+# PR 2147 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/a271825c41f0.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/exp-b61cf0c617ea.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 137e9fda8b4ab6f273d2fc4827e2cdc0b9d21068
+Evidence: scripts/hooks/repo_python.sh:51-71 and tests/test_pre_commit_hook_python_resolver.py:234 prove absolute env/git resolution, sanitized Git queries, and interposition rejection.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3608891821 -> 137e9fda8b4ab6f273d2fc4827e2cdc0b9d21068
+
+Disposition: FIXED
+Commit: b2d40b7b3b67f8af3dee6bb4be546cf13cee270b
+Evidence: scripts/hooks/repo_python.sh:90-113 and tests/test_pre_commit_hook_python_resolver.py:463 prove reciprocal regular-file backlink ownership and forged copied/symlinked .git rejection.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3608929925 -> b2d40b7b3b67f8af3dee6bb4be546cf13cee270b
+
+Disposition: FIXED
+Commit: 8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d
+Evidence: scripts/hooks/repo_python.sh:98-111 and tests/test_pre_commit_hook_python_resolver.py:194 prove relative admin backlinks resolve from the canonical admin dir while preserving reciprocal ownership.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#discussion_r3609034120 -> 8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d
+
+Disposition: NOT-A-BUG
+Evidence: scripts/hooks/repo_python.sh:24-27 canonicalizes repo_root before identity comparisons; lines 55-71 and 119-129 keep the six-variable sanitized Git envelope identical, and tests/test_pre_commit_hook_python_resolver.py:128 covers a symlink alias.
+Reason: The first premise is false on the reviewed implementation, while extracting a helper is an optional refactor explicitly outside this micro-PR and would not change runtime correctness.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#pullrequestreview-4729010204
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"review_commit_ref":"8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d","review_commit_ref_kind":"repository_commit","review_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#issuecomment-5012865615","reviewed_material_digest":"sha256:17fd3d19ea85b094d263f9f6200075e2e406454e98787397f9b61b6992a35b3f","status":"completed"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:112fed270db41098a262c6bd51cd505b35379f1e495ced1b8cda7fae1369a86f","findings_sha256":"sha256:e06d33ed17eee7dff417d80dd4280631de499e6e431b0ab0197253b17f605b2c","work_ledger_sha256":"sha256:63119448f19b5116d14b3b2311caf4bf92d385e06552758dcc7c0d672d8e92cf"},"authority":"human_asserted_content_receipt","base_revision":"bf31be9b3d015414c0b11917ff940146b2c1f81a","coverage_completeness":"complete","findings_count":0,"head_revision":"8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d","manifest_sha256":"sha256:24c1515664f770d22eeba433c4a6ef1798f65aa81fa27cc00ba240832e9f3482","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"c412f317-c7ff-4fd6-bbbf-ba0ad80010bd","snapshot_digest":"codex-security-snapshot/v1:sha256:1d74df0bc5da366ec7aad16a4841552de3d91d1cb5319d4e849096130ccb54eb"},"material":{"base_ref_oid":"bf31be9b3d015414c0b11917ff940146b2c1f81a","digest":"sha256:17fd3d19ea85b094d263f9f6200075e2e406454e98787397f9b61b6992a35b3f","material_head_sha":"8b6df0ccdbac6c7d5e61b82f31f468828e1f8c2d","merge_base_sha":"bf31be9b3d015414c0b11917ff940146b2c1f81a","policy_version":"pulseplate.material-classification/v1"},"pr_number":2147,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -11,6 +11,7 @@ resolve_repo_python() {
     local primary_root=""
     local primary_top_level=""
     local raw_python_override="${VENV_PYTHON:-${DEV_PYTHON:-}}"
+    local env_binary=""
     local git_binary=""
     local candidates=()
 
@@ -41,59 +42,56 @@ resolve_repo_python() {
         "${repo_root}/.venv/Scripts/python.exe"
     )
 
-    if git_binary="$(command -v git 2>/dev/null)"; then
-        case "${git_binary}" in
-            /*)
-                if [[ -f "${git_binary}" && -x "${git_binary}" ]] &&
-                    git_common_dir="$(
-                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
-                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
-                            "${git_binary}" -C "${repo_root}" rev-parse \
-                            --path-format=absolute --git-common-dir 2>/dev/null
-                    )" &&
-                    checkout_top_level="$(
-                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
-                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
-                            "${git_binary}" -C "${repo_root}" rev-parse \
-                            --path-format=absolute --show-toplevel 2>/dev/null
-                    )" &&
-                    checkout_git_dir="$(
-                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
-                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
-                            "${git_binary}" -C "${repo_root}" rev-parse \
-                            --path-format=absolute --git-dir 2>/dev/null
-                    )" &&
-                    git_common_dir="$(cd "${git_common_dir}" 2>/dev/null && pwd -P)" &&
-                    checkout_top_level="$(cd "${checkout_top_level}" 2>/dev/null && pwd -P)" &&
-                    checkout_git_dir="$(cd "${checkout_git_dir}" 2>/dev/null && pwd -P)" &&
-                    [[ "$(basename "${git_common_dir}")" == ".git" ]] &&
-                    primary_root="$(cd "$(dirname "${git_common_dir}")" 2>/dev/null && pwd -P)" &&
-                    [[ "${checkout_top_level}" == "${repo_root}" ]] &&
-                    [[ "${repo_root}" == "${primary_root}" ||
-                        "${checkout_git_dir}" == "${git_common_dir}/worktrees/"* ]] &&
-                    primary_top_level="$(
-                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
-                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
-                            "${git_binary}" -C "${primary_root}" rev-parse \
-                            --path-format=absolute --show-toplevel 2>/dev/null
-                    )" &&
-                    primary_common_dir="$(
-                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
-                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
-                            "${git_binary}" -C "${primary_root}" rev-parse \
-                            --path-format=absolute --git-common-dir 2>/dev/null
-                    )" &&
-                    primary_top_level="$(cd "${primary_top_level}" 2>/dev/null && pwd -P)" &&
-                    primary_common_dir="$(cd "${primary_common_dir}" 2>/dev/null && pwd -P)" &&
-                    [[ "${primary_top_level}" == "${primary_root}" ]] &&
-                    [[ "${primary_common_dir}" == "${git_common_dir}" ]]; then
-                candidates+=(
-                    "${primary_root}/.venv/bin/python"
-                    "${primary_root}/.venv/Scripts/python.exe"
-                )
-                fi
-                ;;
-        esac
+    if env_binary="$(command -v env 2>/dev/null)" &&
+        git_binary="$(command -v git 2>/dev/null)" &&
+        [[ "${env_binary}" == /* && -f "${env_binary}" && -x "${env_binary}" &&
+            "${git_binary}" == /* && -f "${git_binary}" && -x "${git_binary}" ]] &&
+        git_common_dir="$(
+            "${env_binary}" -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                "${git_binary}" -C "${repo_root}" rev-parse \
+                --path-format=absolute --git-common-dir 2>/dev/null
+        )" &&
+        checkout_top_level="$(
+            "${env_binary}" -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                "${git_binary}" -C "${repo_root}" rev-parse \
+                --path-format=absolute --show-toplevel 2>/dev/null
+        )" &&
+        checkout_git_dir="$(
+            "${env_binary}" -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                "${git_binary}" -C "${repo_root}" rev-parse \
+                --path-format=absolute --git-dir 2>/dev/null
+        )" &&
+        git_common_dir="$(cd "${git_common_dir}" 2>/dev/null && pwd -P)" &&
+        checkout_top_level="$(cd "${checkout_top_level}" 2>/dev/null && pwd -P)" &&
+        checkout_git_dir="$(cd "${checkout_git_dir}" 2>/dev/null && pwd -P)" &&
+        [[ "${git_common_dir##*/}" == ".git" ]] &&
+        primary_root="$(cd "${git_common_dir}/.." 2>/dev/null && pwd -P)" &&
+        [[ "${checkout_top_level}" == "${repo_root}" ]] &&
+        [[ "${repo_root}" == "${primary_root}" ||
+            "${checkout_git_dir}" == "${git_common_dir}/worktrees/"* ]] &&
+        primary_top_level="$(
+            "${env_binary}" -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                "${git_binary}" -C "${primary_root}" rev-parse \
+                --path-format=absolute --show-toplevel 2>/dev/null
+        )" &&
+        primary_common_dir="$(
+            "${env_binary}" -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                "${git_binary}" -C "${primary_root}" rev-parse \
+                --path-format=absolute --git-common-dir 2>/dev/null
+        )" &&
+        primary_top_level="$(cd "${primary_top_level}" 2>/dev/null && pwd -P)" &&
+        primary_common_dir="$(cd "${primary_common_dir}" 2>/dev/null && pwd -P)" &&
+        [[ "${primary_top_level}" == "${primary_root}" ]] &&
+        [[ "${primary_common_dir}" == "${git_common_dir}" ]]; then
+        candidates+=(
+            "${primary_root}/.venv/bin/python"
+            "${primary_root}/.venv/Scripts/python.exe"
+        )
     fi
 
     for candidate in "${candidates[@]}"; do

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -4,8 +4,13 @@
 resolve_repo_python() {
     local repo_root="${1:?repo root required}"
     local candidate=""
+    local checkout_binding_valid="false"
+    local checkout_git_backlink=""
+    local checkout_git_backlink_parent=""
     local checkout_git_dir=""
     local checkout_top_level=""
+    local checkout_worktree_name=""
+    local checkout_worktrees_prefix=""
     local git_common_dir=""
     local primary_common_dir=""
     local primary_root=""
@@ -77,33 +82,58 @@ resolve_repo_python() {
         primary_root="$(
             builtin cd -- "${git_common_dir}/.." 2>/dev/null && builtin pwd -P
         )" &&
-        [[ "${checkout_top_level}" == "${repo_root}" ]] &&
-        [[ "${repo_root}" == "${primary_root}" ||
-            "${checkout_git_dir}" == "${git_common_dir}/worktrees/"* ]] &&
-        primary_top_level="$(
-            "${env_binary}" -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
-                -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
-                "${git_binary}" -C "${primary_root}" rev-parse \
-                --path-format=absolute --show-toplevel 2>/dev/null
-        )" &&
-        primary_common_dir="$(
-            "${env_binary}" -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
-                -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
-                "${git_binary}" -C "${primary_root}" rev-parse \
-                --path-format=absolute --git-common-dir 2>/dev/null
-        )" &&
-        primary_top_level="$(
-            builtin cd -- "${primary_top_level}" 2>/dev/null && builtin pwd -P
-        )" &&
-        primary_common_dir="$(
-            builtin cd -- "${primary_common_dir}" 2>/dev/null && builtin pwd -P
-        )" &&
-        [[ "${primary_top_level}" == "${primary_root}" ]] &&
-        [[ "${primary_common_dir}" == "${git_common_dir}" ]]; then
-        candidates+=(
-            "${primary_root}/.venv/bin/python"
-            "${primary_root}/.venv/Scripts/python.exe"
-        )
+        [[ "${checkout_top_level}" == "${repo_root}" ]]; then
+        if [[ "${repo_root}" == "${primary_root}" ]]; then
+            checkout_binding_valid="true"
+        else
+            checkout_worktrees_prefix="${git_common_dir}/worktrees/"
+            if [[ "${checkout_git_dir}" == "${checkout_worktrees_prefix}"* &&
+                -f "${repo_root}/.git" && ! -L "${repo_root}/.git" &&
+                -f "${checkout_git_dir}/gitdir" && ! -L "${checkout_git_dir}/gitdir" ]]; then
+                checkout_worktree_name="${checkout_git_dir:${#checkout_worktrees_prefix}}"
+                if [[ -n "${checkout_worktree_name}" &&
+                    "${checkout_worktree_name}" != */* ]] &&
+                    IFS= read -r checkout_git_backlink < "${checkout_git_dir}/gitdir" &&
+                    [[ "${checkout_git_backlink}" == /* &&
+                        "${checkout_git_backlink##*/}" == ".git" &&
+                        -f "${checkout_git_backlink}" &&
+                        ! -L "${checkout_git_backlink}" ]] &&
+                    checkout_git_backlink_parent="$(
+                        builtin cd -- "${checkout_git_backlink%/*}" 2>/dev/null &&
+                            builtin pwd -P
+                    )" &&
+                    [[ "${checkout_git_backlink_parent}" == "${repo_root}" ]]; then
+                    checkout_binding_valid="true"
+                fi
+            fi
+        fi
+
+        if [[ "${checkout_binding_valid}" == "true" ]] &&
+            primary_top_level="$(
+                "${env_binary}" -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                    -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                    "${git_binary}" -C "${primary_root}" rev-parse \
+                    --path-format=absolute --show-toplevel 2>/dev/null
+            )" &&
+            primary_common_dir="$(
+                "${env_binary}" -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                    -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                    "${git_binary}" -C "${primary_root}" rev-parse \
+                    --path-format=absolute --git-common-dir 2>/dev/null
+            )" &&
+            primary_top_level="$(
+                builtin cd -- "${primary_top_level}" 2>/dev/null && builtin pwd -P
+            )" &&
+            primary_common_dir="$(
+                builtin cd -- "${primary_common_dir}" 2>/dev/null && builtin pwd -P
+            )" &&
+            [[ "${primary_top_level}" == "${primary_root}" ]] &&
+            [[ "${primary_common_dir}" == "${git_common_dir}" ]]; then
+            candidates+=(
+                "${primary_root}/.venv/bin/python"
+                "${primary_root}/.venv/Scripts/python.exe"
+            )
+        fi
     fi
 
     for candidate in "${candidates[@]}"; do

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -19,13 +19,14 @@ esac
 # shadow even `builtin`, so in-process lookup is not a trustworthy boundary.
 resolve_repo_python() {
     /usr/bin/env -i \
-        PATH="${PATH:-}" \
+        PATH="/usr/bin:/bin:/mingw64/bin:/mingw32/bin" \
+        _REPO_PYTHON_CI_PATH="${PATH:-}" \
         HOME="${HOME:-}" \
         XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-}" \
         VENV_PYTHON="${VENV_PYTHON:-}" \
         DEV_PYTHON="${DEV_PYTHON:-}" \
         CI="${CI:-}" \
-        bash --noprofile --norc -c '
+        /bin/bash --noprofile --norc -c '
             source "$1"
             _resolve_repo_python_clean "$2"
         ' pulseplate-repo-python \
@@ -182,7 +183,9 @@ _resolve_repo_python_clean() {
     done
 
     if [[ "${CI:-}" == "true" ]]; then
-        if candidate="$(builtin command -v python3 2>/dev/null)"; then
+        if candidate="$(
+            PATH="${_REPO_PYTHON_CI_PATH:-}" builtin command -v python3 2>/dev/null
+        )"; then
             case "${candidate}" in
                 /*)
                     if [[ -f "${candidate}" && -x "${candidate}" ]]; then
@@ -192,7 +195,9 @@ _resolve_repo_python_clean() {
                     ;;
             esac
         fi
-        if candidate="$(builtin command -v python 2>/dev/null)"; then
+        if candidate="$(
+            PATH="${_REPO_PYTHON_CI_PATH:-}" builtin command -v python 2>/dev/null
+        )"; then
             case "${candidate}" in
                 /*)
                     if [[ -f "${candidate}" && -x "${candidate}" ]]; then

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -6,6 +6,7 @@ resolve_repo_python() {
     local candidate=""
     local checkout_binding_valid="false"
     local checkout_git_backlink=""
+    local checkout_git_backlink_path=""
     local checkout_git_backlink_parent=""
     local checkout_git_dir=""
     local checkout_top_level=""
@@ -93,17 +94,23 @@ resolve_repo_python() {
                 checkout_worktree_name="${checkout_git_dir:${#checkout_worktrees_prefix}}"
                 if [[ -n "${checkout_worktree_name}" &&
                     "${checkout_worktree_name}" != */* ]] &&
-                    IFS= read -r checkout_git_backlink < "${checkout_git_dir}/gitdir" &&
-                    [[ "${checkout_git_backlink}" == /* &&
-                        "${checkout_git_backlink##*/}" == ".git" &&
-                        -f "${checkout_git_backlink}" &&
-                        ! -L "${checkout_git_backlink}" ]] &&
-                    checkout_git_backlink_parent="$(
-                        builtin cd -- "${checkout_git_backlink%/*}" 2>/dev/null &&
-                            builtin pwd -P
-                    )" &&
-                    [[ "${checkout_git_backlink_parent}" == "${repo_root}" ]]; then
-                    checkout_binding_valid="true"
+                    IFS= read -r checkout_git_backlink < "${checkout_git_dir}/gitdir"; then
+                    case "${checkout_git_backlink}" in
+                        /*) checkout_git_backlink_path="${checkout_git_backlink}" ;;
+                        *)
+                            checkout_git_backlink_path="${checkout_git_dir}/${checkout_git_backlink}"
+                            ;;
+                    esac
+                    if [[ "${checkout_git_backlink_path##*/}" == ".git" &&
+                        -f "${checkout_git_backlink_path}" &&
+                        ! -L "${checkout_git_backlink_path}" ]] &&
+                        checkout_git_backlink_parent="$(
+                            builtin cd -- "${checkout_git_backlink_path%/*}" 2>/dev/null &&
+                                builtin pwd -P
+                        )" &&
+                        [[ "${checkout_git_backlink_parent}" == "${repo_root}" ]]; then
+                        checkout_binding_valid="true"
+                    fi
                 fi
             fi
         fi

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -1,7 +1,38 @@
 #!/usr/bin/env bash
 # Resolve the Python interpreter that owns PulsePlate's locked developer deps.
 
+if [[ -n "${BASH_VERSION:-}" ]]; then
+    _REPO_PYTHON_RESOLVER_SOURCE="${BASH_SOURCE[0]}"
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    _REPO_PYTHON_RESOLVER_SOURCE="${(%):-%N}"
+else
+    echo "ERROR: repo Python resolver must be sourced from Bash or zsh" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+case "${_REPO_PYTHON_RESOLVER_SOURCE}" in
+    /*) ;;
+    *) _REPO_PYTHON_RESOLVER_SOURCE="${PWD%/}/${_REPO_PYTHON_RESOLVER_SOURCE}" ;;
+esac
+
+# Run the resolver body in a clean Bash process. Exported shell functions can
+# shadow even `builtin`, so in-process lookup is not a trustworthy boundary.
 resolve_repo_python() {
+    /usr/bin/env -i \
+        PATH="${PATH:-}" \
+        HOME="${HOME:-}" \
+        XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-}" \
+        VENV_PYTHON="${VENV_PYTHON:-}" \
+        DEV_PYTHON="${DEV_PYTHON:-}" \
+        CI="${CI:-}" \
+        bash --noprofile --norc -c '
+            source "$1"
+            _resolve_repo_python_clean "$2"
+        ' pulseplate-repo-python \
+        "${_REPO_PYTHON_RESOLVER_SOURCE}" "${1:?repo root required}"
+}
+
+_resolve_repo_python_clean() {
     local repo_root="${1:?repo root required}"
     local candidate=""
     local checkout_binding_valid="false"

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -60,7 +60,18 @@ _resolve_repo_python_clean() {
 
     if [[ -n "${raw_python_override}" ]]; then
         case "${raw_python_override}" in
-            /*)
+            /* | [A-Za-z]:/*)
+                case "${raw_python_override}" in
+                    [A-Za-z]:/*)
+                        case "${OSTYPE:-}" in
+                            msys* | cygwin*) ;;
+                            *)
+                                echo "ERROR: VENV_PYTHON/DEV_PYTHON must be an absolute executable path for hooks: ${raw_python_override}" >&2
+                                return 1
+                                ;;
+                        esac
+                        ;;
+                esac
                 if [[ -f "${raw_python_override}" && -x "${raw_python_override}" ]]; then
                     printf '%s\n' "${raw_python_override}"
                     return 0
@@ -129,6 +140,16 @@ _resolve_repo_python_clean() {
                     IFS= read -r checkout_git_backlink < "${checkout_git_dir}/gitdir"; then
                     case "${checkout_git_backlink}" in
                         /*) checkout_git_backlink_path="${checkout_git_backlink}" ;;
+                        [A-Za-z]:/*)
+                            case "${OSTYPE:-}" in
+                                msys* | cygwin*)
+                                    checkout_git_backlink_path="${checkout_git_backlink}"
+                                    ;;
+                                *)
+                                    checkout_git_backlink_path="${checkout_git_dir}/${checkout_git_backlink}"
+                                    ;;
+                            esac
+                            ;;
                         *)
                             checkout_git_backlink_path="${checkout_git_dir}/${checkout_git_backlink}"
                             ;;

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -15,7 +15,7 @@ resolve_repo_python() {
     local git_binary=""
     local candidates=()
 
-    if ! repo_root="$(cd "${repo_root}" 2>/dev/null && pwd -P)"; then
+    if ! repo_root="$(builtin cd -- "${repo_root}" 2>/dev/null && builtin pwd -P)"; then
         echo "ERROR: repo root is not a readable directory: ${1:?repo root required}" >&2
         return 1
     fi
@@ -64,11 +64,19 @@ resolve_repo_python() {
                 "${git_binary}" -C "${repo_root}" rev-parse \
                 --path-format=absolute --git-dir 2>/dev/null
         )" &&
-        git_common_dir="$(cd "${git_common_dir}" 2>/dev/null && pwd -P)" &&
-        checkout_top_level="$(cd "${checkout_top_level}" 2>/dev/null && pwd -P)" &&
-        checkout_git_dir="$(cd "${checkout_git_dir}" 2>/dev/null && pwd -P)" &&
+        git_common_dir="$(
+            builtin cd -- "${git_common_dir}" 2>/dev/null && builtin pwd -P
+        )" &&
+        checkout_top_level="$(
+            builtin cd -- "${checkout_top_level}" 2>/dev/null && builtin pwd -P
+        )" &&
+        checkout_git_dir="$(
+            builtin cd -- "${checkout_git_dir}" 2>/dev/null && builtin pwd -P
+        )" &&
         [[ "${git_common_dir##*/}" == ".git" ]] &&
-        primary_root="$(cd "${git_common_dir}/.." 2>/dev/null && pwd -P)" &&
+        primary_root="$(
+            builtin cd -- "${git_common_dir}/.." 2>/dev/null && builtin pwd -P
+        )" &&
         [[ "${checkout_top_level}" == "${repo_root}" ]] &&
         [[ "${repo_root}" == "${primary_root}" ||
             "${checkout_git_dir}" == "${git_common_dir}/worktrees/"* ]] &&
@@ -84,8 +92,12 @@ resolve_repo_python() {
                 "${git_binary}" -C "${primary_root}" rev-parse \
                 --path-format=absolute --git-common-dir 2>/dev/null
         )" &&
-        primary_top_level="$(cd "${primary_top_level}" 2>/dev/null && pwd -P)" &&
-        primary_common_dir="$(cd "${primary_common_dir}" 2>/dev/null && pwd -P)" &&
+        primary_top_level="$(
+            builtin cd -- "${primary_top_level}" 2>/dev/null && builtin pwd -P
+        )" &&
+        primary_common_dir="$(
+            builtin cd -- "${primary_common_dir}" 2>/dev/null && builtin pwd -P
+        )" &&
         [[ "${primary_top_level}" == "${primary_root}" ]] &&
         [[ "${primary_common_dir}" == "${git_common_dir}" ]]; then
         candidates+=(

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -12,6 +12,14 @@ fi
 
 case "${_REPO_PYTHON_RESOLVER_SOURCE}" in
     /*) ;;
+    [A-Za-z]:/*)
+        case "${OSTYPE:-}" in
+            msys* | cygwin*) ;;
+            *)
+                _REPO_PYTHON_RESOLVER_SOURCE="${PWD%/}/${_REPO_PYTHON_RESOLVER_SOURCE}"
+                ;;
+        esac
+        ;;
     *) _REPO_PYTHON_RESOLVER_SOURCE="${PWD%/}/${_REPO_PYTHON_RESOLVER_SOURCE}" ;;
 esac
 

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -4,9 +4,12 @@
 resolve_repo_python() {
     local repo_root="${1:?repo root required}"
     local candidate=""
+    local checkout_git_dir=""
+    local checkout_top_level=""
     local git_common_dir=""
-    local parent_dir=""
-    local shared_root=""
+    local primary_common_dir=""
+    local primary_root=""
+    local primary_top_level=""
     local raw_python_override="${VENV_PYTHON:-${DEV_PYTHON:-}}"
     local git_binary=""
     local candidates=()
@@ -19,11 +22,11 @@ resolve_repo_python() {
     if [[ -n "${raw_python_override}" ]]; then
         case "${raw_python_override}" in
             /*)
-                if [[ -x "${raw_python_override}" ]]; then
+                if [[ -f "${raw_python_override}" && -x "${raw_python_override}" ]]; then
                     printf '%s\n' "${raw_python_override}"
                     return 0
                 fi
-                echo "ERROR: VENV_PYTHON/DEV_PYTHON is set but is not executable: ${raw_python_override}" >&2
+                echo "ERROR: VENV_PYTHON/DEV_PYTHON is set but is not a regular executable file: ${raw_python_override}" >&2
                 return 1
                 ;;
             *)
@@ -38,40 +41,89 @@ resolve_repo_python() {
         "${repo_root}/.venv/Scripts/python.exe"
     )
 
-    parent_dir="$(dirname "${repo_root}")"
-    git_binary="$(command -v git || true)"
-    if [[ "$(basename "${parent_dir}")" == "worktrees" ]] &&
-        [[ -n "${git_binary}" ]] &&
-        git_common_dir="$(
-            env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX -u GIT_COMMON_DIR \
-                "${git_binary}" -C "${repo_root}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null
-        )"; then
-        shared_root="$(cd "$(dirname "${parent_dir}")" 2>/dev/null && pwd -P)"
-        git_common_dir="$(cd "${git_common_dir}" 2>/dev/null && pwd -P)"
-        case "${git_common_dir}" in
-            "${shared_root}/.git" | "${shared_root}/.git/"*)
+    if git_binary="$(command -v git 2>/dev/null)"; then
+        case "${git_binary}" in
+            /*)
+                if [[ -f "${git_binary}" && -x "${git_binary}" ]] &&
+                    git_common_dir="$(
+                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                            "${git_binary}" -C "${repo_root}" rev-parse \
+                            --path-format=absolute --git-common-dir 2>/dev/null
+                    )" &&
+                    checkout_top_level="$(
+                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                            "${git_binary}" -C "${repo_root}" rev-parse \
+                            --path-format=absolute --show-toplevel 2>/dev/null
+                    )" &&
+                    checkout_git_dir="$(
+                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                            "${git_binary}" -C "${repo_root}" rev-parse \
+                            --path-format=absolute --git-dir 2>/dev/null
+                    )" &&
+                    git_common_dir="$(cd "${git_common_dir}" 2>/dev/null && pwd -P)" &&
+                    checkout_top_level="$(cd "${checkout_top_level}" 2>/dev/null && pwd -P)" &&
+                    checkout_git_dir="$(cd "${checkout_git_dir}" 2>/dev/null && pwd -P)" &&
+                    [[ "$(basename "${git_common_dir}")" == ".git" ]] &&
+                    primary_root="$(cd "$(dirname "${git_common_dir}")" 2>/dev/null && pwd -P)" &&
+                    [[ "${checkout_top_level}" == "${repo_root}" ]] &&
+                    [[ "${repo_root}" == "${primary_root}" ||
+                        "${checkout_git_dir}" == "${git_common_dir}/worktrees/"* ]] &&
+                    primary_top_level="$(
+                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                            "${git_binary}" -C "${primary_root}" rev-parse \
+                            --path-format=absolute --show-toplevel 2>/dev/null
+                    )" &&
+                    primary_common_dir="$(
+                        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+                            -u GIT_COMMON_DIR -u GIT_IMPLICIT_WORK_TREE \
+                            "${git_binary}" -C "${primary_root}" rev-parse \
+                            --path-format=absolute --git-common-dir 2>/dev/null
+                    )" &&
+                    primary_top_level="$(cd "${primary_top_level}" 2>/dev/null && pwd -P)" &&
+                    primary_common_dir="$(cd "${primary_common_dir}" 2>/dev/null && pwd -P)" &&
+                    [[ "${primary_top_level}" == "${primary_root}" ]] &&
+                    [[ "${primary_common_dir}" == "${git_common_dir}" ]]; then
                 candidates+=(
-                    "${shared_root}/.venv/bin/python"
-                    "${shared_root}/.venv/Scripts/python.exe"
+                    "${primary_root}/.venv/bin/python"
+                    "${primary_root}/.venv/Scripts/python.exe"
                 )
+                fi
                 ;;
         esac
     fi
 
     for candidate in "${candidates[@]}"; do
-        if [[ -x "${candidate}" ]]; then
+        if [[ -f "${candidate}" && -x "${candidate}" ]]; then
             printf '%s\n' "${candidate}"
             return 0
         fi
     done
 
-    if [[ "${CI:-}" == "true" ]] && command -v python3 >/dev/null 2>&1; then
-        command -v python3
-        return 0
-    fi
-    if [[ "${CI:-}" == "true" ]] && command -v python >/dev/null 2>&1; then
-        command -v python
-        return 0
+    if [[ "${CI:-}" == "true" ]]; then
+        if candidate="$(command -v python3 2>/dev/null)"; then
+            case "${candidate}" in
+                /*)
+                    if [[ -f "${candidate}" && -x "${candidate}" ]]; then
+                        printf '%s\n' "${candidate}"
+                        return 0
+                    fi
+                    ;;
+            esac
+        fi
+        if candidate="$(command -v python 2>/dev/null)"; then
+            case "${candidate}" in
+                /*)
+                    if [[ -f "${candidate}" && -x "${candidate}" ]]; then
+                        printf '%s\n' "${candidate}"
+                        return 0
+                    fi
+                    ;;
+            esac
+        fi
     fi
 
     echo "ERROR: no repo/shared .venv Python found for local hook execution" >&2

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -48,8 +48,8 @@ resolve_repo_python() {
         "${repo_root}/.venv/Scripts/python.exe"
     )
 
-    if env_binary="$(command -v env 2>/dev/null)" &&
-        git_binary="$(command -v git 2>/dev/null)" &&
+    if env_binary="$(builtin command -v env 2>/dev/null)" &&
+        git_binary="$(builtin command -v git 2>/dev/null)" &&
         [[ "${env_binary}" == /* && -f "${env_binary}" && -x "${env_binary}" &&
             "${git_binary}" == /* && -f "${git_binary}" && -x "${git_binary}" ]] &&
         git_common_dir="$(
@@ -151,7 +151,7 @@ resolve_repo_python() {
     done
 
     if [[ "${CI:-}" == "true" ]]; then
-        if candidate="$(command -v python3 2>/dev/null)"; then
+        if candidate="$(builtin command -v python3 2>/dev/null)"; then
             case "${candidate}" in
                 /*)
                     if [[ -f "${candidate}" && -x "${candidate}" ]]; then
@@ -161,7 +161,7 @@ resolve_repo_python() {
                     ;;
             esac
         fi
-        if candidate="$(command -v python 2>/dev/null)"; then
+        if candidate="$(builtin command -v python 2>/dev/null)"; then
             case "${candidate}" in
                 /*)
                     if [[ -f "${candidate}" && -x "${candidate}" ]]; then

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -246,6 +246,46 @@ def test_hook_resolver_accepts_relative_reciprocal_worktree_metadata(
     assert resolved == str(shared_python)
 
 
+def test_hook_resolver_accepts_git_bash_drive_absolute_worktree_backlink(
+    tmp_path: Path,
+) -> None:
+    drive_root = tmp_path / "C:"
+    repo = drive_root / "primary"
+    repo.mkdir(parents=True)
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "Scripts" / "python.exe"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = drive_root / "lane"
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(worktree), "HEAD")
+    checkout_git_dir = Path(
+        _git(
+            worktree,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-dir",
+        ).stdout.strip()
+    )
+    (checkout_git_dir / "gitdir").write_text(
+        "C:/lane/.git\n",
+        encoding="utf-8",
+    )
+    command = (
+        f"source {shlex.quote(str(HOOK_RESOLVER))}; "
+        "OSTYPE=msys; "
+        '_resolve_repo_python_clean "C:/lane"'
+    )
+
+    resolved = _bash(command, cwd=tmp_path)
+
+    assert resolved == str(shared_python)
+
+
 def test_hook_resolver_rejects_shell_function_tool_interposition(
     tmp_path: Path,
 ) -> None:
@@ -695,6 +735,43 @@ def test_hook_resolver_uses_valid_dev_override_when_venv_override_is_unset(
     resolved = _bash(RESOLVE_COMMAND, cwd=repo, env=env)
 
     assert resolved == str(dev_override)
+
+
+def test_hook_resolver_accepts_git_bash_drive_absolute_override(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    drive_python = tmp_path / "C:" / "repo" / ".venv" / "Scripts" / "python.exe"
+    drive_python.parent.mkdir(parents=True)
+    _write_executable(drive_python)
+    command = (
+        f"source {shlex.quote(str(HOOK_RESOLVER))}; "
+        "OSTYPE=msys; "
+        'VENV_PYTHON="C:/repo/.venv/Scripts/python.exe"; '
+        "_resolve_repo_python_clean repo"
+    )
+
+    resolved = _bash(command, cwd=tmp_path)
+
+    assert resolved == "C:/repo/.venv/Scripts/python.exe"
+
+
+def test_hook_resolver_rejects_drive_override_outside_git_bash(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    drive_python = tmp_path / "C:" / "repo" / ".venv" / "Scripts" / "python.exe"
+    drive_python.parent.mkdir(parents=True)
+    _write_executable(drive_python)
+    command = (
+        f"source {shlex.quote(str(HOOK_RESOLVER))}; "
+        "OSTYPE=darwin; "
+        'VENV_PYTHON="C:/repo/.venv/Scripts/python.exe"; '
+        "_resolve_repo_python_clean repo"
+    )
+
+    completed = _bash_failure(command, cwd=tmp_path, env=_clean_hook_env())
+
+    assert completed.returncode == 1
+    assert "must be an absolute executable path" in completed.stderr
 
 
 def test_hook_resolver_rejects_relative_python_override(tmp_path: Path) -> None:

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -475,7 +475,8 @@ def test_hook_resolver_ignores_caller_path_bash_interposition(tmp_path: Path) ->
     env = _clean_hook_env()
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
     command = (
-        f'[[ "$(builtin command -v bash)" == {shlex.quote(str(fake_bash))} ]]; '
+        f'[[ "$(builtin command -v bash)" == {shlex.quote(str(fake_bash))} ]] '
+        "|| exit 96; "
         f"{RESOLVE_COMMAND}"
     )
 
@@ -490,6 +491,50 @@ def test_hook_resolver_fixed_tool_path_covers_unix_and_git_bash() -> None:
 
     assert 'PATH="/usr/bin:/bin:/mingw64/bin:/mingw32/bin"' in resolver_source
     assert "/bin/bash --noprofile --norc" in resolver_source
+
+
+def test_hook_resolver_preserves_git_bash_drive_absolute_source_binding(
+    tmp_path: Path,
+) -> None:
+    drive_repo = tmp_path / "C:" / "repo"
+    resolver_copy = drive_repo / "scripts" / "hooks" / "repo_python.sh"
+    resolver_copy.parent.mkdir(parents=True)
+    shutil.copy2(HOOK_RESOLVER, resolver_copy)
+    checkout_python = drive_repo / ".venv" / "Scripts" / "python.exe"
+    checkout_python.parent.mkdir(parents=True)
+    _write_executable(checkout_python)
+    drive_source = "C:/repo/scripts/hooks/repo_python.sh"
+    command = (
+        "OSTYPE=msys; "
+        f"source {shlex.quote(drive_source)}; "
+        f'[[ "$_REPO_PYTHON_RESOLVER_SOURCE" == {shlex.quote(drive_source)} ]] '
+        "|| exit 96; "
+        'resolve_repo_python "C:/repo"'
+    )
+
+    resolved = _bash(command, cwd=tmp_path)
+
+    assert resolved == str(checkout_python)
+
+
+def test_hook_resolver_keeps_drive_source_relative_outside_git_bash(
+    tmp_path: Path,
+) -> None:
+    drive_repo = tmp_path / "C:" / "repo"
+    resolver_copy = drive_repo / "scripts" / "hooks" / "repo_python.sh"
+    resolver_copy.parent.mkdir(parents=True)
+    shutil.copy2(HOOK_RESOLVER, resolver_copy)
+    drive_source = "C:/repo/scripts/hooks/repo_python.sh"
+    expected_source = str(tmp_path / drive_source)
+    command = (
+        "OSTYPE=darwin; "
+        f"source {shlex.quote(drive_source)}; "
+        'printf "%s\\n" "$_REPO_PYTHON_RESOLVER_SOURCE"'
+    )
+
+    resolved = _bash(command, cwd=tmp_path)
+
+    assert resolved == expected_source
 
 
 def test_hook_resolver_ignores_caller_path_git_identity_tools(
@@ -568,8 +613,10 @@ def test_hook_resolver_ignores_caller_path_git_identity_tools(
     env = _clean_hook_env()
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
     command = (
-        f'[[ "$(builtin command -v env)" == {shlex.quote(str(fake_env))} ]]; '
-        f'[[ "$(builtin command -v git)" == {shlex.quote(str(fake_git))} ]]; '
+        f'[[ "$(builtin command -v env)" == {shlex.quote(str(fake_env))} ]] '
+        "|| exit 96; "
+        f'[[ "$(builtin command -v git)" == {shlex.quote(str(fake_git))} ]] '
+        "|| exit 97; "
         f"{RESOLVE_COMMAND}"
     )
 

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -74,7 +74,7 @@ def _bash(command: str, *, cwd: Path, env: dict[str, str] | None = None) -> str:
     bash_binary = shutil.which("bash")
     assert bash_binary is not None, "bash binary is required for hook resolver tests"
     completed = subprocess.run(
-        [bash_binary, "-lc", command],
+        [bash_binary, "-c", command],
         cwd=str(cwd),
         env=env or _clean_hook_env(),
         capture_output=True,
@@ -90,7 +90,7 @@ def _bash_failure(
     bash_binary = shutil.which("bash")
     assert bash_binary is not None, "bash binary is required for hook resolver tests"
     return subprocess.run(
-        [bash_binary, "-lc", command],
+        [bash_binary, "-c", command],
         cwd=str(cwd),
         env=env,
         capture_output=True,
@@ -434,8 +434,12 @@ def test_hook_resolver_ignores_caller_path_bash_interposition(tmp_path: Path) ->
     fake_bash.chmod(0o755)
     env = _clean_hook_env()
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    command = (
+        f'[[ "$(builtin command -v bash)" == {shlex.quote(str(fake_bash))} ]]; '
+        f"{RESOLVE_COMMAND}"
+    )
 
-    resolved = _bash(RESOLVE_COMMAND, cwd=repo, env=env)
+    resolved = _bash(command, cwd=repo, env=env)
 
     assert resolved == str(checkout_python)
     assert resolved != str(decoy_python)
@@ -523,8 +527,13 @@ def test_hook_resolver_ignores_caller_path_git_identity_tools(
     fake_git.chmod(0o755)
     env = _clean_hook_env()
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    command = (
+        f'[[ "$(builtin command -v env)" == {shlex.quote(str(fake_env))} ]]; '
+        f'[[ "$(builtin command -v git)" == {shlex.quote(str(fake_git))} ]]; '
+        f"{RESOLVE_COMMAND}"
+    )
 
-    resolved = _bash(RESOLVE_COMMAND, cwd=worktree, env=env)
+    resolved = _bash(command, cwd=worktree, env=env)
 
     assert resolved == str(shared_python)
     assert resolved != str(decoy_python)

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-import shutil
 import shlex
+import shutil
 import subprocess
+import sys
 import textwrap
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -96,6 +97,20 @@ def _bash_failure(
         text=True,
         check=False,
     )
+
+
+def _zsh(command: str, *, cwd: Path, env: dict[str, str] | None = None) -> str:
+    zsh_binary = shutil.which("zsh")
+    assert zsh_binary is not None, "zsh is required for hook resolver tests"
+    completed = subprocess.run(
+        [zsh_binary, "-lc", command],
+        cwd=str(cwd),
+        env=env or _clean_hook_env(),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
 
 
 def test_hook_resolver_prefers_root_checkout_venv(tmp_path: Path) -> None:
@@ -320,6 +335,177 @@ def test_hook_resolver_ignores_command_function_tool_lookup_interposition(
     """
 
     resolved = _bash(command, cwd=worktree, env=env)
+
+    assert resolved == str(shared_python)
+
+
+def test_hook_resolver_ignores_builtin_function_tool_lookup_interposition(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = tmp_path / "external-linked-lane"
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(worktree), "HEAD")
+
+    decoy_root = tmp_path / "decoy-root"
+    decoy_admin_dir = decoy_root / ".git" / "worktrees" / "lane"
+    decoy_admin_dir.mkdir(parents=True)
+    (decoy_admin_dir / "gitdir").write_text(
+        f"{worktree / '.git'}\n",
+        encoding="utf-8",
+    )
+    decoy_python = decoy_root / ".venv" / "bin" / "python"
+    decoy_python.parent.mkdir(parents=True)
+    _write_executable(decoy_python)
+    fake_env = tmp_path / "fake-env"
+    fake_env.write_text(
+        textwrap.dedent("""\
+            #!/bin/sh
+            case "$*" in
+                *--git-common-dir*) printf '%s\\n' "$DECOY_ROOT/.git" ;;
+                *--git-dir*) printf '%s\\n' "$DECOY_ROOT/.git/worktrees/lane" ;;
+                *--show-toplevel*)
+                    case "$*" in
+                        *"-C $DECOY_ROOT "*) printf '%s\\n' "$DECOY_ROOT" ;;
+                        *) printf '%s\\n' "$REAL_WORKTREE" ;;
+                    esac
+                    ;;
+                *) exit 1 ;;
+            esac
+            """),
+        encoding="utf-8",
+    )
+    fake_env.chmod(0o755)
+    fake_git = tmp_path / "fake-git"
+    _write_executable(fake_git)
+    env = _clean_hook_env()
+    env.update(
+        {
+            "DECOY_ROOT": str(decoy_root),
+            "FAKE_ENV": str(fake_env),
+            "FAKE_GIT": str(fake_git),
+            "REAL_WORKTREE": str(worktree),
+        }
+    )
+    command = f"""
+        builtin() {{
+            case "$*" in
+                "command -v env") printf '%s\\n' "$FAKE_ENV" ;;
+                "command -v git") printf '%s\\n' "$FAKE_GIT" ;;
+                "cd -- "*) FAKE_BUILTIN_CWD="$3" ;;
+                "pwd -P") printf '%s\\n' "${{FAKE_BUILTIN_CWD:-$PWD}}" ;;
+                *) return 1 ;;
+            esac
+        }}
+        export -f builtin
+        {RESOLVE_COMMAND}
+    """
+
+    resolved = _bash(command, cwd=worktree, env=env)
+
+    assert resolved == str(shared_python)
+    assert resolved != str(decoy_python)
+
+
+def test_hook_resolver_keeps_relative_source_binding_after_chdir(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    checkout_python = repo / ".venv" / "bin" / "python"
+    checkout_python.parent.mkdir(parents=True)
+    _write_executable(checkout_python)
+    invocation_dir = tmp_path / "invocation"
+    invocation_dir.mkdir()
+    relative_resolver = os.path.relpath(HOOK_RESOLVER, start=REPO_ROOT)
+    command = (
+        f"source {shlex.quote(relative_resolver)}; "
+        f"cd {shlex.quote(str(invocation_dir))}; "
+        f"resolve_repo_python {shlex.quote(str(repo))}"
+    )
+
+    resolved = _bash(command, cwd=REPO_ROOT)
+
+    assert resolved == str(checkout_python)
+
+
+def test_hook_resolver_supports_direct_source_from_zsh_after_chdir(
+    tmp_path: Path,
+) -> None:
+    if shutil.which("zsh") is None:
+        assert sys.platform != "darwin", "zsh must be available on macOS"
+        resolver_source = HOOK_RESOLVER.read_text(encoding="utf-8")
+        assert 'elif [[ -n "${ZSH_VERSION:-}" ]]; then' in resolver_source
+        assert '_REPO_PYTHON_RESOLVER_SOURCE="${(%):-%N}"' in resolver_source
+        return
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    checkout_python = repo / ".venv" / "bin" / "python"
+    checkout_python.parent.mkdir(parents=True)
+    _write_executable(checkout_python)
+    invocation_dir = tmp_path / "invocation"
+    invocation_dir.mkdir()
+    relative_resolver = os.path.relpath(HOOK_RESOLVER, start=REPO_ROOT)
+    command = (
+        "function bash() { return 98; }; "
+        f"source {shlex.quote(relative_resolver)}; "
+        f"cd {shlex.quote(str(invocation_dir))}; "
+        f"resolve_repo_python {shlex.quote(str(repo))}"
+    )
+
+    resolved = _zsh(command, cwd=REPO_ROOT)
+
+    assert resolved == str(checkout_python)
+
+
+def test_hook_resolver_preserves_home_for_git_configuration(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = tmp_path / "external-linked-lane"
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(worktree), "HEAD")
+
+    expected_home = tmp_path / "hook-home"
+    expected_home.mkdir()
+    real_git = shutil.which("git")
+    assert real_git is not None
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    git_wrapper = fake_bin / "git"
+    git_wrapper.write_text(
+        textwrap.dedent(f"""\
+            #!/bin/sh
+            if [ "${{HOME:-}}" != {shlex.quote(str(expected_home))} ]; then
+                exit 97
+            fi
+            exec {shlex.quote(real_git)} "$@"
+            """),
+        encoding="utf-8",
+    )
+    git_wrapper.chmod(0o755)
+    env = _clean_hook_env()
+    env["HOME"] = str(expected_home)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    resolved = _bash(RESOLVE_COMMAND, cwd=worktree, env=env)
 
     assert resolved == str(shared_python)
 
@@ -575,7 +761,7 @@ def test_hook_resolver_allows_ambient_python_only_in_ci(tmp_path: Path) -> None:
     assert resolved.name in {"python3", "python"}
 
 
-def test_hook_resolver_ci_rejects_shell_function_python_interposition(
+def test_hook_resolver_ci_ignores_shell_function_python_interposition(
     tmp_path: Path,
 ) -> None:
     repo = tmp_path / "repo"
@@ -584,15 +770,12 @@ def test_hook_resolver_ci_rejects_shell_function_python_interposition(
     env["CI"] = "true"
     command = f"python3() {{ :; }}; python() {{ :; }}; {RESOLVE_COMMAND}"
 
-    completed = _bash_failure(
-        command,
-        cwd=repo,
-        env=env,
-    )
+    resolved = Path(_bash(command, cwd=repo, env=env))
 
-    assert completed.returncode == 1
-    assert completed.stdout == ""
-    assert "no repo/shared .venv Python found" in completed.stderr
+    assert resolved.is_absolute()
+    assert resolved.is_file()
+    assert os.access(resolved, os.X_OK)
+    assert resolved.name in {"python3", "python"}
 
 
 def test_hook_resolver_ci_ignores_command_function_python_lookup_interposition(

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -286,6 +286,44 @@ def test_hook_resolver_rejects_shell_function_tool_interposition(
     assert "no repo/shared .venv Python found" in completed.stderr
 
 
+def test_hook_resolver_ignores_command_function_tool_lookup_interposition(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = tmp_path / "external-linked-lane"
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(worktree), "HEAD")
+    fake_env = tmp_path / "fake-env"
+    fake_git = tmp_path / "fake-git"
+    _write_executable(fake_env)
+    _write_executable(fake_git)
+    env = _clean_hook_env()
+    env.update({"FAKE_ENV": str(fake_env), "FAKE_GIT": str(fake_git)})
+    command = f"""
+        command() {{
+            case "$*" in
+                "-v env") printf '%s\\n' "$FAKE_ENV" ;;
+                "-v git") printf '%s\\n' "$FAKE_GIT" ;;
+                *) return 1 ;;
+            esac
+        }}
+        {RESOLVE_COMMAND}
+    """
+
+    resolved = _bash(command, cwd=worktree, env=env)
+
+    assert resolved == str(shared_python)
+
+
 def test_hook_resolver_prefers_current_worktree_venv_symlink_to_primary_venv(
     tmp_path: Path,
 ) -> None:
@@ -555,6 +593,42 @@ def test_hook_resolver_ci_rejects_shell_function_python_interposition(
     assert completed.returncode == 1
     assert completed.stdout == ""
     assert "no repo/shared .venv Python found" in completed.stderr
+
+
+def test_hook_resolver_ci_ignores_command_function_python_lookup_interposition(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    fake_python3 = tmp_path / "fake-python3"
+    fake_python = tmp_path / "fake-python"
+    _write_executable(fake_python3)
+    _write_executable(fake_python)
+    env = _clean_hook_env()
+    env.update(
+        {
+            "CI": "true",
+            "FAKE_PYTHON3": str(fake_python3),
+            "FAKE_PYTHON": str(fake_python),
+        }
+    )
+    command = f"""
+        command() {{
+            case "$*" in
+                "-v python3") printf '%s\\n' "$FAKE_PYTHON3" ;;
+                "-v python") printf '%s\\n' "$FAKE_PYTHON" ;;
+                *) return 1 ;;
+            esac
+        }}
+        {RESOLVE_COMMAND}
+    """
+
+    resolved = Path(_bash(command, cwd=repo, env=env))
+
+    assert resolved not in {fake_python3, fake_python}
+    assert resolved.is_absolute()
+    assert resolved.is_file()
+    assert os.access(resolved, os.X_OK)
 
 
 def test_hook_resolver_rejects_ambient_python_outside_ci(tmp_path: Path) -> None:

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -191,6 +191,46 @@ def test_hook_resolver_sanitizes_commit_hook_git_env_for_every_git_query(
     assert resolved == str(shared_python)
 
 
+def test_hook_resolver_accepts_relative_reciprocal_worktree_metadata(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "primary checkout"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = tmp_path / "external relative linked lane"
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(worktree), "HEAD")
+    checkout_git_dir = Path(
+        _git(
+            worktree,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-dir",
+        ).stdout.strip()
+    )
+    relative_admin_dir = os.path.relpath(checkout_git_dir, start=worktree)
+    (worktree / ".git").write_text(
+        f"gitdir: {relative_admin_dir}\n",
+        encoding="utf-8",
+    )
+    relative_backlink = os.path.relpath(worktree / ".git", start=checkout_git_dir)
+    (checkout_git_dir / "gitdir").write_text(
+        f"{relative_backlink}\n",
+        encoding="utf-8",
+    )
+
+    resolved = _bash(RESOLVE_COMMAND, cwd=worktree)
+
+    assert resolved == str(shared_python)
+
+
 def test_hook_resolver_rejects_shell_function_tool_interposition(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -416,6 +416,122 @@ def test_hook_resolver_ignores_builtin_function_tool_lookup_interposition(
     assert resolved != str(decoy_python)
 
 
+def test_hook_resolver_ignores_caller_path_bash_interposition(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    checkout_python = repo / ".venv" / "bin" / "python"
+    checkout_python.parent.mkdir(parents=True)
+    _write_executable(checkout_python)
+    decoy_python = tmp_path / "decoy-python"
+    _write_executable(decoy_python)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_bash = fake_bin / "bash"
+    fake_bash.write_text(
+        f"#!/bin/sh\nprintf '%s\\n' {shlex.quote(str(decoy_python))}\n",
+        encoding="utf-8",
+    )
+    fake_bash.chmod(0o755)
+    env = _clean_hook_env()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    resolved = _bash(RESOLVE_COMMAND, cwd=repo, env=env)
+
+    assert resolved == str(checkout_python)
+    assert resolved != str(decoy_python)
+
+
+def test_hook_resolver_fixed_tool_path_covers_unix_and_git_bash() -> None:
+    resolver_source = HOOK_RESOLVER.read_text(encoding="utf-8")
+
+    assert 'PATH="/usr/bin:/bin:/mingw64/bin:/mingw32/bin"' in resolver_source
+    assert "/bin/bash --noprofile --norc" in resolver_source
+
+
+def test_hook_resolver_ignores_caller_path_git_identity_tools(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = tmp_path / "external-linked-lane"
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(worktree), "HEAD")
+
+    decoy_root = tmp_path / "decoy-root"
+    decoy_admin_dir = decoy_root / ".git" / "worktrees" / "lane"
+    decoy_admin_dir.mkdir(parents=True)
+    (decoy_admin_dir / "gitdir").write_text(
+        f"{worktree / '.git'}\n",
+        encoding="utf-8",
+    )
+    decoy_python = decoy_root / ".venv" / "bin" / "python"
+    decoy_python.parent.mkdir(parents=True)
+    _write_executable(decoy_python)
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_bash = fake_bin / "bash"
+    fake_bash.write_text(
+        '#!/bin/sh\nexec /bin/bash "$@"\n',
+        encoding="utf-8",
+    )
+    fake_bash.chmod(0o755)
+    fake_env_called = tmp_path / "fake-env-called"
+    fake_env = fake_bin / "env"
+    fake_env.write_text(
+        textwrap.dedent(f"""\
+            #!/bin/sh
+            : > {shlex.quote(str(fake_env_called))}
+            while [ "$#" -gt 1 ] && [ "$1" = "-u" ]; do
+                shift 2
+            done
+            exec "$@"
+            """),
+        encoding="utf-8",
+    )
+    fake_env.chmod(0o755)
+    fake_git_called = tmp_path / "fake-git-called"
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        textwrap.dedent(f"""\
+            #!/bin/sh
+            : > {shlex.quote(str(fake_git_called))}
+            DECOY_ROOT={shlex.quote(str(decoy_root))}
+            REAL_WORKTREE={shlex.quote(str(worktree))}
+            case "$*" in
+                *--git-common-dir*) printf '%s\\n' "$DECOY_ROOT/.git" ;;
+                *--git-dir*) printf '%s\\n' "$DECOY_ROOT/.git/worktrees/lane" ;;
+                *--show-toplevel*)
+                    case "$*" in
+                        *"-C $DECOY_ROOT "*) printf '%s\\n' "$DECOY_ROOT" ;;
+                        *) printf '%s\\n' "$REAL_WORKTREE" ;;
+                    esac
+                    ;;
+                *) exit 1 ;;
+            esac
+            """),
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    env = _clean_hook_env()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    resolved = _bash(RESOLVE_COMMAND, cwd=worktree, env=env)
+
+    assert resolved == str(shared_python)
+    assert resolved != str(decoy_python)
+    assert not fake_env_called.exists()
+    assert not fake_git_called.exists()
+
+
 def test_hook_resolver_keeps_relative_source_binding_after_chdir(
     tmp_path: Path,
 ) -> None:
@@ -485,18 +601,15 @@ def test_hook_resolver_preserves_home_for_git_configuration(tmp_path: Path) -> N
 
     expected_home = tmp_path / "hook-home"
     expected_home.mkdir()
-    real_git = shutil.which("git")
-    assert real_git is not None
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
+    fake_git_called = tmp_path / "fake-git-called"
     git_wrapper = fake_bin / "git"
     git_wrapper.write_text(
         textwrap.dedent(f"""\
             #!/bin/sh
-            if [ "${{HOME:-}}" != {shlex.quote(str(expected_home))} ]; then
-                exit 97
-            fi
-            exec {shlex.quote(real_git)} "$@"
+            : > {shlex.quote(str(fake_git_called))}
+            exit 97
             """),
         encoding="utf-8",
     )
@@ -508,6 +621,10 @@ def test_hook_resolver_preserves_home_for_git_configuration(tmp_path: Path) -> N
     resolved = _bash(RESOLVE_COMMAND, cwd=worktree, env=env)
 
     assert resolved == str(shared_python)
+    assert not fake_git_called.exists()
+    resolver_source = HOOK_RESOLVER.read_text(encoding="utf-8")
+    assert 'HOME="${HOME:-}"' in resolver_source
+    assert 'XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-}"' in resolver_source
 
 
 def test_hook_resolver_prefers_current_worktree_venv_symlink_to_primary_venv(

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -220,6 +220,8 @@ def test_hook_resolver_rejects_shell_function_tool_interposition(
         }}
         basename() {{ printf '%s\\n' '.git'; }}
         dirname() {{ printf '%s\\n' "$DECOY_ROOT"; }}
+        cd() {{ builtin cd -- "$DECOY_ROOT"; }}
+        pwd() {{ printf '%s\\n' "$DECOY_ROOT"; }}
         {RESOLVE_COMMAND}
     """
 

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -98,30 +98,20 @@ def _bash_failure(
     )
 
 
-def test_hook_resolver_prefers_shared_root_venv_from_worktree(tmp_path: Path) -> None:
+def test_hook_resolver_prefers_root_checkout_venv(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(tmp_path, "init", "--quiet", str(repo))
-    _git(repo, "config", "user.email", "pulseplate@pm.me")
-    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
-    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
-    _git(repo, "add", "README.md")
-    _git(repo, "commit", "--quiet", "-m", "init")
-    shared_python = repo / ".venv" / "bin" / "python"
-    shared_python.parent.mkdir(parents=True)
-    _write_executable(shared_python)
-    worktree = repo / "worktrees" / "lane"
-    _git(repo, "worktree", "add", "--quiet", str(worktree), "HEAD")
+    checkout_python = repo / ".venv" / "bin" / "python"
+    checkout_python.parent.mkdir(parents=True)
+    _write_executable(checkout_python)
 
-    resolved = _bash(
-        RESOLVE_COMMAND,
-        cwd=worktree,
-    )
+    resolved = _bash(RESOLVE_COMMAND, cwd=repo)
 
-    assert resolved == str(shared_python)
+    assert resolved == str(checkout_python)
 
 
-def test_hook_resolver_ignores_commit_hook_git_env_for_worktree_lookup(
+def test_hook_resolver_finds_primary_venv_from_arbitrary_worktree_locations(
     tmp_path: Path,
 ) -> None:
     repo = tmp_path / "repo"
@@ -135,11 +125,52 @@ def test_hook_resolver_ignores_commit_hook_git_env_for_worktree_lookup(
     shared_python = repo / ".venv" / "bin" / "python"
     shared_python.parent.mkdir(parents=True)
     _write_executable(shared_python)
-    worktree = repo / "worktrees" / "lane"
-    _git(repo, "worktree", "add", "--quiet", str(worktree), "HEAD")
+    worktrees = [
+        repo / "worktrees" / "lane",
+        repo / "nested" / "linked" / "lane",
+        repo.parent / "sibling-lane",
+        tmp_path / "external" / "arbitrary" / "lane",
+    ]
+
+    for worktree in worktrees:
+        _git(repo, "worktree", "add", "--detach", "--quiet", str(worktree), "HEAD")
+
+        resolved = _bash(
+            RESOLVE_COMMAND,
+            cwd=worktree,
+        )
+
+        assert resolved == str(shared_python)
+
+
+def test_hook_resolver_sanitizes_commit_hook_git_env_for_every_git_query(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = tmp_path / "external" / "lane"
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(worktree), "HEAD")
     env = _clean_hook_env()
-    env["GIT_DIR"] = str(repo / ".git")
-    env["GIT_INDEX_FILE"] = str(repo / ".git" / "index")
+    poisoned = str(tmp_path / "poisoned-git-state")
+    env.update(
+        {
+            "GIT_DIR": poisoned,
+            "GIT_WORK_TREE": poisoned,
+            "GIT_INDEX_FILE": poisoned,
+            "GIT_PREFIX": poisoned,
+            "GIT_COMMON_DIR": poisoned,
+            "GIT_IMPLICIT_WORK_TREE": "0",
+        }
+    )
 
     resolved = _bash(
         RESOLVE_COMMAND,
@@ -148,6 +179,67 @@ def test_hook_resolver_ignores_commit_hook_git_env_for_worktree_lookup(
     )
 
     assert resolved == str(shared_python)
+
+
+def test_hook_resolver_prefers_current_worktree_venv_symlink_to_primary_venv(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = tmp_path / "external" / "lane"
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(worktree), "HEAD")
+    local_python = worktree / ".venv" / "bin" / "python"
+    local_python.parent.mkdir(parents=True)
+    local_python.symlink_to(shared_python)
+
+    resolved = _bash(RESOLVE_COMMAND, cwd=worktree)
+
+    assert resolved == str(local_python)
+
+
+def test_hook_resolver_prefers_valid_venv_override(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    checkout_python = repo / ".venv" / "bin" / "python"
+    checkout_python.parent.mkdir(parents=True)
+    _write_executable(checkout_python)
+    dev_override = tmp_path / "dev-python"
+    _write_executable(dev_override)
+    venv_override = tmp_path / "venv-python"
+    _write_executable(venv_override)
+    env = _clean_hook_env()
+    env["DEV_PYTHON"] = str(dev_override)
+    env["VENV_PYTHON"] = str(venv_override)
+
+    resolved = _bash(RESOLVE_COMMAND, cwd=repo, env=env)
+
+    assert resolved == str(venv_override)
+
+
+def test_hook_resolver_uses_valid_dev_override_when_venv_override_is_unset(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    dev_override = tmp_path / "dev-python"
+    _write_executable(dev_override)
+    env = _clean_hook_env()
+    env["DEV_PYTHON"] = str(dev_override)
+
+    resolved = _bash(RESOLVE_COMMAND, cwd=repo, env=env)
+
+    assert resolved == str(dev_override)
 
 
 def test_hook_resolver_rejects_relative_python_override(tmp_path: Path) -> None:
@@ -187,11 +279,145 @@ def test_hook_resolver_rejects_non_executable_absolute_python_override(
     )
 
     assert completed.returncode == 1
-    assert "is set but is not executable" in completed.stderr
+    assert "is set but is not a regular executable file" in completed.stderr
     assert str(shared_python) not in completed.stdout
 
 
-def test_hook_resolver_fails_closed_without_repo_python(tmp_path: Path) -> None:
+def test_hook_resolver_rejects_directory_python_override(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    directory_override = tmp_path / "python-directory"
+    directory_override.mkdir()
+    env = _clean_hook_env()
+    env["VENV_PYTHON"] = str(directory_override)
+
+    completed = _bash_failure(
+        RESOLVE_COMMAND,
+        cwd=repo,
+        env=env,
+    )
+
+    assert completed.returncode == 1
+    assert "is set but is not a regular executable file" in completed.stderr
+
+
+def test_hook_resolver_rejects_directory_checkout_python(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    directory_python = repo / ".venv" / "bin" / "python"
+    directory_python.mkdir(parents=True)
+
+    completed = _bash_failure(
+        RESOLVE_COMMAND,
+        cwd=repo,
+        env=_clean_hook_env(),
+    )
+
+    assert completed.returncode == 1
+    assert "no repo/shared .venv Python found" in completed.stderr
+
+
+def test_hook_resolver_rejects_bare_dot_git_decoy(tmp_path: Path) -> None:
+    decoy_root = tmp_path / "decoy-root"
+    decoy_root.mkdir()
+    _git(tmp_path, "init", "--bare", "--quiet", str(decoy_root / ".git"))
+    shared_python = decoy_root / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    apparent_worktree = decoy_root / "linked" / "lane"
+    apparent_worktree.mkdir(parents=True)
+
+    completed = _bash_failure(
+        RESOLVE_COMMAND,
+        cwd=apparent_worktree,
+        env=_clean_hook_env(),
+    )
+
+    assert completed.returncode == 1
+    assert str(shared_python) not in completed.stdout
+
+
+def test_hook_resolver_rejects_ordinary_non_git_dot_git_decoy(tmp_path: Path) -> None:
+    decoy_root = tmp_path / "decoy-root"
+    (decoy_root / ".git").mkdir(parents=True)
+    shared_python = decoy_root / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    apparent_worktree = decoy_root / "linked" / "lane"
+    apparent_worktree.mkdir(parents=True)
+
+    completed = _bash_failure(
+        RESOLVE_COMMAND,
+        cwd=apparent_worktree,
+        env=_clean_hook_env(),
+    )
+
+    assert completed.returncode == 1
+    assert str(shared_python) not in completed.stdout
+
+
+def test_hook_resolver_rejects_separate_git_dir_as_primary_checkout(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "separate-worktree"
+    decoy_root = tmp_path / "decoy-root"
+    decoy_root.mkdir()
+    separate_git_dir = decoy_root / ".git"
+    _git(
+        tmp_path,
+        "init",
+        "--quiet",
+        f"--separate-git-dir={separate_git_dir}",
+        str(repo),
+    )
+    decoy_python = decoy_root / ".venv" / "bin" / "python"
+    decoy_python.parent.mkdir(parents=True)
+    _write_executable(decoy_python)
+
+    completed = _bash_failure(
+        RESOLVE_COMMAND,
+        cwd=repo,
+        env=_clean_hook_env(),
+    )
+
+    assert completed.returncode == 1
+    assert str(decoy_python) not in completed.stdout
+
+
+def test_hook_resolver_allows_ambient_python_only_in_ci(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = _clean_hook_env()
+    env["CI"] = "true"
+
+    resolved = Path(_bash(RESOLVE_COMMAND, cwd=repo, env=env))
+
+    assert resolved.is_absolute()
+    assert resolved.is_file()
+    assert os.access(resolved, os.X_OK)
+    assert resolved.name in {"python3", "python"}
+
+
+def test_hook_resolver_ci_rejects_shell_function_python_interposition(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = _clean_hook_env()
+    env["CI"] = "true"
+    command = f"python3() {{ :; }}; python() {{ :; }}; {RESOLVE_COMMAND}"
+
+    completed = _bash_failure(
+        command,
+        cwd=repo,
+        env=env,
+    )
+
+    assert completed.returncode == 1
+    assert completed.stdout == ""
+    assert "no repo/shared .venv Python found" in completed.stderr
+
+
+def test_hook_resolver_rejects_ambient_python_outside_ci(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     env = _clean_hook_env()

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -181,6 +181,59 @@ def test_hook_resolver_sanitizes_commit_hook_git_env_for_every_git_query(
     assert resolved == str(shared_python)
 
 
+def test_hook_resolver_rejects_shell_function_tool_interposition(
+    tmp_path: Path,
+) -> None:
+    apparent_checkout = tmp_path / "apparent-checkout"
+    apparent_checkout.mkdir()
+    decoy_root = tmp_path / "decoy-root"
+    (decoy_root / ".git" / "worktrees" / "lane").mkdir(parents=True)
+    decoy_python = decoy_root / ".venv" / "bin" / "python"
+    decoy_python.parent.mkdir(parents=True)
+    _write_executable(decoy_python)
+    env = _clean_hook_env()
+    env.update(
+        {
+            "DECOY_ROOT": str(decoy_root),
+            "GIT_DIR": str(tmp_path / "poisoned-git-dir"),
+            "GIT_WORK_TREE": str(tmp_path / "poisoned-work-tree"),
+            "GIT_INDEX_FILE": str(tmp_path / "poisoned-index"),
+            "GIT_PREFIX": "poisoned-prefix",
+            "GIT_COMMON_DIR": str(tmp_path / "poisoned-common-dir"),
+            "GIT_IMPLICIT_WORK_TREE": "0",
+        }
+    )
+    command = f"""
+        env() {{
+            case "$*" in
+                *--git-common-dir*) printf '%s\\n' "$DECOY_ROOT/.git" ;;
+                *--git-dir*) printf '%s\\n' "$DECOY_ROOT/.git/worktrees/lane" ;;
+                *--show-toplevel*)
+                    if [[ "$*" == *"-C $DECOY_ROOT "* ]]; then
+                        printf '%s\\n' "$DECOY_ROOT"
+                    else
+                        printf '%s\\n' "$PWD"
+                    fi
+                    ;;
+                *) return 1 ;;
+            esac
+        }}
+        basename() {{ printf '%s\\n' '.git'; }}
+        dirname() {{ printf '%s\\n' "$DECOY_ROOT"; }}
+        {RESOLVE_COMMAND}
+    """
+
+    completed = _bash_failure(
+        command,
+        cwd=apparent_checkout,
+        env=env,
+    )
+
+    assert completed.returncode == 1
+    assert str(decoy_python) not in completed.stdout
+    assert "no repo/shared .venv Python found" in completed.stderr
+
+
 def test_hook_resolver_prefers_current_worktree_venv_symlink_to_primary_venv(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -130,6 +130,7 @@ def test_hook_resolver_finds_primary_venv_from_arbitrary_worktree_locations(
         repo / "nested" / "linked" / "lane",
         repo.parent / "sibling-lane",
         tmp_path / "external" / "arbitrary" / "lane",
+        tmp_path / "external with spaces" / "linked lane",
     ]
 
     for worktree in worktrees:
@@ -141,6 +142,15 @@ def test_hook_resolver_finds_primary_venv_from_arbitrary_worktree_locations(
         )
 
         assert resolved == str(shared_python)
+
+    worktree_alias = tmp_path / "external-worktree-alias"
+    worktree_alias.symlink_to(worktrees[-1], target_is_directory=True)
+    alias_command = (
+        f"source {shlex.quote(str(HOOK_RESOLVER))}; "
+        f"resolve_repo_python {shlex.quote(str(worktree_alias))}"
+    )
+
+    assert _bash(alias_command, cwd=repo) == str(shared_python)
 
 
 def test_hook_resolver_sanitizes_commit_hook_git_env_for_every_git_query(
@@ -408,6 +418,41 @@ def test_hook_resolver_rejects_ordinary_non_git_dot_git_decoy(tmp_path: Path) ->
 
     assert completed.returncode == 1
     assert str(shared_python) not in completed.stdout
+
+
+def test_hook_resolver_rejects_forged_linked_worktree_gitdir_file(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    real_worktree = tmp_path / "real-linked-worktree"
+    _git(repo, "worktree", "add", "--detach", "--quiet", str(real_worktree), "HEAD")
+    forged_checkout = tmp_path / "forged-checkout"
+    forged_checkout.mkdir()
+    shutil.copy2(real_worktree / ".git", forged_checkout / ".git")
+    symlinked_forged_checkout = tmp_path / "symlinked-forged-checkout"
+    symlinked_forged_checkout.mkdir()
+    (symlinked_forged_checkout / ".git").symlink_to(real_worktree / ".git")
+
+    for checkout in (forged_checkout, symlinked_forged_checkout):
+        completed = _bash_failure(
+            RESOLVE_COMMAND,
+            cwd=checkout,
+            env=_clean_hook_env(),
+        )
+
+        assert completed.returncode == 1
+        assert str(shared_python) not in completed.stdout
+        assert "no repo/shared .venv Python found" in completed.stderr
 
 
 def test_hook_resolver_rejects_separate_git_dir_as_primary_checkout(


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# Pull Request

## Goal

Make checked-in hooks resolve the primary checkout's locked `.venv` from nested, sibling, arbitrary external, and Git Bash linked worktrees while preserving fail-closed interpreter precedence.

## Business reason

Restore reliable hooks-enabled commits in isolated agent worktrees without duplicating virtual environments, disabling validation, or relying on ambient Python.

## Scope

- Resolve the primary checkout through canonical Git common-dir identity and reciprocal worktree-admin ownership.
- Preserve precedence: valid absolute `VENV_PYTHON`, otherwise `DEV_PYTHON`; checkout-local `.venv`; validated primary-checkout `.venv`; CI-only system Python; local failure.
- Reject invalid overrides, bare/separate/decoy `.git` layouts, forged or symlinked metadata, poisoned repository-selection `GIT_*`, shell-function interposition, and caller-PATH tool substitution.
- Support relative Git metadata and OS-gated MSYS/Cygwin drive-absolute overrides, backlinks, and resolver source bindings.
- Add deterministic real-worktree and hostile-environment regressions.
- Synchronize the bilingual hook guide and operational recovery runbook.

## Out of scope

- Compare ancestry governance already fixed by merged PR #2142.
- Experiment Runner budget/schema changes.
- Parent/sibling scanning, `git worktree list`, bare/separate-git-dir support, Python probing, or a new resolver abstraction.
- Hook entrypoints, Makefile, `.pre-commit-config.yaml`, AGENTS, MyPy, backlog, OpenAPI, product runtime, or public API changes.

## Files changed

Material files:

- `scripts/hooks/repo_python.sh`
- `tests/test_pre_commit_hook_python_resolver.py`
- `docs/PRE_COMMIT_HOOKS.md`
- `RUNBOOK_AGENT.md`

Material-excluded closeout artifact:

- Canonical review mapping (linked once in the closeout section below)

## Key decisions

- Git identity plus reciprocal regular-file metadata ownership, not filesystem naming, binds a linked worktree to its primary checkout.
- Repository-selection queries execute inside an `env -i` Bash child with fixed tool identities and the six repository-selection `GIT_*` variables removed.
- Git Bash drive paths are accepted only for `msys*`/`cygwin*`; POSIX callers retain fail-closed path semantics.
- Invalid explicit overrides remain terminal. Local ambient Python remains forbidden; the existing CI-only fallback remains last.

## Lane Start Provenance

Packet: `artifacts/orchestration/task_packets/72463acb54a2.json`

Final role route:

`agent-coordinator -> cursor-specialist-agent -> security-auditor -> architecture-specialist -> premortem -> Experiment Runner oracle-only -> qa-engineer-agent -> bug-hunter -> security-auditor`

No final Codex Security scan was repeated after the confirmed MCP timeout; the canonical bounded operator-outage path is recorded below.

## Tests / validation

Final material head: `6f5a14479bb04cde044f2c07156324814cded1ad`

- `bash -n scripts/hooks/repo_python.sh` - PASS.
- Resolver suite - PASS, 53/53 on Bash 5 and 53/53 on system Bash 3.2.
- Privileged bootstrap guards - PASS, 79/79.
- Canonical branch-diff backend pre-commit selector - PASS.
- `python3 scripts/orchestration/check_preflight.py` - PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
- `make validate-changed` - PASS.
- `pre-commit run --all-files` - PASS without an explicit `VENV_PYTHON`; the external worktree automatically used the primary checkout `.venv`.
- `git diff --check` - PASS.
- Commit and pre-push hooks - PASS, including backend tests, pip-audit, full-repo Bandit, and applicable Docker validation.
- Exact-material GitHub CI run `29677489931`: `lint`, `security`, `test-pr (3.13)`, `coverage-pr`, OpenAPI, proxy/governance guards, and `diff-coverage` passed. Diff coverage reported no coverable lines after the configured Bash/docs/tests exclusions.

Local full `make verify` was not run, per the repository machine-budget rule.

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/exp-d5a8b5a40026.json`

The final oracle-only Apple Container execution was accepted with two immutable oracles at return code 0, `network_budget=0`, `shared_tree_untouched=true`, `mutated_paths=[]`, and image digest `sha256:cefe9cfa20a89e2b24b4041c50d02f9bc202664d44e81470f962d5b72f063e13`.

Attribution: material `oracle_review`; contributing commits carry `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

## Review and security evidence

- Exact-head official Codex review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#pullrequestreview-4730308698
- Canonical owner outage evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2147#issuecomment-5014901578
- The outage receipt binds immutable owner id `169792616`, PR #2147, material head `6f5a14479bb04cde044f2c07156324814cded1ad`, and digest `sha256:f0081ae7114e41b946921ef7e2f983cb7fcd45e4a5f4fa4eb7bbef2ecb02873c`.
- It records `MCP -32001 Request timed out`, `scan_id: none`, and tooling unavailability. It is not a security scan or a no-findings claim.
- Exact-head `security`, CodeQL, Docker `security-scan`, private-proxy, and Trivy-policy substitute checks passed with trusted producer identities.

## Security notes

This is a local orchestration trust-boundary change. It adds no network access, auth, secrets, product data, workflow authority, or runtime endpoint. Primary-checkout discovery fails closed unless checkout, admin metadata, and primary Git identities agree canonically.

## Risks / rollback

Main risk is accepting a decoy interpreter from an unsupported layout; clean-process tool identity, canonical Git checks, reciprocal metadata ownership, and deterministic negative tests block that path. A normal revert restores the previous nested-only behavior. An explicit absolute `VENV_PYTHON` remains the safe one-shot recovery.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- [Canonical review mapping artifact](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/4df57128565ecbc911f16e35d8e5de800d84e53d/docs/review/PR_2147_FIXED_MAPPING.md)
- All thread URLs, dispositions, commit SHAs, and evidence live only in that artifact.

## Split justification

The raw diff is test/documentation heavy, but the production change remains one resolver file. The resolver, its real-worktree/hostile-environment matrix, and the two operational documents form one executable contract; splitting them would remove either regression proof or recovery guidance.

## Deferred / Follow-ups

None. If a helper later reproduces truncation of a complete Experiment Runner context list, that independently evidenced defect should receive its own regression PR.

## AGENTS.md or agent-instruction updates

None; this PR implements existing worktree, hook, and orchestration policy.

## Next best step

Resolve the now-mapped review threads, wait one final exact-head CI/review cycle, run strict authenticated merge readiness, then merge and perform lane-scoped synchronization/cleanup while retaining Experiment Runner and creative artifacts.

<!-- markdownlint-enable MD013 -->
