### PR TITLE
fix(ci): handle partial variadic bindings

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -5481,7 +5481,9 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
                 for parameter in (
                     *template.function.args.posonlyargs,
                     *template.function.args.args,
+                    *([template.function.args.vararg] if template.function.args.vararg else []),
                     *template.function.args.kwonlyargs,
+                    *([template.function.args.kwarg] if template.function.args.kwarg else []),
                 )
             }
         positional = [

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -6071,6 +6071,38 @@ def test_legacy_growth_guard_replays_invoked_partial_helpers(
 
 
 @pytest.mark.parametrize(
+    ("helper", "seed", "binding"),
+    [
+        (
+            "def install(*registrars):\n"
+            "    for registrar in registrars:\n"
+            "        registrar(handler)\n",
+            "seed = [app.middleware(\"http\")]\n",
+            "run = partial(install, *seed)\n",
+        ),
+        (
+            "def install(**registrars):\n" "    registrars[\"registrar\"](handler)\n",
+            "seed = {\"registrar\": app.middleware(\"http\")}\n",
+            "run = partial(install, **seed)\n",
+        ),
+    ],
+    ids=["varargs", "kwargs"],
+)
+def test_legacy_growth_guard_handles_unresolved_partial_variadic_helpers(
+    helper: str,
+    seed: str,
+    binding: str,
+) -> None:
+    source = (
+        "from functools import partial\n\n" f"{helper}" f"{seed}" f"{binding}" "run()\n"
+    )
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert isinstance(errors, list)
+
+
+@pytest.mark.parametrize(
     "execution",
     [
         '    asyncio.gather(install(app.middleware("http")))',


### PR DESCRIPTION
### Motivation
- A guard path that builds conservative argument bindings for unresolved `functools.partial` invocations omitted `*args` and `**kwargs` parameter names, allowing a later replay merge to raise `KeyError` when analyzing valid Python that uses variadic helpers.
- The failure affects CI/static-analysis (`scripts/ci/check_legacy_growth_guard.py`) robustness rather than production FastAPI runtime, so the goal is to make the guard fail-safe for these patterns.

### Description
- Include variadic parameter names in the conservative unresolved-partial binding map by adding the function `vararg` and `kwarg` names to the returned mapping in `_resolve_partial_invocation_bindings` in `scripts/ci/check_legacy_growth_guard.py`.
- Add a regression test `test_legacy_growth_guard_handles_unresolved_partial_variadic_helpers` in `tests/test_legacy_growth_guard.py` that covers unresolved `partial` wrappers around helpers using `*args` and `**kwargs` to ensure the guard returns normally (a list) instead of crashing.
- The change is limited to the static-analysis guard code and its tests and preserves existing behavior for non-variadic partials and normal replay paths.

### Testing
- `python3 -m py_compile scripts/ci/check_legacy_growth_guard.py tests/test_legacy_growth_guard.py` succeeded. 
- Ran repository smoke checks `python3 scripts/orchestration/check_preflight.py` and `python3 scripts/orchestration/check_agent_consistency.py`, both passed. 
- Executed direct `validate_legacy_growth(...)` smoke invocations for representative `*args` / `**kwargs` partial uses and confirmed the guard returns a list of errors (no uncaught `KeyError`) for the exercised cases. 
- Attempts to run `pytest` for the targeted tests in this environment were blocked because `pytest` and `fastapi` are not installed, and `make validate-changed` / `pre-commit` could not run due to a missing repo-shared `.venv` and `pre-commit` binary; these environment-limited checks were therefore not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c5ffdf3e8832c9b1049e1a527286e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI static-analysis crashes by correctly handling unresolved `functools.partial` calls with `*args` and `**kwargs`, so the guard returns a list of errors instead of raising `KeyError`. This improves robustness of the legacy growth guard without affecting production runtime.

- **Bug Fixes**
  - Include `vararg` and `kwarg` names when building conservative bindings in `_resolve_partial_invocation_bindings`.
  - Add a regression test to cover unresolved `partial` wrappers using `*args`/`**kwargs`.

<sup>Written for commit 7efa453fdac4b53d941233b397a3c22b6b297859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

