### PR TITLE
fix(ci): cap iterable-element provenance depth to avoid loop non-convergence in growth guard

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -2465,6 +2465,7 @@ _CLASS_REFERENCE_PREFIX = "<class:"
 _INSTANCE_REFERENCE_PREFIX = "<instance:"
 _MAX_LOOP_BINDING_ITERATIONS = 32
 _MAX_TOTAL_LOOP_BINDING_ITERATIONS = 128
+_MAX_ITERABLE_ELEMENT_BINDING_DEPTH = 8
 _MAPPING_MUTATOR_METHODS = frozenset(
     {
         "__delitem__",
@@ -4975,7 +4976,9 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
                 element_bindings.append(
                     nested if nested is not None else self._conservative_argument_binding()
                 )
-            return self._join_resolved_bindings(element_bindings)
+            return self._limit_iterable_element_depth(
+                self._join_resolved_bindings(element_bindings)
+            )
         return None
 
     def _capture_iterable_element_binding(self, node: ast.AST) -> _ResolvedBinding:
@@ -5179,6 +5182,42 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
             string=_DYNAMIC_STRING_BINDING,
         )
 
+    @staticmethod
+    def _limit_iterable_element_depth(
+        binding: _ResolvedBinding,
+        *,
+        remaining_depth: int = _MAX_ITERABLE_ELEMENT_BINDING_DEPTH,
+    ) -> _ResolvedBinding:
+        nested = binding.iterable_element
+        if nested is None:
+            return binding
+        if remaining_depth <= 0:
+            return _ResolvedBinding(
+                reference=binding.reference,
+                string=binding.string,
+                callables=binding.callables,
+                deferred_calls=binding.deferred_calls,
+                mapping=binding.mapping,
+                class_references=binding.class_references,
+                descriptors=binding.descriptors,
+            )
+        limited_nested = _ApiKeyLookupVisitor._limit_iterable_element_depth(
+            nested,
+            remaining_depth=remaining_depth - 1,
+        )
+        if limited_nested is nested:
+            return binding
+        return _ResolvedBinding(
+            reference=binding.reference,
+            string=binding.string,
+            callables=binding.callables,
+            deferred_calls=binding.deferred_calls,
+            mapping=binding.mapping,
+            class_references=binding.class_references,
+            descriptors=binding.descriptors,
+            iterable_element=limited_nested,
+        )
+
     def _join_resolved_bindings(
         self,
         bindings: Sequence[_ResolvedBinding],
@@ -5205,20 +5244,24 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
         active_scope = self.scope
         self._merge_outcomes(merged, outcomes)
         self.scope = active_scope
-        return _ResolvedBinding(
-            reference=merged.references.get(marker),
-            string=merged.strings.get(marker),
-            callables=merged.callables.get(marker, frozenset()),
-            deferred_calls=merged.deferred_calls.get(marker, frozenset()),
-            mapping=(
-                bindings[0].mapping
-                if bindings[0].mapping is not None
-                and all(binding.mapping is bindings[0].mapping for binding in bindings)
-                else None
-            ),
-            class_references=frozenset().union(*(binding.class_references for binding in bindings)),
-            descriptors=frozenset().union(*(binding.descriptors for binding in bindings)),
-            iterable_element=merged.iterable_elements.get(marker),
+        return self._limit_iterable_element_depth(
+            _ResolvedBinding(
+                reference=merged.references.get(marker),
+                string=merged.strings.get(marker),
+                callables=merged.callables.get(marker, frozenset()),
+                deferred_calls=merged.deferred_calls.get(marker, frozenset()),
+                mapping=(
+                    bindings[0].mapping
+                    if bindings[0].mapping is not None
+                    and all(binding.mapping is bindings[0].mapping for binding in bindings)
+                    else None
+                ),
+                class_references=frozenset().union(
+                    *(binding.class_references for binding in bindings)
+                ),
+                descriptors=frozenset().union(*(binding.descriptors for binding in bindings)),
+                iterable_element=merged.iterable_elements.get(marker),
+            )
         )
 
     @staticmethod

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -4086,6 +4086,19 @@ def test_legacy_growth_guard_converges_for_nested_loop_function_bindings() -> No
     ]
 
 
+def test_legacy_growth_guard_converges_for_self_nested_iterable_provenance() -> None:
+    source = textwrap.dedent("""
+        def install(target):
+            target.get("/api/v1/not-called-from-self-nested-list")(handler)
+
+        items = [install]
+        for _ in values:
+            items = [items]
+        """)
+
+    assert legacy_guard.validate_legacy_growth(source) == []
+
+
 @pytest.mark.parametrize(
     "safe_rebinding",
     [


### PR DESCRIPTION
### Motivation
- The legacy growth guard's iterable-element provenance was allowed to nest unboundedly for patterns like `items = [install]` followed by `items = [items]`, preventing loop-analysis fixpoint convergence and causing the analyzer to fail-closed. 
- Introduce a minimal, bounded control so provenance is preserved shallowly but cannot grow recursively without bound, preserving the guard's fail-closed semantics while restoring CI/static-analysis availability.

### Description
- Added a new constant ` _MAX_ITERABLE_ELEMENT_BINDING_DEPTH = 8` to bound nested iterable-element provenance in `scripts/ci/check_legacy_growth_guard.py`.
- Implemented `_limit_iterable_element_depth(binding, *, remaining_depth)` as a static helper on `_ApiKeyLookupVisitor` that truncates/limits nested `iterable_element` chains beyond the configured depth.
- Applied the depth limiter when resolving collection elements and when joining resolved bindings so joined/returned `_ResolvedBinding` objects cannot carry unbounded nested `iterable_element` provenance.
- Added a regression test `test_legacy_growth_guard_converges_for_self_nested_iterable_provenance` in `tests/test_legacy_growth_guard.py` that reproduces the reported `items = [install]` / `items = [items]` pattern and asserts the guard converges (returns `[]`).

### Testing
- Ran preflight checks `python3 scripts/orchestration/check_preflight.py && python3 scripts/orchestration/check_agent_consistency.py` which passed.
- Compiled changed modules with `python -m py_compile scripts/ci/check_legacy_growth_guard.py tests/test_legacy_growth_guard.py` which succeeded (syntax/type-compile smoke-check).
- Performed direct smoke invocations of `validate_legacy_growth(...)` from the modified module for positive and negative cases which produced the expected outcomes (regression fixed for the self-nested iterable pattern).
- Attempted focused `pytest` runs (`pytest -q tests/test_legacy_growth_guard.py -k 'self_nested_iterable_provenance or nested_loop_function_bindings'`) but they were blocked by missing repository test dependencies in this environment (e.g. `fastapi` not installed), so full local test execution and `make validate-changed` / `pre-commit run --all-files` could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c5ffe51ec832c8d99a313762c17f7)

## Summary by Sourcery

Ограничена глубина происхождения элементов итерируемых объектов в устаревшем механизме контроля роста, чтобы предотвратить не сходящийся анализ циклов при сохранении поведения с отказом по умолчанию (fail-closed).

Bug Fixes:
- Предотвращён бесконечный или не сходящийся рост происхождения для само-вложенных привязок итерируемых объектов в анализаторе устаревшего механизма контроля роста.

Enhancements:
- Добавлена константа ограниченной глубины привязки элементов итерируемых объектов и вспомогательная функция для усечения вложенного происхождения итерируемых объектов при разрешении и объединении привязок.

Tests:
- Добавлен регрессионный тест, обеспечивающий сходжение устаревшего механизма контроля роста для само-вложенных шаблонов происхождения итерируемых объектов, таких как повторяющееся переназначение `items = [items]`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cap iterable-element provenance depth in the legacy growth guard to prevent non-converging loop analysis while preserving fail-closed behavior.

Bug Fixes:
- Prevent infinite or non-converging provenance growth for self-nested iterable bindings in the legacy growth guard analyzer.

Enhancements:
- Add a bounded iterable-element binding depth constant and helper to truncate nested iterable provenance when resolving and joining bindings.

Tests:
- Add a regression test ensuring the legacy growth guard converges for self-nested iterable provenance patterns like repeated `items = [items]` rebinding.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound iterable-element provenance depth in the legacy growth guard to restore fixpoint convergence and stop CI static-analysis failures. Caps nested iterable-element chains at 8 and adds a regression test for the self-nested list pattern.

- **Bug Fixes**
  - Added ` _MAX_ITERABLE_ELEMENT_BINDING_DEPTH = 8` and ` _limit_iterable_element_depth(...)` in `scripts/ci/check_legacy_growth_guard.py`.
  - Applied the limiter when resolving collection elements and when joining bindings.
  - Added `test_legacy_growth_guard_converges_for_self_nested_iterable_provenance` to ensure `items = [items]` patterns converge (returns `[]`).

<sup>Written for commit bbb66066edcaf60c26461de70db934ddb3c9097a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

