### PR TITLE
fix(ci): fail-closed on object() rebinding in legacy growth guard

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -3131,6 +3131,8 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
                 import_module_aliases=frozenset(),
                 static_string_bindings=strings,
             )
+            if constructor == "builtins.object":
+                return _KNOWN_NON_APP_REFERENCE
             if self.preserve_route_method_conflicts and constructor == "pulseplate.app.middleware":
                 return f"{_MIDDLEWARE_DECORATOR_REFERENCE_PREFIX}{_first_arg_label(node)}"
             if constructor in {"fastapi.FastAPI", "fastapi.applications.FastAPI"}:
@@ -3495,13 +3497,6 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
     def _is_definitely_non_app_value(self, node: ast.AST) -> bool:
         if isinstance(node, (ast.Constant, ast.JoinedStr, ast.Lambda)):
             return True
-        if (
-            isinstance(node, ast.Call)
-            and not node.args
-            and not node.keywords
-            and self._resolve_reference(node.func) == "builtins.object"
-        ):
-            return True
         if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
             return all(
                 not isinstance(element, ast.Starred) and self._is_definitely_non_app_value(element)
@@ -3577,6 +3572,40 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
         }:
             return current
         return None
+
+    def _is_module_object_namespace_target(self, target: ast.AST) -> bool:
+        return (
+            isinstance(target, ast.Subscript)
+            and _is_namespace_mapping(target.value)
+            and self._resolve_string(target.slice) == "object"
+        )
+
+    def _is_builtins_object_attribute_target(self, target: ast.AST) -> bool:
+        if not isinstance(target, ast.Attribute):
+            return False
+        references = self.scope.visible_references()
+        return (
+            _static_module_reference(
+                target,
+                module_aliases=references,
+                import_module_aliases=frozenset(),
+                static_string_bindings=self.scope.visible_strings(),
+            )
+            == "builtins.object"
+        )
+
+    def _bind_object_rebinding_target(self, target: ast.AST) -> bool:
+        if not (
+            self._is_module_object_namespace_target(target)
+            or self._is_builtins_object_attribute_target(target)
+        ):
+            return False
+        self._bind_name(
+            "object",
+            reference=None,
+            string=None,
+        )
+        return True
 
     def _bind_target_value(
         self,
@@ -5035,6 +5064,7 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
         value_mapping = self._resolve_mapping(node.value)
         for target in node.targets:
             self._invalidate_mapping_target(target)
+            self._bind_object_rebinding_target(target)
             self._bind_target_value(
                 target,
                 node.value,
@@ -5055,6 +5085,7 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
         self.visit(node.value)
         value_mapping = self._resolve_mapping(node.value)
         self._invalidate_mapping_target(node.target)
+        self._bind_object_rebinding_target(node.target)
         self._bind_target_value(
             node.target,
             node.value,

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -4130,6 +4130,36 @@ def test_legacy_growth_guard_clears_dynamic_app_after_builtin_object_rebinding()
     assert legacy_guard.validate_legacy_growth(source) == []
 
 
+def test_legacy_growth_guard_keeps_globals_object_rebinding_fail_closed() -> None:
+    source = textwrap.dedent("""
+        app = resolve_app()
+        globals()["object"] = lambda: app
+        app = object()
+        app.get("/api/v1/globals-object-rebind")(handler)
+        """)
+
+    assert legacy_guard.validate_legacy_growth(source) == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:get:/api/v1/globals-object-rebind"
+    ]
+
+
+def test_legacy_growth_guard_keeps_builtins_object_rebinding_fail_closed() -> None:
+    source = textwrap.dedent("""
+        import builtins
+
+        app = resolve_app()
+        builtins.object = lambda: app
+        app = object()
+        app.get("/api/v1/builtins-object-rebind")(handler)
+        """)
+
+    assert legacy_guard.validate_legacy_growth(source) == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:get:/api/v1/builtins-object-rebind"
+    ]
+
+
 def test_legacy_growth_guard_keeps_shadowed_object_call_fail_closed() -> None:
     source = textwrap.dedent("""
         app = resolve_app()


### PR DESCRIPTION
### Motivation
- The legacy growth guard treated zero-argument `object()` as a lexical "definitely non-app" value which allowed a malicious dynamic rebinding of `object` (via `globals()` or `builtins`) to erase the tracked FastAPI `app` reference and hide route registrations from the CI guard.
- The intent is to preserve the safe builtin `object()` path while remaining fail-closed for any dynamic/global/builtins rebinding that could turn `object()` into an app constructor at runtime.

### Description
- Remove the broad `object()` shortcut from `_is_definitely_non_app_value` so `object()` is no longer assumed safe purely by syntactic form.
- Add a narrow explicit handling in `_resolve_reference` for call-sites whose constructor statically resolves to `builtins.object`, returning `_KNOWN_NON_APP_REFERENCE` only when the static resolver proves the builtin constructor is in use.
- Add helper methods `_is_module_object_namespace_target`, `_is_builtins_object_attribute_target`, and `_bind_object_rebinding_target` to detect assignment targets that rebind the module/global `object` (e.g. `globals()["object"] = ...` or `builtins.object = ...`) and mark such rebindings so they do not clear tracked app/router bindings.
- Invoke `_bind_object_rebinding_target` in `visit_Assign` and `visit_AnnAssign` so module/global/builtins object rebinding is treated as a rebinding target (fail-closed) before regular binding logic runs.
- Add regression tests that assert the guard remains fail-closed for `globals()["object"] = ...` and `builtins.object = ...` rebindings and preserve the existing test that `app = object()` is safe when the builtin is genuinely in effect.

### Testing
- Ran static compile checks: `python -m py_compile scripts/ci/check_legacy_growth_guard.py tests/test_legacy_growth_guard.py` succeeded.
- Executed the guard CLI probe: `python scripts/ci/check_legacy_growth_guard.py` (guard self-check) succeeded and reported "legacy compatibility seam guard passed".
- Performed direct no-edit Python probes that exercised cases for `builtin object()`, `globals()`-based rebinding, `builtins.object` rebinding, shadowed `object`, and module `del object`; the probe confirmed expected behavior (builtin-safe, globals/builtins/shadowed fail-closed where appropriate).
- Ran repo sanity checks: `python scripts/orchestration/check_preflight.py` and `python scripts/orchestration/check_agent_consistency.py` and they passed.
- Focused `pytest` runs and `make validate-changed` were environment-blocked and could not be completed in this execution environment because `fastapi` is not installed and no repo `.venv`/`pre-commit` is available; run the focused tests locally or in CI with the repo venv: `python -m pytest -q tests/test_legacy_growth_guard.py -k "builtin_object_rebinding or globals_object_rebinding or builtins_object_rebinding or shadowed_object_call or restores_builtin_object_after_module_delete or deleted_function_local_object"` once dependencies and `.venv` are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c5ffeb4b8832ca240ff7fe2b6325e)

## Summary by Sourcery

Ужесточена обработка `object()` в устаревшем защитном механизме роста, чтобы встроенные вызовы `object` явно считались безопасными, при этом любое переназначение `object` в `globals`/`builtins` остаётся в режиме «fail‑closed» и не может скрыть регистрации устаревших маршрутов.

Bug Fixes:
- Гарантировать, что динамическое переназначение `object` через `globals()["object"]` или `builtins.object` не очищает отслеживаемые привязки FastAPI app/router и остаётся обнаруживаемым защитным механизмом.

Enhancements:
- Уточнить разрешение ссылок, чтобы явно классифицировать вызовы `builtins.object` как значения, не являющиеся приложением, только когда встроенный конструктор статически разрешён.
- Ввести логику обнаружения и привязки целей переназначения `object` на уровне модуля/global/builtins, чтобы такие присваивания рассматривались как чувствительные операции переназначения.

Tests:
- Добавить регрессионные тесты, охватывающие сценарии переназначения `globals()["object"]` и `builtins.object`, чтобы подтвердить, что защитный механизм остаётся в режиме «fail‑closed», сохраняя при этом существующее безопасное поведение встроенного `object()`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the legacy growth guard’s handling of object() so that builtin object calls are explicitly treated as safe while any globals/builtins rebinding of object remains fail‑closed and cannot hide legacy route registrations.

Bug Fixes:
- Ensure dynamic rebinding of object via globals()["object"] or builtins.object does not clear tracked FastAPI app/router bindings and remains detectable by the guard.

Enhancements:
- Refine reference resolution to explicitly classify calls to builtins.object as non‑app values only when the builtin constructor is statically resolved.
- Introduce detection and binding logic for module/global/builtins object rebinding targets so these assignments are treated as sensitive rebinding operations.

Tests:
- Add regression tests covering globals()["object"] and builtins.object rebinding scenarios to confirm the guard stays fail‑closed while preserving the existing safe builtin object() behavior.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the legacy growth guard to fail-closed when `object` is rebound (via `globals()` or `builtins`) so malicious `object()` calls can’t hide route registrations. Genuine builtin `object()` is still treated as safe when statically resolved to `builtins.object`.

- **Bug Fixes**
  - Removed the blanket `object()` non-app shortcut from `_is_definitely_non_app_value`.
  - Treat `object()` as safe only when `_resolve_reference` proves the constructor is `builtins.object`.
  - Detect and bind `object` rebindings in assignment targets (`globals()["object"]`, `builtins.object`) before normal binding via `_bind_object_rebinding_target`.
  - Added helpers `_is_module_object_namespace_target`, `_is_builtins_object_attribute_target`, and `_bind_object_rebinding_target`.
  - Added regression tests to keep `globals()`/`builtins` rebindings fail-closed and preserve the builtin-safe `object()` path.

<sup>Written for commit b371de4a2c874274c139e4910390e28388bc6cf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

