### PR TITLE
fix(ci): inspect deferred lambda bodies in legacy growth guard

### DIFF
--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -3917,6 +3917,7 @@ class _ApiKeyLookupVisitor(ast.NodeVisitor):
         self._function_default_bindings[synthetic] = {}
         if self.scope.scope_kind != "module":
             self._function_definition_scopes[synthetic] = self.scope
+        self._visit_function(synthetic)
 
     def _build_class_mro(
         self,

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -1847,6 +1847,19 @@ def test_api_key_ownership_guard_preserves_late_bound_aliases(source: str) -> No
     ) == ["app/main.py: legacy API-key dependency attribute access is forbidden: get_api_key"]
 
 
+def test_api_key_ownership_guard_inspects_deferred_lambda_body() -> None:
+    legacy_source = "from app.routers.api_key import _get_api_key_dynamic, get_api_key\n"
+    source = textwrap.dedent("""
+        import legacy_app as legacy
+        dependency = lambda: legacy.get_api_key
+        """)
+
+    assert legacy_guard.validate_api_key_dependency_ownership(
+        legacy_source,
+        {"app/main.py": source},
+    ) == ["app/main.py: legacy API-key dependency attribute access is forbidden: get_api_key"]
+
+
 @pytest.mark.parametrize("operator", ["and", "or"])
 def test_api_key_ownership_guard_joins_boolean_short_circuit_state(operator: str) -> None:
     legacy_source = "from app.routers.api_key import _get_api_key_dynamic, get_api_key\n"
@@ -6176,6 +6189,15 @@ def test_legacy_growth_guard_applies_local_class_decorator_result() -> None:
         """)
 
     assert len(legacy_guard.validate_legacy_growth(source)) == 1
+
+
+def test_legacy_growth_guard_inspects_deferred_lambda_route_registration() -> None:
+    source = 'deferred = lambda: app.get("/api/v1/deferred-lambda")(handler)\n'
+
+    assert legacy_guard.validate_legacy_growth(source) == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:get:/api/v1/deferred-lambda"
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- The legacy-growth static analyzer stopped traversing lambda bodies at definition time, allowing deferred callbacks to hide forbidden legacy API-key lookups and route registrations. This weakens a CI security guard that must remain fail-closed.

### Description

- Restore immediate analysis of lambda bodies by invoking the same function analysis used for `FunctionDef` nodes inside `visit_Lambda` in `_ApiKeyLookupVisitor` so synthetic lambda FunctionDefs are inspected at definition time. (change in `scripts/ci/check_legacy_growth_guard.py`)
- Add focused regression tests that assert deferred lambda API-key dependency access and deferred lambda route registration are detected by the guard. (additions to `tests/test_legacy_growth_guard.py`)
- Preserve existing behavior for directly-invoked lambda helpers while ensuring deferred/uninvoked lambdas no longer evade detection.

### Testing

- Ran static syntax/compile checks with `python3 -m py_compile` for `scripts/ci/check_legacy_growth_guard.py` and the modified tests, and they succeeded. 
- Executed focused semantic checks by calling the guard functions directly (asserting `validate_api_key_dependency_ownership(...)` and `validate_legacy_growth(...)` on deferred-lambda inputs), and the assertions passed, demonstrating the regression is fixed for the targeted cases. 
- Attempts to run the local `pytest` focused suite were not completed due to local environment limitations: `.venv` was not present and `pytest`/`fastapi` were not available, so `pytest -q tests/test_legacy_growth_guard.py` was not executed. 
- `make validate-changed` could not complete because no repo/shared `.venv` Python was found, and `pre-commit run --all-files` was not run because `pre-commit` is not installed in the environment used for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c5e093380832ca1dd5689d362b7eb)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the legacy-growth CI guard to analyze lambda bodies at definition time, closing a bypass where deferred lambdas hid legacy API-key lookups and route registrations. This keeps the guard fail-closed and blocks unexpected legacy growth.

- **Bug Fixes**
  - Call `_visit_function(...)` from `visit_Lambda` in `scripts/ci/check_legacy_growth_guard.py` to analyze lambda function nodes immediately.
  - Add regression tests for detecting deferred-lambda API-key access and deferred-lambda route registration in `tests/test_legacy_growth_guard.py`.
  - Preserve behavior for directly-invoked lambdas.

<sup>Written for commit 5bc4969065c4d58d6d49acae93c3967cb2d9d067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

