### PR TITLE
fix(governance): admit terminal review quota evidence with anti-drift guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,10 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    to the current material seal context with `review_claim=none`; it is never a
    Codex review, approval, or no-findings result. A later material change
    requires a new seal, but the same immutable quota comment may be reverified
-   and reused. Historical PR `#2142` review-credit override receipts remain
+   and reused. The canonical negative projection is `retry_required=false`,
+   `substitute_review_required=false`, `prior_review_required=false`,
+   `operator_override_required=false`, and `ttl_required=false`. Historical PR
+   `#2142` review-credit override receipts remain
    readable everywhere but are live-authenticated only for PR `#2142`; the
    legacy override path is not an active authoring contract for later PRs.
    The trusted submitted review object's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,8 +227,8 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    Codex review, approval, or no-findings result. A later material change
    requires a new seal, but the same immutable quota comment may be reverified
    and reused. Historical PR `#2142` review-credit override receipts remain
-   readable and revalidated for compatibility only; the legacy override path
-   is not an active authoring contract.
+   readable everywhere but are live-authenticated only for PR `#2142`; the
+   legacy override path is not an active authoring contract for later PRs.
    The trusted submitted review object's
    real GitHub `commit_id` must equal the frozen material head. When the official
    Codex connector emits an unedited no-findings issue comment instead, its

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,8 +204,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    PR head. Reviewer execution SHAs are opaque until the Commit API proves
    them repository-addressable; unavailable/API-unknown refs must never enter
    ancestry checks.
-9. **Material identity:** one Codex review and one completed final Codex Security
-   diff scan bind to one material digest. When Codex Security is systemically
+9. **Material identity:** one completed Codex review or one trusted terminal
+   review-source unavailability receipt, plus one completed final Codex Security
+   diff scan, bind to one material digest. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
    operator-outage override may replace only the plugin receipt: it must be an
    unedited exact-material GitHub comment from an `OWNER` or `MEMBER`, bind the
@@ -217,18 +218,17 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    implementation/policy input of the substitute security checks cannot authorize themselves with
    this override. It is tooling-unavailability evidence, never
    a security scan or no-findings claim. When the official Codex connector
-   reports exhausted code-review credits for the final review cycle, a
-   short-lived review-credit override may replace only the unavailable exact-head
-   connector receipt. It requires the unedited trusted quota response, a prior
-   real Codex review on an ancestor PR commit, and a subsequent exact-head
-   `OWNER`/`MEMBER` review with no remaining actionables. The same operator must
-   then publish one unedited canonical override comment binding the final
-   material head/digest and all three evidence URLs. The receipt binds that
-   operator comment plus the quota and review references. PR `#2142` is the
-   one-time trust-boundary bootstrap; later PRs that change review/seal/merge
-   verification, current-head check authority, or GitHub workflow/action
-   authority cannot authorize themselves with this override. It records
-   review-provider unavailability, never a Codex review or no-findings result.
+   reports an exact known rate-limit or usage-limit response, its unedited
+   same-PR GitHub App comment is terminal review-source unavailability evidence:
+   `source_degraded=true`, `fallback_required=false`, and `blocking=false`.
+   Do not retry, request a substitute/prior review, require an operator
+   override, or impose a TTL. The receipt binds the unavailable source attempt
+   to the current material seal context with `review_claim=none`; it is never a
+   Codex review, approval, or no-findings result. A later material change
+   requires a new seal, but the same immutable quota comment may be reverified
+   and reused. Historical PR `#2142` review-credit override receipts remain
+   readable and revalidated for compatibility only; the legacy override path
+   is not an active authoring contract.
    The trusted submitted review object's
    real GitHub `commit_id` must equal the frozen material head. When the official
    Codex connector emits an unedited no-findings issue comment instead, its

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -674,9 +674,9 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    merge gate, current-head check identity parser, CI/security workflows, local
    GitHub Actions, or implementations/policy inputs of the substitute security checks cannot use
    the override. This writes the sole canonical mapping/seal artifact.
-   Historical PR `#2142` review-credit override receipts remain readable and
-   revalidated for existing artifacts only; their old multi-reference authoring
-   flags are not active CLI options.
+   Historical PR `#2142` review-credit override receipts remain readable
+   everywhere but are live-authenticated only for PR `#2142`; their old
+   multi-reference authoring flags are not active CLI options for later PRs.
 6. Commit that artifact once, update the PR body link without a Git commit, and
    run the authenticated strict wrapper.
 7. A later validated duplicate uses the exact structured reply contract and an

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -510,19 +510,20 @@ Use this as the canonical operating loop from branch creation to merge window:
    - Read `AGENTS.md`, `RUNBOOK_AGENT.md`, and the nearest scoped `AGENTS.md`
    - Decide scope, risk, and which sub-agents or helpers are needed before edits
 2. **Open non-draft by default**
-   - For lanes using the material review seal, first disable automatic
-     synchronize-triggered Codex review in the external GitHub integration.
-     Repository code cannot enforce that external setting.
    - Open the PR ready-for-review once scope, artifact strategy, and initial local gates are coherent so bots and current-head checks run
+   - Let the configured review bots react automatically to the opened or
+     synchronized diff. Do not post manual bot-review commands or disable their
+     automatic review setting.
    - Use draft only with an explicit operator exception when review/check suppression is intentional
    - Create or confirm the canonical artifact path `docs/review/PR_<N>_FIXED_MAPPING.md`
 3. **Post-open review entry**
    - Once the PR exists, run the mandatory post-open reviewer path declared by the lane packet/runbook before calling the lane stable
    - When the lane declares `qa-engineer-agent -> bug-hunter -> security-auditor`, that pass happens after PR open, not as a substitute for pre-PR local gates
-   - Finish all implementation/docs/tests, then freeze the material digest with
-     `pr_review_closeout.py freeze`. The coordinator posts one manual
-     `@codex review` for that digest. A material fix invalidates the freeze and
-     returns here.
+   - Finish all implementation/docs/tests, publish the coherent diff, then
+     freeze the material digest with `pr_review_closeout.py freeze`. Observe the
+     automatic Codex response for that published digest; do not trigger or
+     retrigger it manually. A material fix invalidates the freeze and returns
+     here.
    - After the final freeze, run the declared
      `qa-engineer-agent -> bug-hunter -> security-auditor` pass, one Codex
      Security diff scan / finding discovery, and `pulseplate-pr-review`.
@@ -644,18 +645,27 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
 **Material-seal closeout cycle:**
 
 1. `pr_review_closeout.py init` creates/resumes the gitignored local draft.
-2. `freeze` proves local HEAD equals the live PR head and records the material
-   digest. Request one manual Codex review for that digest. If the trusted
-   connector instead returns its exact review-credit exhaustion response, keep
-   that immutable comment URL and use the bounded credit-outage path below.
+2. Publish the coherent material diff, then `freeze` proves local HEAD equals
+   the live PR head and records its digest. Observe the configured automatic
+   Codex response; do not post a manual bot-review command. If the trusted
+   connector returns its exact review-credit exhaustion response, keep that
+   immutable same-PR comment URL as terminal source-unavailability evidence. Do
+   not retrigger the review.
 3. Apply actionable fixes. Any material change returns to step 2; governance
    draft/body activity does not.
 4. After the final material freeze, complete the required role pass and one
    final Codex Security diff scan. If the plugin is systemically unavailable
    with MCP `-32001 Request timed out`, use the bounded operator-outage path only
    after an explicit operator decision; it is not scan or no-findings evidence.
-5. Record dispositions with `add-disposition`, then run `seal --review-ref ...`
-   with exactly one of `--scan-manifest ...` or
+5. Record dispositions with `add-disposition`, then run `seal` with exactly one
+   review-evidence mode: `--review-ref ...` for a completed trusted review, or
+   `--review-source-unavailable-ref ...` for an exact trusted Codex rate-limit /
+   usage-limit comment. The source-unavailable path requires no retry,
+   substitute review, prior review, operator override, or TTL; it proves only
+   source unavailability (`review_claim=none`), never review/PASS/no-findings.
+   The comment is re-fetched and its exact UTF-8 body hash recomputed. A later
+   material change requires resealing, while the same immutable quota reference
+   may be reused. Also provide exactly one of `--scan-manifest ...` or
    `--security-outage-override-ref <exact GitHub comment URL>`. The override
    comment must be unedited, from an `OWNER`/`MEMBER`, bind the immutable GitHub
    user id and exact material head/digest, remain within its TTL, and pass the
@@ -664,19 +674,9 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    merge gate, current-head check identity parser, CI/security workflows, local
    GitHub Actions, or implementations/policy inputs of the substitute security checks cannot use
    the override. This writes the sole canonical mapping/seal artifact.
-   When code-review credits are exhausted, `--review-ref` must name a subsequent
-   exact-head `OWNER`/`MEMBER` review and `seal` must also receive
-   `--review-credit-outage-ref <canonical owner override comment URL>`,
-   `--review-credit-quota-ref <trusted connector quota comment URL>`, plus
-   `--prior-codex-review-ref <trusted ancestor review URL>`. The quota response
-   must be current, the exact-head review must follow it, and the unedited owner
-   override comment must bind the frozen material head/digest and all three
-   evidence URLs. All evidence must remain within its TTL, use the same
-   `OWNER`/`MEMBER` identity where required, and no unresolved/actionable review
-   item may remain. This is an unavailable-provider receipt, not a Codex
-   no-findings claim. PR `#2142` is the only self-bootstrap; later
-   review/seal/merge verification, current-head check authority, or GitHub
-   workflow/action authority changes cannot use the override.
+   Historical PR `#2142` review-credit override receipts remain readable and
+   revalidated for existing artifacts only; their old multi-reference authoring
+   flags are not active CLI options.
 6. Commit that artifact once, update the PR body link without a Git commit, and
    run the authenticated strict wrapper.
 7. A later validated duplicate uses the exact structured reply contract and an

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -662,7 +662,11 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    `--review-source-unavailable-ref ...` for an exact trusted Codex rate-limit /
    usage-limit comment. The source-unavailable path requires no retry,
    substitute review, prior review, operator override, or TTL; it proves only
-   source unavailability (`review_claim=none`), never review/PASS/no-findings.
+   source unavailability (`source_degraded=true`, `fallback_required=false`,
+   `blocking=false`, and `review_claim=none`), never review/PASS/no-findings.
+   The exact negative projection is `retry_required=false`,
+   `substitute_review_required=false`, `prior_review_required=false`,
+   `operator_override_required=false`, and `ttl_required=false`.
    The comment is re-fetched and its exact UTF-8 body hash recomputed. A later
    material change requires resealing, while the same immutable quota reference
    may be reused. Also provide exactly one of `--scan-manifest ...` or

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -136,10 +136,10 @@ governance PR number + 1; the governance PR may opt in with
   the frozen material head. An official unedited no-findings issue comment is
   accepted only when the trusted Codex GitHub App identity and its short
   reviewed-commit marker resolve through the Commit API to that same full head;
-  reviewer-execution/synthetic refs never satisfy this proof. Code review and
-  one completed final Codex Security diff scan bind to the same digest. A
-  systemic MCP `-32001 Request timed out` outage may use a distinct
-  `operator_outage_override` evidence variant only when an unedited GitHub
+  reviewer-execution/synthetic refs never satisfy this proof. The selected
+  review-evidence variant and one completed final Codex Security diff scan bind
+  to the same digest. A systemic MCP `-32001 Request timed out` outage may use a
+  distinct `operator_outage_override` evidence variant only when an unedited GitHub
   comment from an `OWNER` or `MEMBER` binds the immutable GitHub user id, exact
   PR, material head, and material digest, declares `scan_id: none`, remains
   within its TTL, and the current-head `security`, `CodeQL`, `security-scan`,
@@ -152,17 +152,20 @@ governance PR number + 1; the governance PR may opt in with
   The embedded scan record is a
   `human_asserted_content_receipt`: CI verifies schema, hashes, coverage, range,
   and content binding but does not claim signed/plugin attestation.
-- If the trusted connector returns its exact review-credit exhaustion response
-  for the final review cycle, the seal may use the closed
-  `operator_review_credit_exhaustion_override` variant. It requires a prior
-  trusted Codex review on an ancestor PR commit and a later exact-head
-  `OWNER`/`MEMBER` review. That same operator must publish one unedited canonical
-  override comment binding the trusted quota response, both review references,
-  the exact head, and the material digest. The receipt is time-limited and
-  records provider unavailability, not Codex review/no-findings. PR `#2142` is
-  the one-time trust-boundary bootstrap; subsequent changes to review/seal/merge
-  verification, current-head check authority, or GitHub workflow/action
-  authority cannot authorize themselves with it.
+- If the trusted connector returns an exact known rate-limit or usage-limit
+  response, the seal uses the tagged
+  `pulseplate.codex-review-source-unavailability/v1` variant. The canonical
+  same-PR, unedited trusted Codex GitHub App comment is terminal unavailable
+  evidence: no retry, substitute review, prior review, operator override, or
+  TTL is required. It binds the current material head/digest with
+  `binding_kind=seal_context_only` and `review_claim=none`; it is not review,
+  approval, PASS, or no-findings evidence. Unknown/changed bodies and identity,
+  URL, timestamp, body-hash, PR/repository, or material-binding drift fail
+  closed. The same immutable quota reference may be reverified after a later
+  material change, but the material seal itself must be regenerated.
+- Historical PR `#2142` `operator_review_credit_exhaustion_override` receipts
+  remain parseable and revalidated only for artifact compatibility. The legacy
+  multi-reference override is not an active authoring mode.
 - `pr_review_closeout.py` keeps `init`, `freeze`, and `add-disposition` state
   gitignored. `seal` is the only tracked authoring step; mapping and seal publish
   in one batched governance-closeout commit. Resealing after a base sync is

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -164,8 +164,9 @@ governance PR number + 1; the governance PR may opt in with
   closed. The same immutable quota reference may be reverified after a later
   material change, but the material seal itself must be regenerated.
 - Historical PR `#2142` `operator_review_credit_exhaustion_override` receipts
-  remain parseable and revalidated only for artifact compatibility. The legacy
-  multi-reference override is not an active authoring mode.
+  remain parseable everywhere but are live-authenticated only for PR `#2142`.
+  The legacy multi-reference override is not an active authoring mode for later
+  PRs.
 - `pr_review_closeout.py` keeps `init`, `freeze`, and `add-disposition` state
   gitignored. `seal` is the only tracked authoring step; mapping and seal publish
   in one batched governance-closeout commit. Resealing after a base sync is

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -157,12 +157,17 @@ governance PR number + 1; the governance PR may opt in with
   `pulseplate.codex-review-source-unavailability/v1` variant. The canonical
   same-PR, unedited trusted Codex GitHub App comment is terminal unavailable
   evidence: no retry, substitute review, prior review, operator override, or
-  TTL is required. It binds the current material head/digest with
-  `binding_kind=seal_context_only` and `review_claim=none`; it is not review,
-  approval, PASS, or no-findings evidence. Unknown/changed bodies and identity,
-  URL, timestamp, body-hash, PR/repository, or material-binding drift fail
-  closed. The same immutable quota reference may be reverified after a later
-  material change, but the material seal itself must be regenerated.
+  TTL is required. It is recorded as `source_degraded=true`,
+  `fallback_required=false`, and `blocking=false`, and binds the current
+  material head/digest with `binding_kind=seal_context_only` and
+  `review_claim=none`; it is not review, approval, PASS, or no-findings
+  evidence. Its exact negative projection is `retry_required=false`,
+  `substitute_review_required=false`, `prior_review_required=false`,
+  `operator_override_required=false`, and `ttl_required=false`.
+  Unknown/changed bodies and identity, URL, timestamp, body-hash, PR/repository,
+  or material-binding drift fail closed. The same immutable quota reference may
+  be reverified after a later material change, but the material seal itself must
+  be regenerated.
 - Historical PR `#2142` `operator_review_credit_exhaustion_override` receipts
   remain parseable everywhere but are live-authenticated only for PR `#2142`.
   The legacy multi-reference override is not an active authoring mode for later

--- a/docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md
+++ b/docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md
@@ -32,5 +32,6 @@ but the same immutable comment may be reverified and reused.
 
 Historical compatibility: the PR `#2142`
 `operator_review_credit_exhaustion_override` receipt remains parseable and
-revalidated for existing artifacts. Its multi-reference authoring flags are no
-longer active CLI options and do not define current quota handling.
+is live-authenticated only for PR `#2142`. Its multi-reference authoring flags
+are no longer active CLI options for later PRs and do not define current quota
+handling.

--- a/docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md
+++ b/docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md
@@ -15,7 +15,10 @@ review-source unavailability: `source_degraded=true`,
 `fallback_required=false`, and `blocking=false`. No retry, substitute review,
 prior review, operator override, or TTL is required. The trusted evidence has
 `review_claim=none`; it proves only that the configured source was unavailable
-at the recorded attempt.
+at the recorded attempt. The exact negative projection is
+`retry_required=false`, `substitute_review_required=false`,
+`prior_review_required=false`, `operator_override_required=false`, and
+`ttl_required=false`.
 
 This policy cannot replace GitHub review-thread truth, CodeRabbit/Sourcery/Cubic
 dispositions, `docs/review/PR_<N>_FIXED_MAPPING.md`, PR body mirror governance,

--- a/docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md
+++ b/docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md
@@ -10,13 +10,27 @@ Schema: `docs/orchestration/contracts/review_source_status.v1.json`.
 itself. Blocking comes only from explicit fallback findings, failed required
 checks, unresolved review threads, or actionable bot comments.
 
+Exact `rate_limited` and `usage_limit_reached` statuses are terminal
+review-source unavailability: `source_degraded=true`,
+`fallback_required=false`, and `blocking=false`. No retry, substitute review,
+prior review, operator override, or TTL is required. The trusted evidence has
+`review_claim=none`; it proves only that the configured source was unavailable
+at the recorded attempt.
+
 This policy cannot replace GitHub review-thread truth, CodeRabbit/Sourcery/Cubic
 dispositions, `docs/review/PR_<N>_FIXED_MAPPING.md`, PR body mirror governance,
 current-head CI, or strict merge-readiness checks.
 
-The material-seal review-credit outage variant is a separate, machine-validated
-exception. It requires a current trusted immutable connector quota response, a
-prior trusted Codex review on an ancestor PR commit, a subsequent exact-head
-`OWNER`/`MEMBER` review, and an unedited canonical override comment from that
-same operator binding the exact head, material digest, and all evidence URLs. A
-`source_degraded` record alone never activates that exception.
+For a material seal, `--review-source-unavailable-ref` accepts only a canonical
+same-repository, same-PR, unedited issue-comment URL from the trusted Codex
+GitHub App. The verifier authenticates the bot and App identity, exact
+`html_url`/`issue_url`, immutable timestamp, and exact known quota body, then
+recomputes the UTF-8 body SHA-256 on every validation. Unknown or changed text
+fails closed. The receipt binds the immutable evidence to the current material
+head/digest as `seal_context_only`; a later material change requires resealing,
+but the same immutable comment may be reverified and reused.
+
+Historical compatibility: the PR `#2142`
+`operator_review_credit_exhaustion_override` receipt remains parseable and
+revalidated for existing artifacts. Its multi-reference authoring flags are no
+longer active CLI options and do not define current quota handling.

--- a/docs/orchestration/contracts/review_source_status.v1.json
+++ b/docs/orchestration/contracts/review_source_status.v1.json
@@ -35,5 +35,27 @@
     "reason": { "type": "string" },
     "evidence": { "type": "string" }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "enum": [
+              "rate_limited",
+              "usage_limit_reached"
+            ]
+          }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "source_degraded": { "const": true },
+          "fallback_required": { "const": false },
+          "blocking": { "const": false }
+        }
+      }
+    }
+  ],
   "additionalProperties": false
 }

--- a/docs/review/PR_2165_FIXED_MAPPING.md
+++ b/docs/review/PR_2165_FIXED_MAPPING.md
@@ -1,0 +1,71 @@
+# PR 2165 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/3404669df002.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/exp-ccb41d22ec23.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 627b113f090f31ff5b0c86bc99e3c9dc183d719e
+Evidence: scripts/orchestration/review_source_status.py:25; tests/test_review_source_status.py:63; tests/guards/test_review_source_quota_policy_guard.py:110
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#discussion_r3614455381 -> 627b113f090f31ff5b0c86bc99e3c9dc183d719e
+
+Disposition: FIXED
+Commit: 627b113f090f31ff5b0c86bc99e3c9dc183d719e
+Evidence: scripts/run-backend-tests-pre-commit.sh:168; tests/guards/test_review_source_quota_policy_guard.py:210
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#discussion_r3614459381 -> 627b113f090f31ff5b0c86bc99e3c9dc183d719e
+
+Disposition: FIXED
+Commit: bcd25611498c335815d6c098f075335bf932e595
+Evidence: scripts/ci/check_pr_merge_readiness.py:635; scripts/orchestration/pr_review_closeout.py:575; tests/test_pr_merge_readiness_gate.py:1317; tests/test_pr_review_material_seal.py:2057
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#discussion_r3614991507 -> bcd25611498c335815d6c098f075335bf932e595
+
+Disposition: NOT-A-BUG
+Evidence: AGENTS.md:220; scripts/orchestration/pr_review_evidence.py:1043; scripts/ci/check_pr_merge_readiness.py:635
+Reason: The authenticated receipt explicitly claims review_claim=none and preserves independent current-head CI, material-bound Code Security, actionable-item disposition, and human merge authority; path-scoped no-review blocking is outside the terminal source-unavailability contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#discussion_r3614459375
+
+Disposition: NOT-A-BUG
+Evidence: .pre-commit-config.yaml:135; local pre-commit and pre-push pydocstyle gates passed at bcd25611498c335815d6c098f075335bf932e595
+Reason: CodeRabbit global docstring percentage is an advisory external metric, not the repository merge criterion; adding unrelated docstrings would widen this governance fix.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#issuecomment-5022466053
+
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/review_source_status.py:17; scripts/orchestration/review_source_status.py:140
+Reason: Sourcery returned only a terminal provider rate limit and no actionable finding; terminal rate_limited status is source-degraded but nonblocking and requires no manual retrigger.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#pullrequestreview-4735084156
+
+Disposition: NOT-A-BUG
+Evidence: scripts/run-backend-tests-pre-commit.sh:168; scripts/run-backend-tests-pre-commit.sh:211; tests/guards/test_review_source_quota_policy_guard.py:210
+Reason: This disposition covers only the outside-diff suggestion: canonical policy docs and schema intentionally select the anti-drift suite even without a Python change; the inline exact-body defect is separately FIXED.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#pullrequestreview-4735141129
+
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/pr_review_evidence.py:1086
+Reason: The executable condition already checks both the configured repository and exact bootstrap PR and the emitted diagnostic names both allowed identifiers; the suggested prose change does not alter or clarify runtime enforcement enough to justify material churn.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#pullrequestreview-4735782686
+
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/pr_review_evidence.py:1255; scripts/orchestration/pr_review_evidence.py:1303; scripts/orchestration/pr_review_evidence.py:1498
+Reason: The embedded seal is parsed through validate_review_seal before merge-readiness accesses quota_reference; the closed exact-key receipt validator requires the key and validates its string bounds, so a missing key fails with ReviewEvidenceError before this branch.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#pullrequestreview-4736518169
+
+Disposition: NOT-A-BUG
+Evidence: AGENTS.md:204; AGENTS.md:239; git merge-base --is-ancestor proved 627b113f090f31ff5b0c86bc99e3c9dc183d719e reachable from sealed material head bcd25611498c335815d6c098f075335bf932e595, which is itself a live PR commit
+Reason: The finding compares valid live-graph proof commits against a non-live synthetic execution ref a9b4eee; GitHub and local ancestry both prove the mapped SHAs are reachable from the sealed material head and its mapping-only descendants.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#discussion_r3615577692
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"authority":"trusted_codex_review_source_unavailability","binding_kind":"seal_context_only","blocking":false,"fallback_required":false,"material_digest":"sha256:b00e9bec133b041510a1682fa7267a2db3d458425b2d129ef632593a2e8b8171","material_head_sha":"bcd25611498c335815d6c098f075335bf932e595","quota_body_sha256":"sha256:e39b189a2ed6388c9d919876a2893ca0216a023301e11d788df190b4366991b9","quota_created_at":"2026-07-20T15:29:26Z","quota_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2165#issuecomment-5024013178","review_claim":"none","schema_version":"pulseplate.codex-review-source-unavailability/v1","source":"codex_review","source_degraded":true,"source_status":"usage_limit_reached","status":"tooling_unavailable"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:5a61c919169bac51b90129d745f71cab5017f1c52409f9012fe57ed6962df334","findings_sha256":"sha256:f35f0f024b7f53d00f071e11c71c9c41bb62c6643180bd87ca33d3f44b44f2af","work_ledger_sha256":"sha256:5c991a0afca876c6810a87ee42290c6ef6b79716958829d888057336de32c371"},"authority":"human_asserted_content_receipt","base_revision":"b9d637c2f89cea1faae9fbd19ed3489ea9bf5a1b","coverage_completeness":"complete","findings_count":0,"head_revision":"bcd25611498c335815d6c098f075335bf932e595","manifest_sha256":"sha256:1b6c3954c6aa402ae4c6afa448435fceac4fc3867a9cfe1a7e1e06dd076955c6","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"178ee7a3-8447-4819-9f0a-27f4c35b8593","snapshot_digest":"codex-security-snapshot/v1:sha256:dcb345fe0a93bdc55af6b9ec9bfdc483d5a3fddf48304460699d55de2927f411"},"material":{"base_ref_oid":"b9d637c2f89cea1faae9fbd19ed3489ea9bf5a1b","digest":"sha256:b00e9bec133b041510a1682fa7267a2db3d458425b2d129ef632593a2e8b8171","material_head_sha":"bcd25611498c335815d6c098f075335bf932e595","merge_base_sha":"b9d637c2f89cea1faae9fbd19ed3489ea9bf5a1b","policy_version":"pulseplate.material-classification/v1"},"pr_number":2165,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -49,15 +49,18 @@ from scripts.orchestration.pr_commit_identity import (  # noqa: E402
     fetch_review_threads,
     is_ancestor,
     verify_codex_review_reference,
+    verify_codex_review_source_unavailability_reference,
     verify_review_credit_outage_references,
     verify_security_outage_override_reference,
 )
 from scripts.orchestration.pr_review_evidence import (  # noqa: E402
     ReviewEvidenceError,
     build_review_credit_outage_receipt,
+    build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
     is_review_credit_outage_receipt,
+    is_review_source_unavailability_receipt,
     is_security_outage_override_receipt,
     parse_embedded_review_seal,
     validate_review_credit_outage_scope,
@@ -622,9 +625,6 @@ def _validate_v1_seal(
         or material["digest"] != manifest.digest
     ):
         raise ReviewEvidenceError("review seal does not match the live material digest")
-    review_prefix = f"https://github.com/{repository}/pull/{pr_number}#"
-    if not seal["code_review"]["review_reference"].startswith(review_prefix):
-        raise ReviewEvidenceError("code-review reference belongs to another PR")
     material_head = classify_commit_ref(material["material_head_sha"], snapshot, token=token)
     if not isinstance(material_head, RepositoryCommitRef) or material_head.kind not in {
         CommitRefKind.PR_HEAD,
@@ -632,7 +632,27 @@ def _validate_v1_seal(
     }:
         raise ReviewEvidenceError("material head is not a real commit in the live PR")
     code_review = seal["code_review"]
-    if is_review_credit_outage_receipt(code_review):
+    if is_review_source_unavailability_receipt(code_review):
+        source_evidence = verify_codex_review_source_unavailability_reference(
+            code_review["quota_reference"],
+            repository=repository,
+            pr_number=pr_number,
+            token=token,
+        )
+        expected_code_review = build_review_source_unavailability_receipt(
+            material_digest=material["digest"],
+            material_head_sha=material_head.sha,
+            quota_reference=source_evidence.reference,
+            quota_created_at=source_evidence.created_at,
+            quota_body_sha256=source_evidence.body_sha256,
+            source_status=source_evidence.source_status,
+        )
+        if code_review != expected_code_review:
+            raise ReviewEvidenceError("Codex review-source unavailability receipt is stale")
+    elif is_review_credit_outage_receipt(code_review):
+        review_prefix = f"https://github.com/{repository}/pull/{pr_number}#"
+        if not code_review["review_reference"].startswith(review_prefix):
+            raise ReviewEvidenceError("code-review reference belongs to another PR")
         validate_review_credit_outage_scope(
             repository=repository,
             pr_number=pr_number,
@@ -669,6 +689,9 @@ def _validate_v1_seal(
         if code_review != expected_code_review:
             raise ReviewEvidenceError("Codex review credit-outage receipt is stale")
     else:
+        review_prefix = f"https://github.com/{repository}/pull/{pr_number}#"
+        if not code_review["review_reference"].startswith(review_prefix):
+            raise ReviewEvidenceError("code-review reference belongs to another PR")
         review_evidence = verify_codex_review_reference(
             code_review["review_reference"],
             repository=repository,
@@ -1031,7 +1054,9 @@ def main() -> int:
     print("merge-readiness-gate: passed (review governance only).")
     if seal is not None:
         print(f"CONTENT_BOUND_RECEIPT_VALID {seal['material']['digest']}")
-        if is_review_credit_outage_receipt(seal["code_review"]):
+        if is_review_source_unavailability_receipt(seal["code_review"]):
+            print("REVIEW_SOURCE_UNAVAILABLE_VALID " f"{seal['code_review']['source_status']}")
+        elif is_review_credit_outage_receipt(seal["code_review"]):
             print(
                 "REVIEW_CREDIT_OUTAGE_OVERRIDE_VALID " f"{seal['code_review']['review_commit_ref']}"
             )

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -633,6 +633,16 @@ def _validate_v1_seal(
         raise ReviewEvidenceError("material head is not a real commit in the live PR")
     code_review = seal["code_review"]
     if is_review_source_unavailability_receipt(code_review):
+        unavailable_manifest = compute_material_manifest(
+            REPO_ROOT,
+            base_ref_oid=snapshot.base_sha,
+            head_ref_oid=material_head.sha,
+            pr_number=pr_number,
+        )
+        if unavailable_manifest.digest != material["digest"]:
+            raise ReviewEvidenceError(
+                "review-source unavailable material head has a different material digest"
+            )
         source_evidence = verify_codex_review_source_unavailability_reference(
             code_review["quota_reference"],
             repository=repository,

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -8,6 +8,7 @@ real commits in the live pull-request snapshot.
 
 from __future__ import annotations
 
+import hashlib
 import http.client
 import json
 import re
@@ -16,6 +17,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Mapping
+
+from scripts.orchestration.review_source_status import (
+    classify_codex_review_source_unavailability_body,
+)
 
 _API_HOST = "api.github.com"
 _API_ROOT = f"https://{_API_HOST}"
@@ -55,24 +60,6 @@ _CODEX_SECURITY_OUTAGE_MESSAGE = "Request timed out"
 _CODEX_SECURITY_OUTAGE_STATUS = "TOOLING_UNAVAILABLE"
 _CODEX_SECURITY_OUTAGE_TTL = timedelta(hours=24)
 _CODEX_SECURITY_OUTAGE_CLOCK_SKEW = timedelta(minutes=5)
-_CODEX_REVIEW_CREDIT_OUTAGE_BODIES = frozenset(
-    {
-        (
-            "Codex usage limits have been reached for code reviews. "
-            "Please check with the admins of this repo to increase the limits by adding credits."
-        ),
-        (
-            "Codex usage limits have been reached for code reviews. "
-            "Please check with the admins of this repo to increase the limits by adding credits.\n"
-            "Credits must be used to enable repository wide code reviews."
-        ),
-        (
-            "You have reached your Codex usage limits for code reviews. "
-            "You can see your limits in the "
-            "[Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage)."
-        ),
-    }
-)
 _CODEX_REVIEW_CREDIT_OUTAGE_TTL = timedelta(hours=24)
 _CODEX_REVIEW_CREDIT_OUTAGE_CLOCK_SKEW = timedelta(minutes=5)
 _OPERATOR_EXACT_HEAD_REVIEW_PREFIX = "Exact-head bounded review completed for"
@@ -172,6 +159,16 @@ class CodexReviewEvidence:
     reference: str
     submitted_at: str
     commit_ref: str
+
+
+@dataclass(frozen=True)
+class CodexReviewSourceUnavailabilityEvidence:
+    """Immutable trusted Codex evidence that the review source was unavailable."""
+
+    reference: str
+    created_at: str
+    source_status: str
+    body_sha256: str
 
 
 @dataclass(frozen=True)
@@ -537,6 +534,58 @@ def _trusted_codex_app_comment(
     return body, created_at, updated_at
 
 
+def verify_codex_review_source_unavailability_reference(
+    reference: str,
+    *,
+    repository: str,
+    pr_number: int,
+    token: str,
+    request_json: ApiRequest = github_api_request,
+) -> CodexReviewSourceUnavailabilityEvidence:
+    """Prove one immutable same-PR trusted Codex quota response.
+
+    The evidence proves only that the configured review source was unavailable
+    at the recorded attempt. It does not claim a review or no-findings result.
+    """
+
+    owner, name = _require_repository(repository)
+    if pr_number <= 0:
+        raise CommitIdentityError("pr_number must be positive")
+    pattern = re.compile(
+        rf"^https://github\.com/{re.escape(owner)}/{re.escape(name)}/pull/"
+        rf"{pr_number}#issuecomment-(\d+)$"
+    )
+    match = pattern.fullmatch(reference)
+    if not match:
+        raise CommitIdentityError(
+            "review-source unavailability evidence must be a GitHub issue comment "
+            "on the exact PR"
+        )
+    response = request_json(
+        f"{_API_ROOT}/repos/{owner}/{name}/issues/comments/{match.group(1)}",
+        token=token,
+    )
+    if not isinstance(response, dict) or response.get("id") != int(match.group(1)):
+        raise CommitIdentityError(
+            "review-source unavailability comment id does not match its canonical URL"
+        )
+    body, created_at, _updated_at = _trusted_codex_app_comment(
+        response,
+        reference=reference,
+        expected_issue_url=f"{_API_ROOT}/repos/{owner}/{name}/issues/{pr_number}",
+    )
+    try:
+        source_status = classify_codex_review_source_unavailability_body(body)
+    except ValueError as exc:
+        raise CommitIdentityError(str(exc)) from exc
+    return CodexReviewSourceUnavailabilityEvidence(
+        reference=reference,
+        created_at=created_at,
+        source_status=source_status,
+        body_sha256="sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest(),
+    )
+
+
 def verify_review_credit_outage_references(
     *,
     override_reference: str,
@@ -588,8 +637,12 @@ def verify_review_credit_outage_references(
         reference=quota_reference,
         expected_issue_url=f"{_API_ROOT}/repos/{owner}/{name}/issues/{pr_number}",
     )
-    if quota_body not in _CODEX_REVIEW_CREDIT_OUTAGE_BODIES:
-        raise CommitIdentityError("Codex comment is not an exact review-credit outage response")
+    try:
+        classify_codex_review_source_unavailability_body(quota_body)
+    except ValueError as exc:
+        raise CommitIdentityError(
+            "Codex comment is not an exact review-credit outage response"
+        ) from exc
 
     current = now or datetime.now(timezone.utc)
     if current.tzinfo is None:

--- a/scripts/orchestration/pr_review_closeout.py
+++ b/scripts/orchestration/pr_review_closeout.py
@@ -756,6 +756,16 @@ def validate_live_mapping(*, repository: str, pr_number: int, token: str | None)
         raise CloseoutError("sealed material head is not a real live PR commit")
     code_review = seal["code_review"]
     if is_review_source_unavailability_receipt(code_review):
+        unavailable_manifest = compute_material_manifest(
+            REPO_ROOT,
+            base_ref_oid=snapshot.base_sha,
+            head_ref_oid=material_head.sha,
+            pr_number=pr_number,
+        )
+        if unavailable_manifest.digest != material["digest"]:
+            raise CloseoutError(
+                "review-source unavailable material head has a different material digest"
+            )
         source_evidence = verify_codex_review_source_unavailability_reference(
             code_review["quota_reference"],
             repository=repository,

--- a/scripts/orchestration/pr_review_closeout.py
+++ b/scripts/orchestration/pr_review_closeout.py
@@ -32,6 +32,7 @@ from scripts.orchestration.pr_commit_identity import (  # noqa: E402
     fetch_pr_snapshot,
     is_ancestor,
     verify_codex_review_reference,
+    verify_codex_review_source_unavailability_reference,
     verify_review_credit_outage_references,
     verify_security_outage_override_reference,
 )
@@ -42,10 +43,12 @@ from scripts.orchestration.pr_review_evidence import (  # noqa: E402
     UNAVAILABLE_REVIEW_REF_CAUSE,
     ReviewEvidenceError,
     build_review_credit_outage_receipt,
+    build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
     ingest_codex_security_receipt,
     is_review_credit_outage_receipt,
+    is_review_source_unavailability_receipt,
     is_security_outage_override_receipt,
     parse_embedded_review_seal,
     render_embedded_review_seal,
@@ -581,60 +584,29 @@ def _cmd_seal(args: argparse.Namespace) -> None:
     }
     if freeze != expected_freeze:
         raise CloseoutError("material state changed after freeze; freeze and review again")
-    review_ref = _required_line(args.review_ref, label="review-ref")
-    review_prefix = f"https://github.com/{args.repo}/pull/{args.pr_number}#"
-    if not review_ref.startswith(review_prefix):
-        raise CloseoutError("review-ref must identify the requested GitHub PR")
-    if args.review_credit_outage_ref:
-        quota_ref = _required_line(
-            args.review_credit_quota_ref,
-            label="review-credit-quota-ref",
-        )
-        validate_review_credit_outage_scope(
-            repository=args.repo,
-            pr_number=args.pr_number,
-            material_paths=(entry.path for entry in manifest.entries),
-        )
-        credit_evidence = verify_review_credit_outage_references(
-            override_reference=_required_line(
-                args.review_credit_outage_ref,
-                label="review-credit-outage-ref",
+    if args.review_source_unavailable_ref:
+        source_evidence = verify_codex_review_source_unavailability_reference(
+            _required_line(
+                args.review_source_unavailable_ref,
+                label="review-source-unavailable-ref",
             ),
-            quota_reference=quota_ref,
-            prior_review_reference=_required_line(
-                args.prior_codex_review_ref,
-                label="prior-codex-review-ref",
-            ),
-            operator_review_reference=review_ref,
             repository=args.repo,
             pr_number=args.pr_number,
             token=token,
-            snapshot=snapshot,
-            expected_material_head_sha=snapshot.head_sha,
-            expected_material_digest=manifest.digest,
         )
-        code_review_receipt = build_review_credit_outage_receipt(
+        code_review_receipt = build_review_source_unavailability_receipt(
             material_digest=manifest.digest,
             material_head_sha=snapshot.head_sha,
-            override_reference=credit_evidence.override_reference,
-            override_created_at=credit_evidence.override_created_at,
-            quota_reference=credit_evidence.quota_reference,
-            quota_created_at=credit_evidence.quota_created_at,
-            prior_review_reference=credit_evidence.prior_review_reference,
-            prior_review_submitted_at=credit_evidence.prior_review_submitted_at,
-            prior_review_commit_ref=credit_evidence.prior_review_commit_ref,
-            operator_review_reference=credit_evidence.operator_review_reference,
-            operator_review_submitted_at=credit_evidence.operator_review_submitted_at,
-            operator_user_id=credit_evidence.operator_user_id,
-            operator_login=credit_evidence.operator_login,
-            operator_association=credit_evidence.operator_association,
+            quota_reference=source_evidence.reference,
+            quota_created_at=source_evidence.created_at,
+            quota_body_sha256=source_evidence.body_sha256,
+            source_status=source_evidence.source_status,
         )
     else:
-        if args.review_credit_quota_ref or args.prior_codex_review_ref:
-            raise CloseoutError(
-                "--review-credit-quota-ref and --prior-codex-review-ref require "
-                "--review-credit-outage-ref"
-            )
+        review_ref = _required_line(args.review_ref, label="review-ref")
+        review_prefix = f"https://github.com/{args.repo}/pull/{args.pr_number}#"
+        if not review_ref.startswith(review_prefix):
+            raise CloseoutError("review-ref must identify the requested GitHub PR")
         review_evidence = verify_codex_review_reference(
             review_ref,
             repository=args.repo,
@@ -783,11 +755,28 @@ def validate_live_mapping(*, repository: str, pr_number: int, token: str | None)
     }:
         raise CloseoutError("sealed material head is not a real live PR commit")
     code_review = seal["code_review"]
-    review_prefix = f"https://github.com/{repository}/pull/{pr_number}#"
-    review_reference = code_review["review_reference"]
-    if not review_reference.startswith(review_prefix):
-        raise CloseoutError("code-review reference belongs to another PR")
-    if is_review_credit_outage_receipt(code_review):
+    if is_review_source_unavailability_receipt(code_review):
+        source_evidence = verify_codex_review_source_unavailability_reference(
+            code_review["quota_reference"],
+            repository=repository,
+            pr_number=pr_number,
+            token=token,
+        )
+        expected_code_review = build_review_source_unavailability_receipt(
+            material_digest=material["digest"],
+            material_head_sha=material_head.sha,
+            quota_reference=source_evidence.reference,
+            quota_created_at=source_evidence.created_at,
+            quota_body_sha256=source_evidence.body_sha256,
+            source_status=source_evidence.source_status,
+        )
+        if code_review != expected_code_review:
+            raise CloseoutError("Codex review-source unavailability receipt is stale")
+    elif is_review_credit_outage_receipt(code_review):
+        review_prefix = f"https://github.com/{repository}/pull/{pr_number}#"
+        review_reference = code_review["review_reference"]
+        if not review_reference.startswith(review_prefix):
+            raise CloseoutError("code-review reference belongs to another PR")
         validate_review_credit_outage_scope(
             repository=repository,
             pr_number=pr_number,
@@ -824,6 +813,10 @@ def validate_live_mapping(*, repository: str, pr_number: int, token: str | None)
         if code_review != expected_code_review:
             raise CloseoutError("Codex review credit-outage receipt is stale")
     else:
+        review_prefix = f"https://github.com/{repository}/pull/{pr_number}#"
+        review_reference = code_review["review_reference"]
+        if not review_reference.startswith(review_prefix):
+            raise CloseoutError("code-review reference belongs to another PR")
         review_evidence = verify_codex_review_reference(
             review_reference,
             repository=repository,
@@ -931,10 +924,9 @@ def _parser() -> argparse.ArgumentParser:
     seal = subparsers.add_parser("seal")
     seal.add_argument("--repo", required=True)
     seal.add_argument("--pr-number", required=True, type=int)
-    seal.add_argument("--review-ref", required=True)
-    seal.add_argument("--review-credit-outage-ref")
-    seal.add_argument("--review-credit-quota-ref")
-    seal.add_argument("--prior-codex-review-ref")
+    review_evidence = seal.add_mutually_exclusive_group(required=True)
+    review_evidence.add_argument("--review-ref")
+    review_evidence.add_argument("--review-source-unavailable-ref")
     security_evidence = seal.add_mutually_exclusive_group(required=True)
     security_evidence.add_argument("--scan-manifest")
     security_evidence.add_argument("--security-outage-override-ref")

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -1086,7 +1086,7 @@ def is_review_credit_outage_receipt(receipt: Any) -> bool:
 def validate_review_credit_outage_scope(
     *, repository: str, pr_number: int, material_paths: Iterable[str]
 ) -> None:
-    """Prevent later review-governance changes from authorizing themselves."""
+    """Keep the historical credit-outage receipt live-valid only for PR #2142."""
 
     touched = sorted(
         {
@@ -1096,17 +1096,19 @@ def validate_review_credit_outage_scope(
             or path.startswith(REVIEW_CREDIT_OUTAGE_TRUST_BOUNDARY_PREFIXES)
         }
     )
-    if not touched:
-        return
     is_bootstrap = (
         repository.casefold() == REVIEW_CREDIT_OUTAGE_BOOTSTRAP_REPOSITORY.casefold()
         and pr_number == REVIEW_CREDIT_OUTAGE_BOOTSTRAP_PR
     )
-    if not is_bootstrap:
-        raise ReviewEvidenceError(
-            "Codex review credit-outage override cannot authorize trust-boundary changes: "
-            + ", ".join(touched)
-        )
+    if is_bootstrap:
+        return
+    touched_suffix = " Material paths: " + ", ".join(touched) + "." if touched else ""
+    raise ReviewEvidenceError(
+        "Historical Codex review credit-outage receipts are live-valid only for "
+        f"{REVIEW_CREDIT_OUTAGE_BOOTSTRAP_REPOSITORY} PR "
+        f"#{REVIEW_CREDIT_OUTAGE_BOOTSTRAP_PR}; later PRs cannot authenticate "
+        f"the legacy receipt.{touched_suffix}"
+    )
 
 
 def is_security_outage_override_receipt(receipt: Any) -> bool:

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -19,6 +19,11 @@ from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping
 
+from scripts.orchestration.review_source_status import (
+    TERMINAL_NONBLOCKING_STATUSES,
+    review_source_policy_projection,
+)
+
 MATERIAL_SCHEMA_VERSION = "pulseplate.material-diff/v1"
 MATERIAL_POLICY_VERSION = "pulseplate.material-classification/v1"
 MATERIAL_DOMAIN = b"pulseplate-material-diff/v1\0"
@@ -37,6 +42,9 @@ REVIEW_CREDIT_OUTAGE_AUTHORITY = "operator_review_credit_exhaustion_override"
 REVIEW_CREDIT_OUTAGE_CLASS = "codex_review_credits_exhausted"
 REVIEW_CREDIT_OUTAGE_BOOTSTRAP_REPOSITORY = "Katsiarynakavaleuskaya/PulsePlate"
 REVIEW_CREDIT_OUTAGE_BOOTSTRAP_PR = 2142
+REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION = "pulseplate.codex-review-source-unavailability/v1"
+REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY = "trusted_codex_review_source_unavailability"
+REVIEW_SOURCE_UNAVAILABILITY_SOURCE = "codex_review"
 OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS = frozenset(
     {
         ".bandit",
@@ -1023,6 +1031,52 @@ def build_review_credit_outage_receipt(
     return receipt
 
 
+def build_review_source_unavailability_receipt(
+    *,
+    material_digest: str,
+    material_head_sha: str,
+    quota_reference: str,
+    quota_created_at: str,
+    quota_body_sha256: str,
+    source_status: str,
+) -> dict[str, Any]:
+    """Build a material-context receipt for one trusted terminal quota response."""
+
+    policy = review_source_policy_projection()
+    terminal = policy["terminal_unavailability"]
+    if not isinstance(terminal, dict):
+        raise ReviewEvidenceError("review-source policy projection is malformed")
+    receipt = {
+        "authority": REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY,
+        "binding_kind": "seal_context_only",
+        "blocking": terminal["blocking"],
+        "fallback_required": terminal["fallback_required"],
+        "material_digest": material_digest,
+        "material_head_sha": material_head_sha,
+        "quota_body_sha256": quota_body_sha256,
+        "quota_created_at": quota_created_at,
+        "quota_reference": quota_reference,
+        "review_claim": terminal["review_claim"],
+        "schema_version": REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION,
+        "source": REVIEW_SOURCE_UNAVAILABILITY_SOURCE,
+        "source_degraded": terminal["source_degraded"],
+        "source_status": source_status,
+        "status": "tooling_unavailable",
+    }
+    _validate_code_review_receipt(receipt, material_digest=material_digest)
+    return receipt
+
+
+def is_review_source_unavailability_receipt(receipt: Any) -> bool:
+    """Return whether code-review evidence uses the tagged quota variant."""
+
+    return (
+        isinstance(receipt, dict)
+        and receipt.get("schema_version") == REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION
+        and receipt.get("authority") == REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY
+    )
+
+
 def is_review_credit_outage_receipt(receipt: Any) -> bool:
     """Return whether code-review evidence uses the credit-outage variant."""
 
@@ -1191,6 +1245,67 @@ def _validate_security_receipt(receipt: Any) -> None:
 def _validate_code_review_receipt(receipt: Any, *, material_digest: str) -> None:
     if not isinstance(receipt, dict):
         raise ReviewEvidenceError("review seal code_review must be an object")
+    has_source_schema = receipt.get("schema_version") == REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION
+    has_source_authority = receipt.get("authority") == REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY
+    if has_source_schema != has_source_authority:
+        raise ReviewEvidenceError("review seal code_review tagged-union identity is ambiguous")
+    if has_source_schema:
+        _require_exact_keys(
+            receipt,
+            {
+                "authority",
+                "binding_kind",
+                "blocking",
+                "fallback_required",
+                "material_digest",
+                "material_head_sha",
+                "quota_body_sha256",
+                "quota_created_at",
+                "quota_reference",
+                "review_claim",
+                "schema_version",
+                "source",
+                "source_degraded",
+                "source_status",
+                "status",
+            },
+            label="review seal code_review source unavailability",
+        )
+        _require_sha(
+            receipt["material_head_sha"],
+            label="code_review.material_head_sha",
+        )
+        _require_digest(
+            receipt["material_digest"],
+            label="code_review.material_digest",
+        )
+        _require_digest(
+            receipt["quota_body_sha256"],
+            label="code_review.quota_body_sha256",
+        )
+        _parse_timestamp(
+            receipt["quota_created_at"],
+            label="code_review.quota_created_at",
+        )
+        if (
+            receipt["material_digest"] != material_digest
+            or receipt["source"] != REVIEW_SOURCE_UNAVAILABILITY_SOURCE
+            or not isinstance(receipt["source_status"], str)
+            or receipt["source_status"] not in TERMINAL_NONBLOCKING_STATUSES
+            or receipt["status"] != "tooling_unavailable"
+            or receipt["binding_kind"] != "seal_context_only"
+            or receipt["review_claim"] != "none"
+            or receipt["source_degraded"] is not True
+            or receipt["fallback_required"] is not False
+            or receipt["blocking"] is not False
+            or not isinstance(receipt["quota_reference"], str)
+            or not 1 <= len(receipt["quota_reference"]) <= 500
+            or any(ord(ch) < 32 for ch in receipt["quota_reference"])
+        ):
+            raise ReviewEvidenceError(
+                "review seal code_review source unavailability is malformed or stale"
+            )
+        return
     if is_review_credit_outage_receipt(receipt):
         _require_exact_keys(
             receipt,
@@ -1334,6 +1449,12 @@ def validate_review_seal(seal: Any) -> dict[str, Any]:
         raise ReviewEvidenceError("review seal material policy version is unsupported")
     code_review = seal["code_review"]
     _validate_code_review_receipt(code_review, material_digest=material_digest)
+    if is_review_source_unavailability_receipt(code_review) and (
+        code_review["material_head_sha"] != material["material_head_sha"]
+    ):
+        raise ReviewEvidenceError(
+            "review-source unavailability receipt does not match sealed material head"
+        )
     _validate_security_receipt(seal["codex_security"])
     if (
         seal["codex_security"]["base_revision"] != material["merge_base_sha"]

--- a/scripts/orchestration/review_source_status.py
+++ b/scripts/orchestration/review_source_status.py
@@ -10,6 +10,8 @@ import argparse
 from dataclasses import asdict, dataclass
 import json
 import re
+from types import MappingProxyType
+from typing import Mapping
 
 DEGRADED_STATUSES = frozenset(
     {"degraded", "unavailable", "rate_limited", "usage_limit_reached", "auth_missing", "partial"}
@@ -18,6 +20,26 @@ BLOCKING_STATUSES = frozenset(
     {"fallback_finding", "failed_required_check", "unresolved_threads", "actionable_bot_comments"}
 )
 REVIEW_SOURCE_STATUSES = frozenset({"available"}) | DEGRADED_STATUSES | BLOCKING_STATUSES
+REVIEW_SOURCE_POLICY_VERSION = "pulseplate.review-source-policy/v1"
+TERMINAL_NONBLOCKING_STATUSES = frozenset({"rate_limited", "usage_limit_reached"})
+_CODEX_REVIEW_SOURCE_UNAVAILABILITY_BODY_STATUSES: Mapping[str, str] = MappingProxyType(
+    {
+        (
+            "Codex usage limits have been reached for code reviews. "
+            "Please check with the admins of this repo to increase the limits by adding credits."
+        ): "usage_limit_reached",
+        (
+            "Codex usage limits have been reached for code reviews. "
+            "Please check with the admins of this repo to increase the limits by adding credits.\n"
+            "Credits must be used to enable repository wide code reviews."
+        ): "usage_limit_reached",
+        (
+            "You have reached your Codex usage limits for code reviews. "
+            "You can see your limits in the "
+            "[Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage)."
+        ): "usage_limit_reached",
+    }
+)
 _SECRETISH_RE = re.compile(
     r"(?i)(github_pat_[a-z0-9_]+|gh[opsru]_[a-z0-9_]+|ghp_[a-z0-9_]+|"
     r"ghs_[a-z0-9_.-]+|sk-[a-z0-9_-]+|"
@@ -41,6 +63,40 @@ class ReviewSourceStatus:
     blocking: bool
     reason: str
     evidence: str
+
+
+def review_source_policy_projection() -> dict[str, object]:
+    """Return the versioned, machine-checkable review-source policy."""
+
+    return {
+        "blocking_statuses": sorted(BLOCKING_STATUSES),
+        "policy_version": REVIEW_SOURCE_POLICY_VERSION,
+        "terminal_nonblocking_statuses": sorted(TERMINAL_NONBLOCKING_STATUSES),
+        "terminal_unavailability": {
+            "blocking": False,
+            "fallback_required": False,
+            "operator_override_required": False,
+            "prior_review_required": False,
+            "retry_required": False,
+            "review_claim": "none",
+            "source_degraded": True,
+            "substitute_review_required": False,
+            "ttl_required": False,
+        },
+    }
+
+
+def classify_codex_review_source_unavailability_body(body: str) -> str:
+    """Map an exact trusted Codex quota body to its closed source status."""
+
+    if not isinstance(body, str):
+        raise ValueError("Codex review-source response body must be a string")
+    try:
+        return _CODEX_REVIEW_SOURCE_UNAVAILABILITY_BODY_STATUSES[body]
+    except KeyError as exc:
+        raise ValueError(
+            "Codex review-source response is not an exact known quota response"
+        ) from exc
 
 
 def redact_review_source_text(value: str) -> str:
@@ -83,7 +139,8 @@ def build_review_source_status(
             source=source,
             status=normalized_status,
             source_degraded=source_degraded,
-            fallback_required=source_degraded or source_blocking,
+            fallback_required=source_blocking
+            or (source_degraded and normalized_status not in TERMINAL_NONBLOCKING_STATUSES),
             blocking=source_blocking,
             reason=redacted_reason,
             evidence=redacted_evidence,

--- a/scripts/orchestration/review_source_status.py
+++ b/scripts/orchestration/review_source_status.py
@@ -129,6 +129,8 @@ def build_review_source_status(
     if normalized_status not in REVIEW_SOURCE_STATUSES:
         allowed = ", ".join(sorted(REVIEW_SOURCE_STATUSES))
         raise ValueError(f"status must be one of: {allowed}.")
+    if normalized_status in TERMINAL_NONBLOCKING_STATUSES and blocking:
+        raise ValueError("terminal review-source unavailability cannot be marked blocking")
     source_degraded = degraded or normalized_status in DEGRADED_STATUSES
     source_blocking = blocking or normalized_status in BLOCKING_STATUSES
     redacted_reason = redact_review_source_text(reason)

--- a/scripts/orchestration/review_source_status.py
+++ b/scripts/orchestration/review_source_status.py
@@ -38,6 +38,14 @@ _CODEX_REVIEW_SOURCE_UNAVAILABILITY_BODY_STATUSES: Mapping[str, str] = MappingPr
             "You can see your limits in the "
             "[Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage)."
         ): "usage_limit_reached",
+        (
+            "You have reached your Codex usage limits for code reviews. "
+            "You can see your limits in the "
+            "[Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).\n"
+            "To continue using code reviews, add credits to your account and enable them "
+            "for code reviews in your "
+            "[settings](https://chatgpt.com/codex/cloud/settings/code-review)."
+        ): "usage_limit_reached",
     }
 )
 _SECRETISH_RE = re.compile(

--- a/scripts/run-backend-tests-pre-commit.sh
+++ b/scripts/run-backend-tests-pre-commit.sh
@@ -213,7 +213,7 @@ add_extra_tests_for_changed_files() {
                 break
             fi
         done
-    done <<< "$CHANGED_FILES"
+    done < <(printf '%s\n' "$CHANGED_FILES")
 }
 
 add_extra_tests_for_changed_files
@@ -332,7 +332,7 @@ if [ -n "$PYTHON_CHANGES" ]; then
         if [ ${#FOUND_FOR_FILE[@]} -gt 0 ]; then
             TEST_FILES+=("${FOUND_FOR_FILE[@]}")
         fi
-    done <<< "$PYTHON_CHANGES"
+    done < <(printf '%s\n' "$PYTHON_CHANGES")
 fi
 
 if [ ${#EXTRA_TEST_FILES[@]} -gt 0 ]; then

--- a/scripts/run-backend-tests-pre-commit.sh
+++ b/scripts/run-backend-tests-pre-commit.sh
@@ -165,6 +165,19 @@ declare -a PYTHON_DEPENDENCY_TESTCLIENT_SURFACE_FILES=(
     "tests/test_httpx_testclient_compat_guard.py"
     "tests/test_python_supply_chain_controls.py"
 )
+declare -a REVIEW_SOURCE_QUOTA_POLICY_SURFACE_FILES=(
+    "AGENTS.md"
+    "RUNBOOK_AGENT.md"
+    "docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md"
+    "docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md"
+    "scripts/ci/check_pr_merge_readiness.py"
+    "scripts/orchestration/pr_commit_identity.py"
+    "scripts/orchestration/pr_review_closeout.py"
+    "scripts/orchestration/pr_review_evidence.py"
+    "scripts/orchestration/review_source_status.py"
+    "scripts/run-backend-tests-pre-commit.sh"
+    "tests/guards/test_review_source_quota_policy_guard.py"
+)
 
 add_python_dependency_testclient_tests() {
     # CI lint runs the pre-commit hook from the ci-lite dependency profile,
@@ -191,6 +204,12 @@ add_extra_tests_for_changed_files() {
         for dependency_file in "${PYTHON_DEPENDENCY_TESTCLIENT_SURFACE_FILES[@]}"; do
             if [ "$file" = "$dependency_file" ]; then
                 add_python_dependency_testclient_tests
+                break
+            fi
+        done
+        for policy_file in "${REVIEW_SOURCE_QUOTA_POLICY_SURFACE_FILES[@]}"; do
+            if [ "$file" = "$policy_file" ]; then
+                EXTRA_TEST_FILES+=("tests/guards/test_review_source_quota_policy_guard.py")
                 break
             fi
         done

--- a/scripts/run-backend-tests-pre-commit.sh
+++ b/scripts/run-backend-tests-pre-commit.sh
@@ -170,6 +170,7 @@ declare -a REVIEW_SOURCE_QUOTA_POLICY_SURFACE_FILES=(
     "RUNBOOK_AGENT.md"
     "docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md"
     "docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md"
+    "docs/orchestration/contracts/review_source_status.v1.json"
     "scripts/ci/check_pr_merge_readiness.py"
     "scripts/orchestration/pr_commit_identity.py"
     "scripts/orchestration/pr_review_closeout.py"
@@ -210,6 +211,9 @@ add_extra_tests_for_changed_files() {
         for policy_file in "${REVIEW_SOURCE_QUOTA_POLICY_SURFACE_FILES[@]}"; do
             if [ "$file" = "$policy_file" ]; then
                 EXTRA_TEST_FILES+=("tests/guards/test_review_source_quota_policy_guard.py")
+                EXTRA_TEST_FILES+=("tests/test_review_source_status.py")
+                EXTRA_TEST_FILES+=("tests/test_pr_review_material_seal.py")
+                EXTRA_TEST_FILES+=("tests/test_pr_merge_readiness_gate.py")
                 break
             fi
         done

--- a/tests/guards/test_review_source_quota_policy_guard.py
+++ b/tests/guards/test_review_source_quota_policy_guard.py
@@ -31,6 +31,7 @@ POLICY_SURFACE_FILES = {
     "RUNBOOK_AGENT.md",
     "docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md",
     "docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md",
+    "docs/orchestration/contracts/review_source_status.v1.json",
     "scripts/ci/check_pr_merge_readiness.py",
     "scripts/orchestration/pr_commit_identity.py",
     "scripts/orchestration/pr_review_closeout.py",
@@ -38,6 +39,12 @@ POLICY_SURFACE_FILES = {
     "scripts/orchestration/review_source_status.py",
     "scripts/run-backend-tests-pre-commit.sh",
     "tests/guards/test_review_source_quota_policy_guard.py",
+}
+POLICY_SUITE_TEST_FILES = {
+    "tests/guards/test_review_source_quota_policy_guard.py",
+    "tests/test_pr_merge_readiness_gate.py",
+    "tests/test_pr_review_material_seal.py",
+    "tests/test_review_source_status.py",
 }
 
 
@@ -130,6 +137,14 @@ def test_known_codex_quota_bodies_remain_exact_terminal_evidence() -> None:
             "You can see your limits in the "
             "[Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage)."
         ),
+        (
+            "You have reached your Codex usage limits for code reviews. "
+            "You can see your limits in the "
+            "[Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).\n"
+            "To continue using code reviews, add credits to your account and enable them "
+            "for code reviews in your "
+            "[settings](https://chatgpt.com/codex/cloud/settings/code-review)."
+        ),
     )
     assert {classify_codex_review_source_unavailability_body(body) for body in bodies} == {
         "usage_limit_reached"
@@ -174,22 +189,37 @@ def test_authoritative_docs_keep_terminal_warning_only_contract() -> None:
         "docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md",
     )
     documents = {path: (REPO_ROOT / path).read_text(encoding="utf-8") for path in paths}
-    joined = "\n".join(documents.values())
-    normalized = " ".join(joined.split())
-    assert all(option not in joined for option in LEGACY_AUTHORING_OPTIONS)
-    assert all(
-        phrase not in normalized
-        for phrase in (
-            "requires a prior trusted Codex review",
-            "must name a subsequent exact-head",
-            "quota response must be current",
-            "All evidence must remain within its TTL",
-        )
+    contradictory_phrases = (
+        "requires a prior trusted Codex review",
+        "must name a subsequent exact-head",
+        "quota response must be current",
+        "All evidence must remain within its TTL",
     )
-    assert "No retry, substitute review, prior review, operator override, or TTL" in normalized
-    assert "`review_claim=none`" in joined
-    assert "Historical PR `#2142`" in joined
-    assert "not an active authoring" in joined
+    for path, document in documents.items():
+        normalized = " ".join(document.split())
+        normalized_casefold = normalized.casefold()
+        assert all(option not in document for option in LEGACY_AUTHORING_OPTIONS), path
+        assert all(phrase not in normalized for phrase in contradictory_phrases), path
+        for anchor in (
+            "source_degraded=true",
+            "fallback_required=false",
+            "blocking=false",
+            "review_claim=none",
+            "retry_required=false",
+            "substitute_review_required=false",
+            "prior_review_required=false",
+            "operator_override_required=false",
+            "ttl_required=false",
+        ):
+            assert anchor in document, f"{path}: missing {anchor}"
+        assert any(
+            marker in normalized_casefold
+            for marker in (
+                "no retry",
+                "do not retry",
+                "requires no retry",
+            )
+        ), f"{path}: missing terminal no-retry contract"
     runbook = documents["RUNBOOK_AGENT.md"]
     normalized_runbook = " ".join(runbook.split())
     assert "do not trigger or retrigger it manually" in normalized_runbook
@@ -201,10 +231,11 @@ def test_authoritative_docs_keep_terminal_warning_only_contract() -> None:
 def test_every_policy_surface_selects_this_guard_in_diff_validation() -> None:
     runner = (REPO_ROOT / "scripts/run-backend-tests-pre-commit.sh").read_text(encoding="utf-8")
     assert "declare -a REVIEW_SOURCE_QUOTA_POLICY_SURFACE_FILES=(" in runner
-    assert 'EXTRA_TEST_FILES+=("tests/guards/test_review_source_quota_policy_guard.py")' in runner
     assert 'done <<< "$CHANGED_FILES"' not in runner
     assert 'done <<< "$PYTHON_CHANGES"' not in runner
     assert "done < <(printf '%s\\n' \"$CHANGED_FILES\")" in runner
     assert "done < <(printf '%s\\n' \"$PYTHON_CHANGES\")" in runner
     for path in POLICY_SURFACE_FILES:
         assert f'"{path}"' in runner
+    for test_file in POLICY_SUITE_TEST_FILES:
+        assert f'EXTRA_TEST_FILES+=("{test_file}")' in runner

--- a/tests/guards/test_review_source_quota_policy_guard.py
+++ b/tests/guards/test_review_source_quota_policy_guard.py
@@ -202,5 +202,9 @@ def test_every_policy_surface_selects_this_guard_in_diff_validation() -> None:
     runner = (REPO_ROOT / "scripts/run-backend-tests-pre-commit.sh").read_text(encoding="utf-8")
     assert "declare -a REVIEW_SOURCE_QUOTA_POLICY_SURFACE_FILES=(" in runner
     assert 'EXTRA_TEST_FILES+=("tests/guards/test_review_source_quota_policy_guard.py")' in runner
+    assert 'done <<< "$CHANGED_FILES"' not in runner
+    assert 'done <<< "$PYTHON_CHANGES"' not in runner
+    assert "done < <(printf '%s\\n' \"$CHANGED_FILES\")" in runner
+    assert "done < <(printf '%s\\n' \"$PYTHON_CHANGES\")" in runner
     for path in POLICY_SURFACE_FILES:
         assert f'"{path}"' in runner

--- a/tests/guards/test_review_source_quota_policy_guard.py
+++ b/tests/guards/test_review_source_quota_policy_guard.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from scripts.orchestration import pr_review_closeout
 from scripts.orchestration.pr_review_evidence import (
     REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY,
     REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION,
+    ReviewEvidenceError,
     build_review_source_unavailability_receipt,
+    validate_review_credit_outage_scope,
 )
 from scripts.orchestration.review_source_status import (
+    build_review_source_status,
     classify_codex_review_source_unavailability_body,
     review_source_policy_projection,
 )
@@ -70,6 +75,41 @@ def test_terminal_quota_policy_projection_is_exact() -> None:
             "ttl_required": False,
         },
     }
+
+
+@pytest.mark.parametrize("status", ["rate_limited", "usage_limit_reached"])
+def test_terminal_quota_policy_cannot_be_overridden_to_blocking(status: str) -> None:
+    with pytest.raises(
+        ValueError,
+        match="terminal review-source unavailability cannot be marked blocking",
+    ):
+        build_review_source_status(
+            source="codex_review",
+            status=status,
+            blocking=True,
+        )
+
+
+def test_legacy_credit_override_is_live_valid_only_for_bootstrap_pr() -> None:
+    validate_review_credit_outage_scope(
+        repository="Katsiarynakavaleuskaya/PulsePlate",
+        pr_number=2142,
+        material_paths=("scripts/ci/check_pr_merge_readiness.py",),
+    )
+    for repository, pr_number, paths in (
+        (
+            "Katsiarynakavaleuskaya/PulsePlate",
+            2143,
+            ("requirements-test.txt",),
+        ),
+        ("owner/repo", 42, ()),
+    ):
+        with pytest.raises(ReviewEvidenceError, match="live-valid only.*PR #2142"):
+            validate_review_credit_outage_scope(
+                repository=repository,
+                pr_number=pr_number,
+                material_paths=paths,
+            )
 
 
 def test_known_codex_quota_bodies_remain_exact_terminal_evidence() -> None:

--- a/tests/guards/test_review_source_quota_policy_guard.py
+++ b/tests/guards/test_review_source_quota_policy_guard.py
@@ -1,0 +1,166 @@
+"""Anti-drift guard for terminal Codex review-source quota evidence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.orchestration import pr_review_closeout
+from scripts.orchestration.pr_review_evidence import (
+    REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY,
+    REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION,
+    build_review_source_unavailability_receipt,
+)
+from scripts.orchestration.review_source_status import (
+    classify_codex_review_source_unavailability_body,
+    review_source_policy_projection,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEGACY_AUTHORING_OPTIONS = {
+    "--prior-codex-review-ref",
+    "--review-credit-outage-ref",
+    "--review-credit-quota-ref",
+}
+POLICY_SURFACE_FILES = {
+    "AGENTS.md",
+    "RUNBOOK_AGENT.md",
+    "docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md",
+    "docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md",
+    "scripts/ci/check_pr_merge_readiness.py",
+    "scripts/orchestration/pr_commit_identity.py",
+    "scripts/orchestration/pr_review_closeout.py",
+    "scripts/orchestration/pr_review_evidence.py",
+    "scripts/orchestration/review_source_status.py",
+    "scripts/run-backend-tests-pre-commit.sh",
+    "tests/guards/test_review_source_quota_policy_guard.py",
+}
+
+
+def _seal_option_strings() -> set[str]:
+    parser = pr_review_closeout._parser()
+    subparsers_action = next(
+        action for action in parser._actions if isinstance(action.choices, dict)
+    )
+    seal_parser = subparsers_action.choices["seal"]
+    return {option for action in seal_parser._actions for option in action.option_strings}
+
+
+def test_terminal_quota_policy_projection_is_exact() -> None:
+    assert review_source_policy_projection() == {
+        "blocking_statuses": [
+            "actionable_bot_comments",
+            "failed_required_check",
+            "fallback_finding",
+            "unresolved_threads",
+        ],
+        "policy_version": "pulseplate.review-source-policy/v1",
+        "terminal_nonblocking_statuses": [
+            "rate_limited",
+            "usage_limit_reached",
+        ],
+        "terminal_unavailability": {
+            "blocking": False,
+            "fallback_required": False,
+            "operator_override_required": False,
+            "prior_review_required": False,
+            "retry_required": False,
+            "review_claim": "none",
+            "source_degraded": True,
+            "substitute_review_required": False,
+            "ttl_required": False,
+        },
+    }
+
+
+def test_known_codex_quota_bodies_remain_exact_terminal_evidence() -> None:
+    bodies = (
+        (
+            "Codex usage limits have been reached for code reviews. "
+            "Please check with the admins of this repo to increase the limits "
+            "by adding credits."
+        ),
+        (
+            "Codex usage limits have been reached for code reviews. "
+            "Please check with the admins of this repo to increase the limits "
+            "by adding credits.\n"
+            "Credits must be used to enable repository wide code reviews."
+        ),
+        (
+            "You have reached your Codex usage limits for code reviews. "
+            "You can see your limits in the "
+            "[Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage)."
+        ),
+    )
+    assert {classify_codex_review_source_unavailability_body(body) for body in bodies} == {
+        "usage_limit_reached"
+    }
+
+
+def test_closeout_exposes_only_current_review_authoring_modes() -> None:
+    options = _seal_option_strings()
+    assert {"--review-ref", "--review-source-unavailable-ref"} <= options
+    assert not options.intersection(LEGACY_AUTHORING_OPTIONS)
+    closeout_source = (REPO_ROOT / "scripts/orchestration/pr_review_closeout.py").read_text(
+        encoding="utf-8"
+    )
+    assert all(option not in closeout_source for option in LEGACY_AUTHORING_OPTIONS)
+
+
+def test_quota_receipt_authority_never_claims_review_or_blocking() -> None:
+    receipt = build_review_source_unavailability_receipt(
+        material_digest="sha256:" + "a" * 64,
+        material_head_sha="b" * 40,
+        quota_reference="https://github.com/owner/repo/pull/42#issuecomment-1",
+        quota_created_at="2020-01-01T00:00:00Z",
+        quota_body_sha256="sha256:" + "c" * 64,
+        source_status="usage_limit_reached",
+    )
+    assert receipt["schema_version"] == REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION
+    assert receipt["authority"] == REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY
+    assert receipt["binding_kind"] == "seal_context_only"
+    assert receipt["review_claim"] == "none"
+    assert receipt["source_degraded"] is True
+    assert receipt["fallback_required"] is False
+    assert receipt["blocking"] is False
+    assert "review_reference" not in receipt
+    assert "review_commit_ref" not in receipt
+
+
+def test_authoritative_docs_keep_terminal_warning_only_contract() -> None:
+    paths = (
+        "AGENTS.md",
+        "RUNBOOK_AGENT.md",
+        "docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md",
+        "docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md",
+    )
+    documents = {path: (REPO_ROOT / path).read_text(encoding="utf-8") for path in paths}
+    joined = "\n".join(documents.values())
+    normalized = " ".join(joined.split())
+    assert all(option not in joined for option in LEGACY_AUTHORING_OPTIONS)
+    assert all(
+        phrase not in normalized
+        for phrase in (
+            "requires a prior trusted Codex review",
+            "must name a subsequent exact-head",
+            "quota response must be current",
+            "All evidence must remain within its TTL",
+        )
+    )
+    assert "No retry, substitute review, prior review, operator override, or TTL" in normalized
+    assert "`review_claim=none`" in joined
+    assert "Historical PR `#2142`" in joined
+    assert "not an active authoring" in joined
+    runbook = documents["RUNBOOK_AGENT.md"]
+    normalized_runbook = " ".join(runbook.split())
+    assert "do not trigger or retrigger it manually" in normalized_runbook
+    assert "Do not post manual bot-review commands" in normalized_runbook
+    assert "first disable automatic" not in normalized_runbook
+    assert "@codex review" not in runbook
+
+
+def test_every_policy_surface_selects_this_guard_in_diff_validation() -> None:
+    runner = (REPO_ROOT / "scripts/run-backend-tests-pre-commit.sh").read_text(encoding="utf-8")
+    assert "declare -a REVIEW_SOURCE_QUOTA_POLICY_SURFACE_FILES=(" in runner
+    assert 'EXTRA_TEST_FILES+=("tests/guards/test_review_source_quota_policy_guard.py")' in runner
+    for path in POLICY_SURFACE_FILES:
+        assert f'"{path}"' in runner

--- a/tests/test_pr_merge_readiness_gate.py
+++ b/tests/test_pr_merge_readiness_gate.py
@@ -1091,6 +1091,8 @@ def test_ci_gate_revalidates_live_operator_outage_override(
 def test_ci_gate_revalidates_review_credit_outage_against_material_head(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    repository = "Katsiarynakavaleuskaya/PulsePlate"
+    pr_number = 2142
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(repo, "init", "-q")
@@ -1101,12 +1103,12 @@ def test_ci_gate_revalidates_review_credit_outage_against_material_head(
     source.write_text("ENFORCED = True\n", encoding="utf-8")
     material_head = _commit(repo, "material")
     frozen = compute_material_manifest(
-        repo, base_ref_oid=base_sha, head_ref_oid=material_head, pr_number=42
+        repo, base_ref_oid=base_sha, head_ref_oid=material_head, pr_number=pr_number
     )
-    quota_reference = "https://github.com/owner/repo/pull/42#issuecomment-456"
-    override_reference = "https://github.com/owner/repo/pull/42#issuecomment-654"
-    prior_reference = "https://github.com/owner/repo/pull/42#pullrequestreview-123"
-    operator_reference = "https://github.com/owner/repo/pull/42#pullrequestreview-789"
+    quota_reference = f"https://github.com/{repository}/pull/{pr_number}#issuecomment-456"
+    override_reference = f"https://github.com/{repository}/pull/{pr_number}#issuecomment-654"
+    prior_reference = f"https://github.com/{repository}/pull/{pr_number}#pullrequestreview-123"
+    operator_reference = f"https://github.com/{repository}/pull/{pr_number}#pullrequestreview-789"
     code_review = build_review_credit_outage_receipt(
         material_digest=frozen.digest,
         material_head_sha=material_head,
@@ -1134,18 +1136,18 @@ def test_ci_gate_revalidates_review_credit_outage_against_material_head(
             "merge_base_sha": frozen.merge_base_sha,
             "policy_version": MATERIAL_POLICY_VERSION,
         },
-        "pr_number": 42,
-        "repository": "owner/repo",
+        "pr_number": pr_number,
+        "repository": repository,
         "schema_version": "pulseplate.pr-review-seal/v1",
     }
     artifact = _artifact_with_seal(seal)
-    mapping = repo / "docs" / "review" / "PR_42_FIXED_MAPPING.md"
+    mapping = repo / "docs" / "review" / f"PR_{pr_number}_FIXED_MAPPING.md"
     mapping.parent.mkdir(parents=True)
     mapping.write_text(artifact, encoding="utf-8")
     governance_head = _commit(repo, "governance closeout")
     snapshot = PrSnapshot(
-        repository="owner/repo",
-        pr_number=42,
+        repository=repository,
+        pr_number=pr_number,
         base_sha=base_sha,
         head_sha=governance_head,
         commits=(
@@ -1197,8 +1199,8 @@ def test_ci_gate_revalidates_review_credit_outage_against_material_head(
 
     validated = merge_gate._validate_v1_seal(
         artifact_text=artifact,
-        repository="owner/repo",
-        pr_number=42,
+        repository=repository,
+        pr_number=pr_number,
         snapshot=snapshot,
         token="opaque",
     )

--- a/tests/test_pr_merge_readiness_gate.py
+++ b/tests/test_pr_merge_readiness_gate.py
@@ -16,6 +16,7 @@ from scripts.ci import check_pr_merge_readiness as merge_gate
 from scripts.ci.check_pr_merge_readiness import _is_actionable, _mapped_urls
 from scripts.orchestration.pr_commit_identity import (
     CodexReviewEvidence,
+    CodexReviewSourceUnavailabilityEvidence,
     CommitRefKind,
     PrCommitEvidence,
     PrSnapshot,
@@ -28,6 +29,7 @@ from scripts.orchestration.pr_review_evidence import (
     RECEIPT_AUTHORITY,
     ReviewEvidenceError,
     build_review_credit_outage_receipt,
+    build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
     render_embedded_review_seal,
@@ -1203,6 +1205,143 @@ def test_ci_gate_revalidates_review_credit_outage_against_material_head(
 
     assert validated["code_review"]["status"] == "tooling_unavailable"
     assert verified_heads == [material_head]
+
+
+def test_ci_gate_reauthenticates_terminal_review_source_unavailability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    base_sha = _commit(repo, "base")
+    source = repo / "src" / "policy.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("ENFORCED = True\n", encoding="utf-8")
+    material_head = _commit(repo, "material")
+    frozen = compute_material_manifest(
+        repo, base_ref_oid=base_sha, head_ref_oid=material_head, pr_number=42
+    )
+    quota_reference = "https://github.com/owner/repo/pull/42#issuecomment-456"
+    quota_body_sha256 = "sha256:" + "c" * 64
+    code_review = build_review_source_unavailability_receipt(
+        material_digest=frozen.digest,
+        material_head_sha=material_head,
+        quota_reference=quota_reference,
+        quota_created_at="2020-01-01T00:00:00Z",
+        quota_body_sha256=quota_body_sha256,
+        source_status="usage_limit_reached",
+    )
+    seal = {
+        "authority": RECEIPT_AUTHORITY,
+        "code_review": code_review,
+        "codex_security": _receipt(base_sha, material_head),
+        "material": {
+            "base_ref_oid": base_sha,
+            "digest": frozen.digest,
+            "material_head_sha": material_head,
+            "merge_base_sha": frozen.merge_base_sha,
+            "policy_version": MATERIAL_POLICY_VERSION,
+        },
+        "pr_number": 42,
+        "repository": "owner/repo",
+        "schema_version": "pulseplate.pr-review-seal/v1",
+    }
+    artifact = _artifact_with_seal(seal)
+    mapping = repo / "docs" / "review" / "PR_42_FIXED_MAPPING.md"
+    mapping.parent.mkdir(parents=True)
+    mapping.write_text(artifact, encoding="utf-8")
+    governance_head = _commit(repo, "governance closeout")
+    snapshot = PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=base_sha,
+        head_sha=governance_head,
+        commits=(
+            PrCommitEvidence(material_head, None),
+            PrCommitEvidence(governance_head, None),
+        ),
+    )
+    monkeypatch.setattr(merge_gate, "REPO_ROOT", repo)
+    monkeypatch.setattr(
+        merge_gate,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(
+            value,
+            CommitRefKind.PR_HEAD if value == governance_head else CommitRefKind.PR_COMMIT,
+        ),
+    )
+    monkeypatch.setattr(merge_gate, "is_ancestor", lambda *_a, **_k: True)
+    verified_refs: list[str] = []
+
+    def verify_source(
+        reference: str, *_args: Any, **_kwargs: Any
+    ) -> CodexReviewSourceUnavailabilityEvidence:
+        verified_refs.append(reference)
+        return CodexReviewSourceUnavailabilityEvidence(
+            reference=quota_reference,
+            created_at="2020-01-01T00:00:00Z",
+            source_status="usage_limit_reached",
+            body_sha256=quota_body_sha256,
+        )
+
+    monkeypatch.setattr(
+        merge_gate,
+        "verify_codex_review_source_unavailability_reference",
+        verify_source,
+    )
+    monkeypatch.setattr(
+        merge_gate,
+        "verify_codex_review_reference",
+        lambda *_a, **_k: pytest.fail("normal Codex review path must not run"),
+    )
+
+    validated = merge_gate._validate_v1_seal(
+        artifact_text=artifact,
+        repository="owner/repo",
+        pr_number=42,
+        snapshot=snapshot,
+        token="opaque",
+    )
+    assert validated["code_review"] == code_review
+    assert verified_refs == [quota_reference]
+
+    monkeypatch.setenv("GITHUB_TOKEN", "opaque")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_pr_merge_readiness.py",
+            "--pr-number",
+            "42",
+            "--repo",
+            "owner/repo",
+        ],
+    )
+    monkeypatch.setattr(
+        merge_gate,
+        "_fetch_pr_context",
+        lambda *_a, **_k: (
+            42,
+            "owner/repo",
+            False,
+            "Canonical artifact: docs/review/PR_42_FIXED_MAPPING.md",
+        ),
+    )
+    monkeypatch.setattr(merge_gate, "fetch_pr_snapshot", lambda *_a, **_k: snapshot)
+    monkeypatch.setattr(merge_gate, "_local_head_sha", lambda: governance_head)
+    monkeypatch.setattr(merge_gate, "fetch_review_threads", lambda *_a, **_k: ())
+    monkeypatch.setattr(merge_gate, "_collect_actionable_items", lambda **_k: [])
+    monkeypatch.setattr(merge_gate, "read_mapping_artifact", lambda _pr: artifact)
+    monkeypatch.setattr(merge_gate, "assert_snapshot_unchanged", lambda *_a, **_k: None)
+
+    assert merge_gate.main() == 0
+    output = capsys.readouterr().out
+    assert "REVIEW_SOURCE_UNAVAILABLE_VALID usage_limit_reached" in output
+    assert "MACHINE_BOUND_REVIEW_COMMIT" not in output
+    assert "REVIEW_CREDIT_OUTAGE_OVERRIDE_VALID" not in output
 
 
 def test_merge_readiness_main_blocks_missing_mapping(

--- a/tests/test_pr_merge_readiness_gate.py
+++ b/tests/test_pr_merge_readiness_gate.py
@@ -1345,6 +1345,46 @@ def test_ci_gate_reauthenticates_terminal_review_source_unavailability(
     assert "MACHINE_BOUND_REVIEW_COMMIT" not in output
     assert "REVIEW_CREDIT_OUTAGE_OVERRIDE_VALID" not in output
 
+    source.write_text("ENFORCED = False\n", encoding="utf-8")
+    changed_head = _commit(repo, "post-scan material change")
+    changed_manifest = compute_material_manifest(
+        repo,
+        base_ref_oid=base_sha,
+        head_ref_oid=changed_head,
+        pr_number=42,
+    )
+    tampered_seal = json.loads(json.dumps(seal))
+    tampered_seal["material"]["digest"] = changed_manifest.digest
+    tampered_seal["code_review"] = build_review_source_unavailability_receipt(
+        material_digest=changed_manifest.digest,
+        material_head_sha=material_head,
+        quota_reference=quota_reference,
+        quota_created_at="2020-01-01T00:00:00Z",
+        quota_body_sha256=quota_body_sha256,
+        source_status="usage_limit_reached",
+    )
+    changed_snapshot = PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=base_sha,
+        head_sha=changed_head,
+        commits=(
+            *snapshot.commits,
+            PrCommitEvidence(changed_head, None),
+        ),
+    )
+    with pytest.raises(
+        ReviewEvidenceError,
+        match="unavailable material head has a different material digest",
+    ):
+        merge_gate._validate_v1_seal(
+            artifact_text=_artifact_with_seal(tampered_seal),
+            repository="owner/repo",
+            pr_number=42,
+            snapshot=changed_snapshot,
+            token="opaque",
+        )
+
 
 def test_merge_readiness_main_blocks_missing_mapping(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -18,6 +18,7 @@ import pytest
 from scripts.orchestration.pr_commit_identity import (
     CommitIdentityError,
     CommitRefKind,
+    CodexReviewSourceUnavailabilityEvidence,
     GitHubHttpError,
     PrCommitEvidence,
     PrSnapshot,
@@ -35,6 +36,7 @@ from scripts.orchestration.pr_commit_identity import (
     render_review_credit_outage_override_comment,
     render_security_outage_override_comment,
     verify_codex_review_reference,
+    verify_codex_review_source_unavailability_reference,
     verify_review_credit_outage_references,
     verify_security_outage_override_reference,
 )
@@ -49,10 +51,12 @@ from scripts.orchestration.pr_review_evidence import (
     MaterialManifest,
     ReviewEvidenceError,
     build_review_credit_outage_receipt,
+    build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
     ingest_codex_security_receipt,
     is_review_credit_outage_receipt,
+    is_review_source_unavailability_receipt,
     is_security_outage_override_receipt,
     parse_duplicate_disposition_reply,
     parse_embedded_review_seal,
@@ -759,6 +763,7 @@ def _review_credit_quota_comment(
         ),
         "created_at": created_at,
         "html_url": reference,
+        "id": 456,
         "issue_url": "https://api.github.com/repos/owner/repo/issues/42",
         "performed_via_github_app": {
             "id": 1_144_995,
@@ -768,6 +773,135 @@ def _review_credit_quota_comment(
         "updated_at": created_at,
         "user": {"login": "chatgpt-codex-connector[bot]", "type": "Bot"},
     }
+
+
+def test_review_source_unavailability_verifies_exact_immutable_codex_comment() -> None:
+    reference = "https://github.com/owner/repo/pull/42#issuecomment-456"
+    response = _review_credit_quota_comment(
+        reference,
+        created_at="2020-01-01T00:00:00Z",
+    )
+
+    evidence = verify_codex_review_source_unavailability_reference(
+        reference,
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+        request_json=lambda *_a, **_k: response,
+    )
+
+    assert evidence == CodexReviewSourceUnavailabilityEvidence(
+        reference=reference,
+        created_at="2020-01-01T00:00:00Z",
+        source_status="usage_limit_reached",
+        body_sha256=("sha256:" + hashlib.sha256(response["body"].encode("utf-8")).hexdigest()),
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        (
+            lambda response: response["user"].update(login="spoofed[bot]"),
+            "not trusted Codex evidence",
+        ),
+        (
+            lambda response: response["user"].update(type="User"),
+            "not trusted Codex evidence",
+        ),
+        (
+            lambda response: response["performed_via_github_app"].update(id=1),
+            "not trusted Codex evidence",
+        ),
+        (
+            lambda response: response["performed_via_github_app"].update(slug="spoofed"),
+            "not trusted Codex evidence",
+        ),
+        (
+            lambda response: response["performed_via_github_app"]["owner"].update(login="spoofed"),
+            "not trusted Codex evidence",
+        ),
+        (
+            lambda response: response.update(updated_at="2026-07-15T11:06:00Z"),
+            "edited after creation",
+        ),
+        (
+            lambda response: response.update(body=response["body"] + " "),
+            "not an exact known quota response",
+        ),
+        (
+            lambda response: response.update(body="Codex review unavailable"),
+            "not an exact known quota response",
+        ),
+        (
+            lambda response: response.update(id=999),
+            "comment id does not match",
+        ),
+        (
+            lambda response: response.update(
+                html_url="https://github.com/owner/repo/pull/42#issuecomment-999"
+            ),
+            "not trusted Codex evidence",
+        ),
+        (
+            lambda response: response.update(
+                issue_url="https://api.github.com/repos/owner/repo/issues/43"
+            ),
+            "not trusted Codex evidence",
+        ),
+    ],
+)
+def test_review_source_unavailability_rejects_spoofed_or_changed_comment(
+    mutation: Any,
+    error: str,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#issuecomment-456"
+    response = _review_credit_quota_comment(reference)
+    mutation(response)
+
+    with pytest.raises(CommitIdentityError, match=error):
+        verify_codex_review_source_unavailability_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            request_json=lambda *_a, **_k: response,
+        )
+
+
+@pytest.mark.parametrize(
+    ("reference", "repository", "pr_number"),
+    [
+        (
+            "https://github.com/owner/repo/pull/43#issuecomment-456",
+            "owner/repo",
+            42,
+        ),
+        (
+            "https://github.com/owner/repo/pull/42#issuecomment-abc",
+            "owner/repo",
+            42,
+        ),
+        (
+            "https://github.com/owner/repo/pull/42#issuecomment-456",
+            "other/repo",
+            42,
+        ),
+    ],
+)
+def test_review_source_unavailability_rejects_cross_pr_repo_or_noncanonical_id(
+    reference: str,
+    repository: str,
+    pr_number: int,
+) -> None:
+    with pytest.raises(CommitIdentityError, match="exact PR"):
+        verify_codex_review_source_unavailability_reference(
+            reference,
+            repository=repository,
+            pr_number=pr_number,
+            token="opaque",
+            request_json=lambda *_a, **_k: pytest.fail("must reject before refetch"),
+        )
 
 
 def _prior_codex_review(reference: str) -> dict[str, Any]:
@@ -1699,6 +1833,133 @@ def _seal(receipt: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _review_source_unavailability_receipt(
+    *,
+    material_digest: str = DIGEST,
+    material_head_sha: str = HEAD_SHA,
+) -> dict[str, Any]:
+    response = _review_credit_quota_comment(
+        "https://github.com/owner/repo/pull/42#issuecomment-456"
+    )
+    return build_review_source_unavailability_receipt(
+        material_digest=material_digest,
+        material_head_sha=material_head_sha,
+        quota_reference=response["html_url"],
+        quota_created_at=response["created_at"],
+        quota_body_sha256=(
+            "sha256:" + hashlib.sha256(response["body"].encode("utf-8")).hexdigest()
+        ),
+        source_status="usage_limit_reached",
+    )
+
+
+def test_review_source_unavailability_receipt_is_tagged_and_material_bound() -> None:
+    receipt = _review_source_unavailability_receipt()
+    seal = _seal(
+        build_security_outage_override_receipt(
+            base_revision=BASE_SHA,
+            head_revision=HEAD_SHA,
+            material_digest=DIGEST,
+            override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+            created_at="2026-07-15T11:00:00Z",
+            operator_user_id=123,
+            operator_login="owner",
+            operator_association="OWNER",
+        )
+    )
+    seal["code_review"] = receipt
+
+    parsed = parse_embedded_review_seal(render_embedded_review_seal(seal))
+
+    assert is_review_source_unavailability_receipt(parsed["code_review"])
+    assert parsed["code_review"] == {
+        "authority": "trusted_codex_review_source_unavailability",
+        "binding_kind": "seal_context_only",
+        "blocking": False,
+        "fallback_required": False,
+        "material_digest": DIGEST,
+        "material_head_sha": HEAD_SHA,
+        "quota_body_sha256": receipt["quota_body_sha256"],
+        "quota_created_at": "2026-07-15T11:05:00Z",
+        "quota_reference": "https://github.com/owner/repo/pull/42#issuecomment-456",
+        "review_claim": "none",
+        "schema_version": "pulseplate.codex-review-source-unavailability/v1",
+        "source": "codex_review",
+        "source_degraded": True,
+        "source_status": "usage_limit_reached",
+        "status": "tooling_unavailable",
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        (
+            lambda receipt: receipt.update(source_status="unknown"),
+            "malformed or stale",
+        ),
+        (
+            lambda receipt: receipt.update(review_claim="no_findings"),
+            "malformed or stale",
+        ),
+        (
+            lambda receipt: receipt.update(review_reference="legacy"),
+            "keys mismatch",
+        ),
+        (
+            lambda receipt: receipt.update(quota_body_sha256="sha256:invalid"),
+            "64 lowercase hex",
+        ),
+        (
+            lambda receipt: receipt.update(authority="operator_review_credit_exhaustion_override"),
+            "tagged-union identity is ambiguous",
+        ),
+    ],
+)
+def test_review_source_unavailability_receipt_rejects_ambiguous_or_unsafe_fields(
+    mutation: Any,
+    error: str,
+) -> None:
+    receipt = _review_source_unavailability_receipt()
+    mutation(receipt)
+    seal = _seal(
+        build_security_outage_override_receipt(
+            base_revision=BASE_SHA,
+            head_revision=HEAD_SHA,
+            material_digest=DIGEST,
+            override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+            created_at="2026-07-15T11:00:00Z",
+            operator_user_id=123,
+            operator_login="owner",
+            operator_association="OWNER",
+        )
+    )
+    seal["code_review"] = receipt
+
+    with pytest.raises(ReviewEvidenceError, match=error):
+        render_embedded_review_seal(seal)
+
+
+def test_review_source_unavailability_receipt_rejects_stale_material_binding() -> None:
+    receipt = _review_source_unavailability_receipt(material_head_sha=FIX_SHA)
+    seal = _seal(
+        build_security_outage_override_receipt(
+            base_revision=BASE_SHA,
+            head_revision=HEAD_SHA,
+            material_digest=DIGEST,
+            override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+            created_at="2026-07-15T11:00:00Z",
+            operator_user_id=123,
+            operator_login="owner",
+            operator_association="OWNER",
+        )
+    )
+    seal["code_review"] = receipt
+
+    with pytest.raises(ReviewEvidenceError, match="sealed material head"):
+        render_embedded_review_seal(seal)
+
+
 def _mapping_artifact_with_seal(seal: dict[str, Any]) -> str:
     return "\n".join(
         [
@@ -1718,6 +1979,95 @@ def _mapping_artifact_with_seal(seal: dict[str, Any]) -> str:
             "",
         ]
     )
+
+
+def test_closeout_seal_authors_terminal_review_source_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    target = repo / "docs/review/PR_42_FIXED_MAPPING.md"
+    freeze = {
+        "base_ref_oid": BASE_SHA,
+        "digest": DIGEST,
+        "material_head_sha": HEAD_SHA,
+        "merge_base_sha": BASE_SHA,
+        "policy_version": MATERIAL_POLICY_VERSION,
+    }
+    state = {
+        "dispositions": [],
+        "experiment_result": None,
+        "freeze": freeze,
+        "packet": None,
+        "pr_number": 42,
+        "repository": "owner/repo",
+        "schema_version": closeout_module.DRAFT_SCHEMA_VERSION,
+    }
+    source_evidence = CodexReviewSourceUnavailabilityEvidence(
+        reference="https://github.com/owner/repo/pull/42#issuecomment-456",
+        created_at="2020-01-01T00:00:00Z",
+        source_status="usage_limit_reached",
+        body_sha256="sha256:" + "c" * 64,
+    )
+    security_receipt = build_security_outage_override_receipt(
+        base_revision=BASE_SHA,
+        head_revision=HEAD_SHA,
+        material_digest=DIGEST,
+        override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+        created_at="2026-07-15T11:00:00Z",
+        operator_user_id=123,
+        operator_login="owner",
+        operator_association="OWNER",
+    )
+    monkeypatch.setattr(closeout_module, "REPO_ROOT", repo)
+    monkeypatch.setattr(closeout_module, "_load_state", lambda _pr: state)
+    monkeypatch.setattr(closeout_module, "_token", lambda: "opaque")
+    monkeypatch.setattr(closeout_module, "fetch_pr_snapshot", lambda *_a, **_k: _snapshot())
+    monkeypatch.setattr(closeout_module, "_require_clean_live_head", lambda _head: None)
+    monkeypatch.setattr(
+        closeout_module,
+        "compute_material_manifest",
+        lambda *_a, **_k: _material_manifest(HEAD_SHA),
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_review_source_unavailability_reference",
+        lambda *_a, **_k: source_evidence,
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_review_reference",
+        lambda *_a, **_k: pytest.fail("normal review path must not run"),
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "ingest_codex_security_receipt",
+        lambda *_a, **_k: security_receipt,
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "_render_mapping",
+        lambda _state, seal: _mapping_artifact_with_seal(seal),
+    )
+    monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: target)
+    monkeypatch.setattr(closeout_module, "_git", lambda *_a, **_k: "")
+    monkeypatch.setattr(closeout_module, "assert_snapshot_unchanged", lambda *_a, **_k: None)
+    args = Namespace(
+        pr_number=42,
+        repo="owner/repo",
+        review_ref=None,
+        review_source_unavailable_ref=source_evidence.reference,
+        scan_manifest="/tmp/scan-manifest.json",
+        security_outage_override_ref=None,
+    )
+
+    closeout_module._cmd_seal(args)
+
+    parsed = parse_embedded_review_seal(target.read_text(encoding="utf-8"))
+    assert parsed["code_review"]["authority"] == ("trusted_codex_review_source_unavailability")
+    assert parsed["code_review"]["review_claim"] == "none"
+    assert "CONTENT_BOUND_RECEIPT_VALID" in capsys.readouterr().out
 
 
 def test_authenticated_closeout_validation_rejects_nonexistent_review(
@@ -1848,6 +2198,77 @@ def test_authenticated_closeout_revalidates_operator_outage_override(
 
     assert seal["codex_security"] == receipt
     assert override_calls == [(HEAD_SHA, DIGEST)]
+
+
+def test_authenticated_closeout_recomputes_quota_body_sha(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    code_review = _review_source_unavailability_receipt()
+    security_receipt = ingest_codex_security_receipt(
+        _build_scan_bundle(tmp_path / "scan"),
+        expected_base_sha=BASE_SHA,
+        expected_head_sha=HEAD_SHA,
+    )
+    seal = _seal(security_receipt)
+    seal["code_review"] = code_review
+    mapping = tmp_path / "PR_42_FIXED_MAPPING.md"
+    mapping.write_text(_mapping_artifact_with_seal(seal), encoding="utf-8")
+    manifest = _material_manifest(HEAD_SHA)
+    monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: mapping)
+    monkeypatch.setattr(closeout_module, "fetch_pr_snapshot", lambda *_a, **_k: _snapshot())
+    monkeypatch.setattr(closeout_module, "_git", lambda *_a, **_k: HEAD_SHA)
+    monkeypatch.setattr(
+        closeout_module,
+        "compute_material_manifest",
+        lambda *_a, **_k: manifest,
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(value, CommitRefKind.PR_HEAD),
+    )
+    monkeypatch.setattr(closeout_module, "is_ancestor", lambda *_a, **_k: True)
+    monkeypatch.setattr(closeout_module, "assert_snapshot_unchanged", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_review_reference",
+        lambda *_a, **_k: pytest.fail("normal review path must not run"),
+    )
+    evidence = CodexReviewSourceUnavailabilityEvidence(
+        reference=code_review["quota_reference"],
+        created_at=code_review["quota_created_at"],
+        source_status=code_review["source_status"],
+        body_sha256=code_review["quota_body_sha256"],
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_review_source_unavailability_reference",
+        lambda *_a, **_k: evidence,
+    )
+
+    validated = closeout_module.validate_live_mapping(
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+    )
+    assert validated["code_review"] == code_review
+
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_review_source_unavailability_reference",
+        lambda *_a, **_k: CodexReviewSourceUnavailabilityEvidence(
+            reference=evidence.reference,
+            created_at=evidence.created_at,
+            source_status=evidence.source_status,
+            body_sha256="sha256:" + "f" * 64,
+        ),
+    )
+    with pytest.raises(closeout_module.CloseoutError, match="receipt is stale"):
+        closeout_module.validate_live_mapping(
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+        )
 
 
 def test_authenticated_closeout_revalidates_review_credit_override(
@@ -3145,18 +3566,29 @@ def test_closeout_init_is_atomic_and_idempotent(
 
 def test_closeout_seal_requires_exactly_one_security_evidence_input() -> None:
     parser = closeout_module._parser()
-    common = [
+    base = [
         "seal",
         "--repo",
         "owner/repo",
         "--pr-number",
         "42",
+    ]
+    common = [
+        *base,
         "--review-ref",
         "https://github.com/owner/repo/pull/42#issuecomment-456",
     ]
 
     with pytest.raises(SystemExit):
         parser.parse_args(common)
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                *base,
+                "--scan-manifest",
+                "/tmp/scan-manifest.json",
+            ]
+        )
     with pytest.raises(SystemExit):
         parser.parse_args(
             [
@@ -3176,5 +3608,25 @@ def test_closeout_seal_requires_exactly_one_security_evidence_input() -> None:
             "https://github.com/owner/repo/pull/42#issuecomment-789",
         ]
     )
+    source_args = parser.parse_args(
+        [
+            *base,
+            "--review-source-unavailable-ref",
+            "https://github.com/owner/repo/pull/42#issuecomment-456",
+            "--scan-manifest",
+            "/tmp/scan-manifest.json",
+        ]
+    )
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                *common,
+                "--review-source-unavailable-ref",
+                "https://github.com/owner/repo/pull/42#issuecomment-456",
+                "--scan-manifest",
+                "/tmp/scan-manifest.json",
+            ]
+        )
     assert scan_args.security_outage_override_ref is None
     assert override_args.scan_manifest is None
+    assert source_args.review_ref is None

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -2277,6 +2277,70 @@ def test_authenticated_closeout_recomputes_quota_body_sha(
         )
 
 
+def test_authenticated_closeout_rejects_unavailable_receipt_with_ancestor_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live_digest = DIGEST
+    ancestor_digest = "sha256:" + "d" * 64
+    code_review = _review_source_unavailability_receipt(
+        material_digest=live_digest,
+        material_head_sha=FIX_SHA,
+    )
+    security_receipt = build_security_outage_override_receipt(
+        base_revision=BASE_SHA,
+        head_revision=FIX_SHA,
+        material_digest=live_digest,
+        override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+        created_at="2026-07-15T11:00:00Z",
+        operator_user_id=123,
+        operator_login="owner",
+        operator_association="OWNER",
+    )
+    seal = _seal(security_receipt)
+    seal["code_review"] = code_review
+    seal["material"]["digest"] = live_digest
+    seal["material"]["material_head_sha"] = FIX_SHA
+    mapping = tmp_path / "PR_42_FIXED_MAPPING.md"
+    mapping.write_text(_mapping_artifact_with_seal(seal), encoding="utf-8")
+
+    def manifest_for_head(
+        _root: Path,
+        *,
+        base_ref_oid: str,
+        head_ref_oid: str,
+        pr_number: int,
+    ) -> MaterialManifest:
+        assert base_ref_oid == BASE_SHA
+        assert pr_number == 42
+        if head_ref_oid == HEAD_SHA:
+            return _material_manifest(HEAD_SHA, digest=live_digest)
+        assert head_ref_oid == FIX_SHA
+        return _material_manifest(FIX_SHA, digest=ancestor_digest)
+
+    monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: mapping)
+    monkeypatch.setattr(closeout_module, "fetch_pr_snapshot", lambda *_a, **_k: _snapshot())
+    monkeypatch.setattr(closeout_module, "_git", lambda *_a, **_k: HEAD_SHA)
+    monkeypatch.setattr(closeout_module, "compute_material_manifest", manifest_for_head)
+    monkeypatch.setattr(
+        closeout_module,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(
+            value,
+            CommitRefKind.PR_HEAD if value == HEAD_SHA else CommitRefKind.PR_COMMIT,
+        ),
+    )
+
+    with pytest.raises(
+        closeout_module.CloseoutError,
+        match="unavailable material head has a different material digest",
+    ):
+        closeout_module.validate_live_mapping(
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+        )
+
+
 def test_authenticated_closeout_revalidates_review_credit_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -1260,10 +1260,16 @@ def test_review_credit_outage_receipt_is_distinct_and_material_bound() -> None:
             ("scripts/ci/ci_risk_profile.py",),
             False,
         ),
-        ("owner/repo", 42, ("requirements-test.txt",), True),
+        (
+            "Katsiarynakavaleuskaya/PulsePlate",
+            2143,
+            ("requirements-test.txt",),
+            False,
+        ),
+        ("owner/repo", 42, ("requirements-test.txt",), False),
     ],
 )
-def test_review_credit_outage_scope_blocks_future_self_authorization(
+def test_review_credit_outage_scope_is_live_only_for_bootstrap_pr(
     repository: str,
     pr_number: int,
     paths: tuple[str, ...],
@@ -1276,7 +1282,7 @@ def test_review_credit_outage_scope_blocks_future_self_authorization(
             material_paths=paths,
         )
         return
-    with pytest.raises(ReviewEvidenceError, match="trust-boundary changes"):
+    with pytest.raises(ReviewEvidenceError, match="live-valid only.*PR #2142"):
         validate_review_credit_outage_scope(
             repository=repository,
             pr_number=pr_number,
@@ -2274,10 +2280,12 @@ def test_authenticated_closeout_recomputes_quota_body_sha(
 def test_authenticated_closeout_revalidates_review_credit_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    quota_reference = "https://github.com/owner/repo/pull/42#issuecomment-456"
-    override_reference = "https://github.com/owner/repo/pull/42#issuecomment-654"
-    prior_reference = "https://github.com/owner/repo/pull/42#pullrequestreview-123"
-    operator_reference = "https://github.com/owner/repo/pull/42#pullrequestreview-789"
+    repository = "Katsiarynakavaleuskaya/PulsePlate"
+    pr_number = 2142
+    quota_reference = f"https://github.com/{repository}/pull/{pr_number}#issuecomment-456"
+    override_reference = f"https://github.com/{repository}/pull/{pr_number}#issuecomment-654"
+    prior_reference = f"https://github.com/{repository}/pull/{pr_number}#pullrequestreview-123"
+    operator_reference = f"https://github.com/{repository}/pull/{pr_number}#pullrequestreview-789"
     code_review = build_review_credit_outage_receipt(
         material_digest=DIGEST,
         material_head_sha=HEAD_SHA,
@@ -2298,26 +2306,38 @@ def test_authenticated_closeout_revalidates_review_credit_override(
         base_revision=BASE_SHA,
         head_revision=HEAD_SHA,
         material_digest=DIGEST,
-        override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+        override_reference=(f"https://github.com/{repository}/pull/{pr_number}#issuecomment-789"),
         created_at="2026-07-15T11:00:00Z",
         operator_user_id=123,
         operator_login="owner",
         operator_association="OWNER",
     )
     seal = _seal(security_receipt)
+    seal["repository"] = repository
+    seal["pr_number"] = pr_number
     seal["code_review"] = code_review
-    mapping = tmp_path / "PR_42_FIXED_MAPPING.md"
+    mapping = tmp_path / f"PR_{pr_number}_FIXED_MAPPING.md"
     mapping.write_text(_mapping_artifact_with_seal(seal), encoding="utf-8")
     manifest = MaterialManifest(
         base_ref_oid=BASE_SHA,
         head_ref_oid=HEAD_SHA,
         merge_base_sha=BASE_SHA,
-        pr_number=42,
+        pr_number=pr_number,
         entries=(),
         digest=DIGEST,
     )
+    snapshot = PrSnapshot(
+        repository=repository,
+        pr_number=pr_number,
+        base_sha=BASE_SHA,
+        head_sha=HEAD_SHA,
+        commits=(
+            PrCommitEvidence(FIX_SHA, "2026-07-15T10:00:00Z"),
+            PrCommitEvidence(HEAD_SHA, "2026-07-15T11:00:00Z"),
+        ),
+    )
     monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: mapping)
-    monkeypatch.setattr(closeout_module, "fetch_pr_snapshot", lambda *_a, **_k: _snapshot())
+    monkeypatch.setattr(closeout_module, "fetch_pr_snapshot", lambda *_a, **_k: snapshot)
     monkeypatch.setattr(closeout_module, "_git", lambda *_a, **_k: HEAD_SHA)
     monkeypatch.setattr(
         closeout_module,
@@ -2377,8 +2397,8 @@ def test_authenticated_closeout_revalidates_review_credit_override(
     monkeypatch.setattr(closeout_module, "assert_snapshot_unchanged", lambda *_a, **_k: None)
 
     validated = closeout_module.validate_live_mapping(
-        repository="owner/repo",
-        pr_number=42,
+        repository=repository,
+        pr_number=pr_number,
         token="opaque",
     )
 

--- a/tests/test_review_source_status.py
+++ b/tests/test_review_source_status.py
@@ -8,7 +8,15 @@ from pathlib import Path
 from scripts.orchestration.review_source_status import (
     REVIEW_SOURCE_STATUSES,
     build_review_source_status,
+    classify_codex_review_source_unavailability_body,
+    review_source_policy_projection,
     summarize_degraded_sources,
+)
+
+CODEX_USAGE_LIMIT_BODY = (
+    "You have reached your Codex usage limits for code reviews. "
+    "You can see your limits in the "
+    "[Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage)."
 )
 
 
@@ -24,7 +32,7 @@ def test_review_source_degraded_is_warning_only_by_default() -> None:
         "source": "coderabbit",
         "status": "rate_limited",
         "source_degraded": True,
-        "fallback_required": True,
+        "fallback_required": False,
         "blocking": False,
         "reason": "usage limit reached",
         "evidence": "fallback dry run",
@@ -32,6 +40,51 @@ def test_review_source_degraded_is_warning_only_by_default() -> None:
     assert summarize_degraded_sources([status]) == [
         "coderabbit: rate_limited (usage limit reached)"
     ]
+
+
+def test_terminal_quota_policy_requires_no_retry_or_substitute_authority() -> None:
+    assert review_source_policy_projection() == {
+        "blocking_statuses": [
+            "actionable_bot_comments",
+            "failed_required_check",
+            "fallback_finding",
+            "unresolved_threads",
+        ],
+        "policy_version": "pulseplate.review-source-policy/v1",
+        "terminal_nonblocking_statuses": [
+            "rate_limited",
+            "usage_limit_reached",
+        ],
+        "terminal_unavailability": {
+            "blocking": False,
+            "fallback_required": False,
+            "operator_override_required": False,
+            "prior_review_required": False,
+            "retry_required": False,
+            "review_claim": "none",
+            "source_degraded": True,
+            "substitute_review_required": False,
+            "ttl_required": False,
+        },
+    }
+
+
+def test_codex_quota_body_classification_is_exact_and_fail_closed() -> None:
+    assert (
+        classify_codex_review_source_unavailability_body(CODEX_USAGE_LIMIT_BODY)
+        == "usage_limit_reached"
+    )
+    for body in (
+        CODEX_USAGE_LIMIT_BODY + " ",
+        CODEX_USAGE_LIMIT_BODY.replace("usage limits", "rate limits"),
+        "Codex review unavailable",
+    ):
+        try:
+            classify_codex_review_source_unavailability_body(body)
+        except ValueError as exc:
+            assert "exact known quota response" in str(exc)
+        else:  # pragma: no cover - assertion branch
+            raise AssertionError("changed quota text must fail closed")
 
 
 def test_review_source_blocking_requires_explicit_blocking_status() -> None:

--- a/tests/test_review_source_status.py
+++ b/tests/test_review_source_status.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts.orchestration.review_source_status import (
     REVIEW_SOURCE_STATUSES,
     build_review_source_status,
@@ -67,6 +69,19 @@ def test_terminal_quota_policy_requires_no_retry_or_substitute_authority() -> No
             "ttl_required": False,
         },
     }
+
+
+@pytest.mark.parametrize("status", ["rate_limited", "usage_limit_reached"])
+def test_terminal_quota_status_rejects_blocking_override(status: str) -> None:
+    with pytest.raises(
+        ValueError,
+        match="terminal review-source unavailability cannot be marked blocking",
+    ):
+        build_review_source_status(
+            source="codex_review",
+            status=status,
+            blocking=True,
+        )
 
 
 def test_codex_quota_body_classification_is_exact_and_fail_closed() -> None:

--- a/tests/test_review_source_status.py
+++ b/tests/test_review_source_status.py
@@ -20,6 +20,12 @@ CODEX_USAGE_LIMIT_BODY = (
     "You can see your limits in the "
     "[Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage)."
 )
+CODEX_USAGE_LIMIT_BODY_WITH_SETTINGS = (
+    CODEX_USAGE_LIMIT_BODY
+    + "\nTo continue using code reviews, add credits to your account and enable them "
+    "for code reviews in your "
+    "[settings](https://chatgpt.com/codex/cloud/settings/code-review)."
+)
 
 
 def test_review_source_degraded_is_warning_only_by_default() -> None:
@@ -84,14 +90,19 @@ def test_terminal_quota_status_rejects_blocking_override(status: str) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "body",
+    [CODEX_USAGE_LIMIT_BODY, CODEX_USAGE_LIMIT_BODY_WITH_SETTINGS],
+)
+def test_codex_quota_body_classification_accepts_exact_known_bodies(body: str) -> None:
+    assert classify_codex_review_source_unavailability_body(body) == "usage_limit_reached"
+
+
 def test_codex_quota_body_classification_is_exact_and_fail_closed() -> None:
-    assert (
-        classify_codex_review_source_unavailability_body(CODEX_USAGE_LIMIT_BODY)
-        == "usage_limit_reached"
-    )
     for body in (
-        CODEX_USAGE_LIMIT_BODY + " ",
-        CODEX_USAGE_LIMIT_BODY.replace("usage limits", "rate limits"),
+        CODEX_USAGE_LIMIT_BODY_WITH_SETTINGS + " ",
+        CODEX_USAGE_LIMIT_BODY_WITH_SETTINGS.replace("usage limits", "rate limits"),
+        CODEX_USAGE_LIMIT_BODY_WITH_SETTINGS.replace("settings/code-review", "settings/review"),
         "Codex review unavailable",
     ):
         try:
@@ -128,6 +139,28 @@ def test_review_source_status_schema_matches_helper_shape() -> None:
     assert set(schema["required"]) == set(status)
     assert schema["additionalProperties"] is False
     assert schema["properties"]["status"]["enum"] == sorted(REVIEW_SOURCE_STATUSES)
+    assert schema["allOf"] == [
+        {
+            "if": {
+                "properties": {
+                    "status": {
+                        "enum": [
+                            "rate_limited",
+                            "usage_limit_reached",
+                        ]
+                    }
+                },
+                "required": ["status"],
+            },
+            "then": {
+                "properties": {
+                    "source_degraded": {"const": True},
+                    "fallback_required": {"const": False},
+                    "blocking": {"const": False},
+                }
+            },
+        }
+    ]
 
 
 def test_review_source_status_rejects_unknown_status() -> None:


### PR DESCRIPTION
## Goal

Make an exact trusted Codex rate/usage-limit response terminal, non-blocking review-source evidence and prevent the canonical contract from drifting back to manual retries or substitute-review overrides.

## Business reason

Reduce wasted review budget and repeated operator intervention while preserving actionable findings, required CI, review-thread dispositions, and final security evidence as hard blockers.

## Scope

- Add a closed `pulseplate.codex-review-source-unavailability/v1` receipt variant.
- Authenticate and re-fetch the same-PR Codex GitHub App quota comment, exact body, immutable timestamps, canonical URLs, and UTF-8 body hash.
- Accept that receipt in closeout and strict merge-readiness with `review_claim=none` and a distinct marker.
- Remove legacy review-credit override authoring flags while retaining PR 2142 artifact parsing and revalidation.
- Keep configured bots automatic; prohibit manual review trigger/retrigger instructions.
- Select the anti-drift guard whenever any policy, identity, closeout, merge-gate, or canonical-doc surface changes.

## Out of scope

- No security-scan policy change.
- No weakening of required checks, unresolved-thread handling, actionable bot findings, or disposition mapping.
- No GitHub repository-settings or branch-ruleset mutation.
- No product runtime, API, schema, dependency, migration, or workflow behavior change.

## Files changed

- Canonical governance: `AGENTS.md`, `RUNBOOK_AGENT.md`, and two orchestration policy documents.
- Review evidence and identity: `review_source_status.py`, `pr_commit_identity.py`, `pr_review_evidence.py`, and `pr_review_closeout.py`.
- Strict gate: `scripts/ci/check_pr_merge_readiness.py`.
- Always-selected guard wiring: `scripts/run-backend-tests-pre-commit.sh`.
- Deterministic receipt, spoofing, closeout, merge-gate, policy, and anti-drift tests.

## Key decisions

- Quota evidence proves only source unavailability, never review, approval, PASS, or no-findings.
- `rate_limited` and `usage_limit_reached` are terminal non-blocking statuses with no review retry, prior/substitute review, operator override, or TTL.
- A material change requires a new seal; the same immutable quota comment may be reverified and reused.
- Historical PR 2142 receipts remain read-compatible only.

## Tests / validation

Passed locally for material commit `bcd25611498c335815d6c098f075335bf932e595`; mapping-only closeout commit `76a59df4f113d629ddfe99d5f51b9af21ab7d4fd` reran the required local bundle:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- focused pytest for quota guard, review-source status, material seal, merge readiness, and review-pattern oracles
- targeted MyPy for five changed source modules
- `make validate-changed`
- `pre-commit run --all-files`
- `git diff --check`
- pre-push MyPy, pip-audit, backend tests, Bandit, and hook bundle

Current-head GitHub CI is rerunning automatically for mapping-only head `76a59df4f113d629ddfe99d5f51b9af21ab7d4fd`.

## Security notes

This changes a governance trust boundary. The verifier fails closed on spoofed App/user identity, edited comments, wrong comment id, cross-repository/PR URLs, unknown body text, body-hash drift, malformed tagged-union fields, and stale material binding. Required checks, unresolved threads, actionable bot comments, fallback findings, and the final Codex Security receipt remain independent blockers.

## Risks / rollback

Risk: quota evidence could be mislabeled as a clean review or policy docs could drift without running the guard. Mitigation: closed exact-key schema, `review_claim=none`, a distinct `REVIEW_SOURCE_UNAVAILABLE_VALID` marker, and diff-runner selection for every protected surface. Rollback: revert `b834d57f3cc3a059749a4dbca6c5ee50516274bc`; legacy PR 2142 read compatibility remains isolated.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: [canonical review artifact](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/76a59df4f113d629ddfe99d5f51b9af21ab7d4fd/docs/review/PR_2165_FIXED_MAPPING.md)
- URL→SHA and disposition details belong only in the canonical artifact.

## Split justification

- Why this PR cannot be split safely: receipt schema, authenticated identity proof, authoring CLI, live revalidation, merge-gate consumption, canonical docs, always-on selection, and negative tests form one admission contract.
- Invariant or rollout constraint requiring one PR: no intermediate state may either accept unauthenticated quota evidence or document non-blocking behavior that the strict gate still rejects.
- Follow-up PRs: none for repository code; any GitHub branch-ruleset enforcement change requires a separate explicit operator decision.

## Operator-approved privileged scope exception

Operator approval: approved for the mandatory generated closeout mapping as the 16th file.
Privileged scope exception: approved because the frozen material diff has 15 files and the required generated mapping is the 16th file.

## Deferred / Follow-ups

None. Repository-wide branch settings remain operator-owned and unchanged.

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/exp-ccb41d22ec23.json`
- Result: accepted; Apple Container 1.1.0; `network_budget=0`; `mutated_paths=[]`; both immutable oracles passed.
- Premortem: `artifacts/orchestration/premortem/review-quota-evidence-admission.md` (local retained evidence).

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/3404669df002.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Pre-open order: agent-coordinator → architecture-specialist → security-auditor → dev-operator.

## Next best step

Wait for automatic current-head CI and the mandatory review cycle, run strict merge readiness, then merge this prerequisite before resuming PR 2162 closeout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admits trusted same‑PR Codex quota comments as terminal, non‑blocking review‑source evidence and seals them to the exact material head to prevent ancestor‑scan bypass. Hardens verification with exact UTF‑8 body hashing, trusted GitHub App re‑auth, and an anti‑drift guard.

- **New Features**
  - Added `pulseplate.codex-review-source-unavailability/v1` receipt for exact Codex usage/limit comments; `review_claim=none`, non‑blocking, bound to the material head.
  - Locked terminal constants for `rate_limited` and `usage_limit_reached` in `review_source_status.v1.json`; CI/closeout re‑fetch and re‑auth the same comment, verify PR/repo URLs and `created_at`, recompute the body SHA‑256, accept only known texts (including the settings variant); gate prints `REVIEW_SOURCE_UNAVAILABLE_VALID`.

- **Bug Fixes**
  - Recompute and seal the material manifest for quota evidence and revalidate it in CI so an ancestor Codex Security scan cannot satisfy newer material.
  - Fixed pre‑push file‑list deadlock by using process substitution and guarding both transport paths.

<sup>Written for commit 76a59df4f113d629ddfe99d5f51b9af21ab7d4fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sealing with trusted Codex “review-source unavailable” evidence for terminal rate/usage-limit cases.
  * Updated merge-readiness validation and output to surface terminal unavailability status markers.
* **Bug Fixes**
  * Strengthened fail-closed verification to reject edited/spoofed/unrecognized unavailability receipts and stale material/digest bindings.
  * Tightened enforcement so terminal unavailability cannot be overridden into blocking flows.
* **Documentation**
  * Updated enforcement rules, runbooks, and orchestration contract specs for the terminal-only evidence workflow and legacy compatibility notes.
* **Tests**
  * Expanded guard and CI gate coverage for policy projections and terminal seal validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





