### PR TITLE
fix(governance): accept Codex Security v0.1.11 manifests

### DIFF
--- a/docs/review/PR_2167_FIXED_MAPPING.md
+++ b/docs/review/PR_2167_FIXED_MAPPING.md
@@ -24,8 +24,31 @@ Commit: cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4
 Evidence: scripts/orchestration/pr_review_evidence.py:639,717; tests/test_pr_review_material_seal.py:1960-2004
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2167#discussion_r3617402788 -> cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4
 
+Disposition: NOT-A-BUG
+Evidence: GitHub proves cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4 is the real sealed material commit and an ancestor of live PR head 3eaaa8142e8f1004094aaf798a9f6fb7ef1e1552; the cited 99d1d2bee0ef5e26b0a91fa35ded8b7fd1596882 is unavailable to the Commit API.
+Reason: The finding applies ancestry to an opaque reviewer execution ref; repository-addressable PR commits and the mapping-excluded material digest remain valid.
+Fingerprint: sha256:6eaead831ece5e173d12863060607ddedaf06f7d5e3d2986744d7379baacd2bf
+Cause: unavailable_review_ref_ancestry
+Material-Digest: sha256:0a07d3a79b51b12d2ed82e79a39cfcecb858a7c0170f45d5c34b697dcb3e463b
+Verified-Fix: cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2167#discussion_r3617767361
+
+Disposition: NOT-A-BUG
+Evidence: The minimum-artifact message states the required canonical subset; the separate 64-artifact cap is explicit. Distinct buffered JSON and streaming supplemental paths have deterministic mutation, size, FIFO, and descriptor regression coverage.
+Reason: The review contains wording and helper-extraction nitpicks, not a correctness or production-safety defect; broadening post-freeze refactoring would add risk without changing the contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2167#pullrequestreview-4738756672
+
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/pr_review_closeout.py:_render_mapping and scripts/orchestration/review_mapping_artifact.py:validate_mapping_artifact_text define the canonical generated artifact; Deferred / Follow-ups remains a PR-body section and is None for this lane.
+Reason: The generated canonical mapping contract does not require that PR-body section. An optional reader-facing None section may be added without altering the sealed evidence.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2167#pullrequestreview-4739193549
+
 ## Review Material Seal
 <!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
 <!-- pragma: allowlist nextline secret -->
 {"authority":"human_asserted_content_receipt","code_review":{"authority":"trusted_codex_review_source_unavailability","binding_kind":"seal_context_only","blocking":false,"fallback_required":false,"material_digest":"sha256:0a07d3a79b51b12d2ed82e79a39cfcecb858a7c0170f45d5c34b697dcb3e463b","material_head_sha":"cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4","quota_body_sha256":"sha256:e39b189a2ed6388c9d919876a2893ca0216a023301e11d788df190b4366991b9","quota_created_at":"2026-07-20T21:29:43Z","quota_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2167#issuecomment-5027472129","review_claim":"none","schema_version":"pulseplate.codex-review-source-unavailability/v1","source":"codex_review","source_degraded":true,"source_status":"usage_limit_reached","status":"tooling_unavailable"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:82d8b4711d93020596ac1afd9188f01d04f13448e93354e593672006cc352617","findings_sha256":"sha256:c9d7ebb453ba811fafde7804319c2b6ce543b64c020370674b2d23c7eecf054c","work_ledger_sha256":"sha256:681be5c185cd6edb51ba18a4ae727b7d0b5b489984ed7066cfe3d93fad85a645"},"authority":"human_asserted_content_receipt","base_revision":"c325489612809e0c9dfc8bb300aca606a8bf7c49","coverage_completeness":"complete","findings_count":0,"head_revision":"cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4","manifest_sha256":"sha256:4dd994c53e2163bd4188984084fad4d6d1980e90d7855ca39c4acb461b86c5c0","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"26ac8fbb-5fb9-4b62-86c6-f3a50e1101cd","snapshot_digest":"codex-security-snapshot/v1:sha256:0a07d3a79b51b12d2ed82e79a39cfcecb858a7c0170f45d5c34b697dcb3e463b"},"material":{"base_ref_oid":"c325489612809e0c9dfc8bb300aca606a8bf7c49","digest":"sha256:0a07d3a79b51b12d2ed82e79a39cfcecb858a7c0170f45d5c34b697dcb3e463b","material_head_sha":"cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4","merge_base_sha":"c325489612809e0c9dfc8bb300aca606a8bf7c49","policy_version":"pulseplate.material-classification/v1"},"pr_number":2167,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
 <!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->
+
+## Deferred / Follow-ups
+
+None.

--- a/docs/review/PR_2167_FIXED_MAPPING.md
+++ b/docs/review/PR_2167_FIXED_MAPPING.md
@@ -1,0 +1,31 @@
+# PR 2167 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/2ec8d8552cbf.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/exp-2167-v011-freeze-oracle-result.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 8675810f969b9dc69acf98de2158503b243c4e97
+Evidence: scripts/orchestration/pr_review_evidence.py:138-139,914-961; tests/test_pr_review_material_seal.py:2014-2052
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2167#discussion_r3617225703 -> 8675810f969b9dc69acf98de2158503b243c4e97
+
+Disposition: FIXED
+Commit: cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4
+Evidence: scripts/orchestration/pr_review_evidence.py:639,717; tests/test_pr_review_material_seal.py:1960-2004
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2167#discussion_r3617402788 -> cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"authority":"trusted_codex_review_source_unavailability","binding_kind":"seal_context_only","blocking":false,"fallback_required":false,"material_digest":"sha256:0a07d3a79b51b12d2ed82e79a39cfcecb858a7c0170f45d5c34b697dcb3e463b","material_head_sha":"cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4","quota_body_sha256":"sha256:e39b189a2ed6388c9d919876a2893ca0216a023301e11d788df190b4366991b9","quota_created_at":"2026-07-20T21:29:43Z","quota_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2167#issuecomment-5027472129","review_claim":"none","schema_version":"pulseplate.codex-review-source-unavailability/v1","source":"codex_review","source_degraded":true,"source_status":"usage_limit_reached","status":"tooling_unavailable"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:82d8b4711d93020596ac1afd9188f01d04f13448e93354e593672006cc352617","findings_sha256":"sha256:c9d7ebb453ba811fafde7804319c2b6ce543b64c020370674b2d23c7eecf054c","work_ledger_sha256":"sha256:681be5c185cd6edb51ba18a4ae727b7d0b5b489984ed7066cfe3d93fad85a645"},"authority":"human_asserted_content_receipt","base_revision":"c325489612809e0c9dfc8bb300aca606a8bf7c49","coverage_completeness":"complete","findings_count":0,"head_revision":"cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4","manifest_sha256":"sha256:4dd994c53e2163bd4188984084fad4d6d1980e90d7855ca39c4acb461b86c5c0","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"26ac8fbb-5fb9-4b62-86c6-f3a50e1101cd","snapshot_digest":"codex-security-snapshot/v1:sha256:0a07d3a79b51b12d2ed82e79a39cfcecb858a7c0170f45d5c34b697dcb3e463b"},"material":{"base_ref_oid":"c325489612809e0c9dfc8bb300aca606a8bf7c49","digest":"sha256:0a07d3a79b51b12d2ed82e79a39cfcecb858a7c0170f45d5c34b697dcb3e463b","material_head_sha":"cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4","merge_base_sha":"c325489612809e0c9dfc8bb300aca606a8bf7c49","policy_version":"pulseplate.material-classification/v1"},"pr_number":2167,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -783,7 +783,8 @@ def _ingest_codex_security_receipt_from_descriptor(
             "status",
             "target",
             "threatModel",
-        },
+        }
+        | ({"hardening"} if "hardening" in scan else set()),
         label="scan",
     )
     if scan["status"] != "completed":
@@ -798,6 +799,13 @@ def _ingest_codex_security_receipt_from_descriptor(
         raise ReviewEvidenceError("scan.id must be a lowercase UUID")
     if not isinstance(scan["scope"], dict) or not isinstance(scan["threatModel"], dict):
         raise ReviewEvidenceError("scan scope and threatModel must be objects")
+    if "hardening" in scan:
+        hardening = scan["hardening"]
+        if not isinstance(hardening, dict):
+            raise ReviewEvidenceError("scan.hardening must be an object")
+        _require_exact_keys(hardening, {"portfolioPath"}, label="scan.hardening")
+        if hardening["portfolioPath"] != "hardening/hardening.md":
+            raise ReviewEvidenceError("scan.hardening must use the canonical portfolio path")
 
     producer = scan["producer"]
     if not isinstance(producer, dict):
@@ -815,7 +823,8 @@ def _ingest_codex_security_receipt_from_descriptor(
         raise ReviewEvidenceError("scan.target must be an object")
     _require_exact_keys(
         target,
-        {"baseRevision", "displayName", "headRevision", "kind", "snapshotDigest", "targetId"},
+        {"baseRevision", "displayName", "headRevision", "kind", "snapshotDigest", "targetId"}
+        | ({"remote"} if "remote" in target else set()),
         label="scan.target",
     )
     if (
@@ -828,12 +837,17 @@ def _ingest_codex_security_receipt_from_descriptor(
         or not re.fullmatch(r"target_sha256_[0-9a-f]{64}", target["targetId"])
     ):
         raise ReviewEvidenceError("scan target does not match the expected Git diff")
+    if (
+        "remote" in target
+        and target["remote"] != "https://github.com/Katsiarynakavaleuskaya/PulsePlate"
+    ):
+        raise ReviewEvidenceError("scan.target.remote must use the canonical PulsePlate repository")
 
     if scan["coverageRef"] != "coverage.json" or scan["findingsRef"] != "findings.json":
         raise ReviewEvidenceError("scan coverage/findings refs must use canonical filenames")
     artifacts = scan["artifacts"]
-    if not isinstance(artifacts, list) or len(artifacts) != 3:
-        raise ReviewEvidenceError("scan must list exactly three canonical artifacts")
+    if not isinstance(artifacts, list) or len(artifacts) < 3:
+        raise ReviewEvidenceError("scan must list the three canonical artifacts")
     artifact_specs: dict[str, tuple[str, str]] = {}
     for artifact in artifacts:
         if not isinstance(artifact, dict):
@@ -854,8 +868,11 @@ def _ingest_codex_security_receipt_from_descriptor(
         "findings.json": "application/json",
         "artifacts/02_discovery/work_ledger.jsonl": "application/octet-stream",
     }
-    if {path: spec[0] for path, spec in artifact_specs.items()} != expected_paths:
-        raise ReviewEvidenceError("scan artifact inventory does not match the v1 contract")
+    for path, media_type in expected_paths.items():
+        if artifact_specs.get(path, (None, None))[0] != media_type:
+            raise ReviewEvidenceError(
+                "scan artifact inventory does not contain the v1 canonical artifacts"
+            )
 
     artifact_raw: dict[str, bytes] = {}
     for path, (_media_type, expected_digest) in artifact_specs.items():

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -135,6 +135,8 @@ _ZERO_SHA = "0" * 40
 _MAX_MANIFEST_BYTES = 2 * 1024 * 1024
 _MAX_JSON_ARTIFACT_BYTES = 8 * 1024 * 1024
 _MAX_LEDGER_BYTES = 32 * 1024 * 1024
+_MAX_SCAN_ARTIFACTS = 64
+_MAX_TOTAL_SCAN_ARTIFACT_BYTES = 64 * 1024 * 1024
 _DUPLICATE_REPLY_KEYS = (
     "Disposition",
     "Fingerprint",
@@ -680,13 +682,11 @@ def _open_scan_root(root: Path) -> int:
         raise ReviewEvidenceError("scan root could not be opened safely") from exc
 
 
-def _read_contained_artifact_from_descriptor(
+def _open_contained_artifact_descriptor(
     root_descriptor: int,
     relative: PurePosixPath,
-    *,
-    max_bytes: int,
-) -> bytes:
-    """Read beneath one immutable scan-root descriptor without following symlinks."""
+) -> int:
+    """Open one regular-file candidate beneath an immutable scan-root descriptor."""
 
     descriptor = os.dup(root_descriptor)
     try:
@@ -716,12 +716,70 @@ def _read_contained_artifact_from_descriptor(
             raise ReviewEvidenceError(
                 "scan artifact path contains a symlink or is missing"
             ) from exc
-        try:
-            return _read_regular_descriptor(
-                file_descriptor, max_bytes=max_bytes, label=str(relative)
+        return file_descriptor
+    finally:
+        os.close(descriptor)
+
+
+def _read_contained_artifact_from_descriptor(
+    root_descriptor: int,
+    relative: PurePosixPath,
+    *,
+    max_bytes: int,
+) -> bytes:
+    """Read beneath one immutable scan-root descriptor without following symlinks."""
+
+    descriptor = _open_contained_artifact_descriptor(root_descriptor, relative)
+    try:
+        return _read_regular_descriptor(descriptor, max_bytes=max_bytes, label=str(relative))
+    finally:
+        os.close(descriptor)
+
+
+def _hash_contained_artifact_from_descriptor(
+    root_descriptor: int,
+    relative: PurePosixPath,
+    *,
+    max_bytes: int,
+) -> tuple[str, int]:
+    """Hash one contained regular file without retaining its payload in memory."""
+
+    descriptor = _open_contained_artifact_descriptor(root_descriptor, relative)
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise ReviewEvidenceError(f"{relative} must be a regular file")
+        if before.st_size > max_bytes:
+            raise ReviewEvidenceError(f"{relative} exceeds size limit")
+        digest = hashlib.sha256()
+        bytes_read = 0
+        while bytes_read <= max_bytes:
+            chunk = os.read(
+                descriptor,
+                min(1024 * 1024, max_bytes + 1 - bytes_read),
             )
-        finally:
-            os.close(file_descriptor)
+            if not chunk:
+                break
+            digest.update(chunk)
+            bytes_read += len(chunk)
+        after = os.fstat(descriptor)
+        before_identity = (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+        )
+        after_identity = (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+        )
+        if bytes_read > max_bytes:
+            raise ReviewEvidenceError(f"{relative} exceeds size limit")
+        if before_identity != after_identity or bytes_read != before.st_size:
+            raise ReviewEvidenceError(f"{relative} changed while it was read")
+        return digest.hexdigest(), bytes_read
     finally:
         os.close(descriptor)
 
@@ -848,6 +906,8 @@ def _ingest_codex_security_receipt_from_descriptor(
     artifacts = scan["artifacts"]
     if not isinstance(artifacts, list) or len(artifacts) < 3:
         raise ReviewEvidenceError("scan must list the three canonical artifacts")
+    if len(artifacts) > _MAX_SCAN_ARTIFACTS:
+        raise ReviewEvidenceError("scan artifact count exceeds limit")
     artifact_specs: dict[str, tuple[str, str]] = {}
     for artifact in artifacts:
         if not isinstance(artifact, dict):
@@ -874,17 +934,30 @@ def _ingest_codex_security_receipt_from_descriptor(
                 "scan artifact inventory does not contain the v1 canonical artifacts"
             )
 
-    artifact_raw: dict[str, bytes] = {}
+    canonical_payloads: dict[str, bytes] = {}
+    total_artifact_bytes = 0
     for path, (_media_type, expected_digest) in artifact_specs.items():
         limit = _MAX_LEDGER_BYTES if path.endswith(".jsonl") else _MAX_JSON_ARTIFACT_BYTES
-        raw = _read_contained_artifact_from_descriptor(
-            root_descriptor, PurePosixPath(path), max_bytes=limit
-        )
-        if hashlib.sha256(raw).hexdigest() != expected_digest:
+        if path in {"coverage.json", "findings.json"}:
+            raw = _read_contained_artifact_from_descriptor(
+                root_descriptor, PurePosixPath(path), max_bytes=limit
+            )
+            actual_digest = hashlib.sha256(raw).hexdigest()
+            artifact_bytes = len(raw)
+            canonical_payloads[path] = raw
+        else:
+            actual_digest, artifact_bytes = _hash_contained_artifact_from_descriptor(
+                root_descriptor,
+                PurePosixPath(path),
+                max_bytes=limit,
+            )
+        total_artifact_bytes += artifact_bytes
+        if total_artifact_bytes > _MAX_TOTAL_SCAN_ARTIFACT_BYTES:
+            raise ReviewEvidenceError("scan artifact aggregate size exceeds limit")
+        if actual_digest != expected_digest:
             raise ReviewEvidenceError(f"scan artifact hash mismatch for {path}")
-        artifact_raw[path] = raw
 
-    coverage = _load_json_bytes(artifact_raw["coverage.json"], label="coverage.json")
+    coverage = _load_json_bytes(canonical_payloads["coverage.json"], label="coverage.json")
     if not isinstance(coverage, dict):
         raise ReviewEvidenceError("coverage.json must contain an object")
     _require_exact_keys(
@@ -915,7 +988,7 @@ def _ingest_codex_security_receipt_from_descriptor(
     ):
         raise ReviewEvidenceError("Codex Security coverage is incomplete or inconsistent")
 
-    findings = _load_json_bytes(artifact_raw["findings.json"], label="findings.json")
+    findings = _load_json_bytes(canonical_payloads["findings.json"], label="findings.json")
     if not isinstance(findings, dict):
         raise ReviewEvidenceError("findings.json must contain an object")
     _require_exact_keys(

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -920,8 +920,8 @@ def _ingest_codex_security_receipt_from_descriptor(
             raise ReviewEvidenceError("scan artifact paths must be unique")
         if not isinstance(digest, str) or not _RAW_DIGEST_RE.fullmatch(digest):
             raise ReviewEvidenceError("scan artifact sha256 is malformed")
-        if not isinstance(media_type, str):
-            raise ReviewEvidenceError("scan artifact mediaType must be a string")
+        if not isinstance(media_type, str) or not media_type:
+            raise ReviewEvidenceError("scan artifact mediaType must be a non-empty string")
         artifact_specs[path] = (media_type, digest)
     expected_paths = {
         "coverage.json": "application/json",

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -636,8 +636,10 @@ def compute_material_manifest(
 def _safe_relative_artifact_path(value: Any) -> PurePosixPath:
     if not isinstance(value, str) or not value or "\\" in value:
         raise ReviewEvidenceError("scan artifact path must be a non-empty POSIX path")
+    if any(part in {"", ".", ".."} for part in value.split("/")):
+        raise ReviewEvidenceError("scan artifact path escapes the scan root")
     path = PurePosixPath(value)
-    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+    if path.is_absolute() or not path.parts:
         raise ReviewEvidenceError("scan artifact path escapes the scan root")
     if any(ord(character) < 32 or ord(character) == 127 for character in value):
         raise ReviewEvidenceError("scan artifact path contains control characters")
@@ -709,7 +711,10 @@ def _open_contained_artifact_descriptor(
         try:
             file_descriptor = os.open(
                 relative.parts[-1],
-                os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+                os.O_RDONLY
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_NONBLOCK", 0),
                 dir_fd=descriptor,
             )
         except OSError as exc:

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -1737,6 +1737,51 @@ def _build_scan_bundle(root: Path) -> Path:
     return root / "scan-manifest.json"
 
 
+def _add_manifest_artifact(manifest_path: Path, *, path: str, media_type: str, raw: bytes) -> None:
+    artifact_path = manifest_path.parent / path
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_bytes(raw)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["scan"]["artifacts"].append(
+        {
+            "mediaType": media_type,
+            "path": path,
+            "sha256": hashlib.sha256(raw).hexdigest(),
+        }
+    )
+    _write_json(manifest_path, manifest)
+
+
+def _build_v011_scan_bundle(root: Path) -> Path:
+    manifest_path = _build_scan_bundle(root)
+    hardening_path = root / "hardening" / "hardening.md"
+    hardening_path.parent.mkdir(parents=True, exist_ok=True)
+    hardening_path.write_bytes(b"# Hardening\n")
+    for path, raw in (
+        (
+            "artifacts/02_discovery/finding_discovery_report.md",
+            b"# Finding discovery\n",
+        ),
+        (
+            "artifacts/03_coverage/repository_coverage_ledger.md",
+            b"# Coverage ledger\n",
+        ),
+        (
+            "artifacts/05_findings/attack_path_analysis_report.md",
+            b"# Attack path analysis\n",
+        ),
+        ("artifacts/05_findings/validation_summary.md", b"# Validation summary\n"),
+    ):
+        _add_manifest_artifact(
+            manifest_path, path=path, media_type="application/octet-stream", raw=raw
+        )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["scan"]["hardening"] = {"portfolioPath": "hardening/hardening.md"}
+    manifest["scan"]["target"]["remote"] = "https://github.com/Katsiarynakavaleuskaya/PulsePlate"
+    _write_json(manifest_path, manifest)
+    return manifest_path
+
+
 def test_scan_receipt_validates_real_bundle_and_contains_no_local_path(tmp_path: Path) -> None:
     manifest_path = _build_scan_bundle(tmp_path / "scan")
 
@@ -1747,6 +1792,170 @@ def test_scan_receipt_validates_real_bundle_and_contains_no_local_path(tmp_path:
     assert receipt["authority"] == RECEIPT_AUTHORITY
     assert receipt["findings_count"] == 0
     assert str(tmp_path) not in json.dumps(receipt)
+
+
+def test_scan_receipt_accepts_v011_remote_hardening_and_supplemental_artifacts(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+
+    receipt = ingest_codex_security_receipt(
+        manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+    )
+
+    assert set(receipt) == {
+        "artifacts",
+        "authority",
+        "base_revision",
+        "coverage_completeness",
+        "findings_count",
+        "head_revision",
+        "manifest_sha256",
+        "producer",
+        "scan_id",
+        "snapshot_digest",
+    }
+    assert receipt["producer"]["version"] == "0.1.11"
+    assert set(receipt["artifacts"]) == {
+        "coverage_sha256",
+        "findings_sha256",
+        "work_ledger_sha256",
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error"),
+    [
+        (
+            lambda manifest: manifest["scan"]["target"].update(
+                remote="https://github.com/example/other"
+            ),
+            "remote",
+        ),
+        (lambda manifest: manifest["scan"].update(unexpected=True), "scan keys mismatch"),
+        (
+            lambda manifest: manifest["scan"]["target"].update(unexpected=True),
+            "scan.target keys mismatch",
+        ),
+        (
+            lambda manifest: manifest["scan"].update(hardening={"portfolioPath": "wrong.md"}),
+            "hardening",
+        ),
+        (lambda manifest: manifest["scan"].update(hardening="wrong"), "must be an object"),
+        (lambda manifest: manifest["scan"].update(hardening=[]), "must be an object"),
+        (lambda manifest: manifest["scan"].update(hardening={}), "scan.hardening keys mismatch"),
+        (
+            lambda manifest: manifest["scan"].update(
+                hardening={"portfolioPath": "hardening/hardening.md", "unexpected": True}
+            ),
+            "scan.hardening keys mismatch",
+        ),
+    ],
+)
+def test_scan_receipt_rejects_invalid_v011_manifest_shape(
+    tmp_path: Path, mutate: Any, error: str
+) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    mutate(manifest)
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ReviewEvidenceError, match=error):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
+@pytest.mark.parametrize(
+    "canonical_path",
+    ["coverage.json", "findings.json", "artifacts/02_discovery/work_ledger.jsonl"],
+)
+def test_scan_receipt_requires_canonical_artifact_media_types(
+    tmp_path: Path, canonical_path: str
+) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["scan"]["artifacts"] = [
+        artifact for artifact in manifest["scan"]["artifacts"] if artifact["path"] != canonical_path
+    ]
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ReviewEvidenceError, match="canonical artifacts"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
+@pytest.mark.parametrize(
+    ("canonical_path", "wrong_media_type"),
+    [
+        ("coverage.json", "text/plain"),
+        ("findings.json", "text/plain"),
+        ("artifacts/02_discovery/work_ledger.jsonl", "application/json"),
+    ],
+)
+def test_scan_receipt_rejects_wrong_canonical_artifact_media_type(
+    tmp_path: Path, canonical_path: str, wrong_media_type: str
+) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    for artifact in manifest["scan"]["artifacts"]:
+        if artifact["path"] == canonical_path:
+            artifact["mediaType"] = wrong_media_type
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ReviewEvidenceError, match="canonical artifacts"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
+def test_scan_receipt_rejects_supplemental_artifact_hash_drift(tmp_path: Path) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    supplemental_path = manifest_path.parent / "artifacts" / "05_findings" / "validation_summary.md"
+    supplemental_path.write_text("changed\n", encoding="utf-8")
+
+    with pytest.raises(ReviewEvidenceError, match="artifacts/05_findings/validation_summary.md"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
+@pytest.mark.parametrize(
+    "path", ["artifacts/02_discovery/finding_discovery_report.md", "../outside.txt"]
+)
+def test_scan_receipt_rejects_unsafe_supplemental_artifact_paths(tmp_path: Path, path: str) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    supplemental = manifest["scan"]["artifacts"][3]
+    supplemental["path"] = path
+    if path.startswith("../"):
+        (manifest_path.parent.parent / "outside.txt").write_text("outside\n", encoding="utf-8")
+    else:
+        artifact_path = manifest_path.parent / path
+        outside = tmp_path / "outside.md"
+        outside.write_bytes(artifact_path.read_bytes())
+        artifact_path.unlink()
+        artifact_path.symlink_to(outside)
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ReviewEvidenceError, match="symlink|escapes the scan root"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
+def test_scan_receipt_rejects_duplicate_supplemental_artifact_path(tmp_path: Path) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    duplicate = dict(manifest["scan"]["artifacts"][3])
+    manifest["scan"]["artifacts"].append(duplicate)
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ReviewEvidenceError, match="paths must be unique"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
 
 
 def test_scan_receipt_rejects_symlinked_artifact(tmp_path: Path) -> None:

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -1957,6 +1957,47 @@ def test_scan_receipt_rejects_unsafe_supplemental_artifact_paths(tmp_path: Path,
         )
 
 
+def test_scan_receipt_rejects_dot_supplemental_artifact_path(tmp_path: Path) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["scan"]["artifacts"][3]["path"] = "."
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ReviewEvidenceError, match="escapes the scan root"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
+def test_scan_receipt_rejects_fifo_supplemental_artifact_without_blocking(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    fifo_path = manifest_path.parent / "artifacts" / "05_findings" / "validation_summary.md"
+    fifo_path.unlink()
+    os.mkfifo(fifo_path)
+    original_open = evidence_module.os.open
+    nonblocking_flag = os.O_NONBLOCK
+
+    def require_nonblocking_fifo_open(
+        path: Any,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        if path == fifo_path.name:
+            assert flags & nonblocking_flag
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(evidence_module.os, "open", require_nonblocking_fifo_open)
+
+    with pytest.raises(ReviewEvidenceError, match="must be a regular file"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
 def test_scan_receipt_rejects_duplicate_supplemental_artifact_path(tmp_path: Path) -> None:
     manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -1958,6 +1958,77 @@ def test_scan_receipt_rejects_duplicate_supplemental_artifact_path(tmp_path: Pat
         )
 
 
+def test_scan_receipt_rejects_excessive_artifact_count(tmp_path: Path) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    supplemental_count = (
+        evidence_module._MAX_SCAN_ARTIFACTS + 1 - len(manifest["scan"]["artifacts"])
+    )
+    manifest["scan"]["artifacts"].extend(
+        {
+            "mediaType": "application/octet-stream",
+            "path": f"artifacts/extra/{index}.bin",
+            "sha256": "0" * 64,
+        }
+        for index in range(supplemental_count)
+    )
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ReviewEvidenceError, match="artifact count exceeds limit"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
+def test_scan_receipt_rejects_excessive_aggregate_artifact_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    aggregate_bytes = sum(
+        (manifest_path.parent / artifact["path"]).stat().st_size
+        for artifact in manifest["scan"]["artifacts"]
+    )
+    monkeypatch.setattr(
+        evidence_module,
+        "_MAX_TOTAL_SCAN_ARTIFACT_BYTES",
+        aggregate_bytes - 1,
+    )
+
+    with pytest.raises(ReviewEvidenceError, match="aggregate size exceeds limit"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
+def test_scan_receipt_streams_non_json_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    original_reader = evidence_module._read_contained_artifact_from_descriptor
+
+    def reject_buffered_non_json(descriptor: int, relative: Any, *, max_bytes: int) -> bytes:
+        if str(relative) not in {
+            "scan-manifest.json",
+            "coverage.json",
+            "findings.json",
+        }:
+            raise AssertionError(f"buffered non-JSON artifact: {relative}")
+        return original_reader(descriptor, relative, max_bytes=max_bytes)
+
+    monkeypatch.setattr(
+        evidence_module,
+        "_read_contained_artifact_from_descriptor",
+        reject_buffered_non_json,
+    )
+
+    receipt = ingest_codex_security_receipt(
+        manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+    )
+
+    assert receipt["findings_count"] == 0
+
+
 def test_scan_receipt_rejects_symlinked_artifact(tmp_path: Path) -> None:
     manifest_path = _build_scan_bundle(tmp_path / "scan")
     coverage_path = manifest_path.parent / "coverage.json"

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -1921,6 +1921,18 @@ def test_scan_receipt_rejects_supplemental_artifact_hash_drift(tmp_path: Path) -
         )
 
 
+def test_scan_receipt_rejects_empty_supplemental_artifact_media_type(tmp_path: Path) -> None:
+    manifest_path = _build_v011_scan_bundle(tmp_path / "scan")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["scan"]["artifacts"][3]["mediaType"] = ""
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(ReviewEvidenceError, match="mediaType must be a non-empty string"):
+        ingest_codex_security_receipt(
+            manifest_path, expected_base_sha=BASE_SHA, expected_head_sha=HEAD_SHA
+        )
+
+
 @pytest.mark.parametrize(
     "path", ["artifacts/02_discovery/finding_discovery_report.md", "../outside.txt"]
 )


### PR DESCRIPTION
## Goal

Accept the official Codex Security 0.1.11 manifest shape without weakening the repository's fail-closed review-evidence boundary.

## Business reason

Restore deterministic closeout for the already-completed, zero-finding security scan on PR #2163 so the nutrition legacy-removal sequence can proceed without rerunning scans or changing bot/orchestration contracts.

## Scope

- Admit only the documented optional `scan.hardening` and `target.remote` fields.
- Require the expected PulsePlate repository remote when `target.remote` is present.
- Keep the three canonical scan artifacts mandatory.
- Validate every supplemental sealed artifact with the existing path, containment, size, regular-file, uniqueness, media-type, and SHA-256 checks.
- Require every sealed artifact media type to be non-empty, matching the official schema.
- Cap artifact count and aggregate bytes, and hash non-JSON artifacts without retaining their payloads.
- Reject empty/dot path components and open candidates nonblocking so non-regular files cannot hang closeout.
- Cover the exact retained Codex Security 0.1.11 manifest shape and fail-closed negative cases.

## Out of scope

- No nutrition runtime, API, OpenAPI, auth, tier, formula, or schema changes.
- No review-source, bot, mapping, merge, workflow, or orchestration contract changes.
- No retry or replacement of the completed PR #2163 security scan.
- No GitHub repository-settings or branch-ruleset mutation.

## Files changed

- `scripts/orchestration/pr_review_evidence.py`
- `tests/test_pr_review_material_seal.py`
- canonical review closeout artifact (excluded from material digest)

## Key decisions

- Unknown `scan` and `target` fields remain rejected.
- Supplemental artifacts gain no review or merge authority and do not alter the receipt schema.
- The parser accepts at most 64 artifacts and 64 MiB aggregate sealed content; non-JSON artifacts are streamed.
- Artifact paths retain explicit non-empty components, and FIFO candidates fail the regular-file check without blocking.
- `hardening/hardening.md` remains derived and unsealed, as required by the installed 0.1.11 contract.
- Legacy manifests without `target.remote` remain accepted; a present remote must be the exact PulsePlate repository URL.

## Tests / validation

Passed locally for material head `cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4`:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_pr_review_material_seal.py` — 190 passed
- focused scan-receipt suite — 31 passed
- exact retained PR #2163 Codex Security manifest ingestion
- final official Codex Security scan `26ac8fbb-5fb9-4b62-86c6-f3a50e1101cd` — complete, 2/2 coverage receipts, 0 findings
- coordinator-owned `pulseplate-pr-review` dry run — no code, architecture, or security defect
- `make validate-changed`
- `pre-commit run --all-files`
- `git diff --check`
- Apple Container Experiment Runner oracle — accepted, one attempt, zero retries, zero network

Full local `make verify` was not run per repository machine-budget policy.

## Security notes

This is a narrow governance trust-boundary adapter. It fails closed on cross-repository remotes, malformed or unknown additive fields, missing or mistyped canonical artifacts, duplicate/traversal/symlink paths, non-regular files, oversized files, and hash drift. The emitted receipt remains limited to the canonical three artifact hashes.

## Risks / rollback

Risk: an overly broad parser could admit untrusted supplemental evidence or spend excessive memory/IO on a hostile bundle. Mitigation: exact-key schemas, non-empty media types/path components, nonblocking candidate opens, count/aggregate bounds, streaming hashes, and descriptor-based containment/digest validation for every listed artifact. Rollback: revert commits `cb4eadcb4e06e2e9c7befd9cddc9704c969cf3c4`, `3fb41404dbb9c9a832f0725ecd0722bba86459cf`, `8675810f969b9dc69acf98de2158503b243c4e97`, and `7ea09be70a7deb5f6cf99b1b8c6189156d24ce8b`; this restores the prior strict parser and leaves product runtime unchanged.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- Canonical artifact: [PR #2167 review mapping](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/89b905726e8a35a5dfeb6f6b75f49922bab090d5/docs/review/PR_2167_FIXED_MAPPING.md)
- URL-to-SHA and disposition details live only in that artifact.

## Review disposition notes

- CodeRabbit's wording nitpick is NOT-A-BUG: “must list the three canonical artifacts” states the required subset and does not state “exactly three”; the separate upper bound remains explicit.
- The suggested helper extraction is intentionally not taken: the JSON read path and streaming hash path have different return and memory contracts, while shared safety invariants are already covered by deterministic mutation, size, FIFO, and descriptor tests. A refactor here would add post-freeze churn without correcting a production defect.
- The final official Codex review attempt returned the terminal `usage_limit_reached` source receipt. Per repository policy it is not a review or no-findings claim, requires no retry, and is bound to the closeout seal context.

## Split justification

- Why this PR cannot be split safely: parser admission and its deterministic positive/negative tests form one fail-closed boundary.
- Invariant requiring one PR: no intermediate state may accept the 0.1.11 shape without validating every supplemental artifact.
- Follow-up PRs: resume the already-frozen #2163 closeout after this prerequisite merges.

## Deferred / Follow-ups

None.

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/exp-2167-v011-freeze-oracle-result.json`
- Result: accepted on Apple Container; one attempt, zero retries, `network_budget=0`, and both focused/full deterministic oracles passed.

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/2ec8d8552cbf.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Pre-open order: agent-coordinator → security-auditor → qa-engineer-agent → cursor-specialist → architecture-specialist.

## Next best step

Wait for exact-current-head CI and the mandatory review cycle, run strict merge readiness, then merge this prerequisite before resuming #2163. No additional Codex Security scan or Codex review retry is permitted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for v0.1.1 security scan receipts with optional remote hardening details and supplemental artifacts.
  - Added validation for canonical artifact paths, media types, hashes, and repository metadata.

- **Bug Fixes**
  - Improved protection against unsafe paths, duplicate artifacts, unsupported files, and modified content.
  - Added limits for artifact count and total scan size.
  - Reduced memory usage when processing large non-JSON artifacts.

- **Tests**
  - Expanded coverage for valid v0.1.1 bundles and security receipt validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
