### PR TITLE
fix(ci): align CodeQL actions to verified v4.37.1 pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,7 +402,7 @@ jobs:
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ always() && steps.trivy_fs_sarif.outputs.present == 'true' }}
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: trivy-results.sarif
 
@@ -602,7 +602,7 @@ jobs:
 
       - name: Upload Trivy image scan results
         if: ${{ always() && hashFiles('trivy-image.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: 'trivy-image.sarif'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@dd677812177e0c29f9c970a6c58d8607ae1bfefd
+      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -97,6 +97,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@dd677812177e0c29f9c970a6c58d8607ae1bfefd
+      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -215,7 +215,7 @@ jobs:
           ls -la trivy-results.sarif
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
         with:
           sarif_file: 'trivy-results.sarif'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,9 +209,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    Security diff scan, bind to one material digest. A verified official Codex
    Connector PR-root reaction (`+1`, `heart`, `hooray`, or `rocket`) may satisfy
    the normal `--review-ref` path only when its canonical reaction ID, immutable
-   Connector account id/login, and a trusted Connector review on the same PR whose
-   real `commit_id` is the exact caller material head and whose `submitted_at`
-   strictly precedes the reaction all verify. It is a Connector response bound to that current material state, never a native
+   Connector account id/login, the live PR head equal to the exact caller material
+   head, and a server-timestamped GitHub Actions check suite for that head strictly
+   preceding the reaction all verify. It is a Connector response bound to that current material state, never a native
    GitHub approval, Codex Security result, or review-thread disposition authority.
    Optional advisory rendering remains non-authoritative. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
@@ -243,9 +243,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    frozen material head. A direct PR-root reaction from the official Connector
    may be passed to `seal --review-ref <canonical-reaction-url>` only for `+1`,
    `heart`, `hooray`, or `rocket`, after live verification of its immutable GitHub
-   account id/login and a trusted same-PR Connector review whose real `commit_id`
-   is the caller's full current material head and whose `submitted_at` strictly
-   precedes the reaction. It is
+   account id/login, a live PR head equal to the caller's full current material
+   head, and a server-timestamped GitHub Actions check suite for that head strictly
+   preceding the reaction. It is
    not a native GitHub approval, Codex Security result, or thread-resolution
    authority. The optional `--connector-advisory-reaction` rendering path remains
    non-authoritative and may be omitted with a warning. When

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,10 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    only that GitHub observed the material state before the response; it is not
    Connector-owned proof of a reviewed commit. Authenticated validation after the one
    canonical closeout commit may instead accept that mapping-only descendant as
-   the live head only after the material digest is proven unchanged. The receipt
+   the live head only after the material digest is proven unchanged. If that
+   automatic cycle replaces the sealed reaction, validation may use only a newer
+   live positive reaction from the same trusted Connector with the same content;
+   it does not rewrite the sealed receipt or restart the security scan. The receipt
    uses `binding_kind=seal_context_only`, `review_claim=none`, and `blocking=false`;
    it is a trusted positive Connector response, never an exact-head review claim,
    native GitHub approval, Codex Security result, or review-thread disposition authority.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,8 +209,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    Security diff scan, bind to one material digest. A verified official Codex
    Connector PR-root reaction (`+1`, `heart`, `hooray`, or `rocket`) may satisfy
    the normal `--review-ref` path only when its canonical reaction ID, immutable
-   Connector account id/login, and the caller's full live material head all verify.
-   It is a Connector response bound to that current material state, never a native
+   Connector account id/login, and an immutable GitHub Actions check-suite timestamp
+   proving that the exact caller material head was observed before the reaction all
+   verify. It is a Connector response bound to that current material state, never a native
    GitHub approval, Codex Security result, or review-thread disposition authority.
    Optional advisory rendering remains non-authoritative. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
@@ -242,7 +243,8 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    frozen material head. A direct PR-root reaction from the official Connector
    may be passed to `seal --review-ref <canonical-reaction-url>` only for `+1`,
    `heart`, `hooray`, or `rocket`, after live verification of its immutable GitHub
-   account id/login and binding to the caller's full current material head. It is
+   account id/login and a GitHub Actions check-suite timestamp binding it to the
+   caller's full current material head. It is
    not a native GitHub approval, Codex Security result, or thread-resolution
    authority. The optional `--connector-advisory-reaction` rendering path remains
    non-authoritative and may be omitted with a warning. When

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,8 +210,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    Connector PR-root reaction (`+1`, `heart`, `hooray`, or `rocket`) may satisfy
    the normal `--review-ref` path only when its canonical reaction ID, immutable
    Connector account id/login, the live PR head equal to the exact caller material
-   head, and a server-timestamped GitHub Actions check suite for that head strictly
-   preceding the reaction all verify. It is a Connector response bound to that current material state, never a native
+   head, and a server-timestamped GitHub Actions `pull_request` run linked to that
+   same PR and head strictly preceding the reaction all verify, with no later
+   force-push or head-restoration event. It is a Connector response bound to that current material state, never a native
    GitHub approval, Codex Security result, or review-thread disposition authority.
    Optional advisory rendering remains non-authoritative. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
@@ -244,8 +245,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    may be passed to `seal --review-ref <canonical-reaction-url>` only for `+1`,
    `heart`, `hooray`, or `rocket`, after live verification of its immutable GitHub
    account id/login, a live PR head equal to the caller's full current material
-   head, and a server-timestamped GitHub Actions check suite for that head strictly
-   preceding the reaction. It is
+   head, and a server-timestamped GitHub Actions `pull_request` run linked to that
+   same PR and head strictly preceding the reaction, with no later force-push or
+   head-restoration event. It is
    not a native GitHub approval, Codex Security result, or thread-resolution
    authority. The optional `--connector-advisory-reaction` rendering path remains
    non-authoritative and may be omitted with a warning. When

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,9 +210,11 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    Connector PR-root reaction (`+1`, `heart`, `hooray`, or `rocket`) may satisfy
    the normal `--review-ref` path only when its canonical reaction ID, immutable
    Connector account id/login, the live PR head equal to the exact caller material
-   head, and a server-timestamped GitHub Actions `pull_request` run linked to that
+   head at seal time, and a server-timestamped GitHub Actions `pull_request` run linked to that
    same PR and head strictly preceding the reaction all verify, with no later
-   force-push or head-restoration event. It is a Connector response bound to that current material state, never a native
+   force-push or head-restoration event. Authenticated validation after the one
+   canonical closeout commit may instead accept that mapping-only descendant as
+   the live head only after the material digest is proven unchanged. It is a Connector response bound to that current material state, never a native
    GitHub approval, Codex Security result, or review-thread disposition authority.
    Optional advisory rendering remains non-authoritative. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
@@ -245,9 +247,11 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    may be passed to `seal --review-ref <canonical-reaction-url>` only for `+1`,
    `heart`, `hooray`, or `rocket`, after live verification of its immutable GitHub
    account id/login, a live PR head equal to the caller's full current material
-   head, and a server-timestamped GitHub Actions `pull_request` run linked to that
+   head at seal time, and a server-timestamped GitHub Actions `pull_request` run linked to that
    same PR and head strictly preceding the reaction, with no later force-push or
-   head-restoration event. It is
+   head-restoration event. After the one canonical mapping-only closeout commit,
+   authenticated validation may accept its live descendant head only after
+   material-digest equality is re-established. It is
    not a native GitHub approval, Codex Security result, or thread-resolution
    authority. The optional `--connector-advisory-reaction` rendering path remains
    non-authoritative and may be omitted with a warning. When

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,18 +204,23 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    PR head. Reviewer execution SHAs are opaque until the Commit API proves
    them repository-addressable; unavailable/API-unknown refs must never enter
    ancestry checks.
-9. **Material identity:** one completed Codex review/Connector response or one trusted terminal
-   review-source unavailability receipt, plus one completed final Codex
+9. **Material identity:** one completed Codex review or one trusted terminal
+   Connector response/unavailability receipt, plus one completed final Codex
    Security diff scan, bind to one material digest. A verified official Codex
    Connector PR-root reaction (`+1`, `heart`, `hooray`, or `rocket`) may satisfy
-   the normal `--review-ref` path only when its canonical reaction ID, immutable
+   the normal `--review-ref` path as a nonblocking terminal source response only
+   when its canonical reaction ID, immutable
    Connector account id/login, the live PR head equal to the exact caller material
    head at seal time, and a server-timestamped GitHub Actions `pull_request` run linked to that
    same PR and head strictly preceding the reaction all verify, with no later
-   force-push or head-restoration event. Authenticated validation after the one
+   force-push or head-restoration event. That workflow-run chronology establishes
+   only that GitHub observed the material state before the response; it is not
+   Connector-owned proof of a reviewed commit. Authenticated validation after the one
    canonical closeout commit may instead accept that mapping-only descendant as
-   the live head only after the material digest is proven unchanged. It is a Connector response bound to that current material state, never a native
-   GitHub approval, Codex Security result, or review-thread disposition authority.
+   the live head only after the material digest is proven unchanged. The receipt
+   uses `binding_kind=seal_context_only`, `review_claim=none`, and `blocking=false`;
+   it is a trusted positive Connector response, never an exact-head review claim,
+   native GitHub approval, Codex Security result, or review-thread disposition authority.
    Optional advisory rendering remains non-authoritative. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
    operator-outage override may replace only the plugin receipt: it must be an
@@ -249,11 +254,13 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    account id/login, a live PR head equal to the caller's full current material
    head at seal time, and a server-timestamped GitHub Actions `pull_request` run linked to that
    same PR and head strictly preceding the reaction, with no later force-push or
-   head-restoration event. After the one canonical mapping-only closeout commit,
+   head-restoration event. The chronology is freshness evidence only and must not
+   be projected into a Connector-owned reviewed commit. After the one canonical mapping-only closeout commit,
    authenticated validation may accept its live descendant head only after
-   material-digest equality is re-established. It is
-   not a native GitHub approval, Codex Security result, or thread-resolution
-   authority. The optional `--connector-advisory-reaction` rendering path remains
+   material-digest equality is re-established. Its terminal receipt is nonblocking
+   and explicitly carries `review_claim=none`; it is not exact-head review proof,
+   a native GitHub approval, Codex Security result, or thread-resolution authority.
+   The optional `--connector-advisory-reaction` rendering path remains
    non-authoritative and may be omitted with a warning. When
    the official Codex connector emits an unedited no-findings
    issue comment instead, its trusted GitHub App identity and reviewed-commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,11 +204,15 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    PR head. Reviewer execution SHAs are opaque until the Commit API proves
    them repository-addressable; unavailable/API-unknown refs must never enter
    ancestry checks.
-9. **Material identity:** one completed Codex review or one trusted terminal
+9. **Material identity:** one completed Codex review/Connector response or one trusted terminal
    review-source unavailability receipt, plus one completed final Codex
    Security diff scan, bind to one material digest. A verified official Codex
-   Connector reaction may be recorded as advisory context only; it never binds
-   a material digest or substitutes review evidence. When Codex Security is systemically
+   Connector PR-root reaction (`+1`, `heart`, `hooray`, or `rocket`) may satisfy
+   the normal `--review-ref` path only when its canonical reaction ID, immutable
+   Connector account id/login, and the caller's full live material head all verify.
+   It is a Connector response bound to that current material state, never a native
+   GitHub approval, Codex Security result, or review-thread disposition authority.
+   Optional advisory rendering remains non-authoritative. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
    operator-outage override may replace only the plugin receipt: it must be an
    unedited exact-material GitHub comment from an `OWNER` or `MEMBER`, bind the
@@ -236,13 +240,12 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    legacy override path is not an active authoring contract for later PRs.
    The trusted submitted review object's real GitHub `commit_id` must equal the
    frozen material head. A direct PR-root reaction from the official Connector
-   may be recorded with `seal --connector-advisory-reaction <canonical-reaction-url>`
-   only for `+1`, `heart`, `hooray`, or `rocket`, after live verification of its
-   immutable GitHub account id and exact login. GitHub reactions carry no
-   reviewed SHA or run id, so they are advisory only: never a `--review-ref`,
-   exact-head proof, GitHub approval, Codex Security result, or thread-resolution
-   authority. A missing, malformed, or unavailable advisory reaction is omitted
-   with a warning; it neither blocks closeout nor clears another review gate. When
+   may be passed to `seal --review-ref <canonical-reaction-url>` only for `+1`,
+   `heart`, `hooray`, or `rocket`, after live verification of its immutable GitHub
+   account id/login and binding to the caller's full current material head. It is
+   not a native GitHub approval, Codex Security result, or thread-resolution
+   authority. The optional `--connector-advisory-reaction` rendering path remains
+   non-authoritative and may be omitted with a warning. When
    the official Codex connector emits an unedited no-findings
    issue comment instead, its trusted GitHub App identity and reviewed-commit
    prefix must resolve through the Commit API to that same full frozen head. A

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,10 +204,11 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    PR head. Reviewer execution SHAs are opaque until the Commit API proves
    them repository-addressable; unavailable/API-unknown refs must never enter
    ancestry checks.
-9. **Material identity:** one completed Codex review, one verified positive
-   official Codex Connector reaction, or one trusted terminal review-source
-   unavailability receipt, plus one completed final Codex Security diff scan,
-   bind to one material digest. When Codex Security is systemically
+9. **Material identity:** one completed Codex review or one trusted terminal
+   review-source unavailability receipt, plus one completed final Codex
+   Security diff scan, bind to one material digest. A verified official Codex
+   Connector reaction may be recorded as advisory context only; it never binds
+   a material digest or substitutes review evidence. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
    operator-outage override may replace only the plugin receipt: it must be an
    unedited exact-material GitHub comment from an `OWNER` or `MEMBER`, bind the
@@ -235,13 +236,14 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    legacy override path is not an active authoring contract for later PRs.
    The trusted submitted review object's real GitHub `commit_id` must equal the
    frozen material head. A direct PR-root reaction from the official Connector
-   is accepted only for `+1`, `heart`, `hooray`, or `rocket`, with its immutable
-   GitHub account id and exact login revalidated live; it must postdate the
-   current material head's GitHub push timestamp. It is bounded no-findings
-   evidence, not a GitHub approval, Codex Security result, or thread-resolution
-   authority. GitHub event visibility is polled for at most 30 seconds; a
-   pending event requires a later closeout retry, never a substitute or manual
-   retrigger. When the official Codex connector emits an unedited no-findings
+   may be recorded with `seal --connector-advisory-reaction <canonical-reaction-url>`
+   only for `+1`, `heart`, `hooray`, or `rocket`, after live verification of its
+   immutable GitHub account id and exact login. GitHub reactions carry no
+   reviewed SHA or run id, so they are advisory only: never a `--review-ref`,
+   exact-head proof, GitHub approval, Codex Security result, or thread-resolution
+   authority. A missing, malformed, or unavailable advisory reaction is omitted
+   with a warning; it neither blocks closeout nor clears another review gate. When
+   the official Codex connector emits an unedited no-findings
    issue comment instead, its trusted GitHub App identity and reviewed-commit
    prefix must resolve through the Commit API to that same full frozen head. A
    synthetic execution ref is never review proof. Every path is material except the exact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,9 +209,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    Security diff scan, bind to one material digest. A verified official Codex
    Connector PR-root reaction (`+1`, `heart`, `hooray`, or `rocket`) may satisfy
    the normal `--review-ref` path only when its canonical reaction ID, immutable
-   Connector account id/login, and an immutable GitHub Actions check-suite timestamp
-   proving that the exact caller material head was observed before the reaction all
-   verify. It is a Connector response bound to that current material state, never a native
+   Connector account id/login, and a trusted Connector review on the same PR whose
+   real `commit_id` is the exact caller material head and whose `submitted_at`
+   strictly precedes the reaction all verify. It is a Connector response bound to that current material state, never a native
    GitHub approval, Codex Security result, or review-thread disposition authority.
    Optional advisory rendering remains non-authoritative. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
@@ -243,8 +243,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    frozen material head. A direct PR-root reaction from the official Connector
    may be passed to `seal --review-ref <canonical-reaction-url>` only for `+1`,
    `heart`, `hooray`, or `rocket`, after live verification of its immutable GitHub
-   account id/login and a GitHub Actions check-suite timestamp binding it to the
-   caller's full current material head. It is
+   account id/login and a trusted same-PR Connector review whose real `commit_id`
+   is the caller's full current material head and whose `submitted_at` strictly
+   precedes the reaction. It is
    not a native GitHub approval, Codex Security result, or thread-resolution
    authority. The optional `--connector-advisory-reaction` rendering path remains
    non-authoritative and may be omitted with a warning. When

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,9 +204,10 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    PR head. Reviewer execution SHAs are opaque until the Commit API proves
    them repository-addressable; unavailable/API-unknown refs must never enter
    ancestry checks.
-9. **Material identity:** one completed Codex review or one trusted terminal
-   review-source unavailability receipt, plus one completed final Codex Security
-   diff scan, bind to one material digest. When Codex Security is systemically
+9. **Material identity:** one completed Codex review, one verified positive
+   official Codex Connector reaction, or one trusted terminal review-source
+   unavailability receipt, plus one completed final Codex Security diff scan,
+   bind to one material digest. When Codex Security is systemically
    unavailable with MCP `-32001 Request timed out`, a short-lived fail-closed
    operator-outage override may replace only the plugin receipt: it must be an
    unedited exact-material GitHub comment from an `OWNER` or `MEMBER`, bind the
@@ -232,12 +233,18 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    `#2142` review-credit override receipts remain
    readable everywhere but are live-authenticated only for PR `#2142`; the
    legacy override path is not an active authoring contract for later PRs.
-   The trusted submitted review object's
-   real GitHub `commit_id` must equal the frozen material head. When the official
-   Codex connector emits an unedited no-findings issue comment instead, its
-   trusted GitHub App identity and reviewed-commit prefix must resolve through
-   the Commit API to that same full frozen head. A synthetic execution ref is
-   never review proof. Every path is material except the exact
+   The trusted submitted review object's real GitHub `commit_id` must equal the
+   frozen material head. A direct PR-root reaction from the official Connector
+   is accepted only for `+1`, `heart`, `hooray`, or `rocket`, with its immutable
+   GitHub account id and exact login revalidated live; it must postdate the
+   current material head's GitHub push timestamp. It is bounded no-findings
+   evidence, not a GitHub approval, Codex Security result, or thread-resolution
+   authority. GitHub event visibility is polled for at most 30 seconds; a
+   pending event requires a later closeout retry, never a substitute or manual
+   retrigger. When the official Codex connector emits an unedited no-findings
+   issue comment instead, its trusted GitHub App identity and reviewed-commit
+   prefix must resolve through the Commit API to that same full frozen head. A
+   synthetic execution ref is never review proof. Every path is material except the exact
    current-PR mapping artifact. PR-body edits are outside Git. Any later code,
    test, workflow, dependency, policy, contract, or other docs change invalidates
    the seal and reopens review/final scan.
@@ -554,8 +561,9 @@ Rules:
   pre-open role agents. This post-open chain is a single required pass for the
   lane, not an unbounded loop. Later review or bot comments must be handled by
   fixing or dispositioning the specific finding in `docs/review/PR_<N>_FIXED_MAPPING.md`
-  and rerunning targeted gates. Request Codex review manually after material
-  freeze and run the final Codex Security diff scan only after all material
+  and rerunning targeted gates. Observe the automatic Codex response after
+  material freeze; do not manually retrigger it. Run the final Codex Security
+  diff scan only after all material
   fixes. Do not restart the full role/review/scan chain unless the material
   digest changed, a run failed or was incomplete, the coordinator records a
   new evidence-backed routing update, or the operator explicitly overrides it.
@@ -602,8 +610,8 @@ All non-trivial PR work must follow this coordinator-owned lifecycle:
 1. **Start**: run preflight, inspect the governing docs, and let coordinator define scope, risks, and required agents before editing code or docs.
 2. **Open non-draft by default**: open PRs as ready-for-review once the branch has a coherent scope, initial PR body, and canonical artifact path. Draft PRs require an explicit operator exception because they suppress or delay bot review and current-head merge verification.
 3. **Push cycle**: before each push, run `pre-commit run --all-files` and the applicable local gates; after each push, watch the **current-head** CI state, not stale historical runs.
-4. **Review cycle**: freeze the material state, request one Codex review, apply
-   any material fix and refreeze, then run one final security scan. A systemic
+4. **Review cycle**: freeze the material state, observe one automatic Codex
+   response, apply any material fix and refreeze, then run one final security scan. A systemic
    MCP `-32001` outage may use only the authenticated, expiring operator-outage
    evidence variant described above; do not fabricate or relabel a scan receipt. Keep
    dispositions in the gitignored closeout draft and publish one generated

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -670,7 +670,10 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    force-push or head-restoration event. That chronology proves freshness only;
    it is not projected into a Connector-owned reviewed commit. After the one canonical mapping-only
    closeout commit, authenticated validation may accept the descendant live head
-   only after material-digest equality is re-established. Its receipt is
+   only after material-digest equality is re-established. If the automatic
+   mapping-only cycle replaces the sealed reaction, revalidation may use only a
+   newer live trusted positive reaction with the same content; keep the sealed
+   receipt unchanged and do not restart the security scan. Its receipt is
    `binding_kind=seal_context_only`, `review_claim=none`, and `blocking=false`.
    It is a trusted positive Connector response, not exact-head review proof, a
    native GitHub approval, Codex Security result, or thread-resolution authority. The optional

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -663,8 +663,9 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    reaction, or `--review-source-unavailable-ref ...` for an exact trusted Codex
    rate-limit / usage-limit comment. A reaction supplied through `--review-ref`
    is live-verified by exact PR-root URL and immutable Connector account identity,
-   then bound to the caller's full snapshotted material head through a GitHub Actions
-   check-suite timestamp that precedes the reaction. It is a Connector
+   then bound to the caller's full snapshotted material head through a trusted
+   same-PR Connector review whose real `commit_id` equals that head and whose
+   `submitted_at` strictly precedes the reaction. It is a Connector
    response for that material state, not a native GitHub approval, Codex Security
    result, or thread-resolution authority. The optional
    `--connector-advisory-reaction <canonical-reaction-url>` rendering path remains

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -660,17 +660,20 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
 5. Record dispositions with `add-disposition`, then run `seal` with exactly one
    review-evidence mode: `--review-ref ...` for a completed trusted review or a
    canonical official Connector PR-root `+1`, `heart`, `hooray`, or `rocket`
-   reaction, or `--review-source-unavailable-ref ...` for an exact trusted Codex
+   reaction as a nonblocking terminal positive response, or
+   `--review-source-unavailable-ref ...` for an exact trusted Codex
    rate-limit / usage-limit comment. A reaction supplied through `--review-ref`
    is live-verified by exact PR-root URL and immutable Connector account identity,
    then bound to the caller's full snapshotted material head by requiring the live
    PR head to equal it at seal time and a server-timestamped GitHub Actions `pull_request` run
    linked to that same PR and head to strictly precede the reaction, with no later
-   force-push or head-restoration event. After the one canonical mapping-only
+   force-push or head-restoration event. That chronology proves freshness only;
+   it is not projected into a Connector-owned reviewed commit. After the one canonical mapping-only
    closeout commit, authenticated validation may accept the descendant live head
-   only after material-digest equality is re-established. It is a Connector
-   response for that material state, not a native GitHub approval, Codex Security
-   result, or thread-resolution authority. The optional
+   only after material-digest equality is re-established. Its receipt is
+   `binding_kind=seal_context_only`, `review_claim=none`, and `blocking=false`.
+   It is a trusted positive Connector response, not exact-head review proof, a
+   native GitHub approval, Codex Security result, or thread-resolution authority. The optional
    `--connector-advisory-reaction <canonical-reaction-url>` rendering path remains
    non-authoritative and may be omitted with a warning. The source-unavailable path requires no retry,
    substitute review, prior review, operator override, or TTL; it proves only

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -663,9 +663,9 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    reaction, or `--review-source-unavailable-ref ...` for an exact trusted Codex
    rate-limit / usage-limit comment. A reaction supplied through `--review-ref`
    is live-verified by exact PR-root URL and immutable Connector account identity,
-   then bound to the caller's full snapshotted material head through a trusted
-   same-PR Connector review whose real `commit_id` equals that head and whose
-   `submitted_at` strictly precedes the reaction. It is a Connector
+   then bound to the caller's full snapshotted material head by requiring the live
+   PR head to equal it and a server-timestamped GitHub Actions check suite for that
+   head to strictly precede the reaction. It is a Connector
    response for that material state, not a native GitHub approval, Codex Security
    result, or thread-resolution authority. The optional
    `--connector-advisory-reaction <canonical-reaction-url>` rendering path remains

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -658,9 +658,16 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    with MCP `-32001 Request timed out`, use the bounded operator-outage path only
    after an explicit operator decision; it is not scan or no-findings evidence.
 5. Record dispositions with `add-disposition`, then run `seal` with exactly one
-   review-evidence mode: `--review-ref ...` for a completed trusted review, or
+   review-evidence mode: `--review-ref ...` for a completed trusted review, an
+   official Connector positive PR-root reaction (`#reaction-<id>`), or
    `--review-source-unavailable-ref ...` for an exact trusted Codex rate-limit /
-   usage-limit comment. The source-unavailable path requires no retry,
+   usage-limit comment. A reaction is accepted only when its exact Connector
+   account identity, positive content (`+1`, `heart`, `hooray`, or `rocket`),
+   PR-root location, and post-push timestamp bind it to the frozen material
+   head; it is bounded no-findings evidence, not a GitHub approval, Codex
+   Security result, or thread-resolution authority. The verifier polls GitHub
+   event visibility for at most 30 seconds; a pending event requires a later
+   closeout retry, never a substitute or manual retrigger. The source-unavailable path requires no retry,
    substitute review, prior review, operator override, or TTL; it proves only
    source unavailability (`source_degraded=true`, `fallback_required=false`,
    `blocking=false`, and `review_claim=none`), never review/PASS/no-findings.

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -664,9 +664,11 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    rate-limit / usage-limit comment. A reaction supplied through `--review-ref`
    is live-verified by exact PR-root URL and immutable Connector account identity,
    then bound to the caller's full snapshotted material head by requiring the live
-   PR head to equal it and a server-timestamped GitHub Actions `pull_request` run
+   PR head to equal it at seal time and a server-timestamped GitHub Actions `pull_request` run
    linked to that same PR and head to strictly precede the reaction, with no later
-   force-push or head-restoration event. It is a Connector
+   force-push or head-restoration event. After the one canonical mapping-only
+   closeout commit, authenticated validation may accept the descendant live head
+   only after material-digest equality is re-established. It is a Connector
    response for that material state, not a native GitHub approval, Codex Security
    result, or thread-resolution authority. The optional
    `--connector-advisory-reaction <canonical-reaction-url>` rendering path remains

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -658,17 +658,16 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    with MCP `-32001 Request timed out`, use the bounded operator-outage path only
    after an explicit operator decision; it is not scan or no-findings evidence.
 5. Record dispositions with `add-disposition`, then run `seal` with exactly one
-   review-evidence mode: `--review-ref ...` for a completed trusted review, or
-   `--review-source-unavailable-ref ...` for an exact trusted Codex rate-limit /
-   usage-limit comment. Optionally add one or more
-   `--connector-advisory-reaction <canonical-reaction-url>` values to record verified
-   official Connector `+1`, `heart`, `hooray`, or `rocket` reactions. The
-   verifier checks the exact PR-root URL and immutable Connector account
-   identity, but a reaction has no reviewed SHA or run id: it is advisory only,
-   not review evidence, an exact-head proof, GitHub approval, Codex Security
-   result, or thread-resolution authority. If it cannot be verified, the signal
-   is omitted with a warning; it neither blocks closeout nor clears another review
-   gate. The source-unavailable path requires no retry,
+   review-evidence mode: `--review-ref ...` for a completed trusted review or a
+   canonical official Connector PR-root `+1`, `heart`, `hooray`, or `rocket`
+   reaction, or `--review-source-unavailable-ref ...` for an exact trusted Codex
+   rate-limit / usage-limit comment. A reaction supplied through `--review-ref`
+   is live-verified by exact PR-root URL and immutable Connector account identity,
+   then bound to the caller's full snapshotted material head. It is a Connector
+   response for that material state, not a native GitHub approval, Codex Security
+   result, or thread-resolution authority. The optional
+   `--connector-advisory-reaction <canonical-reaction-url>` rendering path remains
+   non-authoritative and may be omitted with a warning. The source-unavailable path requires no retry,
    substitute review, prior review, operator override, or TTL; it proves only
    source unavailability (`source_degraded=true`, `fallback_required=false`,
    `blocking=false`, and `review_claim=none`), never review/PASS/no-findings.

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -658,16 +658,17 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    with MCP `-32001 Request timed out`, use the bounded operator-outage path only
    after an explicit operator decision; it is not scan or no-findings evidence.
 5. Record dispositions with `add-disposition`, then run `seal` with exactly one
-   review-evidence mode: `--review-ref ...` for a completed trusted review, an
-   official Connector positive PR-root reaction (`#reaction-<id>`), or
+   review-evidence mode: `--review-ref ...` for a completed trusted review, or
    `--review-source-unavailable-ref ...` for an exact trusted Codex rate-limit /
-   usage-limit comment. A reaction is accepted only when its exact Connector
-   account identity, positive content (`+1`, `heart`, `hooray`, or `rocket`),
-   PR-root location, and post-push timestamp bind it to the frozen material
-   head; it is bounded no-findings evidence, not a GitHub approval, Codex
-   Security result, or thread-resolution authority. The verifier polls GitHub
-   event visibility for at most 30 seconds; a pending event requires a later
-   closeout retry, never a substitute or manual retrigger. The source-unavailable path requires no retry,
+   usage-limit comment. Optionally add one or more
+   `--connector-advisory-reaction <canonical-reaction-url>` values to record verified
+   official Connector `+1`, `heart`, `hooray`, or `rocket` reactions. The
+   verifier checks the exact PR-root URL and immutable Connector account
+   identity, but a reaction has no reviewed SHA or run id: it is advisory only,
+   not review evidence, an exact-head proof, GitHub approval, Codex Security
+   result, or thread-resolution authority. If it cannot be verified, the signal
+   is omitted with a warning; it neither blocks closeout nor clears another review
+   gate. The source-unavailable path requires no retry,
    substitute review, prior review, operator override, or TTL; it proves only
    source unavailability (`source_degraded=true`, `fallback_required=false`,
    `blocking=false`, and `review_claim=none`), never review/PASS/no-findings.

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -663,7 +663,8 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    reaction, or `--review-source-unavailable-ref ...` for an exact trusted Codex
    rate-limit / usage-limit comment. A reaction supplied through `--review-ref`
    is live-verified by exact PR-root URL and immutable Connector account identity,
-   then bound to the caller's full snapshotted material head. It is a Connector
+   then bound to the caller's full snapshotted material head through a GitHub Actions
+   check-suite timestamp that precedes the reaction. It is a Connector
    response for that material state, not a native GitHub approval, Codex Security
    result, or thread-resolution authority. The optional
    `--connector-advisory-reaction <canonical-reaction-url>` rendering path remains

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -664,8 +664,9 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    rate-limit / usage-limit comment. A reaction supplied through `--review-ref`
    is live-verified by exact PR-root URL and immutable Connector account identity,
    then bound to the caller's full snapshotted material head by requiring the live
-   PR head to equal it and a server-timestamped GitHub Actions check suite for that
-   head to strictly precede the reaction. It is a Connector
+   PR head to equal it and a server-timestamped GitHub Actions `pull_request` run
+   linked to that same PR and head to strictly precede the reaction, with no later
+   force-push or head-restoration event. It is a Connector
    response for that material state, not a native GitHub approval, Codex Security
    result, or thread-resolution authority. The optional
    `--connector-advisory-reaction <canonical-reaction-url>` rendering path remains

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -134,14 +134,13 @@ governance PR number + 1; the governance PR may opt in with
   dependencies, schemas, and policies remain material.
 - The trusted submitted Codex review object's real GitHub `commit_id` must be
   the frozen material head. A direct PR-root reaction from the official Codex
-  Connector may be recorded through `seal --connector-advisory-reaction` only
-  for `+1`, `heart`, `hooray`, or `rocket`, after live verification of its
-  immutable GitHub account identity and exact PR-root URL. A reaction has no
-  reviewed SHA or run id, so it is advisory only: never review evidence,
-  exact-head proof, GitHub approval, Codex Security evidence, or
-  thread-resolution authority. If verification fails, the advisory signal is
-  omitted with a warning; it neither blocks closeout nor clears another review
-  gate. An official unedited no-findings issue comment
+  Connector may instead use the normal `seal --review-ref` path only for `+1`,
+  `heart`, `hooray`, or `rocket`, after live verification of its immutable
+  GitHub account identity, exact PR-root URL, and binding to the caller's full
+  snapshotted material head. This is a verified Connector response for that
+  material state, not a native GitHub approval, Codex Security evidence, or
+  thread-resolution authority. The optional advisory rendering path remains
+  non-authoritative and may be omitted with a warning. An official unedited no-findings issue comment
   is accepted only when the trusted Codex GitHub App identity and its short
   reviewed-commit marker resolve through the Commit API to that same full head;
   reviewer-execution/synthetic refs never satisfy this proof. The selected

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -137,8 +137,9 @@ governance PR number + 1; the governance PR may opt in with
   Connector may instead use the normal `seal --review-ref` path only for `+1`,
   `heart`, `hooray`, or `rocket`, after live verification of its immutable
   GitHub account identity, exact PR-root URL, a live PR head equal to the caller's
-  full snapshotted material head, and a server-timestamped GitHub Actions check
-  suite for that head strictly preceding the reaction. This is a verified Connector response for that
+  full snapshotted material head, and a server-timestamped GitHub Actions
+  `pull_request` run linked to that same PR and head strictly preceding the
+  reaction, with no later force-push or head-restoration event. This is a verified Connector response for that
   material state, not a native GitHub approval, Codex Security evidence, or
   thread-resolution authority. The optional advisory rendering path remains
   non-authoritative and may be omitted with a warning. An official unedited no-findings issue comment

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -136,8 +136,9 @@ governance PR number + 1; the governance PR may opt in with
   the frozen material head. A direct PR-root reaction from the official Codex
   Connector may instead use the normal `seal --review-ref` path only for `+1`,
   `heart`, `hooray`, or `rocket`, after live verification of its immutable
-  GitHub account identity, exact PR-root URL, and binding to the caller's full
-  snapshotted material head. This is a verified Connector response for that
+  GitHub account identity, exact PR-root URL, and a GitHub Actions check-suite
+  timestamp proving that the caller's full snapshotted material head was observed
+  before the reaction. This is a verified Connector response for that
   material state, not a native GitHub approval, Codex Security evidence, or
   thread-resolution authority. The optional advisory rendering path remains
   non-authoritative and may be omitted with a warning. An official unedited no-findings issue comment

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -134,13 +134,14 @@ governance PR number + 1; the governance PR may opt in with
   dependencies, schemas, and policies remain material.
 - The trusted submitted Codex review object's real GitHub `commit_id` must be
   the frozen material head. A direct PR-root reaction from the official Codex
-  Connector is accepted only for `+1`, `heart`, `hooray`, or `rocket`, after
-  live verification of its immutable GitHub account identity and a timestamp
-  strictly later than the frozen head's GitHub push timestamp. It is bounded
-  no-findings evidence, never a GitHub approval, Codex Security result, or
-  thread-resolution authority. The verifier polls GitHub event visibility for
-  at most 30 seconds; a pending event requires a later closeout retry, never a
-  substitute or manual retrigger. An official unedited no-findings issue comment
+  Connector may be recorded through `seal --connector-advisory-reaction` only
+  for `+1`, `heart`, `hooray`, or `rocket`, after live verification of its
+  immutable GitHub account identity and exact PR-root URL. A reaction has no
+  reviewed SHA or run id, so it is advisory only: never review evidence,
+  exact-head proof, GitHub approval, Codex Security evidence, or
+  thread-resolution authority. If verification fails, the advisory signal is
+  omitted with a warning; it neither blocks closeout nor clears another review
+  gate. An official unedited no-findings issue comment
   is accepted only when the trusted Codex GitHub App identity and its short
   reviewed-commit marker resolve through the Commit API to that same full head;
   reviewer-execution/synthetic refs never satisfy this proof. The selected

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -133,8 +133,15 @@ governance PR number + 1; the governance PR may opt in with
   edits are outside Git. Other docs, AGENTS/runbook, workflows, tests,
   dependencies, schemas, and policies remain material.
 - The trusted submitted Codex review object's real GitHub `commit_id` must be
-  the frozen material head. An official unedited no-findings issue comment is
-  accepted only when the trusted Codex GitHub App identity and its short
+  the frozen material head. A direct PR-root reaction from the official Codex
+  Connector is accepted only for `+1`, `heart`, `hooray`, or `rocket`, after
+  live verification of its immutable GitHub account identity and a timestamp
+  strictly later than the frozen head's GitHub push timestamp. It is bounded
+  no-findings evidence, never a GitHub approval, Codex Security result, or
+  thread-resolution authority. The verifier polls GitHub event visibility for
+  at most 30 seconds; a pending event requires a later closeout retry, never a
+  substitute or manual retrigger. An official unedited no-findings issue comment
+  is accepted only when the trusted Codex GitHub App identity and its short
   reviewed-commit marker resolve through the Commit API to that same full head;
   reviewer-execution/synthetic refs never satisfy this proof. The selected
   review-evidence variant and one completed final Codex Security diff scan bind

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -137,9 +137,12 @@ governance PR number + 1; the governance PR may opt in with
   Connector may instead use the normal `seal --review-ref` path only for `+1`,
   `heart`, `hooray`, or `rocket`, after live verification of its immutable
   GitHub account identity, exact PR-root URL, a live PR head equal to the caller's
-  full snapshotted material head, and a server-timestamped GitHub Actions
+  full snapshotted material head at seal time, and a server-timestamped GitHub Actions
   `pull_request` run linked to that same PR and head strictly preceding the
-  reaction, with no later force-push or head-restoration event. This is a verified Connector response for that
+  reaction, with no later force-push or head-restoration event. Authenticated
+  validation after the one canonical mapping-only closeout commit may accept the
+  descendant live head only after material-digest equality is re-established.
+  This is a verified Connector response for that
   material state, not a native GitHub approval, Codex Security evidence, or
   thread-resolution authority. The optional advisory rendering path remains
   non-authoritative and may be omitted with a warning. An official unedited no-findings issue comment

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -136,9 +136,9 @@ governance PR number + 1; the governance PR may opt in with
   the frozen material head. A direct PR-root reaction from the official Codex
   Connector may instead use the normal `seal --review-ref` path only for `+1`,
   `heart`, `hooray`, or `rocket`, after live verification of its immutable
-  GitHub account identity, exact PR-root URL, and a trusted same-PR Connector
-  review whose real `commit_id` equals the caller's full snapshotted material
-  head and whose `submitted_at` strictly precedes the reaction. This is a verified Connector response for that
+  GitHub account identity, exact PR-root URL, a live PR head equal to the caller's
+  full snapshotted material head, and a server-timestamped GitHub Actions check
+  suite for that head strictly preceding the reaction. This is a verified Connector response for that
   material state, not a native GitHub approval, Codex Security evidence, or
   thread-resolution authority. The optional advisory rendering path remains
   non-authoritative and may be omitted with a warning. An official unedited no-findings issue comment

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -134,16 +134,20 @@ governance PR number + 1; the governance PR may opt in with
   dependencies, schemas, and policies remain material.
 - The trusted submitted Codex review object's real GitHub `commit_id` must be
   the frozen material head. A direct PR-root reaction from the official Codex
-  Connector may instead use the normal `seal --review-ref` path only for `+1`,
+  Connector may instead use the normal `seal --review-ref` path as a nonblocking
+  terminal source response only for `+1`,
   `heart`, `hooray`, or `rocket`, after live verification of its immutable
   GitHub account identity, exact PR-root URL, a live PR head equal to the caller's
   full snapshotted material head at seal time, and a server-timestamped GitHub Actions
   `pull_request` run linked to that same PR and head strictly preceding the
-  reaction, with no later force-push or head-restoration event. Authenticated
+  reaction, with no later force-push or head-restoration event. This chronology
+  proves only that GitHub observed the material head before the response; it is
+  not Connector-owned reviewed-commit provenance. Authenticated
   validation after the one canonical mapping-only closeout commit may accept the
   descendant live head only after material-digest equality is re-established.
-  This is a verified Connector response for that
-  material state, not a native GitHub approval, Codex Security evidence, or
+  The receipt uses `binding_kind=seal_context_only`, `review_claim=none`, and
+  `blocking=false`. This is a verified positive Connector response, not exact-head
+  review proof, a native GitHub approval, Codex Security evidence, or
   thread-resolution authority. The optional advisory rendering path remains
   non-authoritative and may be omitted with a warning. An official unedited no-findings issue comment
   is accepted only when the trusted Codex GitHub App identity and its short

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -145,6 +145,10 @@ governance PR number + 1; the governance PR may opt in with
   not Connector-owned reviewed-commit provenance. Authenticated
   validation after the one canonical mapping-only closeout commit may accept the
   descendant live head only after material-digest equality is re-established.
+  When that automatic mapping-only cycle replaces the sealed reaction, the
+  validator may accept only a newer live positive reaction from the same trusted
+  Connector with the same content; the sealed receipt remains unchanged and the
+  completed security scan is not restarted.
   The receipt uses `binding_kind=seal_context_only`, `review_claim=none`, and
   `blocking=false`. This is a verified positive Connector response, not exact-head
   review proof, a native GitHub approval, Codex Security evidence, or

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -136,9 +136,9 @@ governance PR number + 1; the governance PR may opt in with
   the frozen material head. A direct PR-root reaction from the official Codex
   Connector may instead use the normal `seal --review-ref` path only for `+1`,
   `heart`, `hooray`, or `rocket`, after live verification of its immutable
-  GitHub account identity, exact PR-root URL, and a GitHub Actions check-suite
-  timestamp proving that the caller's full snapshotted material head was observed
-  before the reaction. This is a verified Connector response for that
+  GitHub account identity, exact PR-root URL, and a trusted same-PR Connector
+  review whose real `commit_id` equals the caller's full snapshotted material
+  head and whose `submitted_at` strictly precedes the reaction. This is a verified Connector response for that
   material state, not a native GitHub approval, Codex Security evidence, or
   thread-resolution authority. The optional advisory rendering path remains
   non-authoritative and may be omitted with a warning. An official unedited no-findings issue comment

--- a/docs/review/PR_2169_FIXED_MAPPING.md
+++ b/docs/review/PR_2169_FIXED_MAPPING.md
@@ -1,0 +1,61 @@
+# PR 2169 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/pr2169_remediation_security_corrected.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/pr2169-positive-response-oracle-result-v2.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 228178b0aee112ecdd2ee8eea8032552e9d5ee62
+Evidence: scripts/orchestration/pr_commit_identity.py:1124-1172; direct Compare API ancestry/ref proof replaces finite repository-event history.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3622709472 -> 228178b0aee112ecdd2ee8eea8032552e9d5ee62
+
+Disposition: FIXED
+Commit: 3f839b4dba0af801709b55117787a44b9d735ab4
+Evidence: scripts/orchestration/pr_review_evidence.py:1170-1195; scripts/orchestration/pr_review_closeout.py:718-735,876-903; scripts/ci/check_pr_merge_readiness.py:638-667,748-769; tests/test_pr_review_material_seal.py:3026-3258; tests/test_pr_merge_readiness_gate.py:808-950.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3625033080 -> 3f839b4dba0af801709b55117787a44b9d735ab4
+
+Disposition: FIXED
+Commit: 3f839b4dba0af801709b55117787a44b9d735ab4
+Evidence: scripts/orchestration/pr_review_evidence.py:1170-1195; scripts/orchestration/pr_review_closeout.py:718-735,876-903; scripts/ci/check_pr_merge_readiness.py:638-667,748-769; tests/test_pr_review_material_seal.py:3026-3258; tests/test_pr_merge_readiness_gate.py:808-950.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3625334531 -> 3f839b4dba0af801709b55117787a44b9d735ab4
+
+Disposition: FIXED
+Commit: 3f839b4dba0af801709b55117787a44b9d735ab4
+Evidence: scripts/orchestration/pr_review_evidence.py:1170-1195; scripts/orchestration/pr_review_closeout.py:718-735,876-903; scripts/ci/check_pr_merge_readiness.py:638-667,748-769; tests/test_pr_review_material_seal.py:3026-3258; tests/test_pr_merge_readiness_gate.py:808-950.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3625334538 -> 3f839b4dba0af801709b55117787a44b9d735ab4
+
+Disposition: FIXED
+Commit: 3f839b4dba0af801709b55117787a44b9d735ab4
+Evidence: scripts/orchestration/pr_review_evidence.py:1170-1195; scripts/orchestration/pr_review_closeout.py:718-735,876-903; scripts/ci/check_pr_merge_readiness.py:638-667,748-769; tests/test_pr_review_material_seal.py:3026-3258; tests/test_pr_merge_readiness_gate.py:808-950.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3628474616 -> 3f839b4dba0af801709b55117787a44b9d735ab4
+
+Disposition: FIXED
+Commit: 3f839b4dba0af801709b55117787a44b9d735ab4
+Evidence: scripts/orchestration/pr_review_evidence.py:1170-1195; scripts/orchestration/pr_review_closeout.py:718-735,876-903; scripts/ci/check_pr_merge_readiness.py:638-667,748-769; tests/test_pr_review_material_seal.py:3026-3258; tests/test_pr_merge_readiness_gate.py:808-950.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3628474621 -> 3f839b4dba0af801709b55117787a44b9d735ab4
+
+Disposition: FIXED
+Commit: 3f839b4dba0af801709b55117787a44b9d735ab4
+Evidence: scripts/orchestration/pr_review_evidence.py:1170-1195; scripts/orchestration/pr_review_closeout.py:718-735,876-903; scripts/ci/check_pr_merge_readiness.py:638-667,748-769; tests/test_pr_review_material_seal.py:3026-3258; tests/test_pr_merge_readiness_gate.py:808-950.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3628685476 -> 3f839b4dba0af801709b55117787a44b9d735ab4
+
+Disposition: FIXED
+Commit: 3f839b4dba0af801709b55117787a44b9d735ab4
+Evidence: scripts/orchestration/pr_review_evidence.py:1170-1195; scripts/orchestration/pr_review_closeout.py:718-735,876-903; scripts/ci/check_pr_merge_readiness.py:638-667,748-769; tests/test_pr_review_material_seal.py:3026-3258; tests/test_pr_merge_readiness_gate.py:808-950.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3628685480 -> 3f839b4dba0af801709b55117787a44b9d735ab4
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"authority":"trusted_codex_review_source_positive_response","binding_kind":"seal_context_only","blocking":false,"fallback_required":false,"material_digest":"sha256:aaf7bf5b482a02f37903c9017a3f330480cbaae3ecad0697ec9fa8114f719551","material_head_sha":"3f839b4dba0af801709b55117787a44b9d735ab4","response_content":"+1","response_created_at":"2026-07-22T11:11:26Z","response_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#reaction-419939480","review_claim":"none","schema_version":"pulseplate.codex-review-source-positive-response/v1","source":"codex_review","source_degraded":false,"source_status":"positive_response","status":"completed"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:0c881d1950263a0a2572c6b0593cfb2f79fb5a0433d2334ba26bb125bc8f1b07","findings_sha256":"sha256:f31b24cd3921438f36cc08a4beb334ecfea43c640ce6f40dac21382a53dfab81","work_ledger_sha256":"sha256:537cf54605f8660de2396e4c111f51f26c17b26d96ba5e4bd2d0a37f867ae4cf"},"authority":"human_asserted_content_receipt","base_revision":"880753ee3d1db61c7fc8593798ade03cdb2177c2","coverage_completeness":"complete","findings_count":0,"head_revision":"3f839b4dba0af801709b55117787a44b9d735ab4","manifest_sha256":"sha256:cda3a142f4399933e1062be6d519c1f8554aa8cdf9950f6c49b8ca25048e2e1b","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"4ac1e6d2-f87b-4ab4-9733-a0746fea0cf2","snapshot_digest":"codex-security-snapshot/v1:sha256:1d74df0bc5da366ec7aad16a4841552de3d91d1cb5319d4e849096130ccb54eb"},"material":{"base_ref_oid":"880753ee3d1db61c7fc8593798ade03cdb2177c2","digest":"sha256:aaf7bf5b482a02f37903c9017a3f330480cbaae3ecad0697ec9fa8114f719551","material_head_sha":"3f839b4dba0af801709b55117787a44b9d735ab4","merge_base_sha":"880753ee3d1db61c7fc8593798ade03cdb2177c2","policy_version":"pulseplate.material-classification/v1"},"pr_number":2169,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/docs/review/PR_2169_FIXED_MAPPING.md
+++ b/docs/review/PR_2169_FIXED_MAPPING.md
@@ -84,6 +84,30 @@ Evidence: The submitted review commit is a98dd6a330a930c37ccd49853e78a108d6cb0e6
 Reason: Duplicate expected pre-closeout state; no stale seal can authorize merge.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3630470393
 
+Disposition: NOT-A-BUG
+Evidence: The live mapping-only head is 241c1c83487b979f9b2bbb934cc5496fd2bd183e and authenticated seal validation accepts its unchanged material digest.
+Reason: The reviewer execution SHA is unavailable in the repository commit graph; the repository-addressable mapping-only successor remains valid.
+Fingerprint: sha256:108b54d1c2fa690f905fd99671701da476f534d48a54e91152c4d0816f8af18f
+Cause: unavailable_review_ref_ancestry
+Material-Digest: sha256:4f973a00982d13e6358c914ee6b14e9546a83f6786f54359d46670abdef0f719
+Verified-Fix: 241c1c83487b979f9b2bbb934cc5496fd2bd183e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3630624189
+
+Disposition: NOT-A-BUG
+Evidence: Commit 3f839b4dba0af801709b55117787a44b9d735ab4 is a reachable material commit and authenticated seal validation accepts the unchanged material digest.
+Reason: The reviewer execution SHA is unavailable in the repository commit graph; the reachable FIXED proof remains valid.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3630624195
+
+Disposition: NOT-A-BUG
+Evidence: tests/test_ci_workflow_pr_size_governance_contract.py enforces the approved exact five workflow/job/step/component tuples, full action references, and v4.37.1 comment counts.
+Reason: Relaxing the exact topology or version-comment assertions would violate the accepted PR contract and weaken the intended supply-chain guard.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#pullrequestreview-4743606772
+
+Disposition: FIXED
+Commit: 3f839b4dba0af801709b55117787a44b9d735ab4
+Evidence: scripts/orchestration/pr_review_evidence.py:1170-1195; scripts/orchestration/pr_review_closeout.py:718-735,876-903; scripts/ci/check_pr_merge_readiness.py:638-667,748-769; tests/test_pr_review_material_seal.py:3026-3258; tests/test_pr_merge_readiness_gate.py:808-950.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#pullrequestreview-4748203712 -> 3f839b4dba0af801709b55117787a44b9d735ab4
+
 ## Review Material Seal
 <!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
 <!-- pragma: allowlist nextline secret -->

--- a/docs/review/PR_2169_FIXED_MAPPING.md
+++ b/docs/review/PR_2169_FIXED_MAPPING.md
@@ -54,8 +54,38 @@ Commit: 3f839b4dba0af801709b55117787a44b9d735ab4
 Evidence: scripts/orchestration/pr_review_evidence.py:1170-1195; scripts/orchestration/pr_review_closeout.py:718-735,876-903; scripts/ci/check_pr_merge_readiness.py:638-667,748-769; tests/test_pr_review_material_seal.py:3026-3258; tests/test_pr_merge_readiness_gate.py:808-950.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3628685480 -> 3f839b4dba0af801709b55117787a44b9d735ab4
 
+Disposition: FIXED
+Commit: 504a31689720b0806876ec4e7eacc7fb69e7e234
+Evidence: scripts/orchestration/pr_commit_identity.py bounded mapping-only successor verification; tests/test_pr_review_material_seal.py direct-head and successor regressions.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3630049285 -> 504a31689720b0806876ec4e7eacc7fb69e7e234
+
+Disposition: FIXED
+Commit: a98dd6a330a930c37ccd49853e78a108d6cb0e6e
+Evidence: scripts/orchestration/pr_review_evidence.py:1467 and tests/test_pr_review_material_seal.py malformed-list regression; focused five-case test passes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3630256924 -> a98dd6a330a930c37ccd49853e78a108d6cb0e6e
+
+Disposition: NOT-A-BUG
+Evidence: Authenticated pr_review_closeout.py validate fails closed while the pre-closeout seal is stale; live head is a98dd6a330a930c37ccd49853e78a108d6cb0e6e.
+Reason: Expected intermediate closeout state; the synthetic execution SHA is not the submitted review commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3630256912
+
+Disposition: NOT-A-BUG
+Evidence: Authenticated pr_review_closeout.py validate fails closed while the pre-closeout seal is stale; live head is a98dd6a330a930c37ccd49853e78a108d6cb0e6e.
+Reason: Duplicate expected intermediate state; no stale seal can pass strict readiness.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3630256918
+
+Disposition: NOT-A-BUG
+Evidence: The submitted review commit is a98dd6a330a930c37ccd49853e78a108d6cb0e6e; strict validation rejects the old seal until this closeout.
+Reason: Expected pre-closeout state; the comment cites an opaque synthetic SHA rather than the repository-addressable review commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3630470387
+
+Disposition: NOT-A-BUG
+Evidence: The submitted review commit is a98dd6a330a930c37ccd49853e78a108d6cb0e6e; strict validation rejects the old seal until this closeout.
+Reason: Duplicate expected pre-closeout state; no stale seal can authorize merge.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#discussion_r3630470393
+
 ## Review Material Seal
 <!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
 <!-- pragma: allowlist nextline secret -->
-{"authority":"human_asserted_content_receipt","code_review":{"authority":"trusted_codex_review_source_positive_response","binding_kind":"seal_context_only","blocking":false,"fallback_required":false,"material_digest":"sha256:aaf7bf5b482a02f37903c9017a3f330480cbaae3ecad0697ec9fa8114f719551","material_head_sha":"3f839b4dba0af801709b55117787a44b9d735ab4","response_content":"+1","response_created_at":"2026-07-22T11:11:26Z","response_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#reaction-419939480","review_claim":"none","schema_version":"pulseplate.codex-review-source-positive-response/v1","source":"codex_review","source_degraded":false,"source_status":"positive_response","status":"completed"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:0c881d1950263a0a2572c6b0593cfb2f79fb5a0433d2334ba26bb125bc8f1b07","findings_sha256":"sha256:f31b24cd3921438f36cc08a4beb334ecfea43c640ce6f40dac21382a53dfab81","work_ledger_sha256":"sha256:537cf54605f8660de2396e4c111f51f26c17b26d96ba5e4bd2d0a37f867ae4cf"},"authority":"human_asserted_content_receipt","base_revision":"880753ee3d1db61c7fc8593798ade03cdb2177c2","coverage_completeness":"complete","findings_count":0,"head_revision":"3f839b4dba0af801709b55117787a44b9d735ab4","manifest_sha256":"sha256:cda3a142f4399933e1062be6d519c1f8554aa8cdf9950f6c49b8ca25048e2e1b","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"4ac1e6d2-f87b-4ab4-9733-a0746fea0cf2","snapshot_digest":"codex-security-snapshot/v1:sha256:1d74df0bc5da366ec7aad16a4841552de3d91d1cb5319d4e849096130ccb54eb"},"material":{"base_ref_oid":"880753ee3d1db61c7fc8593798ade03cdb2177c2","digest":"sha256:aaf7bf5b482a02f37903c9017a3f330480cbaae3ecad0697ec9fa8114f719551","material_head_sha":"3f839b4dba0af801709b55117787a44b9d735ab4","merge_base_sha":"880753ee3d1db61c7fc8593798ade03cdb2177c2","policy_version":"pulseplate.material-classification/v1"},"pr_number":2169,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+{"authority":"human_asserted_content_receipt","code_review":{"review_commit_ref":"a98dd6a330a930c37ccd49853e78a108d6cb0e6e","review_commit_ref_kind":"repository_commit","review_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#pullrequestreview-4754641203","reviewed_material_digest":"sha256:4f973a00982d13e6358c914ee6b14e9546a83f6786f54359d46670abdef0f719","status":"completed"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:74059924cdb636e07369d5d5af0bae8fc1b140109d3145b0907ecf68f1436b8e","findings_sha256":"sha256:2faf1070ca64fd47fc2cd9f50c583a5937e5437beae14ff9551115440edfc938","work_ledger_sha256":"sha256:d1724c1aea094b1b8bd0e7dd903a7dcc922095286797f006f25b614ce72afe57"},"authority":"human_asserted_content_receipt","base_revision":"880753ee3d1db61c7fc8593798ade03cdb2177c2","coverage_completeness":"complete","findings_count":0,"head_revision":"a98dd6a330a930c37ccd49853e78a108d6cb0e6e","manifest_sha256":"sha256:3568bb22861a77a932b925a7d6625d09e882d9f5cd0a49db35ae674381f77210","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"233f777e-6561-4e33-b2b4-965d41f7b373","snapshot_digest":"codex-security-snapshot/v1:sha256:066a4915d5d0f548468c0de435626e9bcb62906558df972ad921cd4e57c23fb4"},"material":{"base_ref_oid":"880753ee3d1db61c7fc8593798ade03cdb2177c2","digest":"sha256:4f973a00982d13e6358c914ee6b14e9546a83f6786f54359d46670abdef0f719","material_head_sha":"a98dd6a330a930c37ccd49853e78a108d6cb0e6e","merge_base_sha":"880753ee3d1db61c7fc8593798ade03cdb2177c2","policy_version":"pulseplate.material-classification/v1"},"pr_number":2169,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
 <!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -708,6 +708,9 @@ def _validate_v1_seal(
             pr_number=pr_number,
             token=token,
             expected_commit_ref=material["material_head_sha"],
+            # The digest check above permits only the canonical mapping artifact
+            # to separate the sealed material head from the live PR head.
+            expected_live_pr_head_ref=snapshot.head_sha,
         )
         if (
             review_evidence.commit_ref != code_review["review_commit_ref"]

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -40,6 +40,7 @@ from scripts.orchestration.review_mapping_artifact import (
 from scripts.orchestration.pr_commit_identity import (  # noqa: E402
     CommitIdentityError,
     CommitRefKind,
+    CodexConnectorAdvisoryReactionEvidence,
     PrSnapshot,
     RepositoryCommitRef,
     ReviewThreadEvidence,
@@ -56,10 +57,12 @@ from scripts.orchestration.pr_commit_identity import (  # noqa: E402
 from scripts.orchestration.pr_review_evidence import (  # noqa: E402
     ReviewEvidenceError,
     build_review_credit_outage_receipt,
+    build_review_source_positive_response_receipt,
     build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
     is_review_credit_outage_receipt,
+    is_review_source_positive_response_receipt,
     is_review_source_unavailability_receipt,
     is_security_outage_override_receipt,
     parse_embedded_review_seal,
@@ -632,7 +635,37 @@ def _validate_v1_seal(
     }:
         raise ReviewEvidenceError("material head is not a real commit in the live PR")
     code_review = seal["code_review"]
-    if is_review_source_unavailability_receipt(code_review):
+    if is_review_source_positive_response_receipt(code_review):
+        response_manifest = compute_material_manifest(
+            REPO_ROOT,
+            base_ref_oid=snapshot.base_sha,
+            head_ref_oid=material_head.sha,
+            pr_number=pr_number,
+        )
+        if response_manifest.digest != material["digest"]:
+            raise ReviewEvidenceError(
+                "positive response material head has a different material digest"
+            )
+        response_evidence = verify_codex_review_reference(
+            code_review["response_reference"],
+            repository=repository,
+            pr_number=pr_number,
+            token=token,
+            expected_commit_ref=material_head.sha,
+            expected_live_pr_head_ref=snapshot.head_sha,
+        )
+        if not isinstance(response_evidence, CodexConnectorAdvisoryReactionEvidence):
+            raise ReviewEvidenceError("Codex positive response reference changed evidence type")
+        expected_code_review = build_review_source_positive_response_receipt(
+            material_digest=material["digest"],
+            material_head_sha=material_head.sha,
+            response_reference=response_evidence.reference,
+            response_created_at=response_evidence.created_at,
+            response_content=response_evidence.content,
+        )
+        if code_review != expected_code_review:
+            raise ReviewEvidenceError("Codex positive response receipt is stale")
+    elif is_review_source_unavailability_receipt(code_review):
         unavailable_manifest = compute_material_manifest(
             REPO_ROOT,
             base_ref_oid=snapshot.base_sha,
@@ -712,6 +745,8 @@ def _validate_v1_seal(
             # to separate the sealed material head from the live PR head.
             expected_live_pr_head_ref=snapshot.head_sha,
         )
+        if isinstance(review_evidence, CodexConnectorAdvisoryReactionEvidence):
+            raise ReviewEvidenceError("Codex positive response is not exact-head review evidence")
         if (
             review_evidence.commit_ref != code_review["review_commit_ref"]
             or code_review["review_commit_ref_kind"] != "repository_commit"
@@ -1067,7 +1102,12 @@ def main() -> int:
     print("merge-readiness-gate: passed (review governance only).")
     if seal is not None:
         print(f"CONTENT_BOUND_RECEIPT_VALID {seal['material']['digest']}")
-        if is_review_source_unavailability_receipt(seal["code_review"]):
+        if is_review_source_positive_response_receipt(seal["code_review"]):
+            print(
+                "REVIEW_SOURCE_POSITIVE_RESPONSE_VALID "
+                f"{seal['code_review']['response_content']}"
+            )
+        elif is_review_source_unavailability_receipt(seal["code_review"]):
             print("REVIEW_SOURCE_UNAVAILABLE_VALID " f"{seal['code_review']['source_status']}")
         elif is_review_credit_outage_receipt(seal["code_review"]):
             print(

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -62,6 +62,7 @@ from scripts.orchestration.pr_review_evidence import (  # noqa: E402
     build_security_outage_override_receipt,
     compute_material_manifest,
     is_review_credit_outage_receipt,
+    is_mapping_only_positive_response_successor,
     is_review_source_positive_response_receipt,
     is_review_source_unavailability_receipt,
     is_security_outage_override_receipt,
@@ -663,7 +664,16 @@ def _validate_v1_seal(
             response_created_at=response_evidence.created_at,
             response_content=response_evidence.content,
         )
-        if code_review != expected_code_review:
+        successor_response = (
+            snapshot.head_sha != material_head.sha
+            and is_mapping_only_positive_response_successor(
+                code_review,
+                response_reference=response_evidence.reference,
+                response_created_at=response_evidence.created_at,
+                response_content=response_evidence.content,
+            )
+        )
+        if code_review != expected_code_review and not successor_response:
             raise ReviewEvidenceError("Codex positive response receipt is stale")
     elif is_review_source_unavailability_receipt(code_review):
         unavailable_manifest = compute_material_manifest(

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -29,6 +29,8 @@ _MAX_PR_COMMIT_PAGES = 100
 _MAX_PR_COMMITS = 10_000
 _MAX_PR_REACTION_PAGES = 100
 _MAX_PR_REACTIONS = 10_000
+_MAX_HEAD_CHECK_SUITE_PAGES = 100
+_MAX_HEAD_CHECK_SUITES = 10_000
 _MAX_REVIEW_THREAD_PAGES = 100
 _MAX_REVIEW_COMMENT_PAGES = 100
 _MAX_REVIEW_THREADS = 10_000
@@ -1256,6 +1258,79 @@ def verify_codex_connector_advisory_reaction_reference(
     )
 
 
+def _require_codex_reaction_after_head_check_suite(
+    *,
+    repository: str,
+    expected_commit: str,
+    reaction_created_at: str,
+    token: str,
+    request_json: ApiRequest,
+) -> None:
+    """Require a server-timestamped Actions suite for the exact head before a reaction."""
+
+    owner, name = _require_repository(repository)
+    reaction_created = datetime.fromisoformat(
+        reaction_created_at[:-1] + "+00:00"
+        if reaction_created_at.endswith("Z")
+        else reaction_created_at
+    )
+    check_suite_count = 0
+    for page in range(1, _MAX_HEAD_CHECK_SUITE_PAGES + 1):
+        response = request_json(
+            f"{_API_ROOT}/repos/{owner}/{name}/commits/{expected_commit}/check-suites"
+            f"?per_page=100&page={page}",
+            token=token,
+        )
+        if not isinstance(response, dict):
+            raise CommitIdentityError("GitHub head check-suites response is malformed")
+        total_count = response.get("total_count")
+        check_suites = response.get("check_suites")
+        if (
+            not isinstance(total_count, int)
+            or isinstance(total_count, bool)
+            or total_count < 0
+            or not isinstance(check_suites, list)
+            or len(check_suites) > 100
+        ):
+            raise CommitIdentityError("GitHub head check-suites response is malformed")
+        check_suite_count += len(check_suites)
+        if check_suite_count > _MAX_HEAD_CHECK_SUITES:
+            raise CommitIdentityError("GitHub head check-suites exceed safety limit")
+        for suite in check_suites:
+            if not isinstance(suite, dict):
+                raise CommitIdentityError("GitHub head check-suite entry is malformed")
+            app = suite.get("app")
+            app_slug = app.get("slug") if isinstance(app, dict) else None
+            head_sha = _require_sha(
+                str(suite.get("head_sha") or ""),
+                field="GitHub head check-suite SHA",
+            )
+            suite_created_at = _require_iso8601(
+                suite.get("created_at"),
+                field="GitHub head check-suite created_at",
+            )
+            suite_created = datetime.fromisoformat(
+                suite_created_at[:-1] + "+00:00"
+                if suite_created_at.endswith("Z")
+                else suite_created_at
+            )
+            if (
+                app_slug == "github-actions"
+                and head_sha == expected_commit
+                and suite_created <= reaction_created
+            ):
+                return
+        if len(check_suites) < 100:
+            break
+    else:
+        raise CommitIdentityError("GitHub head check-suite pagination exceeded page limit")
+
+    raise CommitIdentityError(
+        "Codex connector reaction does not follow a GitHub Actions observation "
+        "of the exact material head"
+    )
+
+
 def verify_codex_review_reference(
     reference: str,
     *,
@@ -1323,6 +1398,13 @@ def verify_codex_review_reference(
             reference,
             repository=repository,
             pr_number=pr_number,
+            token=token,
+            request_json=request_json,
+        )
+        _require_codex_reaction_after_head_check_suite(
+            repository=repository,
+            expected_commit=expected_commit,
+            reaction_created_at=reaction.created_at,
             token=token,
             request_json=request_json,
         )

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -12,6 +12,7 @@ import hashlib
 import http.client
 import json
 import re
+import time
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -27,6 +28,12 @@ _API_ROOT = f"https://{_API_HOST}"
 _MAX_RESPONSE_BYTES = 4 * 1024 * 1024
 _MAX_PR_COMMIT_PAGES = 100
 _MAX_PR_COMMITS = 10_000
+_MAX_PR_REACTION_PAGES = 100
+_MAX_PR_REACTIONS = 10_000
+_MAX_PR_PUSH_EVENT_PAGES = 3
+_MAX_PR_PUSH_EVENTS = 300
+_MAX_PR_PUSH_EVENT_VISIBILITY_ATTEMPTS = 4
+_PR_PUSH_EVENT_VISIBILITY_RETRY_SECONDS = 10
 _MAX_REVIEW_THREAD_PAGES = 100
 _MAX_REVIEW_COMMENT_PAGES = 100
 _MAX_REVIEW_THREADS = 10_000
@@ -34,6 +41,7 @@ _MAX_REVIEW_COMMENTS = 10_000
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _ISO_8601_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 _CODEX_CONNECTOR_LOGIN = "chatgpt-codex-connector[bot]"
+_CODEX_CONNECTOR_USER_ID = 199_175_422
 _CODEX_CONNECTOR_APP_ID = 1_144_995
 _CODEX_CONNECTOR_APP_SLUG = "chatgpt-codex-connector"
 _CODEX_CONNECTOR_OWNER = "openai"
@@ -65,6 +73,7 @@ _CODEX_REVIEW_CREDIT_OUTAGE_CLOCK_SKEW = timedelta(minutes=5)
 _OPERATOR_EXACT_HEAD_REVIEW_PREFIX = "Exact-head bounded review completed for"
 _CODEX_REVIEW_CREDIT_OUTAGE_CLASS = "codex_review_credits_exhausted"
 _CODEX_REVIEW_CREDIT_OUTAGE_STATUS = "TOOLING_UNAVAILABLE"
+_CODEX_POSITIVE_REACTION_CONTENTS = frozenset({"+1", "heart", "hooray", "rocket"})
 
 
 class CommitIdentityError(RuntimeError):
@@ -872,6 +881,18 @@ def _require_iso8601(value: Any, *, field: str) -> str:
     return value
 
 
+def _parse_iso8601_datetime(value: Any, *, field: str) -> datetime:
+    """Return one validated timezone-aware GitHub timestamp."""
+
+    timestamp = _require_iso8601(value, field=field)
+    try:
+        return datetime.fromisoformat(
+            timestamp[:-1] + "+00:00" if timestamp.endswith("Z") else timestamp
+        )
+    except ValueError as exc:
+        raise CommitIdentityError(f"{field} is not a valid ISO-8601 timestamp") from exc
+
+
 def _normalize_codex_comment_details(value: str) -> str:
     """Ignore connector-only whitespace while preserving exact nonblank content."""
 
@@ -1151,6 +1172,167 @@ def is_ancestor(
     return True
 
 
+def _verify_codex_positive_reaction_reference(
+    reference: str,
+    *,
+    repository: str,
+    pr_number: int,
+    expected_commit_ref: str,
+    token: str,
+    request_json: ApiRequest,
+) -> CodexReviewEvidence:
+    """Prove one positive official-connector reaction on the exact PR root."""
+
+    owner, name = _require_repository(repository)
+    pattern = re.compile(
+        rf"^https://github\.com/{re.escape(owner)}/{re.escape(name)}/pull/"
+        rf"{pr_number}#reaction-([1-9]\d*)$"
+    )
+    match = pattern.fullmatch(reference)
+    if not match:
+        raise CommitIdentityError(
+            "Codex positive reaction must be a canonical reaction URL on the exact PR"
+        )
+    reaction_id_text = match.group(1)
+    reaction_id = int(reaction_id_text)
+    if str(reaction_id) != reaction_id_text:
+        raise CommitIdentityError("Codex positive reaction reference is not canonical")
+    material_head = _require_sha(expected_commit_ref, field="expected Codex reaction commit")
+
+    pull_response = request_json(
+        f"{_API_ROOT}/repos/{owner}/{name}/pulls/{pr_number}",
+        token=token,
+    )
+    head = pull_response.get("head") if isinstance(pull_response, dict) else None
+    head_sha = head.get("sha") if isinstance(head, dict) else None
+    head_ref = head.get("ref") if isinstance(head, dict) else None
+    head_repository = head.get("repo") if isinstance(head, dict) else None
+    head_repository_full_name = (
+        head_repository.get("full_name") if isinstance(head_repository, dict) else None
+    )
+    if (
+        not isinstance(head_ref, str)
+        or not head_ref
+        or any(ord(character) < 32 for character in head_ref)
+        or not isinstance(head_sha, str)
+        or not isinstance(head_repository_full_name, str)
+    ):
+        raise CommitIdentityError("GitHub PR reaction does not bind the expected material head")
+    _require_sha(head_sha, field="GitHub PR reaction current head")
+    head_owner, head_name = _require_repository(head_repository_full_name)
+    expected_ref = f"refs/heads/{head_ref}"
+    push_events: list[tuple[datetime, str]] = []
+    for visibility_attempt in range(_MAX_PR_PUSH_EVENT_VISIBILITY_ATTEMPTS):
+        event_count = 0
+        for page in range(1, _MAX_PR_PUSH_EVENT_PAGES + 1):
+            events = request_json(
+                f"{_API_ROOT}/repos/{head_owner}/{head_name}/events?per_page=100&page={page}",
+                token=token,
+            )
+            if not isinstance(events, list) or len(events) > 100:
+                raise CommitIdentityError("GitHub PR push-events response is malformed")
+            event_count += len(events)
+            if event_count > _MAX_PR_PUSH_EVENTS:
+                raise CommitIdentityError("GitHub PR push-events exceed safety limit")
+            for event in events:
+                if not isinstance(event, dict) or event.get("type") != "PushEvent":
+                    continue
+                payload = event.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                if payload.get("ref") != expected_ref or payload.get("head") != material_head:
+                    continue
+                created_at = _require_iso8601(
+                    event.get("created_at"),
+                    field="GitHub PR material push created_at",
+                )
+                push_events.append(
+                    (
+                        _parse_iso8601_datetime(
+                            created_at,
+                            field="GitHub PR material push created_at",
+                        ),
+                        created_at,
+                    )
+                )
+            if len(events) < 100 or page == _MAX_PR_PUSH_EVENT_PAGES:
+                break
+        if push_events:
+            break
+        if visibility_attempt < _MAX_PR_PUSH_EVENT_VISIBILITY_ATTEMPTS - 1:
+            time.sleep(_PR_PUSH_EVENT_VISIBILITY_RETRY_SECONDS)
+    if not push_events:
+        raise CommitIdentityError(
+            "GitHub PR material push event is pending visibility; retry closeout shortly"
+        )
+    material_pushed_at = max(push_events)[0]
+
+    matches: list[dict[str, Any]] = []
+    reaction_count = 0
+    for page in range(1, _MAX_PR_REACTION_PAGES + 1):
+        response = request_json(
+            f"{_API_ROOT}/repos/{owner}/{name}/issues/{pr_number}/reactions"
+            f"?per_page=100&page={page}",
+            token=token,
+        )
+        if not isinstance(response, list) or len(response) > 100:
+            raise CommitIdentityError("GitHub PR reactions response is malformed")
+        reaction_count += len(response)
+        if reaction_count > _MAX_PR_REACTIONS:
+            raise CommitIdentityError("GitHub PR reactions exceed safety limit")
+        for reaction in response:
+            if not isinstance(reaction, dict):
+                raise CommitIdentityError("GitHub PR reaction entry is malformed")
+            candidate_id = reaction.get("id")
+            if (
+                not isinstance(candidate_id, int)
+                or isinstance(candidate_id, bool)
+                or candidate_id <= 0
+            ):
+                raise CommitIdentityError("GitHub PR reaction id is malformed")
+            if candidate_id == reaction_id:
+                matches.append(reaction)
+        if len(response) < 100:
+            break
+    else:
+        raise CommitIdentityError("GitHub PR reaction pagination exceeded page limit")
+
+    if len(matches) != 1:
+        raise CommitIdentityError("Codex positive reaction is missing or ambiguous")
+    reaction = matches[0]
+    user = reaction.get("user")
+    user_id = user.get("id") if isinstance(user, dict) else None
+    login = user.get("login") if isinstance(user, dict) else None
+    user_type = user.get("type") if isinstance(user, dict) else None
+    content = reaction.get("content")
+    created_at = _require_iso8601(
+        reaction.get("created_at"),
+        field="Codex positive reaction created_at",
+    )
+    if (
+        not isinstance(user_id, int)
+        or isinstance(user_id, bool)
+        or user_id != _CODEX_CONNECTOR_USER_ID
+        or not isinstance(login, str)
+        or login != _CODEX_CONNECTOR_LOGIN
+        or not isinstance(user_type, str)
+        or user_type not in {"Bot", "User"}
+        or not isinstance(content, str)
+        or content not in _CODEX_POSITIVE_REACTION_CONTENTS
+    ):
+        raise CommitIdentityError("reaction is not a trusted positive Codex connector reaction")
+    if (
+        _parse_iso8601_datetime(created_at, field="Codex positive reaction created_at")
+        <= material_pushed_at
+    ):
+        raise CommitIdentityError("Codex positive reaction does not postdate the material head")
+    return CodexReviewEvidence(
+        reference=reference,
+        submitted_at=created_at,
+        commit_ref=material_head,
+    )
+
+
 def verify_codex_review_reference(
     reference: str,
     *,
@@ -1205,6 +1387,24 @@ def verify_codex_review_reference(
             commit_ref=commit_ref,
         )
 
+    reaction_pattern = re.compile(
+        rf"^https://github\.com/{re.escape(owner)}/{re.escape(name)}/pull/"
+        rf"{pr_number}#reaction-[1-9]\d*$"
+    )
+    if reaction_pattern.fullmatch(reference):
+        if expected_commit is None:
+            raise CommitIdentityError(
+                "Codex positive reaction requires an expected full material commit"
+            )
+        return _verify_codex_positive_reaction_reference(
+            reference,
+            repository=repository,
+            pr_number=pr_number,
+            expected_commit_ref=expected_commit,
+            token=token,
+            request_json=request_json,
+        )
+
     comment_pattern = re.compile(
         rf"^https://github\.com/{re.escape(owner)}/{re.escape(name)}/pull/"
         rf"{pr_number}#issuecomment-(\d+)$"
@@ -1212,7 +1412,8 @@ def verify_codex_review_reference(
     comment_match = comment_pattern.fullmatch(reference)
     if not comment_match:
         raise CommitIdentityError(
-            "code-review reference must be a GitHub PR review or Codex no-findings comment URL"
+            "code-review reference must be a GitHub PR review, Codex no-findings comment, "
+            "or positive connector reaction URL"
         )
     if expected_commit is None:
         raise CommitIdentityError(

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -29,8 +29,8 @@ _MAX_PR_COMMIT_PAGES = 100
 _MAX_PR_COMMITS = 10_000
 _MAX_PR_REACTION_PAGES = 100
 _MAX_PR_REACTIONS = 10_000
-_MAX_PR_REVIEW_PAGES = 100
-_MAX_PR_REVIEWS = 10_000
+_MAX_HEAD_CHECK_SUITE_PAGES = 100
+_MAX_HEAD_CHECK_SUITES = 10_000
 _MAX_REVIEW_THREAD_PAGES = 100
 _MAX_REVIEW_COMMENT_PAGES = 100
 _MAX_REVIEW_THREADS = 10_000
@@ -1258,7 +1258,7 @@ def verify_codex_connector_advisory_reaction_reference(
     )
 
 
-def _require_codex_reaction_after_exact_head_review(
+def _require_codex_reaction_after_current_head_observation(
     *,
     repository: str,
     pr_number: int,
@@ -1267,68 +1267,79 @@ def _require_codex_reaction_after_exact_head_review(
     token: str,
     request_json: ApiRequest,
 ) -> None:
-    """Require a Connector-owned exact-head review before a positive reaction."""
+    """Require a live PR head and server-observed exact head before a reaction."""
 
     owner, name = _require_repository(repository)
+    pull = request_json(
+        f"{_API_ROOT}/repos/{owner}/{name}/pulls/{pr_number}",
+        token=token,
+    )
+    if not isinstance(pull, dict):
+        raise CommitIdentityError("GitHub PR response is malformed")
+    head = pull.get("head")
+    live_head = head.get("sha") if isinstance(head, dict) else None
+    if live_head != expected_commit:
+        raise CommitIdentityError(
+            "Codex connector reaction is not attached to the current material head"
+        )
     reaction_created = datetime.fromisoformat(
         reaction_created_at[:-1] + "+00:00"
         if reaction_created_at.endswith("Z")
         else reaction_created_at
     )
-    review_count = 0
-    review_url_pattern = re.compile(
-        rf"^https://github\.com/{re.escape(owner)}/{re.escape(name)}/pull/"
-        rf"{pr_number}#pullrequestreview-[1-9]\d*$"
-    )
-    for page in range(1, _MAX_PR_REVIEW_PAGES + 1):
+    check_suite_count = 0
+    for page in range(1, _MAX_HEAD_CHECK_SUITE_PAGES + 1):
         response = request_json(
-            f"{_API_ROOT}/repos/{owner}/{name}/pulls/{pr_number}/reviews"
+            f"{_API_ROOT}/repos/{owner}/{name}/commits/{expected_commit}/check-suites"
             f"?per_page=100&page={page}",
             token=token,
         )
-        if not isinstance(response, list) or len(response) > 100:
-            raise CommitIdentityError("GitHub PR reviews response is malformed")
-        review_count += len(response)
-        if review_count > _MAX_PR_REVIEWS:
-            raise CommitIdentityError("GitHub PR reviews exceed safety limit")
-        for review in response:
-            if not isinstance(review, dict):
-                raise CommitIdentityError("GitHub PR review entry is malformed")
-            user = review.get("user")
-            user_id = user.get("id") if isinstance(user, dict) else None
-            login = user.get("login") if isinstance(user, dict) else None
-            user_type = user.get("type") if isinstance(user, dict) else None
+        if not isinstance(response, dict):
+            raise CommitIdentityError("GitHub head check-suites response is malformed")
+        total_count = response.get("total_count")
+        check_suites = response.get("check_suites")
+        if (
+            not isinstance(total_count, int)
+            or isinstance(total_count, bool)
+            or total_count < 0
+            or not isinstance(check_suites, list)
+            or len(check_suites) > 100
+        ):
+            raise CommitIdentityError("GitHub head check-suites response is malformed")
+        check_suite_count += len(check_suites)
+        if check_suite_count > _MAX_HEAD_CHECK_SUITES:
+            raise CommitIdentityError("GitHub head check-suites exceed safety limit")
+        for suite in check_suites:
+            if not isinstance(suite, dict):
+                raise CommitIdentityError("GitHub head check-suite entry is malformed")
+            app = suite.get("app")
+            app_slug = app.get("slug") if isinstance(app, dict) else None
+            head_sha = _require_sha(
+                str(suite.get("head_sha") or ""),
+                field="GitHub head check-suite SHA",
+            )
+            suite_created_at = _require_iso8601(
+                suite.get("created_at"),
+                field="GitHub head check-suite created_at",
+            )
+            suite_created = datetime.fromisoformat(
+                suite_created_at[:-1] + "+00:00"
+                if suite_created_at.endswith("Z")
+                else suite_created_at
+            )
             if (
-                user_id != _CODEX_CONNECTOR_USER_ID
-                or login != _CODEX_CONNECTOR_LOGIN
-                or user_type != "Bot"
-                or review.get("state") not in {"COMMENTED", "APPROVED"}
-                or not isinstance(review.get("html_url"), str)
-                or not review_url_pattern.fullmatch(review["html_url"])
+                app_slug == "github-actions"
+                and head_sha == expected_commit
+                and suite_created < reaction_created
             ):
-                continue
-            review_commit = _require_sha(
-                str(review.get("commit_id") or ""),
-                field="Codex Connector review commit_id",
-            )
-            review_submitted_at = _require_iso8601(
-                review.get("submitted_at"),
-                field="Codex Connector review submitted_at",
-            )
-            review_submitted = datetime.fromisoformat(
-                review_submitted_at[:-1] + "+00:00"
-                if review_submitted_at.endswith("Z")
-                else review_submitted_at
-            )
-            if review_commit == expected_commit and review_submitted < reaction_created:
                 return
-        if len(response) < 100:
+        if len(check_suites) < 100:
             break
     else:
-        raise CommitIdentityError("GitHub PR review pagination exceeded page limit")
+        raise CommitIdentityError("GitHub head check-suite pagination exceeded page limit")
 
     raise CommitIdentityError(
-        "Codex connector reaction does not follow a trusted Connector review "
+        "Codex connector reaction does not follow a GitHub observation "
         "of the exact material head"
     )
 
@@ -1403,7 +1414,7 @@ def verify_codex_review_reference(
             token=token,
             request_json=request_json,
         )
-        _require_codex_reaction_after_exact_head_review(
+        _require_codex_reaction_after_current_head_observation(
             repository=repository,
             pr_number=pr_number,
             expected_commit=expected_commit,

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -12,7 +12,6 @@ import hashlib
 import http.client
 import json
 import re
-import time
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -30,10 +29,6 @@ _MAX_PR_COMMIT_PAGES = 100
 _MAX_PR_COMMITS = 10_000
 _MAX_PR_REACTION_PAGES = 100
 _MAX_PR_REACTIONS = 10_000
-_MAX_PR_PUSH_EVENT_PAGES = 3
-_MAX_PR_PUSH_EVENTS = 300
-_MAX_PR_PUSH_EVENT_VISIBILITY_ATTEMPTS = 4
-_PR_PUSH_EVENT_VISIBILITY_RETRY_SECONDS = 10
 _MAX_REVIEW_THREAD_PAGES = 100
 _MAX_REVIEW_COMMENT_PAGES = 100
 _MAX_REVIEW_THREADS = 10_000
@@ -168,6 +163,15 @@ class CodexReviewEvidence:
     reference: str
     submitted_at: str
     commit_ref: str
+
+
+@dataclass(frozen=True)
+class CodexConnectorAdvisoryReactionEvidence:
+    """Verified Connector reaction that intentionally carries no review claim."""
+
+    reference: str
+    created_at: str
+    content: str
 
 
 @dataclass(frozen=True)
@@ -881,18 +885,6 @@ def _require_iso8601(value: Any, *, field: str) -> str:
     return value
 
 
-def _parse_iso8601_datetime(value: Any, *, field: str) -> datetime:
-    """Return one validated timezone-aware GitHub timestamp."""
-
-    timestamp = _require_iso8601(value, field=field)
-    try:
-        return datetime.fromisoformat(
-            timestamp[:-1] + "+00:00" if timestamp.endswith("Z") else timestamp
-        )
-    except ValueError as exc:
-        raise CommitIdentityError(f"{field} is not a valid ISO-8601 timestamp") from exc
-
-
 def _normalize_codex_comment_details(value: str) -> str:
     """Ignore connector-only whitespace while preserving exact nonblank content."""
 
@@ -1172,16 +1164,20 @@ def is_ancestor(
     return True
 
 
-def _verify_codex_positive_reaction_reference(
+def verify_codex_connector_advisory_reaction_reference(
     reference: str,
     *,
     repository: str,
     pr_number: int,
-    expected_commit_ref: str,
     token: str,
-    request_json: ApiRequest,
-) -> CodexReviewEvidence:
-    """Prove one positive official-connector reaction on the exact PR root."""
+    request_json: ApiRequest = github_api_request,
+) -> CodexConnectorAdvisoryReactionEvidence:
+    """Verify one official positive PR-root reaction as advisory evidence only.
+
+    GitHub reactions do not name a reviewed commit or execution run.  This
+    verifier therefore intentionally cannot bind a reaction to material and
+    must never be used as a code-review or review-seal proof.
+    """
 
     owner, name = _require_repository(repository)
     pattern = re.compile(
@@ -1197,75 +1193,6 @@ def _verify_codex_positive_reaction_reference(
     reaction_id = int(reaction_id_text)
     if str(reaction_id) != reaction_id_text:
         raise CommitIdentityError("Codex positive reaction reference is not canonical")
-    material_head = _require_sha(expected_commit_ref, field="expected Codex reaction commit")
-
-    pull_response = request_json(
-        f"{_API_ROOT}/repos/{owner}/{name}/pulls/{pr_number}",
-        token=token,
-    )
-    head = pull_response.get("head") if isinstance(pull_response, dict) else None
-    head_sha = head.get("sha") if isinstance(head, dict) else None
-    head_ref = head.get("ref") if isinstance(head, dict) else None
-    head_repository = head.get("repo") if isinstance(head, dict) else None
-    head_repository_full_name = (
-        head_repository.get("full_name") if isinstance(head_repository, dict) else None
-    )
-    if (
-        not isinstance(head_ref, str)
-        or not head_ref
-        or any(ord(character) < 32 for character in head_ref)
-        or not isinstance(head_sha, str)
-        or not isinstance(head_repository_full_name, str)
-    ):
-        raise CommitIdentityError("GitHub PR reaction does not bind the expected material head")
-    _require_sha(head_sha, field="GitHub PR reaction current head")
-    head_owner, head_name = _require_repository(head_repository_full_name)
-    expected_ref = f"refs/heads/{head_ref}"
-    push_events: list[tuple[datetime, str]] = []
-    for visibility_attempt in range(_MAX_PR_PUSH_EVENT_VISIBILITY_ATTEMPTS):
-        event_count = 0
-        for page in range(1, _MAX_PR_PUSH_EVENT_PAGES + 1):
-            events = request_json(
-                f"{_API_ROOT}/repos/{head_owner}/{head_name}/events?per_page=100&page={page}",
-                token=token,
-            )
-            if not isinstance(events, list) or len(events) > 100:
-                raise CommitIdentityError("GitHub PR push-events response is malformed")
-            event_count += len(events)
-            if event_count > _MAX_PR_PUSH_EVENTS:
-                raise CommitIdentityError("GitHub PR push-events exceed safety limit")
-            for event in events:
-                if not isinstance(event, dict) or event.get("type") != "PushEvent":
-                    continue
-                payload = event.get("payload")
-                if not isinstance(payload, dict):
-                    continue
-                if payload.get("ref") != expected_ref or payload.get("head") != material_head:
-                    continue
-                created_at = _require_iso8601(
-                    event.get("created_at"),
-                    field="GitHub PR material push created_at",
-                )
-                push_events.append(
-                    (
-                        _parse_iso8601_datetime(
-                            created_at,
-                            field="GitHub PR material push created_at",
-                        ),
-                        created_at,
-                    )
-                )
-            if len(events) < 100 or page == _MAX_PR_PUSH_EVENT_PAGES:
-                break
-        if push_events:
-            break
-        if visibility_attempt < _MAX_PR_PUSH_EVENT_VISIBILITY_ATTEMPTS - 1:
-            time.sleep(_PR_PUSH_EVENT_VISIBILITY_RETRY_SECONDS)
-    if not push_events:
-        raise CommitIdentityError(
-            "GitHub PR material push event is pending visibility; retry closeout shortly"
-        )
-    material_pushed_at = max(push_events)[0]
 
     matches: list[dict[str, Any]] = []
     reaction_count = 0
@@ -1321,15 +1248,10 @@ def _verify_codex_positive_reaction_reference(
         or content not in _CODEX_POSITIVE_REACTION_CONTENTS
     ):
         raise CommitIdentityError("reaction is not a trusted positive Codex connector reaction")
-    if (
-        _parse_iso8601_datetime(created_at, field="Codex positive reaction created_at")
-        <= material_pushed_at
-    ):
-        raise CommitIdentityError("Codex positive reaction does not postdate the material head")
-    return CodexReviewEvidence(
+    return CodexConnectorAdvisoryReactionEvidence(
         reference=reference,
-        submitted_at=created_at,
-        commit_ref=material_head,
+        created_at=created_at,
+        content=content,
     )
 
 
@@ -1392,17 +1314,9 @@ def verify_codex_review_reference(
         rf"{pr_number}#reaction-[1-9]\d*$"
     )
     if reaction_pattern.fullmatch(reference):
-        if expected_commit is None:
-            raise CommitIdentityError(
-                "Codex positive reaction requires an expected full material commit"
-            )
-        return _verify_codex_positive_reaction_reference(
-            reference,
-            repository=repository,
-            pr_number=pr_number,
-            expected_commit_ref=expected_commit,
-            token=token,
-            request_json=request_json,
+        raise CommitIdentityError(
+            "positive Codex connector reactions are advisory only and cannot satisfy "
+            "exact-head code-review evidence"
         )
 
     comment_pattern = re.compile(
@@ -1412,8 +1326,7 @@ def verify_codex_review_reference(
     comment_match = comment_pattern.fullmatch(reference)
     if not comment_match:
         raise CommitIdentityError(
-            "code-review reference must be a GitHub PR review, Codex no-findings comment, "
-            "or positive connector reaction URL"
+            "code-review reference must be a GitHub PR review or Codex no-findings comment URL"
         )
     if expected_commit is None:
         raise CommitIdentityError(

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -1265,6 +1265,7 @@ def _require_codex_reaction_after_current_head_observation(
     repository: str,
     pr_number: int,
     expected_commit: str,
+    expected_live_pr_head: str | None,
     reaction_created_at: str,
     token: str,
     request_json: ApiRequest,
@@ -1280,7 +1281,12 @@ def _require_codex_reaction_after_current_head_observation(
         raise CommitIdentityError("GitHub PR response is malformed")
     head = pull.get("head")
     live_head = head.get("sha") if isinstance(head, dict) else None
-    if live_head != expected_commit:
+    required_live_head = (
+        expected_commit
+        if expected_live_pr_head is None
+        else _require_sha(expected_live_pr_head, field="expected live PR head")
+    )
+    if live_head != required_live_head:
         raise CommitIdentityError(
             "Codex connector reaction is not attached to the current material head"
         )
@@ -1413,6 +1419,7 @@ def verify_codex_review_reference(
     pr_number: int,
     token: str,
     expected_commit_ref: str | None = None,
+    expected_live_pr_head_ref: str | None = None,
     request_json: ApiRequest = github_api_request,
 ) -> CodexReviewEvidence:
     """Prove that a seal reference names trusted exact-head Codex review evidence."""
@@ -1480,6 +1487,7 @@ def verify_codex_review_reference(
             repository=repository,
             pr_number=pr_number,
             expected_commit=expected_commit,
+            expected_live_pr_head=expected_live_pr_head_ref,
             reaction_created_at=reaction.created_at,
             token=token,
             request_json=request_json,

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -1172,11 +1172,12 @@ def verify_codex_connector_advisory_reaction_reference(
     token: str,
     request_json: ApiRequest = github_api_request,
 ) -> CodexConnectorAdvisoryReactionEvidence:
-    """Verify one official positive PR-root reaction as advisory evidence only.
+    """Verify one official positive PR-root Connector reaction.
 
-    GitHub reactions do not name a reviewed commit or execution run.  This
-    verifier therefore intentionally cannot bind a reaction to material and
-    must never be used as a code-review or review-seal proof.
+    The reaction itself has no commit field.  Callers that use it as normal
+    review evidence must supply an independently snapshotted exact material
+    head; the optional advisory rendering path intentionally carries no such
+    binding.
     """
 
     owner, name = _require_repository(repository)
@@ -1314,9 +1315,21 @@ def verify_codex_review_reference(
         rf"{pr_number}#reaction-[1-9]\d*$"
     )
     if reaction_pattern.fullmatch(reference):
-        raise CommitIdentityError(
-            "positive Codex connector reactions are advisory only and cannot satisfy "
-            "exact-head code-review evidence"
+        if expected_commit is None:
+            raise CommitIdentityError(
+                "Codex connector reaction requires an expected full material commit"
+            )
+        reaction = verify_codex_connector_advisory_reaction_reference(
+            reference,
+            repository=repository,
+            pr_number=pr_number,
+            token=token,
+            request_json=request_json,
+        )
+        return CodexReviewEvidence(
+            reference=reference,
+            submitted_at=reaction.created_at,
+            commit_ref=expected_commit,
         )
 
     comment_pattern = re.compile(
@@ -1326,7 +1339,8 @@ def verify_codex_review_reference(
     comment_match = comment_pattern.fullmatch(reference)
     if not comment_match:
         raise CommitIdentityError(
-            "code-review reference must be a GitHub PR review or Codex no-findings comment URL"
+            "code-review reference must be a GitHub PR review, official Connector reaction, "
+            "or Codex no-findings comment URL"
         )
     if expected_commit is None:
         raise CommitIdentityError(

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -1233,8 +1233,10 @@ def verify_codex_connector_advisory_reaction_reference(
     else:
         raise CommitIdentityError("GitHub PR reaction pagination exceeded page limit")
 
+    if not matches:
+        raise CommitIdentityError("Codex positive reaction is missing")
     if len(matches) != 1:
-        raise CommitIdentityError("Codex positive reaction is missing or ambiguous")
+        raise CommitIdentityError("Codex positive reaction is ambiguous")
     reaction = matches[0]
     user = reaction.get("user")
     user_id = user.get("id") if isinstance(user, dict) else None
@@ -1262,6 +1264,81 @@ def verify_codex_connector_advisory_reaction_reference(
         created_at=created_at,
         content=content,
     )
+
+
+def _latest_codex_connector_positive_reaction(
+    *,
+    repository: str,
+    pr_number: int,
+    token: str,
+    request_json: ApiRequest,
+) -> CodexConnectorAdvisoryReactionEvidence:
+    """Return the latest live trusted positive reaction for mapping-only revalidation."""
+
+    owner, name = _require_repository(repository)
+    candidates: list[tuple[datetime, int, CodexConnectorAdvisoryReactionEvidence]] = []
+    reaction_count = 0
+    for page in range(1, _MAX_PR_REACTION_PAGES + 1):
+        response = request_json(
+            f"{_API_ROOT}/repos/{owner}/{name}/issues/{pr_number}/reactions"
+            f"?per_page=100&page={page}",
+            token=token,
+        )
+        if not isinstance(response, list) or len(response) > 100:
+            raise CommitIdentityError("GitHub PR reactions response is malformed")
+        reaction_count += len(response)
+        if reaction_count > _MAX_PR_REACTIONS:
+            raise CommitIdentityError("GitHub PR reactions exceed safety limit")
+        for reaction in response:
+            if not isinstance(reaction, dict):
+                raise CommitIdentityError("GitHub PR reaction entry is malformed")
+            reaction_id = reaction.get("id")
+            if (
+                not isinstance(reaction_id, int)
+                or isinstance(reaction_id, bool)
+                or reaction_id <= 0
+            ):
+                raise CommitIdentityError("GitHub PR reaction id is malformed")
+            user = reaction.get("user")
+            user_id = user.get("id") if isinstance(user, dict) else None
+            login = user.get("login") if isinstance(user, dict) else None
+            user_type = user.get("type") if isinstance(user, dict) else None
+            content = reaction.get("content")
+            if (
+                user_id != _CODEX_CONNECTOR_USER_ID
+                or login != _CODEX_CONNECTOR_LOGIN
+                or not isinstance(user_type, str)
+                or user_type not in {"Bot", "User"}
+                or not isinstance(content, str)
+                or content not in _CODEX_POSITIVE_REACTION_CONTENTS
+            ):
+                continue
+            created_at = _require_iso8601(
+                reaction.get("created_at"),
+                field="Codex positive reaction created_at",
+            )
+            created = datetime.fromisoformat(
+                created_at[:-1] + "+00:00" if created_at.endswith("Z") else created_at
+            )
+            reference = f"https://github.com/{owner}/{name}/pull/{pr_number}#reaction-{reaction_id}"
+            candidates.append(
+                (
+                    created,
+                    reaction_id,
+                    CodexConnectorAdvisoryReactionEvidence(
+                        reference=reference,
+                        created_at=created_at,
+                        content=str(content),
+                    ),
+                )
+            )
+        if len(response) < 100:
+            break
+    else:
+        raise CommitIdentityError("GitHub PR reaction pagination exceeded page limit")
+    if not candidates:
+        raise CommitIdentityError("Codex positive reaction is missing or ambiguous")
+    return max(candidates, key=lambda item: (item[0], item[1]))[2]
 
 
 def _require_codex_reaction_after_current_head_observation(
@@ -1480,13 +1557,27 @@ def verify_codex_review_reference(
             raise CommitIdentityError(
                 "Codex connector reaction requires an expected full material commit"
             )
-        reaction = verify_codex_connector_advisory_reaction_reference(
-            reference,
-            repository=repository,
-            pr_number=pr_number,
-            token=token,
-            request_json=request_json,
-        )
+        try:
+            reaction = verify_codex_connector_advisory_reaction_reference(
+                reference,
+                repository=repository,
+                pr_number=pr_number,
+                token=token,
+                request_json=request_json,
+            )
+        except CommitIdentityError as exc:
+            mapping_only_descendant = (
+                expected_live_pr_head_ref is not None
+                and expected_live_pr_head_ref != expected_commit
+            )
+            if not mapping_only_descendant or str(exc) != "Codex positive reaction is missing":
+                raise
+            reaction = _latest_codex_connector_positive_reaction(
+                repository=repository,
+                pr_number=pr_number,
+                token=token,
+                request_json=request_json,
+            )
         _require_codex_reaction_after_current_head_observation(
             repository=repository,
             pr_number=pr_number,

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -29,8 +29,8 @@ _MAX_PR_COMMIT_PAGES = 100
 _MAX_PR_COMMITS = 10_000
 _MAX_PR_REACTION_PAGES = 100
 _MAX_PR_REACTIONS = 10_000
-_MAX_HEAD_CHECK_SUITE_PAGES = 100
-_MAX_HEAD_CHECK_SUITES = 10_000
+_MAX_PR_REVIEW_PAGES = 100
+_MAX_PR_REVIEWS = 10_000
 _MAX_REVIEW_THREAD_PAGES = 100
 _MAX_REVIEW_COMMENT_PAGES = 100
 _MAX_REVIEW_THREADS = 10_000
@@ -1258,15 +1258,16 @@ def verify_codex_connector_advisory_reaction_reference(
     )
 
 
-def _require_codex_reaction_after_head_check_suite(
+def _require_codex_reaction_after_exact_head_review(
     *,
     repository: str,
+    pr_number: int,
     expected_commit: str,
     reaction_created_at: str,
     token: str,
     request_json: ApiRequest,
 ) -> None:
-    """Require a server-timestamped Actions suite for the exact head before a reaction."""
+    """Require a Connector-owned exact-head review before a positive reaction."""
 
     owner, name = _require_repository(repository)
     reaction_created = datetime.fromisoformat(
@@ -1274,59 +1275,60 @@ def _require_codex_reaction_after_head_check_suite(
         if reaction_created_at.endswith("Z")
         else reaction_created_at
     )
-    check_suite_count = 0
-    for page in range(1, _MAX_HEAD_CHECK_SUITE_PAGES + 1):
+    review_count = 0
+    review_url_pattern = re.compile(
+        rf"^https://github\.com/{re.escape(owner)}/{re.escape(name)}/pull/"
+        rf"{pr_number}#pullrequestreview-[1-9]\d*$"
+    )
+    for page in range(1, _MAX_PR_REVIEW_PAGES + 1):
         response = request_json(
-            f"{_API_ROOT}/repos/{owner}/{name}/commits/{expected_commit}/check-suites"
+            f"{_API_ROOT}/repos/{owner}/{name}/pulls/{pr_number}/reviews"
             f"?per_page=100&page={page}",
             token=token,
         )
-        if not isinstance(response, dict):
-            raise CommitIdentityError("GitHub head check-suites response is malformed")
-        total_count = response.get("total_count")
-        check_suites = response.get("check_suites")
-        if (
-            not isinstance(total_count, int)
-            or isinstance(total_count, bool)
-            or total_count < 0
-            or not isinstance(check_suites, list)
-            or len(check_suites) > 100
-        ):
-            raise CommitIdentityError("GitHub head check-suites response is malformed")
-        check_suite_count += len(check_suites)
-        if check_suite_count > _MAX_HEAD_CHECK_SUITES:
-            raise CommitIdentityError("GitHub head check-suites exceed safety limit")
-        for suite in check_suites:
-            if not isinstance(suite, dict):
-                raise CommitIdentityError("GitHub head check-suite entry is malformed")
-            app = suite.get("app")
-            app_slug = app.get("slug") if isinstance(app, dict) else None
-            head_sha = _require_sha(
-                str(suite.get("head_sha") or ""),
-                field="GitHub head check-suite SHA",
-            )
-            suite_created_at = _require_iso8601(
-                suite.get("created_at"),
-                field="GitHub head check-suite created_at",
-            )
-            suite_created = datetime.fromisoformat(
-                suite_created_at[:-1] + "+00:00"
-                if suite_created_at.endswith("Z")
-                else suite_created_at
-            )
+        if not isinstance(response, list) or len(response) > 100:
+            raise CommitIdentityError("GitHub PR reviews response is malformed")
+        review_count += len(response)
+        if review_count > _MAX_PR_REVIEWS:
+            raise CommitIdentityError("GitHub PR reviews exceed safety limit")
+        for review in response:
+            if not isinstance(review, dict):
+                raise CommitIdentityError("GitHub PR review entry is malformed")
+            user = review.get("user")
+            user_id = user.get("id") if isinstance(user, dict) else None
+            login = user.get("login") if isinstance(user, dict) else None
+            user_type = user.get("type") if isinstance(user, dict) else None
             if (
-                app_slug == "github-actions"
-                and head_sha == expected_commit
-                and suite_created <= reaction_created
+                user_id != _CODEX_CONNECTOR_USER_ID
+                or login != _CODEX_CONNECTOR_LOGIN
+                or user_type != "Bot"
+                or review.get("state") not in {"COMMENTED", "APPROVED"}
+                or not isinstance(review.get("html_url"), str)
+                or not review_url_pattern.fullmatch(review["html_url"])
             ):
+                continue
+            review_commit = _require_sha(
+                str(review.get("commit_id") or ""),
+                field="Codex Connector review commit_id",
+            )
+            review_submitted_at = _require_iso8601(
+                review.get("submitted_at"),
+                field="Codex Connector review submitted_at",
+            )
+            review_submitted = datetime.fromisoformat(
+                review_submitted_at[:-1] + "+00:00"
+                if review_submitted_at.endswith("Z")
+                else review_submitted_at
+            )
+            if review_commit == expected_commit and review_submitted < reaction_created:
                 return
-        if len(check_suites) < 100:
+        if len(response) < 100:
             break
     else:
-        raise CommitIdentityError("GitHub head check-suite pagination exceeded page limit")
+        raise CommitIdentityError("GitHub PR review pagination exceeded page limit")
 
     raise CommitIdentityError(
-        "Codex connector reaction does not follow a GitHub Actions observation "
+        "Codex connector reaction does not follow a trusted Connector review "
         "of the exact material head"
     )
 
@@ -1401,8 +1403,9 @@ def verify_codex_review_reference(
             token=token,
             request_json=request_json,
         )
-        _require_codex_reaction_after_head_check_suite(
+        _require_codex_reaction_after_exact_head_review(
             repository=repository,
+            pr_number=pr_number,
             expected_commit=expected_commit,
             reaction_created_at=reaction.created_at,
             token=token,

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -29,8 +29,10 @@ _MAX_PR_COMMIT_PAGES = 100
 _MAX_PR_COMMITS = 10_000
 _MAX_PR_REACTION_PAGES = 100
 _MAX_PR_REACTIONS = 10_000
-_MAX_HEAD_CHECK_SUITE_PAGES = 100
-_MAX_HEAD_CHECK_SUITES = 10_000
+_MAX_HEAD_WORKFLOW_RUN_PAGES = 100
+_MAX_HEAD_WORKFLOW_RUNS = 10_000
+_MAX_PR_HEAD_EVENT_PAGES = 10
+_MAX_PR_HEAD_EVENTS = 1_000
 _MAX_REVIEW_THREAD_PAGES = 100
 _MAX_REVIEW_COMMENT_PAGES = 100
 _MAX_REVIEW_THREADS = 10_000
@@ -1287,56 +1289,116 @@ def _require_codex_reaction_after_current_head_observation(
         if reaction_created_at.endswith("Z")
         else reaction_created_at
     )
-    check_suite_count = 0
-    for page in range(1, _MAX_HEAD_CHECK_SUITE_PAGES + 1):
+    workflow_run_count = 0
+    latest_same_pr_run: datetime | None = None
+    for page in range(1, _MAX_HEAD_WORKFLOW_RUN_PAGES + 1):
         response = request_json(
-            f"{_API_ROOT}/repos/{owner}/{name}/commits/{expected_commit}/check-suites"
-            f"?per_page=100&page={page}",
+            f"{_API_ROOT}/repos/{owner}/{name}/actions/runs"
+            f"?event=pull_request&head_sha={expected_commit}&per_page=100&page={page}",
             token=token,
         )
         if not isinstance(response, dict):
-            raise CommitIdentityError("GitHub head check-suites response is malformed")
+            raise CommitIdentityError("GitHub head workflow-runs response is malformed")
         total_count = response.get("total_count")
-        check_suites = response.get("check_suites")
+        workflow_runs = response.get("workflow_runs")
         if (
             not isinstance(total_count, int)
             or isinstance(total_count, bool)
             or total_count < 0
-            or not isinstance(check_suites, list)
-            or len(check_suites) > 100
+            or not isinstance(workflow_runs, list)
+            or len(workflow_runs) > 100
         ):
-            raise CommitIdentityError("GitHub head check-suites response is malformed")
-        check_suite_count += len(check_suites)
-        if check_suite_count > _MAX_HEAD_CHECK_SUITES:
-            raise CommitIdentityError("GitHub head check-suites exceed safety limit")
-        for suite in check_suites:
-            if not isinstance(suite, dict):
-                raise CommitIdentityError("GitHub head check-suite entry is malformed")
-            app = suite.get("app")
-            app_slug = app.get("slug") if isinstance(app, dict) else None
+            raise CommitIdentityError("GitHub head workflow-runs response is malformed")
+        if total_count > _MAX_HEAD_WORKFLOW_RUNS:
+            raise CommitIdentityError("GitHub head workflow-runs exceed safety limit")
+        workflow_run_count += len(workflow_runs)
+        if workflow_run_count > _MAX_HEAD_WORKFLOW_RUNS:
+            raise CommitIdentityError("GitHub head workflow-runs exceed safety limit")
+        for workflow_run in workflow_runs:
+            if not isinstance(workflow_run, dict):
+                raise CommitIdentityError("GitHub head workflow-run entry is malformed")
             head_sha = _require_sha(
-                str(suite.get("head_sha") or ""),
-                field="GitHub head check-suite SHA",
+                str(workflow_run.get("head_sha") or ""),
+                field="GitHub head workflow-run SHA",
             )
-            suite_created_at = _require_iso8601(
-                suite.get("created_at"),
-                field="GitHub head check-suite created_at",
+            run_created_at = _require_iso8601(
+                workflow_run.get("created_at"),
+                field="GitHub head workflow-run created_at",
             )
-            suite_created = datetime.fromisoformat(
-                suite_created_at[:-1] + "+00:00"
-                if suite_created_at.endswith("Z")
-                else suite_created_at
+            run_created = datetime.fromisoformat(
+                run_created_at[:-1] + "+00:00" if run_created_at.endswith("Z") else run_created_at
             )
+            pull_requests = workflow_run.get("pull_requests")
+            if not isinstance(pull_requests, list) or len(pull_requests) > 100:
+                raise CommitIdentityError("GitHub head workflow-run PR links are malformed")
+            same_pr = False
+            for pull_request in pull_requests:
+                if not isinstance(pull_request, dict):
+                    raise CommitIdentityError("GitHub head workflow-run PR link is malformed")
+                linked_pr_number = pull_request.get("number")
+                if (
+                    not isinstance(linked_pr_number, int)
+                    or isinstance(linked_pr_number, bool)
+                    or linked_pr_number <= 0
+                ):
+                    raise CommitIdentityError("GitHub head workflow-run PR link is malformed")
+                same_pr = same_pr or linked_pr_number == pr_number
             if (
-                app_slug == "github-actions"
+                workflow_run.get("event") == "pull_request"
                 and head_sha == expected_commit
-                and suite_created < reaction_created
+                and same_pr
+                and run_created < reaction_created
             ):
-                return
-        if len(check_suites) < 100:
+                latest_same_pr_run = (
+                    run_created
+                    if latest_same_pr_run is None or run_created > latest_same_pr_run
+                    else latest_same_pr_run
+                )
+        if len(workflow_runs) < 100:
             break
     else:
-        raise CommitIdentityError("GitHub head check-suite pagination exceeded page limit")
+        raise CommitIdentityError("GitHub head workflow-run pagination exceeded page limit")
+
+    if latest_same_pr_run is not None:
+        head_event_count = 0
+        for page in range(1, _MAX_PR_HEAD_EVENT_PAGES + 1):
+            events = request_json(
+                f"{_API_ROOT}/repos/{owner}/{name}/issues/{pr_number}/events"
+                f"?per_page=100&page={page}",
+                token=token,
+            )
+            if not isinstance(events, list) or len(events) > 100:
+                raise CommitIdentityError("GitHub PR head-events response is malformed")
+            head_event_count += len(events)
+            if head_event_count > _MAX_PR_HEAD_EVENTS:
+                raise CommitIdentityError("GitHub PR head-events exceed safety limit")
+            for event in events:
+                if not isinstance(event, dict):
+                    raise CommitIdentityError("GitHub PR head-event entry is malformed")
+                event_name = event.get("event")
+                if not isinstance(event_name, str) or not event_name:
+                    raise CommitIdentityError("GitHub PR head-event type is malformed")
+                if event_name not in {
+                    "head_ref_force_pushed",
+                    "head_ref_restored",
+                }:
+                    continue
+                event_created_at = _require_iso8601(
+                    event.get("created_at"),
+                    field="GitHub PR head-event created_at",
+                )
+                event_created = datetime.fromisoformat(
+                    event_created_at[:-1] + "+00:00"
+                    if event_created_at.endswith("Z")
+                    else event_created_at
+                )
+                if event_created >= latest_same_pr_run:
+                    raise CommitIdentityError(
+                        "Codex connector reaction follows a superseded PR head observation"
+                    )
+            if len(events) < 100:
+                return
+        raise CommitIdentityError("GitHub PR head-event pagination exceeded page limit")
 
     raise CommitIdentityError(
         "Codex connector reaction does not follow a GitHub observation "

--- a/scripts/orchestration/pr_commit_identity.py
+++ b/scripts/orchestration/pr_commit_identity.py
@@ -679,6 +679,10 @@ def verify_review_credit_outage_references(
         token=token,
         request_json=request_json,
     )
+    if isinstance(prior_review, CodexConnectorAdvisoryReactionEvidence):
+        raise CommitIdentityError(
+            "review credit outage prior review must carry a real commit identity"
+        )
     prior_commit = classify_commit_ref(
         prior_review.commit_ref,
         snapshot,
@@ -1421,8 +1425,8 @@ def verify_codex_review_reference(
     expected_commit_ref: str | None = None,
     expected_live_pr_head_ref: str | None = None,
     request_json: ApiRequest = github_api_request,
-) -> CodexReviewEvidence:
-    """Prove that a seal reference names trusted exact-head Codex review evidence."""
+) -> CodexReviewEvidence | CodexConnectorAdvisoryReactionEvidence:
+    """Verify trusted Codex review evidence or a commitless positive response."""
 
     owner, name = _require_repository(repository)
     expected_commit = (
@@ -1492,11 +1496,7 @@ def verify_codex_review_reference(
             token=token,
             request_json=request_json,
         )
-        return CodexReviewEvidence(
-            reference=reference,
-            submitted_at=reaction.created_at,
-            commit_ref=expected_commit,
-        )
+        return reaction
 
     comment_pattern = re.compile(
         rf"^https://github\.com/{re.escape(owner)}/{re.escape(name)}/pull/"

--- a/scripts/orchestration/pr_review_closeout.py
+++ b/scripts/orchestration/pr_review_closeout.py
@@ -9,6 +9,7 @@ and the content-bound security receipt can be published in one closeout commit.
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import os
 import re
@@ -26,11 +27,13 @@ if str(REPO_ROOT) not in sys.path:
 from scripts.orchestration.pr_commit_identity import (  # noqa: E402
     CommitIdentityError,
     CommitRefKind,
+    CodexConnectorAdvisoryReactionEvidence,
     RepositoryCommitRef,
     assert_snapshot_unchanged,
     classify_commit_ref,
     fetch_pr_snapshot,
     is_ancestor,
+    verify_codex_connector_advisory_reaction_reference,
     verify_codex_review_reference,
     verify_codex_review_source_unavailability_reference,
     verify_review_credit_outage_references,
@@ -214,6 +217,71 @@ def _required_line(value: str | None, *, label: str) -> str:
     if result is None:
         raise CloseoutError(f"{label} is required")
     return result
+
+
+def _verify_connector_advisory_reactions(
+    raw_references: Any,
+    *,
+    repository: str,
+    pr_number: int,
+    token: str,
+) -> tuple[CodexConnectorAdvisoryReactionEvidence, ...]:
+    """Return bounded, unique Connector reaction signals with no seal authority."""
+
+    if raw_references is None:
+        return ()
+    if not isinstance(raw_references, list):
+        raise CloseoutError("connector-advisory-reaction values are malformed")
+    if len(raw_references) > 8:
+        raise CloseoutError("at most eight connector-advisory-reaction values are allowed")
+
+    references: list[str] = []
+    for raw_reference in raw_references:
+        if not isinstance(raw_reference, str):
+            raise CloseoutError("connector-advisory-reaction must be a string")
+        reference = _required_line(
+            raw_reference,
+            label="connector-advisory-reaction",
+        )
+        if reference in references:
+            raise CloseoutError("connector-advisory-reaction values must be unique")
+        references.append(reference)
+
+    return tuple(
+        sorted(
+            (
+                verify_codex_connector_advisory_reaction_reference(
+                    reference,
+                    repository=repository,
+                    pr_number=pr_number,
+                    token=token,
+                )
+                for reference in references
+            ),
+            key=lambda evidence: evidence.reference,
+        )
+    )
+
+
+def _optional_connector_advisory_reactions(
+    raw_references: Any,
+    *,
+    repository: str,
+    pr_number: int,
+    token: str,
+) -> tuple[CodexConnectorAdvisoryReactionEvidence, ...]:
+    """Omit unavailable advisory signals without changing closeout authority."""
+
+    try:
+        return _verify_connector_advisory_reactions(
+            raw_references,
+            repository=repository,
+            pr_number=pr_number,
+            token=token,
+        )
+    except (CloseoutError, CommitIdentityError, OSError, http.client.HTTPException) as exc:
+        print(f"WARNING: Connector advisory reaction omitted: {exc}", file=sys.stderr)
+        return ()
 
 
 def _validated_backlog_reference(value: str | None) -> str:
@@ -444,7 +512,12 @@ def _cmd_add_disposition(args: argparse.Namespace) -> None:
     print(f"closeout-disposition: recorded {disposition} for {url}")
 
 
-def _render_mapping(state: Mapping[str, Any], seal: Mapping[str, Any]) -> str:
+def _render_mapping(
+    state: Mapping[str, Any],
+    seal: Mapping[str, Any],
+    *,
+    connector_advisory_reactions: tuple[CodexConnectorAdvisoryReactionEvidence, ...] = (),
+) -> str:
     pr_number = int(state["pr_number"])
     packet = state.get("packet")
     experiment = state.get("experiment_result")
@@ -494,6 +567,26 @@ def _render_mapping(state: Mapping[str, Any], seal: Mapping[str, Any]) -> str:
             lines.append(f"- {item['url']} -> {item['commit']}")
         else:
             lines.append(f"- {item['url']}")
+    if connector_advisory_reactions:
+        lines.extend(
+            [
+                "",
+                "## Connector Advisory Signals",
+                (
+                    "Accepted Connector reactions are advisory only. They are not a "
+                    "review, exact-head proof, GitHub approval, security receipt, or "
+                    "thread-resolution authority."
+                ),
+            ]
+        )
+        for evidence in connector_advisory_reactions:
+            lines.extend(
+                [
+                    f"- {evidence.reference}",
+                    f"  - Received: {evidence.created_at}",
+                    f"  - Content: {evidence.content}",
+                ]
+            )
     lines.extend(["", "## Review Material Seal", render_embedded_review_seal(seal), ""])
     return "\n".join(lines)
 
@@ -584,6 +677,12 @@ def _cmd_seal(args: argparse.Namespace) -> None:
     }
     if freeze != expected_freeze:
         raise CloseoutError("material state changed after freeze; freeze and review again")
+    connector_advisory_reactions = _optional_connector_advisory_reactions(
+        getattr(args, "connector_advisory_reaction", None),
+        repository=args.repo,
+        pr_number=args.pr_number,
+        token=token,
+    )
     if args.review_source_unavailable_ref:
         source_evidence = verify_codex_review_source_unavailability_reference(
             _required_line(
@@ -672,7 +771,15 @@ def _cmd_seal(args: argparse.Namespace) -> None:
         "repository": args.repo,
         "schema_version": SEAL_SCHEMA_VERSION,
     }
-    markdown = _render_mapping(state, seal)
+    markdown = (
+        _render_mapping(
+            state,
+            seal,
+            connector_advisory_reactions=connector_advisory_reactions,
+        )
+        if connector_advisory_reactions
+        else _render_mapping(state, seal)
+    )
     errors = validate_mapping_artifact_text(markdown)
     if errors:
         raise CloseoutError("generated mapping is invalid: " + "; ".join(errors))
@@ -937,6 +1044,7 @@ def _parser() -> argparse.ArgumentParser:
     review_evidence = seal.add_mutually_exclusive_group(required=True)
     review_evidence.add_argument("--review-ref")
     review_evidence.add_argument("--review-source-unavailable-ref")
+    seal.add_argument("--connector-advisory-reaction", action="append", default=[])
     security_evidence = seal.add_mutually_exclusive_group(required=True)
     security_evidence.add_argument("--scan-manifest")
     security_evidence.add_argument("--security-outage-override-ref")

--- a/scripts/orchestration/pr_review_closeout.py
+++ b/scripts/orchestration/pr_review_closeout.py
@@ -52,6 +52,7 @@ from scripts.orchestration.pr_review_evidence import (  # noqa: E402
     compute_material_manifest,
     ingest_codex_security_receipt,
     is_review_credit_outage_receipt,
+    is_mapping_only_positive_response_successor,
     is_review_source_positive_response_receipt,
     is_review_source_unavailability_receipt,
     is_security_outage_override_receipt,
@@ -899,7 +900,16 @@ def validate_live_mapping(*, repository: str, pr_number: int, token: str | None)
             response_created_at=response_evidence.created_at,
             response_content=response_evidence.content,
         )
-        if code_review != expected_code_review:
+        successor_response = (
+            snapshot.head_sha != material_head.sha
+            and is_mapping_only_positive_response_successor(
+                code_review,
+                response_reference=response_evidence.reference,
+                response_created_at=response_evidence.created_at,
+                response_content=response_evidence.content,
+            )
+        )
+        if code_review != expected_code_review and not successor_response:
             raise CloseoutError("Codex positive response receipt is stale")
     elif is_review_source_unavailability_receipt(code_review):
         unavailable_manifest = compute_material_manifest(

--- a/scripts/orchestration/pr_review_closeout.py
+++ b/scripts/orchestration/pr_review_closeout.py
@@ -940,6 +940,10 @@ def validate_live_mapping(*, repository: str, pr_number: int, token: str | None)
             pr_number=pr_number,
             token=token,
             expected_commit_ref=material_head.sha,
+            # The live head may be the canonical mapping-only closeout commit.
+            # The material-digest equality above proves that no material path
+            # changed after the sealed head.
+            expected_live_pr_head_ref=snapshot.head_sha,
         )
         if (
             code_review["review_commit_ref_kind"] != "repository_commit"

--- a/scripts/orchestration/pr_review_closeout.py
+++ b/scripts/orchestration/pr_review_closeout.py
@@ -46,11 +46,13 @@ from scripts.orchestration.pr_review_evidence import (  # noqa: E402
     UNAVAILABLE_REVIEW_REF_CAUSE,
     ReviewEvidenceError,
     build_review_credit_outage_receipt,
+    build_review_source_positive_response_receipt,
     build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
     ingest_codex_security_receipt,
     is_review_credit_outage_receipt,
+    is_review_source_positive_response_receipt,
     is_review_source_unavailability_receipt,
     is_security_outage_override_receipt,
     parse_embedded_review_seal,
@@ -713,22 +715,31 @@ def _cmd_seal(args: argparse.Namespace) -> None:
             token=token,
             expected_commit_ref=snapshot.head_sha,
         )
-        review_commit = classify_commit_ref(review_evidence.commit_ref, snapshot, token=token)
-        if (
-            not isinstance(review_commit, RepositoryCommitRef)
-            or review_commit.kind is not CommitRefKind.PR_HEAD
-            or review_commit.sha != snapshot.head_sha
-        ):
-            raise CloseoutError(
-                "Codex review must be machine-bound to the exact frozen material head"
+        if isinstance(review_evidence, CodexConnectorAdvisoryReactionEvidence):
+            code_review_receipt = build_review_source_positive_response_receipt(
+                material_digest=manifest.digest,
+                material_head_sha=snapshot.head_sha,
+                response_reference=review_evidence.reference,
+                response_created_at=review_evidence.created_at,
+                response_content=review_evidence.content,
             )
-        code_review_receipt = {
-            "review_commit_ref": review_commit.sha,
-            "review_commit_ref_kind": "repository_commit",
-            "review_reference": review_ref,
-            "reviewed_material_digest": manifest.digest,
-            "status": "completed",
-        }
+        else:
+            review_commit = classify_commit_ref(review_evidence.commit_ref, snapshot, token=token)
+            if (
+                not isinstance(review_commit, RepositoryCommitRef)
+                or review_commit.kind is not CommitRefKind.PR_HEAD
+                or review_commit.sha != snapshot.head_sha
+            ):
+                raise CloseoutError(
+                    "Codex review must be machine-bound to the exact frozen material head"
+                )
+            code_review_receipt = {
+                "review_commit_ref": review_commit.sha,
+                "review_commit_ref_kind": "repository_commit",
+                "review_reference": review_ref,
+                "reviewed_material_digest": manifest.digest,
+                "status": "completed",
+            }
     if args.scan_manifest:
         receipt = ingest_codex_security_receipt(
             Path(args.scan_manifest),
@@ -862,7 +873,35 @@ def validate_live_mapping(*, repository: str, pr_number: int, token: str | None)
     }:
         raise CloseoutError("sealed material head is not a real live PR commit")
     code_review = seal["code_review"]
-    if is_review_source_unavailability_receipt(code_review):
+    if is_review_source_positive_response_receipt(code_review):
+        response_manifest = compute_material_manifest(
+            REPO_ROOT,
+            base_ref_oid=snapshot.base_sha,
+            head_ref_oid=material_head.sha,
+            pr_number=pr_number,
+        )
+        if response_manifest.digest != material["digest"]:
+            raise CloseoutError("positive response material head has a different material digest")
+        response_evidence = verify_codex_review_reference(
+            code_review["response_reference"],
+            repository=repository,
+            pr_number=pr_number,
+            token=token,
+            expected_commit_ref=material_head.sha,
+            expected_live_pr_head_ref=snapshot.head_sha,
+        )
+        if not isinstance(response_evidence, CodexConnectorAdvisoryReactionEvidence):
+            raise CloseoutError("Codex positive response reference changed evidence type")
+        expected_code_review = build_review_source_positive_response_receipt(
+            material_digest=material["digest"],
+            material_head_sha=material_head.sha,
+            response_reference=response_evidence.reference,
+            response_created_at=response_evidence.created_at,
+            response_content=response_evidence.content,
+        )
+        if code_review != expected_code_review:
+            raise CloseoutError("Codex positive response receipt is stale")
+    elif is_review_source_unavailability_receipt(code_review):
         unavailable_manifest = compute_material_manifest(
             REPO_ROOT,
             base_ref_oid=snapshot.base_sha,
@@ -945,6 +984,8 @@ def validate_live_mapping(*, repository: str, pr_number: int, token: str | None)
             # changed after the sealed head.
             expected_live_pr_head_ref=snapshot.head_sha,
         )
+        if isinstance(review_evidence, CodexConnectorAdvisoryReactionEvidence):
+            raise CloseoutError("Codex positive response is not exact-head review evidence")
         if (
             code_review["review_commit_ref_kind"] != "repository_commit"
             or review_evidence.commit_ref != code_review["review_commit_ref"]

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -45,6 +45,11 @@ REVIEW_CREDIT_OUTAGE_BOOTSTRAP_PR = 2142
 REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION = "pulseplate.codex-review-source-unavailability/v1"
 REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY = "trusted_codex_review_source_unavailability"
 REVIEW_SOURCE_UNAVAILABILITY_SOURCE = "codex_review"
+REVIEW_SOURCE_POSITIVE_RESPONSE_SCHEMA_VERSION = (
+    "pulseplate.codex-review-source-positive-response/v1"
+)
+REVIEW_SOURCE_POSITIVE_RESPONSE_AUTHORITY = "trusted_codex_review_source_positive_response"
+REVIEW_SOURCE_POSITIVE_RESPONSE_SOURCE = "codex_review"
 OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS = frozenset(
     {
         ".bandit",
@@ -1162,6 +1167,37 @@ def build_review_source_unavailability_receipt(
     return receipt
 
 
+def build_review_source_positive_response_receipt(
+    *,
+    material_digest: str,
+    material_head_sha: str,
+    response_reference: str,
+    response_created_at: str,
+    response_content: str,
+) -> dict[str, Any]:
+    """Build a material-context receipt for one trusted positive response."""
+
+    receipt = {
+        "authority": REVIEW_SOURCE_POSITIVE_RESPONSE_AUTHORITY,
+        "binding_kind": "seal_context_only",
+        "blocking": False,
+        "fallback_required": False,
+        "material_digest": material_digest,
+        "material_head_sha": material_head_sha,
+        "response_content": response_content,
+        "response_created_at": response_created_at,
+        "response_reference": response_reference,
+        "review_claim": "none",
+        "schema_version": REVIEW_SOURCE_POSITIVE_RESPONSE_SCHEMA_VERSION,
+        "source": REVIEW_SOURCE_POSITIVE_RESPONSE_SOURCE,
+        "source_degraded": False,
+        "source_status": "positive_response",
+        "status": "completed",
+    }
+    _validate_code_review_receipt(receipt, material_digest=material_digest)
+    return receipt
+
+
 def is_review_source_unavailability_receipt(receipt: Any) -> bool:
     """Return whether code-review evidence uses the tagged quota variant."""
 
@@ -1169,6 +1205,16 @@ def is_review_source_unavailability_receipt(receipt: Any) -> bool:
         isinstance(receipt, dict)
         and receipt.get("schema_version") == REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION
         and receipt.get("authority") == REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY
+    )
+
+
+def is_review_source_positive_response_receipt(receipt: Any) -> bool:
+    """Return whether code-review evidence uses the positive-response variant."""
+
+    return (
+        isinstance(receipt, dict)
+        and receipt.get("schema_version") == REVIEW_SOURCE_POSITIVE_RESPONSE_SCHEMA_VERSION
+        and receipt.get("authority") == REVIEW_SOURCE_POSITIVE_RESPONSE_AUTHORITY
     )
 
 
@@ -1346,6 +1392,61 @@ def _validate_code_review_receipt(receipt: Any, *, material_digest: str) -> None
     has_source_authority = receipt.get("authority") == REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY
     if has_source_schema != has_source_authority:
         raise ReviewEvidenceError("review seal code_review tagged-union identity is ambiguous")
+    has_positive_schema = (
+        receipt.get("schema_version") == REVIEW_SOURCE_POSITIVE_RESPONSE_SCHEMA_VERSION
+    )
+    has_positive_authority = receipt.get("authority") == REVIEW_SOURCE_POSITIVE_RESPONSE_AUTHORITY
+    if has_positive_schema != has_positive_authority:
+        raise ReviewEvidenceError("review seal code_review tagged-union identity is ambiguous")
+    if has_source_schema and has_positive_schema:
+        raise ReviewEvidenceError("review seal code_review tagged-union identity is ambiguous")
+    if has_positive_schema:
+        _require_exact_keys(
+            receipt,
+            {
+                "authority",
+                "binding_kind",
+                "blocking",
+                "fallback_required",
+                "material_digest",
+                "material_head_sha",
+                "response_content",
+                "response_created_at",
+                "response_reference",
+                "review_claim",
+                "schema_version",
+                "source",
+                "source_degraded",
+                "source_status",
+                "status",
+            },
+            label="review seal code_review source positive response",
+        )
+        _require_sha(receipt["material_head_sha"], label="code_review.material_head_sha")
+        _require_digest(receipt["material_digest"], label="code_review.material_digest")
+        _parse_timestamp(
+            receipt["response_created_at"],
+            label="code_review.response_created_at",
+        )
+        if (
+            receipt["material_digest"] != material_digest
+            or receipt["source"] != REVIEW_SOURCE_POSITIVE_RESPONSE_SOURCE
+            or receipt["source_status"] != "positive_response"
+            or receipt["status"] != "completed"
+            or receipt["binding_kind"] != "seal_context_only"
+            or receipt["review_claim"] != "none"
+            or receipt["source_degraded"] is not False
+            or receipt["fallback_required"] is not False
+            or receipt["blocking"] is not False
+            or receipt["response_content"] not in {"+1", "heart", "hooray", "rocket"}
+            or not isinstance(receipt["response_reference"], str)
+            or not 1 <= len(receipt["response_reference"]) <= 500
+            or any(ord(ch) < 32 for ch in receipt["response_reference"])
+        ):
+            raise ReviewEvidenceError(
+                "review seal code_review source positive response is malformed or stale"
+            )
+        return
     if has_source_schema:
         _require_exact_keys(
             receipt,
@@ -1546,11 +1647,12 @@ def validate_review_seal(seal: Any) -> dict[str, Any]:
         raise ReviewEvidenceError("review seal material policy version is unsupported")
     code_review = seal["code_review"]
     _validate_code_review_receipt(code_review, material_digest=material_digest)
-    if is_review_source_unavailability_receipt(code_review) and (
-        code_review["material_head_sha"] != material["material_head_sha"]
-    ):
+    if (
+        is_review_source_unavailability_receipt(code_review)
+        or is_review_source_positive_response_receipt(code_review)
+    ) and (code_review["material_head_sha"] != material["material_head_sha"]):
         raise ReviewEvidenceError(
-            "review-source unavailability receipt does not match sealed material head"
+            "review-source context receipt does not match sealed material head"
         )
     _validate_security_receipt(seal["codex_security"])
     if (

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -1467,6 +1467,7 @@ def _validate_code_review_receipt(receipt: Any, *, material_digest: str) -> None
             or receipt["source_degraded"] is not False
             or receipt["fallback_required"] is not False
             or receipt["blocking"] is not False
+            or not isinstance(receipt["response_content"], str)
             or receipt["response_content"] not in {"+1", "heart", "hooray", "rocket"}
             or not isinstance(receipt["response_reference"], str)
             or not 1 <= len(receipt["response_reference"]) <= 500

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -1218,6 +1218,35 @@ def is_review_source_positive_response_receipt(receipt: Any) -> bool:
     )
 
 
+def is_mapping_only_positive_response_successor(
+    receipt: Any,
+    *,
+    response_reference: str,
+    response_created_at: str,
+    response_content: str,
+) -> bool:
+    """Accept a newer live response only after the sealed response was replaced."""
+
+    if not is_review_source_positive_response_receipt(receipt):
+        return False
+    try:
+        sealed_created = _parse_timestamp(
+            receipt.get("response_created_at"),
+            label="code_review.response_created_at",
+        )
+        successor_created = _parse_timestamp(
+            response_created_at,
+            label="successor response_created_at",
+        )
+    except ReviewEvidenceError:
+        return False
+    return (
+        response_reference != receipt.get("response_reference")
+        and response_content == receipt.get("response_content")
+        and successor_created > sealed_created
+    )
+
+
 def is_review_credit_outage_receipt(receipt: Any) -> bool:
     """Return whether code-review evidence uses the credit-outage variant."""
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -434,6 +434,15 @@ pytest -q tests/test_agent_docs_registry_guard.py
     - If an agent spec is added/renamed in `.cursor/agents/`, update the index and context map in the same PR.
     - Keep the agent table under the `## Available Agents` heading in `docs/agents/index.md`.
 
+- **CodeQL action pin guard**: `tests/test_ci_workflow_pr_size_governance_contract.py`
+  - **What it enforces**:
+    - Every active `github/codeql-action/{init,analyze,upload-sarif}` reference uses the verified full commit pin at the exact expected workflow location and version annotation.
+  - **How to run**:
+
+```bash
+pytest -q tests/test_ci_workflow_pr_size_governance_contract.py
+```
+
 ## Guard tests (repo policy scanner stability)
 
 - **Repo policy guard**: `tests/test_repo_policy_guards.py`

--- a/tests/guards/test_review_source_quota_policy_guard.py
+++ b/tests/guards/test_review_source_quota_policy_guard.py
@@ -154,6 +154,7 @@ def test_known_codex_quota_bodies_remain_exact_terminal_evidence() -> None:
 def test_closeout_exposes_only_current_review_authoring_modes() -> None:
     options = _seal_option_strings()
     assert {"--review-ref", "--review-source-unavailable-ref"} <= options
+    assert "--connector-advisory-reaction" in options
     assert not options.intersection(LEGACY_AUTHORING_OPTIONS)
     closeout_source = (REPO_ROOT / "scripts/orchestration/pr_review_closeout.py").read_text(
         encoding="utf-8"

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -173,6 +173,20 @@ TRIVY_ACTION_NODE24_CACHE_SHA = "".join(
         "6c25",
     )
 )
+CODEQL_ACTION_V4_37_1_SHA = "".join(
+    (
+        "7188",
+        "fc36",
+        "3630",
+        "916d",
+        "eb70",
+        "2c7f",
+        "dcf4",
+        "e481",
+        "b751",
+        "f97a",
+    )
+)
 SETUP_GO_NODE24_SHA = "".join(
     (
         "4a36",
@@ -1321,6 +1335,85 @@ def test_active_upload_artifact_refs_all_use_node24_sha() -> None:
             assert workflow_text.count(expected_line) == workflow_upload_count
 
     assert observed_upload_steps
+
+
+def test_active_codeql_action_refs_use_verified_v4_37_1_sha() -> None:
+    """Guard every active CodeQL action ref against pin and location drift."""
+
+    expected_uses_by_component = {
+        "init": f"github/codeql-action/init@{CODEQL_ACTION_V4_37_1_SHA}",
+        "analyze": f"github/codeql-action/analyze@{CODEQL_ACTION_V4_37_1_SHA}",
+        "upload-sarif": f"github/codeql-action/upload-sarif@{CODEQL_ACTION_V4_37_1_SHA}",
+    }
+    expected_line_counts = {
+        BUILD_WORKFLOW_PATH: {
+            f"uses: {expected_uses_by_component['upload-sarif']} # v4.37.1": 2,
+        },
+        CODEQL_WORKFLOW_PATH: {
+            f"uses: {expected_uses_by_component['init']} # v4.37.1": 1,
+            f"uses: {expected_uses_by_component['analyze']} # v4.37.1": 1,
+        },
+        TRIVY_WORKFLOW_PATH: {
+            f"uses: {expected_uses_by_component['upload-sarif']} # v4.37.1": 1,
+        },
+    }
+    observed_contracts: list[tuple[str, str, object, str]] = []
+
+    for workflow_path in _active_workflow_paths():
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        workflow_lines = [line.strip() for line in workflow_text.splitlines()]
+        for expected_line, expected_count in expected_line_counts.get(workflow_path, {}).items():
+            assert workflow_lines.count(expected_line) == expected_count
+
+        for job_id, step in _iter_job_steps(workflow_path):
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not uses.startswith("github/codeql-action/"):
+                continue
+
+            component = uses.removeprefix("github/codeql-action/").split("@", maxsplit=1)[0]
+            assert component in expected_uses_by_component
+            assert uses == expected_uses_by_component[component]
+            observed_contracts.append(
+                (
+                    str(workflow_path.relative_to(REPO_ROOT)),
+                    job_id,
+                    step.get("name"),
+                    uses,
+                )
+            )
+
+    assert observed_contracts == [
+        (
+            ".github/workflows/build.yml",
+            "security-scan",
+            "Upload Trivy scan results to GitHub Security tab",
+            expected_uses_by_component["upload-sarif"],
+        ),
+        (
+            ".github/workflows/build.yml",
+            "publish",
+            "Upload Trivy image scan results",
+            expected_uses_by_component["upload-sarif"],
+        ),
+        (
+            ".github/workflows/codeql.yml",
+            "analyze",
+            "Initialize CodeQL",
+            expected_uses_by_component["init"],
+        ),
+        (
+            ".github/workflows/codeql.yml",
+            "analyze",
+            "Perform CodeQL Analysis",
+            expected_uses_by_component["analyze"],
+        ),
+        (
+            ".github/workflows/trivy.yml",
+            "build",
+            "Upload Trivy scan results to GitHub Security tab",
+            expected_uses_by_component["upload-sarif"],
+        ),
+    ]
 
 
 def test_node24_setup_go_and_upload_artifact_pins_preserve_workflow_contracts() -> None:

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -10,6 +10,7 @@ import re
 from typing import cast
 
 import yaml
+from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
 
 from scripts.ci import ci_risk_profile
 
@@ -1340,10 +1341,26 @@ def test_active_upload_artifact_refs_all_use_node24_sha() -> None:
 def test_active_codeql_action_refs_use_verified_v4_37_1_sha() -> None:
     """Guard every active CodeQL action ref against pin and location drift."""
 
+    def iter_uses_source_mappings(node: Node) -> Iterator[tuple[ScalarNode, ScalarNode]]:
+        if isinstance(node, MappingNode):
+            for key_node, value_node in node.value:
+                if isinstance(key_node, ScalarNode) and key_node.value == "uses":
+                    if isinstance(value_node, ScalarNode):
+                        yield key_node, value_node
+                yield from iter_uses_source_mappings(value_node)
+        elif isinstance(node, SequenceNode):
+            for value_node in node.value:
+                yield from iter_uses_source_mappings(value_node)
+
     expected_uses_by_component = {
         "init": f"github/codeql-action/init@{CODEQL_ACTION_V4_37_1_SHA}",
         "analyze": f"github/codeql-action/analyze@{CODEQL_ACTION_V4_37_1_SHA}",
         "upload-sarif": f"github/codeql-action/upload-sarif@{CODEQL_ACTION_V4_37_1_SHA}",
+    }
+    expected_comment_counts_by_component = {
+        "init": 1,
+        "analyze": 1,
+        "upload-sarif": 3,
     }
     expected_line_counts = {
         BUILD_WORKFLOW_PATH: {
@@ -1358,19 +1375,50 @@ def test_active_codeql_action_refs_use_verified_v4_37_1_sha() -> None:
         },
     }
     observed_contracts: list[tuple[str, str, object, str]] = []
+    observed_comment_counts_by_component = {
+        component: 0 for component in expected_comment_counts_by_component
+    }
 
     for workflow_path in _active_workflow_paths():
         workflow_text = workflow_path.read_text(encoding="utf-8")
-        workflow_lines = [line.strip() for line in workflow_text.splitlines()]
-        for expected_line, expected_count in expected_line_counts.get(workflow_path, {}).items():
-            assert workflow_lines.count(expected_line) == expected_count
+        workflow_lines = workflow_text.splitlines()
+        expected_source_line_counts = expected_line_counts.get(workflow_path, {})
+        observed_source_line_counts = {
+            expected_line: 0 for expected_line in expected_source_line_counts
+        }
+        workflow_document = yaml.compose(workflow_text)
+        assert isinstance(workflow_document, Node)
+        for uses_key_node, uses_value_node in iter_uses_source_mappings(workflow_document):
+            uses = uses_value_node.value
+            normalized_uses = uses.casefold()
+            if not normalized_uses.startswith("github/codeql-action/"):
+                continue
+
+            assert uses.startswith("github/codeql-action/")
+            component = normalized_uses.removeprefix("github/codeql-action/").split(
+                "@", maxsplit=1
+            )[0]
+            assert component in expected_uses_by_component
+            observed_comment_counts_by_component[component] += 1
+            expected_line = f"uses: {uses} # v4.37.1"
+            assert workflow_lines[uses_key_node.start_mark.line].strip() == expected_line
+            if expected_line in observed_source_line_counts:
+                observed_source_line_counts[expected_line] += 1
+
+        assert observed_source_line_counts == expected_source_line_counts
 
         for job_id, step in _iter_job_steps(workflow_path):
             uses = step.get("uses")
-            if not isinstance(uses, str) or not uses.startswith("github/codeql-action/"):
+            if not isinstance(uses, str):
+                continue
+            normalized_uses = uses.casefold()
+            if not normalized_uses.startswith("github/codeql-action/"):
                 continue
 
-            component = uses.removeprefix("github/codeql-action/").split("@", maxsplit=1)[0]
+            assert uses.startswith("github/codeql-action/")
+            component = normalized_uses.removeprefix("github/codeql-action/").split(
+                "@", maxsplit=1
+            )[0]
             assert component in expected_uses_by_component
             assert uses == expected_uses_by_component[component]
             observed_contracts.append(
@@ -1382,6 +1430,7 @@ def test_active_codeql_action_refs_use_verified_v4_37_1_sha() -> None:
                 )
             )
 
+    assert observed_comment_counts_by_component == expected_comment_counts_by_component
     assert observed_contracts == [
         (
             ".github/workflows/build.yml",

--- a/tests/test_pr_merge_readiness_gate.py
+++ b/tests/test_pr_merge_readiness_gate.py
@@ -894,6 +894,47 @@ def test_ci_gate_accepts_trusted_positive_response_without_review_claim(
             token="opaque",
         )
 
+    mapping_path = repo / "docs/review/PR_42_FIXED_MAPPING.md"
+    mapping_path.parent.mkdir(parents=True)
+    mapping_path.write_text("mapping-only\n", encoding="utf-8")
+    mapping_head = _commit(repo, "mapping-only")
+    mapping_snapshot = PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=base_sha,
+        head_sha=mapping_head,
+        commits=(*snapshot.commits, PrCommitEvidence(mapping_head, None)),
+    )
+    monkeypatch.setattr(
+        merge_gate,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(
+            value,
+            CommitRefKind.PR_COMMIT if value == material_head else CommitRefKind.PR_HEAD,
+        ),
+    )
+
+    def verify_successor(*_args: Any, **kwargs: Any) -> CodexConnectorAdvisoryReactionEvidence:
+        verifier_calls.append(
+            (kwargs.get("expected_commit_ref"), kwargs.get("expected_live_pr_head_ref"))
+        )
+        return CodexConnectorAdvisoryReactionEvidence(
+            reference="https://github.com/owner/repo/pull/42#reaction-789",
+            created_at="2026-07-15T12:00:00Z",
+            content=reaction_content,
+        )
+
+    monkeypatch.setattr(merge_gate, "verify_codex_review_reference", verify_successor)
+    validated = merge_gate._validate_v1_seal(
+        artifact_text=artifact,
+        repository="owner/repo",
+        pr_number=42,
+        snapshot=mapping_snapshot,
+        token="opaque",
+    )
+    assert validated["code_review"]["response_reference"] == reaction_reference
+    assert verifier_calls[-1] == (material_head, mapping_head)
+
     (repo / "README.md").write_text("later material\n", encoding="utf-8")
     changed_head = _commit(repo, "later material")
     changed_manifest = compute_material_manifest(
@@ -913,7 +954,7 @@ def test_ci_gate_accepts_trusted_positive_response_without_review_claim(
         pr_number=42,
         base_sha=base_sha,
         head_sha=changed_head,
-        commits=(*snapshot.commits, PrCommitEvidence(changed_head, None)),
+        commits=(*mapping_snapshot.commits, PrCommitEvidence(changed_head, None)),
     )
     with pytest.raises(
         ReviewEvidenceError,

--- a/tests/test_pr_merge_readiness_gate.py
+++ b/tests/test_pr_merge_readiness_gate.py
@@ -818,12 +818,13 @@ def test_ci_gate_accepts_governance_only_head_and_rejects_stale_material(
     frozen = compute_material_manifest(
         repo, base_ref_oid=base_sha, head_ref_oid=material_head, pr_number=42
     )
+    reaction_reference = "https://github.com/owner/repo/pull/42#reaction-456"
     seal = {
         "authority": RECEIPT_AUTHORITY,
         "code_review": {
             "review_commit_ref": material_head,
             "review_commit_ref_kind": "repository_commit",
-            "review_reference": "https://github.com/owner/repo/pull/42#pullrequestreview-1",
+            "review_reference": reaction_reference,
             "reviewed_material_digest": frozen.digest,
             "status": "completed",
         },
@@ -864,12 +865,17 @@ def test_ci_gate_accepts_governance_only_head_and_rejects_stale_material(
         ),
     )
     monkeypatch.setattr(merge_gate, "is_ancestor", lambda *_a, **_k: True)
-    verifier_expected_commits: list[str | None] = []
+    verifier_expected_heads: list[tuple[str | None, str | None]] = []
 
     def verify_review(*_args: Any, **kwargs: Any) -> CodexReviewEvidence:
-        verifier_expected_commits.append(kwargs.get("expected_commit_ref"))
+        verifier_expected_heads.append(
+            (
+                kwargs.get("expected_commit_ref"),
+                kwargs.get("expected_live_pr_head_ref"),
+            )
+        )
         return CodexReviewEvidence(
-            reference="https://github.com/owner/repo/pull/42#pullrequestreview-1",
+            reference=reaction_reference,
             submitted_at="2026-07-15T11:00:00Z",
             commit_ref=material_head,
         )
@@ -884,7 +890,7 @@ def test_ci_gate_accepts_governance_only_head_and_rejects_stale_material(
         token="opaque",
     )
     assert validated["material"]["digest"] == frozen.digest
-    assert verifier_expected_commits == [material_head]
+    assert verifier_expected_heads == [(material_head, governance_head)]
 
     live_snapshot = {"value": snapshot}
     monkeypatch.setenv("GITHUB_TOKEN", "opaque")

--- a/tests/test_pr_merge_readiness_gate.py
+++ b/tests/test_pr_merge_readiness_gate.py
@@ -15,6 +15,7 @@ import yaml
 from scripts.ci import check_pr_merge_readiness as merge_gate
 from scripts.ci.check_pr_merge_readiness import _is_actionable, _mapped_urls
 from scripts.orchestration.pr_commit_identity import (
+    CodexConnectorAdvisoryReactionEvidence,
     CodexReviewEvidence,
     CodexReviewSourceUnavailabilityEvidence,
     CommitRefKind,
@@ -29,6 +30,7 @@ from scripts.orchestration.pr_review_evidence import (
     RECEIPT_AUTHORITY,
     ReviewEvidenceError,
     build_review_credit_outage_receipt,
+    build_review_source_positive_response_receipt,
     build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
@@ -801,6 +803,201 @@ def _artifact_with_seal(seal: dict[str, Any]) -> str:
             "",
         ]
     )
+
+
+@pytest.mark.parametrize("reaction_content", ["+1", "heart", "hooray", "rocket"])
+def test_ci_gate_accepts_trusted_positive_response_without_review_claim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reaction_content: str
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    base_sha = _commit(repo, "base")
+    (repo / "README.md").write_text("material\n", encoding="utf-8")
+    material_head = _commit(repo, "material")
+    manifest = compute_material_manifest(
+        repo, base_ref_oid=base_sha, head_ref_oid=material_head, pr_number=42
+    )
+    reaction_reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    seal = {
+        "authority": RECEIPT_AUTHORITY,
+        "code_review": build_review_source_positive_response_receipt(
+            material_digest=manifest.digest,
+            material_head_sha=material_head,
+            response_reference=reaction_reference,
+            response_created_at="2026-07-15T11:00:00Z",
+            response_content=reaction_content,
+        ),
+        "codex_security": _receipt(base_sha, material_head),
+        "material": {
+            "base_ref_oid": base_sha,
+            "digest": manifest.digest,
+            "material_head_sha": material_head,
+            "merge_base_sha": manifest.merge_base_sha,
+            "policy_version": MATERIAL_POLICY_VERSION,
+        },
+        "pr_number": 42,
+        "repository": "owner/repo",
+        "schema_version": "pulseplate.pr-review-seal/v1",
+    }
+    artifact = _artifact_with_seal(seal)
+    snapshot = PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=base_sha,
+        head_sha=material_head,
+        commits=(PrCommitEvidence(material_head, None),),
+    )
+    verifier_calls: list[tuple[str | None, str | None]] = []
+
+    def verify_response(*_args: Any, **kwargs: Any) -> CodexConnectorAdvisoryReactionEvidence:
+        verifier_calls.append(
+            (kwargs.get("expected_commit_ref"), kwargs.get("expected_live_pr_head_ref"))
+        )
+        return CodexConnectorAdvisoryReactionEvidence(
+            reference=reaction_reference,
+            created_at="2026-07-15T11:00:00Z",
+            content=reaction_content,
+        )
+
+    monkeypatch.setattr(merge_gate, "REPO_ROOT", repo)
+    monkeypatch.setattr(
+        merge_gate,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(value, CommitRefKind.PR_HEAD),
+    )
+    monkeypatch.setattr(merge_gate, "is_ancestor", lambda *_a, **_k: True)
+    monkeypatch.setattr(merge_gate, "verify_codex_review_reference", verify_response)
+
+    validated = merge_gate._validate_v1_seal(
+        artifact_text=artifact,
+        repository="owner/repo",
+        pr_number=42,
+        snapshot=snapshot,
+        token="opaque",
+    )
+
+    assert validated["code_review"]["review_claim"] == "none"
+    assert validated["code_review"]["source_status"] == "positive_response"
+    assert verifier_calls == [(material_head, material_head)]
+
+    stale_seal = dict(seal)
+    stale_seal["code_review"] = dict(seal["code_review"])
+    stale_seal["code_review"]["response_content"] = "heart" if reaction_content != "heart" else "+1"
+    with pytest.raises(ReviewEvidenceError, match="positive response receipt is stale"):
+        merge_gate._validate_v1_seal(
+            artifact_text=_artifact_with_seal(stale_seal),
+            repository="owner/repo",
+            pr_number=42,
+            snapshot=snapshot,
+            token="opaque",
+        )
+
+    (repo / "README.md").write_text("later material\n", encoding="utf-8")
+    changed_head = _commit(repo, "later material")
+    changed_manifest = compute_material_manifest(
+        repo, base_ref_oid=base_sha, head_ref_oid=changed_head, pr_number=42
+    )
+    tampered_seal = json.loads(json.dumps(seal))
+    tampered_seal["material"]["digest"] = changed_manifest.digest
+    tampered_seal["code_review"] = build_review_source_positive_response_receipt(
+        material_digest=changed_manifest.digest,
+        material_head_sha=material_head,
+        response_reference=reaction_reference,
+        response_created_at="2026-07-15T11:00:00Z",
+        response_content=reaction_content,
+    )
+    changed_snapshot = PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=base_sha,
+        head_sha=changed_head,
+        commits=(*snapshot.commits, PrCommitEvidence(changed_head, None)),
+    )
+    with pytest.raises(
+        ReviewEvidenceError,
+        match="positive response material head has a different material digest",
+    ):
+        merge_gate._validate_v1_seal(
+            artifact_text=_artifact_with_seal(tampered_seal),
+            repository="owner/repo",
+            pr_number=42,
+            snapshot=changed_snapshot,
+            token="opaque",
+        )
+
+
+def test_ci_gate_rejects_positive_response_in_exact_review_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    base_sha = _commit(repo, "base")
+    (repo / "README.md").write_text("material\n", encoding="utf-8")
+    material_head = _commit(repo, "material")
+    manifest = compute_material_manifest(
+        repo, base_ref_oid=base_sha, head_ref_oid=material_head, pr_number=42
+    )
+    reaction_reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    seal = {
+        "authority": RECEIPT_AUTHORITY,
+        "code_review": {
+            "review_commit_ref": material_head,
+            "review_commit_ref_kind": "repository_commit",
+            "review_reference": reaction_reference,
+            "reviewed_material_digest": manifest.digest,
+            "status": "completed",
+        },
+        "codex_security": _receipt(base_sha, material_head),
+        "material": {
+            "base_ref_oid": base_sha,
+            "digest": manifest.digest,
+            "material_head_sha": material_head,
+            "merge_base_sha": manifest.merge_base_sha,
+            "policy_version": MATERIAL_POLICY_VERSION,
+        },
+        "pr_number": 42,
+        "repository": "owner/repo",
+        "schema_version": "pulseplate.pr-review-seal/v1",
+    }
+    snapshot = PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=base_sha,
+        head_sha=material_head,
+        commits=(PrCommitEvidence(material_head, None),),
+    )
+
+    monkeypatch.setattr(merge_gate, "REPO_ROOT", repo)
+    monkeypatch.setattr(
+        merge_gate,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(value, CommitRefKind.PR_HEAD),
+    )
+    monkeypatch.setattr(
+        merge_gate,
+        "verify_codex_review_reference",
+        lambda *_a, **_k: CodexConnectorAdvisoryReactionEvidence(
+            reference=reaction_reference,
+            created_at="2026-07-15T11:00:00Z",
+            content="+1",
+        ),
+    )
+
+    with pytest.raises(
+        ReviewEvidenceError,
+        match="Codex positive response is not exact-head review evidence",
+    ):
+        merge_gate._validate_v1_seal(
+            artifact_text=_artifact_with_seal(seal),
+            repository="owner/repo",
+            pr_number=42,
+            snapshot=snapshot,
+            token="opaque",
+        )
 
 
 def test_ci_gate_accepts_governance_only_head_and_rejects_stale_material(

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import http.client
 import json
 import os
 import re
@@ -35,6 +36,7 @@ from scripts.orchestration.pr_commit_identity import (
     is_ancestor,
     render_review_credit_outage_override_comment,
     render_security_outage_override_comment,
+    verify_codex_connector_advisory_reaction_reference,
     verify_codex_review_reference,
     verify_codex_review_source_unavailability_reference,
     verify_review_credit_outage_references,
@@ -764,40 +766,8 @@ def _codex_positive_reaction(
 
 def _codex_positive_reaction_request(
     reaction: dict[str, Any] | list[dict[str, Any]],
-    *,
-    head_sha: str = HEAD_SHA,
-    head_ref: str = "codex/reaction-evidence",
-    head_repository: str = "owner/repo",
-    push_head_sha: str | None = None,
-    push_created_at: str = "2026-07-15T10:59:59Z",
-    push_visible_on_attempt: int = 1,
 ) -> Any:
-    event_repository = head_repository
-    event_head_sha = head_sha if push_head_sha is None else push_head_sha
-    push_event_attempts = 0
-
     def request_json(url: str, **_kwargs: Any) -> Any:
-        if url.endswith("/pulls/42"):
-            return {
-                "head": {
-                    "ref": head_ref,
-                    "repo": {"full_name": head_repository},
-                    "sha": head_sha,
-                }
-            }
-        if "/events?" in url:
-            nonlocal push_event_attempts
-            assert url.startswith(f"https://api.github.com/repos/{event_repository}/events?")
-            push_event_attempts += 1
-            if push_event_attempts < push_visible_on_attempt:
-                return []
-            return [
-                {
-                    "created_at": push_created_at,
-                    "payload": {"head": event_head_sha, "ref": f"refs/heads/{head_ref}"},
-                    "type": "PushEvent",
-                }
-            ]
         if "/reactions?" in url:
             return reaction if isinstance(reaction, list) else [reaction]
         raise AssertionError(f"unexpected GitHub API URL: {url}")
@@ -806,7 +776,7 @@ def _codex_positive_reaction_request(
 
 
 @pytest.mark.parametrize("content", ("+1", "heart", "hooray", "rocket"))
-def test_codex_positive_reaction_is_bound_to_exact_published_head(content: str) -> None:
+def test_codex_positive_reaction_is_accepted_as_advisory_only(content: str) -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
     reaction = _codex_positive_reaction(content=content)
     requested_urls: list[str] = []
@@ -816,82 +786,35 @@ def test_codex_positive_reaction_is_bound_to_exact_published_head(content: str) 
         requested_urls.append(url)
         return request(url)
 
-    evidence = verify_codex_review_reference(
+    evidence = verify_codex_connector_advisory_reaction_reference(
         reference,
         repository="owner/repo",
         pr_number=42,
         token="opaque",
-        expected_commit_ref=HEAD_SHA,
         request_json=request_json,
     )
 
-    assert evidence == identity_module.CodexReviewEvidence(
+    assert evidence == identity_module.CodexConnectorAdvisoryReactionEvidence(
         reference=reference,
-        submitted_at="2026-07-15T11:00:00Z",
-        commit_ref=HEAD_SHA,
+        created_at="2026-07-15T11:00:00Z",
+        content=content,
     )
     assert requested_urls == [
-        "https://api.github.com/repos/owner/repo/pulls/42",
-        "https://api.github.com/repos/owner/repo/events?per_page=100&page=1",
         "https://api.github.com/repos/owner/repo/issues/42/reactions?per_page=100&page=1",
     ]
 
 
-def test_codex_positive_reaction_uses_the_pr_head_repository_push_event() -> None:
+def test_codex_positive_reaction_cannot_satisfy_exact_head_review_evidence() -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
 
-    evidence = verify_codex_review_reference(
-        reference,
-        repository="owner/repo",
-        pr_number=42,
-        token="opaque",
-        expected_commit_ref=HEAD_SHA,
-        request_json=_codex_positive_reaction_request(
-            _codex_positive_reaction(),
-            head_repository="fork-owner/fork-repo",
-        ),
-    )
-
-    assert evidence.commit_ref == HEAD_SHA
-
-
-def test_codex_positive_reaction_retries_for_delayed_material_push_event(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    reference = "https://github.com/owner/repo/pull/42#reaction-456"
-    waited_seconds: list[int] = []
-    monkeypatch.setattr(identity_module.time, "sleep", waited_seconds.append)
-
-    evidence = verify_codex_review_reference(
-        reference,
-        repository="owner/repo",
-        pr_number=42,
-        token="opaque",
-        expected_commit_ref=HEAD_SHA,
-        request_json=_codex_positive_reaction_request(
-            _codex_positive_reaction(),
-            push_visible_on_attempt=2,
-        ),
-    )
-
-    assert evidence.commit_ref == HEAD_SHA
-    assert waited_seconds == [identity_module._PR_PUSH_EVENT_VISIBILITY_RETRY_SECONDS]
-
-
-def test_codex_positive_reaction_rejects_an_invalid_material_push_timestamp() -> None:
-    reference = "https://github.com/owner/repo/pull/42#reaction-456"
-
-    with pytest.raises(CommitIdentityError, match="not a valid ISO-8601"):
+    with pytest.raises(CommitIdentityError, match="advisory only"):
         verify_codex_review_reference(
             reference,
             repository="owner/repo",
             pr_number=42,
             token="opaque",
             expected_commit_ref=HEAD_SHA,
-            request_json=_codex_positive_reaction_request(
-                _codex_positive_reaction(),
-                push_created_at="2026-99-15T10:59:59Z",
-            ),
+            request_json=lambda *_a, **_k: pytest.fail("reaction must not be read as review proof"),
         )
 
 
@@ -904,12 +827,12 @@ def test_codex_positive_reaction_rejects_an_invalid_material_push_timestamp() ->
         (lambda reaction: reaction.update(content="eyes"), "not a trusted"),
         (lambda reaction: reaction.update(content=[]), "not a trusted"),
         (
-            lambda reaction: reaction.update(created_at="2026-07-15T10:59:59Z"),
-            "does not postdate",
+            lambda reaction: reaction.update(created_at="2026-99-15T11:00:00Z"),
+            "not a valid ISO-8601",
         ),
     ],
 )
-def test_codex_positive_reaction_rejects_untrusted_or_stale_inputs(
+def test_codex_positive_reaction_rejects_untrusted_or_malformed_inputs(
     mutate: Any,
     error: str,
 ) -> None:
@@ -918,76 +841,34 @@ def test_codex_positive_reaction_rejects_untrusted_or_stale_inputs(
     mutate(reaction)
 
     with pytest.raises(CommitIdentityError, match=error):
-        verify_codex_review_reference(
+        verify_codex_connector_advisory_reaction_reference(
             reference,
             repository="owner/repo",
             pr_number=42,
             token="opaque",
-            expected_commit_ref=HEAD_SHA,
             request_json=_codex_positive_reaction_request(reaction),
         )
 
 
-def test_codex_positive_reaction_requires_exact_pr_reference_and_one_live_id(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_codex_positive_reaction_requires_exact_pr_reference_and_one_live_id() -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
     reaction = _codex_positive_reaction()
 
-    with pytest.raises(CommitIdentityError, match="requires an expected full material"):
-        verify_codex_review_reference(
-            reference,
-            repository="owner/repo",
-            pr_number=42,
-            token="opaque",
-            request_json=lambda *_a, **_k: pytest.fail("missing material head must not fetch"),
-        )
-
     with pytest.raises(CommitIdentityError, match="missing or ambiguous"):
-        verify_codex_review_reference(
+        verify_codex_connector_advisory_reaction_reference(
             reference,
             repository="owner/repo",
             pr_number=42,
             token="opaque",
-            expected_commit_ref=HEAD_SHA,
             request_json=_codex_positive_reaction_request([reaction, reaction]),
         )
 
-    evidence = verify_codex_review_reference(
-        reference,
-        repository="owner/repo",
-        pr_number=42,
-        token="opaque",
-        expected_commit_ref=HEAD_SHA,
-        request_json=_codex_positive_reaction_request(
-            reaction,
-            head_sha=OUTSIDE_SHA,
-            push_head_sha=HEAD_SHA,
-        ),
-    )
-    assert evidence.commit_ref == HEAD_SHA
-
-    monkeypatch.setattr(identity_module.time, "sleep", lambda _seconds: None)
-    with pytest.raises(CommitIdentityError, match="pending visibility"):
-        verify_codex_review_reference(
-            reference,
-            repository="owner/repo",
-            pr_number=42,
-            token="opaque",
-            expected_commit_ref=HEAD_SHA,
-            request_json=_codex_positive_reaction_request(
-                reaction,
-                push_head_sha=OUTSIDE_SHA,
-            ),
-        )
-
-    with pytest.raises(CommitIdentityError, match="code-review reference must be"):
-        verify_codex_review_reference(
+    with pytest.raises(CommitIdentityError, match="canonical reaction URL"):
+        verify_codex_connector_advisory_reaction_reference(
             "https://github.com/owner/repo/pull/43#reaction-456",
             repository="owner/repo",
             pr_number=42,
             token="opaque",
-            expected_commit_ref=HEAD_SHA,
             request_json=lambda *_a, **_k: pytest.fail("cross-PR reaction must not fetch"),
         )
 
@@ -2627,6 +2508,15 @@ def test_closeout_seal_authors_terminal_review_source_receipt(
         "verify_codex_review_reference",
         lambda *_a, **_k: pytest.fail("normal review path must not run"),
     )
+
+    def unavailable_advisory_reaction(*_args: Any, **_kwargs: Any) -> Any:
+        raise CommitIdentityError("GitHub reaction not found")
+
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_connector_advisory_reaction_reference",
+        unavailable_advisory_reaction,
+    )
     monkeypatch.setattr(
         closeout_module,
         "ingest_codex_security_receipt",
@@ -2645,6 +2535,9 @@ def test_closeout_seal_authors_terminal_review_source_receipt(
         repo="owner/repo",
         review_ref=None,
         review_source_unavailable_ref=source_evidence.reference,
+        connector_advisory_reaction=[
+            "https://github.com/owner/repo/pull/42#reaction-456",
+        ],
         scan_manifest="/tmp/scan-manifest.json",
         security_outage_override_ref=None,
     )
@@ -2654,7 +2547,9 @@ def test_closeout_seal_authors_terminal_review_source_receipt(
     parsed = parse_embedded_review_seal(target.read_text(encoding="utf-8"))
     assert parsed["code_review"]["authority"] == ("trusted_codex_review_source_unavailability")
     assert parsed["code_review"]["review_claim"] == "none"
-    assert "CONTENT_BOUND_RECEIPT_VALID" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert "CONTENT_BOUND_RECEIPT_VALID" in captured.out
+    assert "WARNING: Connector advisory reaction omitted: GitHub reaction not found" in captured.err
 
 
 def test_authenticated_closeout_validation_rejects_nonexistent_review(
@@ -4282,6 +4177,17 @@ def test_closeout_seal_requires_exactly_one_security_evidence_input() -> None:
             "/tmp/scan-manifest.json",
         ]
     )
+    advisory_args = parser.parse_args(
+        [
+            *common,
+            "--scan-manifest",
+            "/tmp/scan-manifest.json",
+            "--connector-advisory-reaction",
+            "https://github.com/owner/repo/pull/42#reaction-456",
+            "--connector-advisory-reaction",
+            "https://github.com/owner/repo/pull/42#reaction-457",
+        ]
+    )
     with pytest.raises(SystemExit):
         parser.parse_args(
             [
@@ -4295,3 +4201,117 @@ def test_closeout_seal_requires_exactly_one_security_evidence_input() -> None:
     assert scan_args.security_outage_override_ref is None
     assert override_args.scan_manifest is None
     assert source_args.review_ref is None
+    assert advisory_args.connector_advisory_reaction == [
+        "https://github.com/owner/repo/pull/42#reaction-456",
+        "https://github.com/owner/repo/pull/42#reaction-457",
+    ]
+
+
+def test_closeout_renders_connector_reactions_as_advisory_without_mutating_seal() -> None:
+    security_receipt = build_security_outage_override_receipt(
+        base_revision=BASE_SHA,
+        head_revision=HEAD_SHA,
+        material_digest=DIGEST,
+        override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+        created_at="2026-07-15T11:00:00Z",
+        operator_user_id=123,
+        operator_login="owner",
+        operator_association="OWNER",
+    )
+    seal = _seal(security_receipt)
+    reaction = identity_module.CodexConnectorAdvisoryReactionEvidence(
+        reference="https://github.com/owner/repo/pull/42#reaction-456",
+        created_at="2026-07-15T11:05:00Z",
+        content="+1",
+    )
+    rendered = closeout_module._render_mapping(
+        {
+            "dispositions": [],
+            "experiment_result": None,
+            "packet": None,
+            "pr_number": 42,
+        },
+        seal,
+        connector_advisory_reactions=(reaction,),
+    )
+
+    assert "## Connector Advisory Signals" in rendered
+    assert reaction.reference in rendered
+    assert "not a review, exact-head proof, GitHub approval, security receipt" in rendered
+    assert parse_embedded_review_seal(rendered) == seal
+    assert validate_mapping_artifact_text(rendered) == []
+
+
+def test_closeout_verifies_unique_bounded_connector_advisory_reactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verified: list[str] = []
+
+    def verify(
+        reference: str, **_kwargs: Any
+    ) -> identity_module.CodexConnectorAdvisoryReactionEvidence:
+        verified.append(reference)
+        return identity_module.CodexConnectorAdvisoryReactionEvidence(
+            reference=reference,
+            created_at="2026-07-15T11:05:00Z",
+            content="+1",
+        )
+
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_connector_advisory_reaction_reference",
+        verify,
+    )
+    reactions = closeout_module._verify_connector_advisory_reactions(
+        [
+            "https://github.com/owner/repo/pull/42#reaction-457",
+            "https://github.com/owner/repo/pull/42#reaction-456",
+        ],
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+    )
+
+    assert verified == [
+        "https://github.com/owner/repo/pull/42#reaction-457",
+        "https://github.com/owner/repo/pull/42#reaction-456",
+    ]
+    assert [reaction.reference for reaction in reactions] == [
+        "https://github.com/owner/repo/pull/42#reaction-456",
+        "https://github.com/owner/repo/pull/42#reaction-457",
+    ]
+
+    with pytest.raises(closeout_module.CloseoutError, match="must be unique"):
+        closeout_module._verify_connector_advisory_reactions(
+            ["https://github.com/owner/repo/pull/42#reaction-456"] * 2,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+        )
+
+
+def test_closeout_omits_connector_advisory_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def transport_failure(*_args: Any, **_kwargs: Any) -> Any:
+        raise http.client.HTTPException("truncated response")
+
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_connector_advisory_reaction_reference",
+        transport_failure,
+    )
+
+    reactions = closeout_module._optional_connector_advisory_reactions(
+        ["https://github.com/owner/repo/pull/42#reaction-456"],
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+    )
+
+    assert reactions == ()
+    assert (
+        "WARNING: Connector advisory reaction omitted: truncated response"
+        in capsys.readouterr().err
+    )

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -766,13 +766,35 @@ def _codex_positive_reaction(
 
 def _codex_positive_reaction_request(
     reaction: dict[str, Any] | list[dict[str, Any]],
+    *,
+    check_suites: dict[str, Any] | None = None,
 ) -> Any:
     def request_json(url: str, **_kwargs: Any) -> Any:
         if "/reactions?" in url:
             return reaction if isinstance(reaction, list) else [reaction]
+        if "/check-suites?" in url and check_suites is not None:
+            return check_suites
         raise AssertionError(f"unexpected GitHub API URL: {url}")
 
     return request_json
+
+
+def _github_actions_check_suites(
+    *,
+    head_sha: str = HEAD_SHA,
+    created_at: str = "2026-07-15T10:59:59Z",
+    app_slug: str = "github-actions",
+) -> dict[str, Any]:
+    return {
+        "total_count": 1,
+        "check_suites": [
+            {
+                "app": {"slug": app_slug},
+                "created_at": created_at,
+                "head_sha": head_sha,
+            }
+        ],
+    }
 
 
 @pytest.mark.parametrize("content", ("+1", "heart", "hooray", "rocket"))
@@ -782,7 +804,10 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
     reaction = _codex_positive_reaction(content=content)
     requested_urls: list[str] = []
-    request = _codex_positive_reaction_request(reaction)
+    request = _codex_positive_reaction_request(
+        reaction,
+        check_suites=_github_actions_check_suites(),
+    )
 
     def request_json(url: str, **_kwargs: Any) -> Any:
         requested_urls.append(url)
@@ -804,7 +829,45 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     )
     assert requested_urls == [
         "https://api.github.com/repos/owner/repo/issues/42/reactions?per_page=100&page=1",
+        f"https://api.github.com/repos/owner/repo/commits/{HEAD_SHA}/check-suites"
+        "?per_page=100&page=1",
     ]
+
+
+@pytest.mark.parametrize(
+    ("suite_head_sha", "suite_created_at", "suite_app_slug"),
+    [
+        (HEAD_SHA, "2026-07-15T11:00:01Z", "github-actions"),
+        (FIX_SHA, "2026-07-15T10:59:59Z", "github-actions"),
+        (HEAD_SHA, "2026-07-15T10:59:59Z", "untrusted-app"),
+    ],
+)
+def test_codex_positive_reaction_rejects_invalid_head_check_suite(
+    suite_head_sha: str,
+    suite_created_at: str,
+    suite_app_slug: str,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+
+    with pytest.raises(
+        CommitIdentityError,
+        match="does not follow a GitHub Actions observation of the exact material head",
+    ):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request(
+                _codex_positive_reaction(),
+                check_suites=_github_actions_check_suites(
+                    head_sha=suite_head_sha,
+                    created_at=suite_created_at,
+                    app_slug=suite_app_slug,
+                ),
+            ),
+        )
 
 
 def test_codex_positive_reaction_requires_expected_full_material_head() -> None:

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -767,34 +767,36 @@ def _codex_positive_reaction(
 def _codex_positive_reaction_request(
     reaction: dict[str, Any] | list[dict[str, Any]],
     *,
-    reviews: list[dict[str, Any]] | None = None,
+    pull_head: str = HEAD_SHA,
+    check_suites: dict[str, Any] | None = None,
 ) -> Any:
     def request_json(url: str, **_kwargs: Any) -> Any:
         if "/reactions?" in url:
             return reaction if isinstance(reaction, list) else [reaction]
-        if "/reviews?" in url and reviews is not None:
-            return reviews
+        if url.endswith("/pulls/42"):
+            return {"head": {"sha": pull_head}}
+        if "/check-suites?" in url and check_suites is not None:
+            return check_suites
         raise AssertionError(f"unexpected GitHub API URL: {url}")
 
     return request_json
 
 
-def _codex_exact_head_review(
+def _github_actions_check_suites(
     *,
-    commit_id: str = HEAD_SHA,
-    submitted_at: str = "2026-07-15T10:59:59Z",
-    user_id: int = 199_175_422,
-    login: str = "chatgpt-codex-connector[bot]",
-    user_type: str = "Bot",
-    state: str = "COMMENTED",
-    html_url: str = "https://github.com/owner/repo/pull/42#pullrequestreview-123",
+    head_sha: str = HEAD_SHA,
+    created_at: str = "2026-07-15T10:59:59Z",
+    app_slug: str = "github-actions",
 ) -> dict[str, Any]:
     return {
-        "commit_id": commit_id,
-        "html_url": html_url,
-        "state": state,
-        "submitted_at": submitted_at,
-        "user": {"id": user_id, "login": login, "type": user_type},
+        "total_count": 1,
+        "check_suites": [
+            {
+                "app": {"slug": app_slug},
+                "created_at": created_at,
+                "head_sha": head_sha,
+            }
+        ],
     }
 
 
@@ -807,7 +809,7 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     requested_urls: list[str] = []
     request = _codex_positive_reaction_request(
         reaction,
-        reviews=[_codex_exact_head_review()],
+        check_suites=_github_actions_check_suites(),
     )
 
     def request_json(url: str, **_kwargs: Any) -> Any:
@@ -830,41 +832,34 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     )
     assert requested_urls == [
         "https://api.github.com/repos/owner/repo/issues/42/reactions?per_page=100&page=1",
-        "https://api.github.com/repos/owner/repo/pulls/42/reviews?per_page=100&page=1",
+        "https://api.github.com/repos/owner/repo/pulls/42",
+        f"https://api.github.com/repos/owner/repo/commits/{HEAD_SHA}/check-suites"
+        "?per_page=100&page=1",
     ]
 
 
-def test_codex_positive_reaction_accepts_approved_exact_head_review() -> None:
+def test_codex_positive_reaction_accepts_head_observation_on_second_page() -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
-
-    evidence = verify_codex_review_reference(
-        reference,
-        repository="owner/repo",
-        pr_number=42,
-        token="opaque",
-        expected_commit_ref=HEAD_SHA,
-        request_json=_codex_positive_reaction_request(
-            _codex_positive_reaction(),
-            reviews=[_codex_exact_head_review(state="APPROVED")],
-        ),
-    )
-
-    assert evidence.commit_ref == HEAD_SHA
-
-
-def test_codex_positive_reaction_accepts_exact_head_review_on_second_page() -> None:
-    reference = "https://github.com/owner/repo/pull/42#reaction-456"
-    untrusted_page = [_codex_exact_head_review(user_id=1) for _ in range(100)]
+    untrusted_page = [
+        {
+            "app": {"slug": "untrusted-app"},
+            "created_at": "2026-07-15T10:59:59Z",
+            "head_sha": HEAD_SHA,
+        }
+        for _ in range(100)
+    ]
     requested_urls: list[str] = []
 
     def request_json(url: str, **_kwargs: Any) -> Any:
         requested_urls.append(url)
         if "/reactions?" in url:
             return [_codex_positive_reaction()]
-        if "/reviews?" in url and url.endswith("&page=1"):
-            return untrusted_page
-        if "/reviews?" in url and url.endswith("&page=2"):
-            return [_codex_exact_head_review()]
+        if url.endswith("/pulls/42"):
+            return {"head": {"sha": HEAD_SHA}}
+        if "/check-suites?" in url and url.endswith("&page=1"):
+            return {"total_count": 101, "check_suites": untrusted_page}
+        if "/check-suites?" in url and url.endswith("&page=2"):
+            return _github_actions_check_suites()
         raise AssertionError(f"unexpected GitHub API URL: {url}")
 
     evidence = verify_codex_review_reference(
@@ -877,20 +872,35 @@ def test_codex_positive_reaction_accepts_exact_head_review_on_second_page() -> N
     )
 
     assert evidence.commit_ref == HEAD_SHA
-    assert requested_urls[-1].endswith("/reviews?per_page=100&page=2")
+    assert requested_urls[-1].endswith("/check-suites?per_page=100&page=2")
 
 
 @pytest.mark.parametrize(
-    ("reviews", "error"),
+    ("pull_response", "check_response", "error"),
     [
-        ({"unexpected": "object"}, "response is malformed"),
-        ([None], "entry is malformed"),
-        ([_codex_exact_head_review(commit_id="not-a-sha")], "review commit_id"),
-        ([_codex_exact_head_review(submitted_at="not-a-date")], "review submitted_at"),
+        ([], _github_actions_check_suites(), "PR response is malformed"),
+        ({"head": {"sha": FIX_SHA}}, _github_actions_check_suites(), "current material head"),
+        ({"head": {"sha": HEAD_SHA}}, [], "check-suites response is malformed"),
+        (
+            {"head": {"sha": HEAD_SHA}},
+            {"total_count": 1, "check_suites": [None]},
+            "check-suite entry is malformed",
+        ),
+        (
+            {"head": {"sha": HEAD_SHA}},
+            _github_actions_check_suites(head_sha="not-a-sha"),
+            "check-suite SHA",
+        ),
+        (
+            {"head": {"sha": HEAD_SHA}},
+            _github_actions_check_suites(created_at="not-a-date"),
+            "check-suite created_at",
+        ),
     ],
 )
-def test_codex_positive_reaction_rejects_malformed_review_api_data(
-    reviews: Any,
+def test_codex_positive_reaction_rejects_malformed_head_observation_data(
+    pull_response: Any,
+    check_response: Any,
     error: str,
 ) -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
@@ -898,8 +908,10 @@ def test_codex_positive_reaction_rejects_malformed_review_api_data(
     def request_json(url: str, **_kwargs: Any) -> Any:
         if "/reactions?" in url:
             return [_codex_positive_reaction()]
-        if "/reviews?" in url:
-            return reviews
+        if url.endswith("/pulls/42"):
+            return pull_response
+        if "/check-suites?" in url:
+            return check_response
         raise AssertionError(f"unexpected GitHub API URL: {url}")
 
     with pytest.raises(CommitIdentityError, match=error):
@@ -913,17 +925,29 @@ def test_codex_positive_reaction_rejects_malformed_review_api_data(
         )
 
 
-def test_codex_positive_reaction_fails_closed_at_review_page_limit(
+def test_codex_positive_reaction_fails_closed_at_check_suite_page_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
-    monkeypatch.setattr(identity_module, "_MAX_PR_REVIEW_PAGES", 1)
+    monkeypatch.setattr(identity_module, "_MAX_HEAD_CHECK_SUITE_PAGES", 1)
 
     def request_json(url: str, **_kwargs: Any) -> Any:
         if "/reactions?" in url:
             return [_codex_positive_reaction()]
-        if "/reviews?" in url:
-            return [_codex_exact_head_review(user_id=1) for _ in range(100)]
+        if url.endswith("/pulls/42"):
+            return {"head": {"sha": HEAD_SHA}}
+        if "/check-suites?" in url:
+            return {
+                "total_count": 100,
+                "check_suites": [
+                    {
+                        "app": {"slug": "untrusted-app"},
+                        "created_at": "2026-07-15T10:59:59Z",
+                        "head_sha": HEAD_SHA,
+                    }
+                    for _ in range(100)
+                ],
+            }
         raise AssertionError(f"unexpected GitHub API URL: {url}")
 
     with pytest.raises(CommitIdentityError, match="pagination exceeded page limit"):
@@ -938,26 +962,24 @@ def test_codex_positive_reaction_fails_closed_at_review_page_limit(
 
 
 @pytest.mark.parametrize(
-    ("review_overrides",),
+    ("suite_head_sha", "suite_created_at", "suite_app_slug"),
     [
-        ({"commit_id": FIX_SHA},),
-        ({"submitted_at": "2026-07-15T11:00:00Z"},),
-        ({"submitted_at": "2026-07-15T11:00:01Z"},),
-        ({"user_id": 1},),
-        ({"login": "spoofed[bot]"},),
-        ({"user_type": "User"},),
-        ({"state": "DISMISSED"},),
-        ({"html_url": "https://github.com/owner/repo/pull/43#pullrequestreview-123"},),
+        (FIX_SHA, "2026-07-15T10:59:59Z", "github-actions"),
+        (HEAD_SHA, "2026-07-15T11:00:00Z", "github-actions"),
+        (HEAD_SHA, "2026-07-15T11:00:01Z", "github-actions"),
+        (HEAD_SHA, "2026-07-15T10:59:59Z", "untrusted-app"),
     ],
 )
-def test_codex_positive_reaction_rejects_invalid_exact_head_connector_review(
-    review_overrides: dict[str, Any],
+def test_codex_positive_reaction_rejects_invalid_head_observation(
+    suite_head_sha: str,
+    suite_created_at: str,
+    suite_app_slug: str,
 ) -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
 
     with pytest.raises(
         CommitIdentityError,
-        match="does not follow a trusted Connector review of the exact material head",
+        match="does not follow a GitHub observation of the exact material head",
     ):
         verify_codex_review_reference(
             reference,
@@ -967,7 +989,11 @@ def test_codex_positive_reaction_rejects_invalid_exact_head_connector_review(
             expected_commit_ref=HEAD_SHA,
             request_json=_codex_positive_reaction_request(
                 _codex_positive_reaction(),
-                reviews=[_codex_exact_head_review(**review_overrides)],
+                check_suites=_github_actions_check_suites(
+                    head_sha=suite_head_sha,
+                    created_at=suite_created_at,
+                    app_slug=suite_app_slug,
+                ),
             ),
         )
 

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -873,6 +873,68 @@ def test_codex_positive_reaction_accepts_revalidated_mapping_only_live_head() ->
     assert evidence.content == "+1"
 
 
+def test_codex_positive_reaction_accepts_new_live_successor_after_mapping_only_push() -> None:
+    sealed_reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    successor_reference = "https://github.com/owner/repo/pull/42#reaction-789"
+
+    evidence = verify_codex_review_reference(
+        sealed_reference,
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+        expected_commit_ref=HEAD_SHA,
+        expected_live_pr_head_ref=OUTSIDE_SHA,
+        request_json=_codex_positive_reaction_request(
+            _codex_positive_reaction(
+                789,
+                created_at="2026-07-15T12:00:00Z",
+            ),
+            pull_head=OUTSIDE_SHA,
+            workflow_runs=_github_actions_workflow_runs(),
+        ),
+    )
+
+    assert evidence == identity_module.CodexConnectorAdvisoryReactionEvidence(
+        reference=successor_reference,
+        created_at="2026-07-15T12:00:00Z",
+        content="+1",
+    )
+
+
+def test_codex_positive_reaction_does_not_rebind_on_material_head() -> None:
+    with pytest.raises(CommitIdentityError, match="missing"):
+        verify_codex_review_reference(
+            "https://github.com/owner/repo/pull/42#reaction-456",
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request(
+                _codex_positive_reaction(789),
+                workflow_runs=_github_actions_workflow_runs(),
+            ),
+        )
+
+
+def test_codex_positive_reaction_successor_rejects_malformed_live_content() -> None:
+    malformed = _codex_positive_reaction(789)
+    malformed["content"] = []
+    with pytest.raises(CommitIdentityError, match="missing or ambiguous"):
+        verify_codex_review_reference(
+            "https://github.com/owner/repo/pull/42#reaction-456",
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            expected_live_pr_head_ref=OUTSIDE_SHA,
+            request_json=_codex_positive_reaction_request(
+                malformed,
+                pull_head=OUTSIDE_SHA,
+                workflow_runs=_github_actions_workflow_runs(),
+            ),
+        )
+
+
 def test_codex_positive_reaction_accepts_head_observation_on_second_page() -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
     untrusted_page = [
@@ -1237,7 +1299,7 @@ def test_codex_positive_reaction_requires_exact_pr_reference_and_one_live_id() -
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
     reaction = _codex_positive_reaction()
 
-    with pytest.raises(CommitIdentityError, match="missing or ambiguous"):
+    with pytest.raises(CommitIdentityError, match="ambiguous"):
         verify_codex_connector_advisory_reaction_reference(
             reference,
             repository="owner/repo",
@@ -3228,6 +3290,7 @@ def test_authenticated_closeout_revalidates_reaction_after_mapping_only_commit(
             PrCommitEvidence(OUTSIDE_SHA, "2026-07-15T12:00:00Z"),
         ),
     )
+    successor_reference = "https://github.com/owner/repo/pull/42#reaction-789"
     verifier_calls: list[tuple[str, str | None, str | None]] = []
 
     def verify_reaction(reference: str, **kwargs: Any) -> Any:
@@ -3239,8 +3302,8 @@ def test_authenticated_closeout_revalidates_reaction_after_mapping_only_commit(
             )
         )
         return identity_module.CodexConnectorAdvisoryReactionEvidence(
-            reference=reference,
-            created_at="2026-07-15T11:00:00Z",
+            reference=successor_reference,
+            created_at="2026-07-15T12:00:00Z",
             content=reaction_content,
         )
 

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -744,6 +744,254 @@ def test_codex_no_findings_comment_rejects_unresolved_short_commit() -> None:
         )
 
 
+def _codex_positive_reaction(
+    reaction_id: int = 456,
+    *,
+    content: str = "+1",
+    created_at: str = "2026-07-15T11:00:00Z",
+) -> dict[str, Any]:
+    return {
+        "content": content,
+        "created_at": created_at,
+        "id": reaction_id,
+        "user": {
+            "id": 199_175_422,
+            "login": "chatgpt-codex-connector[bot]",
+            "type": "User",
+        },
+    }
+
+
+def _codex_positive_reaction_request(
+    reaction: dict[str, Any] | list[dict[str, Any]],
+    *,
+    head_sha: str = HEAD_SHA,
+    head_ref: str = "codex/reaction-evidence",
+    head_repository: str = "owner/repo",
+    push_head_sha: str | None = None,
+    push_created_at: str = "2026-07-15T10:59:59Z",
+    push_visible_on_attempt: int = 1,
+) -> Any:
+    event_repository = head_repository
+    event_head_sha = head_sha if push_head_sha is None else push_head_sha
+    push_event_attempts = 0
+
+    def request_json(url: str, **_kwargs: Any) -> Any:
+        if url.endswith("/pulls/42"):
+            return {
+                "head": {
+                    "ref": head_ref,
+                    "repo": {"full_name": head_repository},
+                    "sha": head_sha,
+                }
+            }
+        if "/events?" in url:
+            nonlocal push_event_attempts
+            assert url.startswith(f"https://api.github.com/repos/{event_repository}/events?")
+            push_event_attempts += 1
+            if push_event_attempts < push_visible_on_attempt:
+                return []
+            return [
+                {
+                    "created_at": push_created_at,
+                    "payload": {"head": event_head_sha, "ref": f"refs/heads/{head_ref}"},
+                    "type": "PushEvent",
+                }
+            ]
+        if "/reactions?" in url:
+            return reaction if isinstance(reaction, list) else [reaction]
+        raise AssertionError(f"unexpected GitHub API URL: {url}")
+
+    return request_json
+
+
+@pytest.mark.parametrize("content", ("+1", "heart", "hooray", "rocket"))
+def test_codex_positive_reaction_is_bound_to_exact_published_head(content: str) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    reaction = _codex_positive_reaction(content=content)
+    requested_urls: list[str] = []
+    request = _codex_positive_reaction_request(reaction)
+
+    def request_json(url: str, **_kwargs: Any) -> Any:
+        requested_urls.append(url)
+        return request(url)
+
+    evidence = verify_codex_review_reference(
+        reference,
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+        expected_commit_ref=HEAD_SHA,
+        request_json=request_json,
+    )
+
+    assert evidence == identity_module.CodexReviewEvidence(
+        reference=reference,
+        submitted_at="2026-07-15T11:00:00Z",
+        commit_ref=HEAD_SHA,
+    )
+    assert requested_urls == [
+        "https://api.github.com/repos/owner/repo/pulls/42",
+        "https://api.github.com/repos/owner/repo/events?per_page=100&page=1",
+        "https://api.github.com/repos/owner/repo/issues/42/reactions?per_page=100&page=1",
+    ]
+
+
+def test_codex_positive_reaction_uses_the_pr_head_repository_push_event() -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+
+    evidence = verify_codex_review_reference(
+        reference,
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+        expected_commit_ref=HEAD_SHA,
+        request_json=_codex_positive_reaction_request(
+            _codex_positive_reaction(),
+            head_repository="fork-owner/fork-repo",
+        ),
+    )
+
+    assert evidence.commit_ref == HEAD_SHA
+
+
+def test_codex_positive_reaction_retries_for_delayed_material_push_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    waited_seconds: list[int] = []
+    monkeypatch.setattr(identity_module.time, "sleep", waited_seconds.append)
+
+    evidence = verify_codex_review_reference(
+        reference,
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+        expected_commit_ref=HEAD_SHA,
+        request_json=_codex_positive_reaction_request(
+            _codex_positive_reaction(),
+            push_visible_on_attempt=2,
+        ),
+    )
+
+    assert evidence.commit_ref == HEAD_SHA
+    assert waited_seconds == [identity_module._PR_PUSH_EVENT_VISIBILITY_RETRY_SECONDS]
+
+
+def test_codex_positive_reaction_rejects_an_invalid_material_push_timestamp() -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+
+    with pytest.raises(CommitIdentityError, match="not a valid ISO-8601"):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request(
+                _codex_positive_reaction(),
+                push_created_at="2026-99-15T10:59:59Z",
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error"),
+    [
+        (lambda reaction: reaction["user"].update(login="spoofed[bot]"), "not a trusted"),
+        (lambda reaction: reaction["user"].update(id=1), "not a trusted"),
+        (lambda reaction: reaction["user"].update(type="Organization"), "not a trusted"),
+        (lambda reaction: reaction.update(content="eyes"), "not a trusted"),
+        (lambda reaction: reaction.update(content=[]), "not a trusted"),
+        (
+            lambda reaction: reaction.update(created_at="2026-07-15T10:59:59Z"),
+            "does not postdate",
+        ),
+    ],
+)
+def test_codex_positive_reaction_rejects_untrusted_or_stale_inputs(
+    mutate: Any,
+    error: str,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    reaction = _codex_positive_reaction()
+    mutate(reaction)
+
+    with pytest.raises(CommitIdentityError, match=error):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request(reaction),
+        )
+
+
+def test_codex_positive_reaction_requires_exact_pr_reference_and_one_live_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    reaction = _codex_positive_reaction()
+
+    with pytest.raises(CommitIdentityError, match="requires an expected full material"):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            request_json=lambda *_a, **_k: pytest.fail("missing material head must not fetch"),
+        )
+
+    with pytest.raises(CommitIdentityError, match="missing or ambiguous"):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request([reaction, reaction]),
+        )
+
+    evidence = verify_codex_review_reference(
+        reference,
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+        expected_commit_ref=HEAD_SHA,
+        request_json=_codex_positive_reaction_request(
+            reaction,
+            head_sha=OUTSIDE_SHA,
+            push_head_sha=HEAD_SHA,
+        ),
+    )
+    assert evidence.commit_ref == HEAD_SHA
+
+    monkeypatch.setattr(identity_module.time, "sleep", lambda _seconds: None)
+    with pytest.raises(CommitIdentityError, match="pending visibility"):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request(
+                reaction,
+                push_head_sha=OUTSIDE_SHA,
+            ),
+        )
+
+    with pytest.raises(CommitIdentityError, match="code-review reference must be"):
+        verify_codex_review_reference(
+            "https://github.com/owner/repo/pull/43#reaction-456",
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=lambda *_a, **_k: pytest.fail("cross-PR reaction must not fetch"),
+        )
+
+
 def _review_credit_quota_comment(
     reference: str,
     *,

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -53,11 +53,13 @@ from scripts.orchestration.pr_review_evidence import (
     MaterialManifest,
     ReviewEvidenceError,
     build_review_credit_outage_receipt,
+    build_review_source_positive_response_receipt,
     build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
     ingest_codex_security_receipt,
     is_review_credit_outage_receipt,
+    is_review_source_positive_response_receipt,
     is_review_source_unavailability_receipt,
     is_security_outage_override_receipt,
     parse_duplicate_disposition_reply,
@@ -812,7 +814,7 @@ def _workflow_run_response_with_pr_links(links: Any) -> dict[str, Any]:
 
 
 @pytest.mark.parametrize("content", ("+1", "heart", "hooray", "rocket"))
-def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
+def test_codex_positive_reaction_is_accepted_without_exact_head_review_claim(
     content: str,
 ) -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
@@ -836,10 +838,10 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
         request_json=request_json,
     )
 
-    assert evidence == identity_module.CodexReviewEvidence(
+    assert evidence == identity_module.CodexConnectorAdvisoryReactionEvidence(
         reference=reference,
-        submitted_at="2026-07-15T11:00:00Z",
-        commit_ref=HEAD_SHA,
+        created_at="2026-07-15T11:00:00Z",
+        content=content,
     )
     assert requested_urls == [
         "https://api.github.com/repos/owner/repo/issues/42/reactions?per_page=100&page=1",
@@ -867,7 +869,8 @@ def test_codex_positive_reaction_accepts_revalidated_mapping_only_live_head() ->
         ),
     )
 
-    assert evidence.commit_ref == HEAD_SHA
+    assert isinstance(evidence, identity_module.CodexConnectorAdvisoryReactionEvidence)
+    assert evidence.content == "+1"
 
 
 def test_codex_positive_reaction_accepts_head_observation_on_second_page() -> None:
@@ -906,7 +909,8 @@ def test_codex_positive_reaction_accepts_head_observation_on_second_page() -> No
         request_json=request_json,
     )
 
-    assert evidence.commit_ref == HEAD_SHA
+    assert isinstance(evidence, identity_module.CodexConnectorAdvisoryReactionEvidence)
+    assert evidence.content == "+1"
     assert requested_urls[-2].endswith("&per_page=100&page=2")
     assert requested_urls[-1].endswith("/issues/42/events?per_page=100&page=1")
 
@@ -2738,6 +2742,94 @@ def test_review_source_unavailability_receipt_is_tagged_and_material_bound() -> 
     }
 
 
+@pytest.mark.parametrize("reaction_content", ["+1", "heart", "hooray", "rocket"])
+def test_review_source_positive_response_receipt_is_nonblocking_without_review_claim(
+    reaction_content: str,
+) -> None:
+    receipt = build_review_source_positive_response_receipt(
+        material_digest=DIGEST,
+        material_head_sha=HEAD_SHA,
+        response_reference="https://github.com/owner/repo/pull/42#reaction-456",
+        response_created_at="2026-07-15T11:00:00Z",
+        response_content=reaction_content,
+    )
+    seal = _seal(
+        build_security_outage_override_receipt(
+            base_revision=BASE_SHA,
+            head_revision=HEAD_SHA,
+            material_digest=DIGEST,
+            override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+            created_at="2026-07-15T11:00:00Z",
+            operator_user_id=123,
+            operator_login="owner",
+            operator_association="OWNER",
+        )
+    )
+    seal["code_review"] = receipt
+
+    parsed = parse_embedded_review_seal(render_embedded_review_seal(seal))
+
+    assert is_review_source_positive_response_receipt(parsed["code_review"])
+    assert parsed["code_review"] == {
+        "authority": "trusted_codex_review_source_positive_response",
+        "binding_kind": "seal_context_only",
+        "blocking": False,
+        "fallback_required": False,
+        "material_digest": DIGEST,
+        "material_head_sha": HEAD_SHA,
+        "response_content": reaction_content,
+        "response_created_at": "2026-07-15T11:00:00Z",
+        "response_reference": "https://github.com/owner/repo/pull/42#reaction-456",
+        "review_claim": "none",
+        "schema_version": "pulseplate.codex-review-source-positive-response/v1",
+        "source": "codex_review",
+        "source_degraded": False,
+        "source_status": "positive_response",
+        "status": "completed",
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        (lambda receipt: receipt.update(review_claim="approved"), "malformed or stale"),
+        (lambda receipt: receipt.update(source_degraded=True), "malformed or stale"),
+        (lambda receipt: receipt.update(response_content="eyes"), "malformed or stale"),
+        (
+            lambda receipt: receipt.update(authority="trusted_codex_review_source_unavailability"),
+            "tagged-union identity is ambiguous",
+        ),
+    ],
+)
+def test_review_source_positive_response_receipt_rejects_authority_escalation(
+    mutation: Any, error: str
+) -> None:
+    receipt = build_review_source_positive_response_receipt(
+        material_digest=DIGEST,
+        material_head_sha=HEAD_SHA,
+        response_reference="https://github.com/owner/repo/pull/42#reaction-456",
+        response_created_at="2026-07-15T11:00:00Z",
+        response_content="+1",
+    )
+    mutation(receipt)
+    seal = _seal(
+        build_security_outage_override_receipt(
+            base_revision=BASE_SHA,
+            head_revision=HEAD_SHA,
+            material_digest=DIGEST,
+            override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+            created_at="2026-07-15T11:00:00Z",
+            operator_user_id=123,
+            operator_login="owner",
+            operator_association="OWNER",
+        )
+    )
+    seal["code_review"] = receipt
+
+    with pytest.raises(ReviewEvidenceError, match=error):
+        render_embedded_review_seal(seal)
+
+
 @pytest.mark.parametrize(
     ("mutation", "error"),
     [
@@ -2931,9 +3023,11 @@ def test_closeout_seal_authors_terminal_review_source_receipt(
     assert "WARNING: Connector advisory reaction omitted: GitHub reaction not found" in captured.err
 
 
-def test_closeout_seal_binds_connector_reaction_through_normal_review_ref(
+@pytest.mark.parametrize("reaction_content", ["+1", "heart", "hooray", "rocket"])
+def test_closeout_seal_records_connector_reaction_as_positive_response(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    reaction_content: str,
 ) -> None:
     repo = tmp_path / "repo"
     target = repo / "docs/review/PR_42_FIXED_MAPPING.md"
@@ -2969,12 +3063,12 @@ def test_closeout_seal_binds_connector_reaction_through_normal_review_ref(
 
     def verify_reaction_review(
         reference: str, **kwargs: Any
-    ) -> identity_module.CodexReviewEvidence:
+    ) -> identity_module.CodexConnectorAdvisoryReactionEvidence:
         review_calls.append((reference, kwargs.get("expected_commit_ref")))
-        return identity_module.CodexReviewEvidence(
+        return identity_module.CodexConnectorAdvisoryReactionEvidence(
             reference=reaction_reference,
-            submitted_at="2026-07-15T11:00:00Z",
-            commit_ref=HEAD_SHA,
+            created_at="2026-07-15T11:00:00Z",
+            content=reaction_content,
         )
 
     monkeypatch.setattr(closeout_module, "REPO_ROOT", repo)
@@ -3025,18 +3119,18 @@ def test_closeout_seal_binds_connector_reaction_through_normal_review_ref(
 
     seal = parse_embedded_review_seal(target.read_text(encoding="utf-8"))
     assert review_calls == [(reaction_reference, HEAD_SHA)]
-    assert seal["code_review"] == {
-        "review_commit_ref": HEAD_SHA,
-        "review_commit_ref_kind": "repository_commit",
-        "review_reference": reaction_reference,
-        "reviewed_material_digest": DIGEST,
-        "status": "completed",
-    }
+    assert seal["code_review"] == build_review_source_positive_response_receipt(
+        material_digest=DIGEST,
+        material_head_sha=HEAD_SHA,
+        response_reference=reaction_reference,
+        response_created_at="2026-07-15T11:00:00Z",
+        response_content=reaction_content,
+    )
     assert seal["codex_security"] == security_receipt
     assert snapshot_rechecks == [_snapshot()]
 
 
-def test_authenticated_closeout_validation_rejects_nonexistent_review(
+def test_authenticated_closeout_rejects_reaction_in_exact_review_receipt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     receipt = ingest_codex_security_receipt(
@@ -3059,7 +3153,7 @@ def test_authenticated_closeout_validation_rejects_nonexistent_review(
     )
     verifier_calls: list[tuple[str, str | None, str | None]] = []
 
-    def reject_review(reference: str, **kwargs: Any) -> Any:
+    def return_positive_response(reference: str, **kwargs: Any) -> Any:
         verifier_calls.append(
             (
                 reference,
@@ -3067,7 +3161,11 @@ def test_authenticated_closeout_validation_rejects_nonexistent_review(
                 kwargs.get("expected_live_pr_head_ref"),
             )
         )
-        raise CommitIdentityError("GitHub review not found")
+        return identity_module.CodexConnectorAdvisoryReactionEvidence(
+            reference=reference,
+            created_at="2026-07-15T11:00:00Z",
+            content="+1",
+        )
 
     monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: mapping)
     monkeypatch.setattr(closeout_module, "fetch_pr_snapshot", lambda *_a, **_k: _snapshot())
@@ -3082,11 +3180,15 @@ def test_authenticated_closeout_validation_rejects_nonexistent_review(
         "classify_commit_ref",
         lambda value, *_a, **_k: RepositoryCommitRef(value, CommitRefKind.PR_HEAD),
     )
-    monkeypatch.setattr(closeout_module, "verify_codex_review_reference", reject_review)
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_review_reference",
+        return_positive_response,
+    )
     monkeypatch.setattr(closeout_module, "is_ancestor", lambda *_a, **_k: True)
     monkeypatch.setattr(closeout_module, "assert_snapshot_unchanged", lambda *_a, **_k: None)
 
-    with pytest.raises(CommitIdentityError, match="review not found"):
+    with pytest.raises(closeout_module.CloseoutError, match="not exact-head review evidence"):
         closeout_module.validate_live_mapping(
             repository="owner/repo",
             pr_number=42,
@@ -3096,8 +3198,9 @@ def test_authenticated_closeout_validation_rejects_nonexistent_review(
     assert verifier_calls == [(reaction_reference, HEAD_SHA, HEAD_SHA)]
 
 
+@pytest.mark.parametrize("reaction_content", ["+1", "heart", "hooray", "rocket"])
 def test_authenticated_closeout_revalidates_reaction_after_mapping_only_commit(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reaction_content: str
 ) -> None:
     receipt = ingest_codex_security_receipt(
         _build_scan_bundle(tmp_path / "scan"),
@@ -3106,7 +3209,13 @@ def test_authenticated_closeout_revalidates_reaction_after_mapping_only_commit(
     )
     reaction_reference = "https://github.com/owner/repo/pull/42#reaction-456"
     seal = _seal(receipt)
-    seal["code_review"]["review_reference"] = reaction_reference
+    seal["code_review"] = build_review_source_positive_response_receipt(
+        material_digest=DIGEST,
+        material_head_sha=HEAD_SHA,
+        response_reference=reaction_reference,
+        response_created_at="2026-07-15T11:00:00Z",
+        response_content=reaction_content,
+    )
     mapping = tmp_path / "PR_42_FIXED_MAPPING.md"
     mapping.write_text(_mapping_artifact_with_seal(seal), encoding="utf-8")
     closeout_snapshot = PrSnapshot(
@@ -3129,10 +3238,10 @@ def test_authenticated_closeout_revalidates_reaction_after_mapping_only_commit(
                 kwargs.get("expected_live_pr_head_ref"),
             )
         )
-        return identity_module.CodexReviewEvidence(
+        return identity_module.CodexConnectorAdvisoryReactionEvidence(
             reference=reference,
-            submitted_at="2026-07-15T11:00:00Z",
-            commit_ref=HEAD_SHA,
+            created_at="2026-07-15T11:00:00Z",
+            content=reaction_content,
         )
 
     monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: mapping)
@@ -3165,8 +3274,45 @@ def test_authenticated_closeout_revalidates_reaction_after_mapping_only_commit(
         token="opaque",
     )
 
-    assert validated["code_review"]["review_reference"] == reaction_reference
+    assert validated["code_review"]["response_reference"] == reaction_reference
     assert verifier_calls == [(reaction_reference, HEAD_SHA, OUTSIDE_SHA)]
+
+    stale_seal = parse_embedded_review_seal(mapping.read_text(encoding="utf-8"))
+    stale_seal["code_review"]["response_content"] = "heart" if reaction_content != "heart" else "+1"
+    mapping.write_text(_mapping_artifact_with_seal(stale_seal), encoding="utf-8")
+    with pytest.raises(closeout_module.CloseoutError, match="positive response receipt is stale"):
+        closeout_module.validate_live_mapping(
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+        )
+
+    mapping.write_text(_mapping_artifact_with_seal(seal), encoding="utf-8")
+
+    def manifest_for_head(
+        _root: Path,
+        *,
+        base_ref_oid: str,
+        head_ref_oid: str,
+        pr_number: int,
+    ) -> MaterialManifest:
+        assert base_ref_oid == BASE_SHA
+        assert pr_number == 42
+        if head_ref_oid == OUTSIDE_SHA:
+            return _material_manifest(OUTSIDE_SHA, digest=DIGEST)
+        assert head_ref_oid == HEAD_SHA
+        return _material_manifest(HEAD_SHA, digest="sha256:" + "d" * 64)
+
+    monkeypatch.setattr(closeout_module, "compute_material_manifest", manifest_for_head)
+    with pytest.raises(
+        closeout_module.CloseoutError,
+        match="positive response material head has a different material digest",
+    ):
+        closeout_module.validate_live_mapping(
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+        )
 
 
 def test_authenticated_closeout_revalidates_operator_outage_override(

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -776,7 +776,9 @@ def _codex_positive_reaction_request(
 
 
 @pytest.mark.parametrize("content", ("+1", "heart", "hooray", "rocket"))
-def test_codex_positive_reaction_is_accepted_as_advisory_only(content: str) -> None:
+def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
+    content: str,
+) -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
     reaction = _codex_positive_reaction(content=content)
     requested_urls: list[str] = []
@@ -786,35 +788,49 @@ def test_codex_positive_reaction_is_accepted_as_advisory_only(content: str) -> N
         requested_urls.append(url)
         return request(url)
 
-    evidence = verify_codex_connector_advisory_reaction_reference(
+    evidence = verify_codex_review_reference(
         reference,
         repository="owner/repo",
         pr_number=42,
         token="opaque",
+        expected_commit_ref=HEAD_SHA,
         request_json=request_json,
     )
 
-    assert evidence == identity_module.CodexConnectorAdvisoryReactionEvidence(
+    assert evidence == identity_module.CodexReviewEvidence(
         reference=reference,
-        created_at="2026-07-15T11:00:00Z",
-        content=content,
+        submitted_at="2026-07-15T11:00:00Z",
+        commit_ref=HEAD_SHA,
     )
     assert requested_urls == [
         "https://api.github.com/repos/owner/repo/issues/42/reactions?per_page=100&page=1",
     ]
 
 
-def test_codex_positive_reaction_cannot_satisfy_exact_head_review_evidence() -> None:
+def test_codex_positive_reaction_requires_expected_full_material_head() -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
 
-    with pytest.raises(CommitIdentityError, match="advisory only"):
+    with pytest.raises(CommitIdentityError, match="requires an expected full material commit"):
         verify_codex_review_reference(
             reference,
             repository="owner/repo",
             pr_number=42,
             token="opaque",
-            expected_commit_ref=HEAD_SHA,
-            request_json=lambda *_a, **_k: pytest.fail("reaction must not be read as review proof"),
+            request_json=lambda *_a, **_k: pytest.fail(
+                "reaction must require a material head first"
+            ),
+        )
+
+    with pytest.raises(CommitIdentityError, match="expected Codex review commit"):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA[:10],
+            request_json=lambda *_a, **_k: pytest.fail(
+                "reaction must reject a short material head"
+            ),
         )
 
 
@@ -2552,6 +2568,111 @@ def test_closeout_seal_authors_terminal_review_source_receipt(
     assert "WARNING: Connector advisory reaction omitted: GitHub reaction not found" in captured.err
 
 
+def test_closeout_seal_binds_connector_reaction_through_normal_review_ref(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    target = repo / "docs/review/PR_42_FIXED_MAPPING.md"
+    reaction_reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    freeze = {
+        "base_ref_oid": BASE_SHA,
+        "digest": DIGEST,
+        "material_head_sha": HEAD_SHA,
+        "merge_base_sha": BASE_SHA,
+        "policy_version": MATERIAL_POLICY_VERSION,
+    }
+    state = {
+        "dispositions": [],
+        "experiment_result": None,
+        "freeze": freeze,
+        "packet": None,
+        "pr_number": 42,
+        "repository": "owner/repo",
+        "schema_version": closeout_module.DRAFT_SCHEMA_VERSION,
+    }
+    security_receipt = build_security_outage_override_receipt(
+        base_revision=BASE_SHA,
+        head_revision=HEAD_SHA,
+        material_digest=DIGEST,
+        override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+        created_at="2026-07-15T11:00:00Z",
+        operator_user_id=123,
+        operator_login="owner",
+        operator_association="OWNER",
+    )
+    review_calls: list[tuple[str, str | None]] = []
+    snapshot_rechecks: list[PrSnapshot] = []
+
+    def verify_reaction_review(
+        reference: str, **kwargs: Any
+    ) -> identity_module.CodexReviewEvidence:
+        review_calls.append((reference, kwargs.get("expected_commit_ref")))
+        return identity_module.CodexReviewEvidence(
+            reference=reaction_reference,
+            submitted_at="2026-07-15T11:00:00Z",
+            commit_ref=HEAD_SHA,
+        )
+
+    monkeypatch.setattr(closeout_module, "REPO_ROOT", repo)
+    monkeypatch.setattr(closeout_module, "_load_state", lambda _pr: state)
+    monkeypatch.setattr(closeout_module, "_token", lambda: "opaque")
+    monkeypatch.setattr(closeout_module, "fetch_pr_snapshot", lambda *_a, **_k: _snapshot())
+    monkeypatch.setattr(closeout_module, "_require_clean_live_head", lambda _head: None)
+    monkeypatch.setattr(
+        closeout_module,
+        "compute_material_manifest",
+        lambda *_a, **_k: _material_manifest(HEAD_SHA),
+    )
+    monkeypatch.setattr(closeout_module, "verify_codex_review_reference", verify_reaction_review)
+    monkeypatch.setattr(
+        closeout_module,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(value, CommitRefKind.PR_HEAD),
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "ingest_codex_security_receipt",
+        lambda *_a, **_k: security_receipt,
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "_render_mapping",
+        lambda _state, seal: _mapping_artifact_with_seal(seal),
+    )
+    monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: target)
+    monkeypatch.setattr(closeout_module, "_git", lambda *_a, **_k: "")
+    monkeypatch.setattr(
+        closeout_module,
+        "assert_snapshot_unchanged",
+        lambda snapshot, **_k: snapshot_rechecks.append(snapshot),
+    )
+
+    closeout_module._cmd_seal(
+        Namespace(
+            pr_number=42,
+            repo="owner/repo",
+            review_ref=reaction_reference,
+            review_source_unavailable_ref=None,
+            connector_advisory_reaction=[],
+            scan_manifest="/tmp/scan-manifest.json",
+            security_outage_override_ref=None,
+        )
+    )
+
+    seal = parse_embedded_review_seal(target.read_text(encoding="utf-8"))
+    assert review_calls == [(reaction_reference, HEAD_SHA)]
+    assert seal["code_review"] == {
+        "review_commit_ref": HEAD_SHA,
+        "review_commit_ref_kind": "repository_commit",
+        "review_reference": reaction_reference,
+        "reviewed_material_digest": DIGEST,
+        "status": "completed",
+    }
+    assert seal["codex_security"] == security_receipt
+    assert snapshot_rechecks == [_snapshot()]
+
+
 def test_authenticated_closeout_validation_rejects_nonexistent_review(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2560,8 +2681,11 @@ def test_authenticated_closeout_validation_rejects_nonexistent_review(
         expected_base_sha=BASE_SHA,
         expected_head_sha=HEAD_SHA,
     )
+    reaction_reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    seal = _seal(receipt)
+    seal["code_review"]["review_reference"] = reaction_reference
     mapping = tmp_path / "PR_42_FIXED_MAPPING.md"
-    mapping.write_text(_mapping_artifact_with_seal(_seal(receipt)), encoding="utf-8")
+    mapping.write_text(_mapping_artifact_with_seal(seal), encoding="utf-8")
     manifest = MaterialManifest(
         base_ref_oid=BASE_SHA,
         head_ref_oid=HEAD_SHA,
@@ -2570,10 +2694,10 @@ def test_authenticated_closeout_validation_rejects_nonexistent_review(
         entries=(),
         digest=DIGEST,
     )
-    verifier_expected_commits: list[str | None] = []
+    verifier_calls: list[tuple[str, str | None]] = []
 
-    def reject_review(*_args: Any, **kwargs: Any) -> Any:
-        verifier_expected_commits.append(kwargs.get("expected_commit_ref"))
+    def reject_review(reference: str, **kwargs: Any) -> Any:
+        verifier_calls.append((reference, kwargs.get("expected_commit_ref")))
         raise CommitIdentityError("GitHub review not found")
 
     monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: mapping)
@@ -2600,7 +2724,7 @@ def test_authenticated_closeout_validation_rejects_nonexistent_review(
             token="opaque",
         )
 
-    assert verifier_expected_commits == [HEAD_SHA]
+    assert verifier_calls == [(reaction_reference, HEAD_SHA)]
 
 
 def test_authenticated_closeout_revalidates_operator_outage_override(

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -767,33 +767,34 @@ def _codex_positive_reaction(
 def _codex_positive_reaction_request(
     reaction: dict[str, Any] | list[dict[str, Any]],
     *,
-    check_suites: dict[str, Any] | None = None,
+    reviews: list[dict[str, Any]] | None = None,
 ) -> Any:
     def request_json(url: str, **_kwargs: Any) -> Any:
         if "/reactions?" in url:
             return reaction if isinstance(reaction, list) else [reaction]
-        if "/check-suites?" in url and check_suites is not None:
-            return check_suites
+        if "/reviews?" in url and reviews is not None:
+            return reviews
         raise AssertionError(f"unexpected GitHub API URL: {url}")
 
     return request_json
 
 
-def _github_actions_check_suites(
+def _codex_exact_head_review(
     *,
-    head_sha: str = HEAD_SHA,
-    created_at: str = "2026-07-15T10:59:59Z",
-    app_slug: str = "github-actions",
+    commit_id: str = HEAD_SHA,
+    submitted_at: str = "2026-07-15T10:59:59Z",
+    user_id: int = 199_175_422,
+    login: str = "chatgpt-codex-connector[bot]",
+    user_type: str = "Bot",
+    state: str = "COMMENTED",
+    html_url: str = "https://github.com/owner/repo/pull/42#pullrequestreview-123",
 ) -> dict[str, Any]:
     return {
-        "total_count": 1,
-        "check_suites": [
-            {
-                "app": {"slug": app_slug},
-                "created_at": created_at,
-                "head_sha": head_sha,
-            }
-        ],
+        "commit_id": commit_id,
+        "html_url": html_url,
+        "state": state,
+        "submitted_at": submitted_at,
+        "user": {"id": user_id, "login": login, "type": user_type},
     }
 
 
@@ -806,7 +807,7 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     requested_urls: list[str] = []
     request = _codex_positive_reaction_request(
         reaction,
-        check_suites=_github_actions_check_suites(),
+        reviews=[_codex_exact_head_review()],
     )
 
     def request_json(url: str, **_kwargs: Any) -> Any:
@@ -829,29 +830,31 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     )
     assert requested_urls == [
         "https://api.github.com/repos/owner/repo/issues/42/reactions?per_page=100&page=1",
-        f"https://api.github.com/repos/owner/repo/commits/{HEAD_SHA}/check-suites"
-        "?per_page=100&page=1",
+        "https://api.github.com/repos/owner/repo/pulls/42/reviews?per_page=100&page=1",
     ]
 
 
 @pytest.mark.parametrize(
-    ("suite_head_sha", "suite_created_at", "suite_app_slug"),
+    ("review_overrides",),
     [
-        (HEAD_SHA, "2026-07-15T11:00:01Z", "github-actions"),
-        (FIX_SHA, "2026-07-15T10:59:59Z", "github-actions"),
-        (HEAD_SHA, "2026-07-15T10:59:59Z", "untrusted-app"),
+        ({"commit_id": FIX_SHA},),
+        ({"submitted_at": "2026-07-15T11:00:00Z"},),
+        ({"submitted_at": "2026-07-15T11:00:01Z"},),
+        ({"user_id": 1},),
+        ({"login": "spoofed[bot]"},),
+        ({"user_type": "User"},),
+        ({"state": "DISMISSED"},),
+        ({"html_url": "https://github.com/owner/repo/pull/43#pullrequestreview-123"},),
     ],
 )
-def test_codex_positive_reaction_rejects_invalid_head_check_suite(
-    suite_head_sha: str,
-    suite_created_at: str,
-    suite_app_slug: str,
+def test_codex_positive_reaction_rejects_invalid_exact_head_connector_review(
+    review_overrides: dict[str, Any],
 ) -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
 
     with pytest.raises(
         CommitIdentityError,
-        match="does not follow a GitHub Actions observation of the exact material head",
+        match="does not follow a trusted Connector review of the exact material head",
     ):
         verify_codex_review_reference(
             reference,
@@ -861,11 +864,7 @@ def test_codex_positive_reaction_rejects_invalid_head_check_suite(
             expected_commit_ref=HEAD_SHA,
             request_json=_codex_positive_reaction_request(
                 _codex_positive_reaction(),
-                check_suites=_github_actions_check_suites(
-                    head_sha=suite_head_sha,
-                    created_at=suite_created_at,
-                    app_slug=suite_app_slug,
-                ),
+                reviews=[_codex_exact_head_review(**review_overrides)],
             ),
         )
 

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -768,36 +768,47 @@ def _codex_positive_reaction_request(
     reaction: dict[str, Any] | list[dict[str, Any]],
     *,
     pull_head: str = HEAD_SHA,
-    check_suites: dict[str, Any] | None = None,
+    workflow_runs: dict[str, Any] | None = None,
+    head_events: list[dict[str, Any]] | None = None,
 ) -> Any:
     def request_json(url: str, **_kwargs: Any) -> Any:
         if "/reactions?" in url:
             return reaction if isinstance(reaction, list) else [reaction]
         if url.endswith("/pulls/42"):
             return {"head": {"sha": pull_head}}
-        if "/check-suites?" in url and check_suites is not None:
-            return check_suites
+        if "/actions/runs?" in url and workflow_runs is not None:
+            return workflow_runs
+        if "/issues/42/events?" in url:
+            return [] if head_events is None else head_events
         raise AssertionError(f"unexpected GitHub API URL: {url}")
 
     return request_json
 
 
-def _github_actions_check_suites(
+def _github_actions_workflow_runs(
     *,
     head_sha: str = HEAD_SHA,
     created_at: str = "2026-07-15T10:59:59Z",
-    app_slug: str = "github-actions",
+    event: str = "pull_request",
+    pr_number: int = 42,
 ) -> dict[str, Any]:
     return {
         "total_count": 1,
-        "check_suites": [
+        "workflow_runs": [
             {
-                "app": {"slug": app_slug},
                 "created_at": created_at,
+                "event": event,
                 "head_sha": head_sha,
+                "pull_requests": [{"number": pr_number}],
             }
         ],
     }
+
+
+def _workflow_run_response_with_pr_links(links: Any) -> dict[str, Any]:
+    response = _github_actions_workflow_runs()
+    response["workflow_runs"][0]["pull_requests"] = links
+    return response
 
 
 @pytest.mark.parametrize("content", ("+1", "heart", "hooray", "rocket"))
@@ -809,7 +820,7 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     requested_urls: list[str] = []
     request = _codex_positive_reaction_request(
         reaction,
-        check_suites=_github_actions_check_suites(),
+        workflow_runs=_github_actions_workflow_runs(),
     )
 
     def request_json(url: str, **_kwargs: Any) -> Any:
@@ -833,8 +844,9 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     assert requested_urls == [
         "https://api.github.com/repos/owner/repo/issues/42/reactions?per_page=100&page=1",
         "https://api.github.com/repos/owner/repo/pulls/42",
-        f"https://api.github.com/repos/owner/repo/commits/{HEAD_SHA}/check-suites"
-        "?per_page=100&page=1",
+        "https://api.github.com/repos/owner/repo/actions/runs"
+        f"?event=pull_request&head_sha={HEAD_SHA}&per_page=100&page=1",
+        "https://api.github.com/repos/owner/repo/issues/42/events?per_page=100&page=1",
     ]
 
 
@@ -842,9 +854,10 @@ def test_codex_positive_reaction_accepts_head_observation_on_second_page() -> No
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
     untrusted_page = [
         {
-            "app": {"slug": "untrusted-app"},
             "created_at": "2026-07-15T10:59:59Z",
+            "event": "pull_request",
             "head_sha": HEAD_SHA,
+            "pull_requests": [{"number": 41}],
         }
         for _ in range(100)
     ]
@@ -856,10 +869,12 @@ def test_codex_positive_reaction_accepts_head_observation_on_second_page() -> No
             return [_codex_positive_reaction()]
         if url.endswith("/pulls/42"):
             return {"head": {"sha": HEAD_SHA}}
-        if "/check-suites?" in url and url.endswith("&page=1"):
-            return {"total_count": 101, "check_suites": untrusted_page}
-        if "/check-suites?" in url and url.endswith("&page=2"):
-            return _github_actions_check_suites()
+        if "/actions/runs?" in url and url.endswith("&page=1"):
+            return {"total_count": 101, "workflow_runs": untrusted_page}
+        if "/actions/runs?" in url and url.endswith("&page=2"):
+            return _github_actions_workflow_runs()
+        if "/issues/42/events?" in url:
+            return []
         raise AssertionError(f"unexpected GitHub API URL: {url}")
 
     evidence = verify_codex_review_reference(
@@ -872,29 +887,59 @@ def test_codex_positive_reaction_accepts_head_observation_on_second_page() -> No
     )
 
     assert evidence.commit_ref == HEAD_SHA
-    assert requested_urls[-1].endswith("/check-suites?per_page=100&page=2")
+    assert requested_urls[-2].endswith("&per_page=100&page=2")
+    assert requested_urls[-1].endswith("/issues/42/events?per_page=100&page=1")
 
 
 @pytest.mark.parametrize(
     ("pull_response", "check_response", "error"),
     [
-        ([], _github_actions_check_suites(), "PR response is malformed"),
-        ({"head": {"sha": FIX_SHA}}, _github_actions_check_suites(), "current material head"),
-        ({"head": {"sha": HEAD_SHA}}, [], "check-suites response is malformed"),
+        ([], _github_actions_workflow_runs(), "PR response is malformed"),
+        (
+            {"head": {"sha": FIX_SHA}},
+            _github_actions_workflow_runs(),
+            "current material head",
+        ),
+        ({"head": {"sha": HEAD_SHA}}, [], "workflow-runs response is malformed"),
         (
             {"head": {"sha": HEAD_SHA}},
-            {"total_count": 1, "check_suites": [None]},
-            "check-suite entry is malformed",
+            {"total_count": 1, "workflow_runs": [None]},
+            "workflow-run entry is malformed",
         ),
         (
             {"head": {"sha": HEAD_SHA}},
-            _github_actions_check_suites(head_sha="not-a-sha"),
-            "check-suite SHA",
+            _github_actions_workflow_runs(head_sha="not-a-sha"),
+            "workflow-run SHA",
         ),
         (
             {"head": {"sha": HEAD_SHA}},
-            _github_actions_check_suites(created_at="not-a-date"),
-            "check-suite created_at",
+            _github_actions_workflow_runs(created_at="not-a-date"),
+            "workflow-run created_at",
+        ),
+        (
+            {"head": {"sha": HEAD_SHA}},
+            {
+                "total_count": 1,
+                "workflow_runs": [
+                    {
+                        "created_at": "2026-07-15T10:59:59Z",
+                        "event": "pull_request",
+                        "head_sha": HEAD_SHA,
+                        "pull_requests": {},
+                    }
+                ],
+            },
+            "workflow-run PR links are malformed",
+        ),
+        (
+            {"head": {"sha": HEAD_SHA}},
+            _workflow_run_response_with_pr_links([None, {"number": 42}]),
+            "workflow-run PR link is malformed",
+        ),
+        (
+            {"head": {"sha": HEAD_SHA}},
+            _workflow_run_response_with_pr_links([{"number": True}]),
+            "workflow-run PR link is malformed",
         ),
     ],
 )
@@ -910,7 +955,7 @@ def test_codex_positive_reaction_rejects_malformed_head_observation_data(
             return [_codex_positive_reaction()]
         if url.endswith("/pulls/42"):
             return pull_response
-        if "/check-suites?" in url:
+        if "/actions/runs?" in url:
             return check_response
         raise AssertionError(f"unexpected GitHub API URL: {url}")
 
@@ -925,25 +970,129 @@ def test_codex_positive_reaction_rejects_malformed_head_observation_data(
         )
 
 
-def test_codex_positive_reaction_fails_closed_at_check_suite_page_limit(
+def test_codex_positive_reaction_rejects_oversized_workflow_run_inventory() -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    response = _github_actions_workflow_runs()
+    response["total_count"] = identity_module._MAX_HEAD_WORKFLOW_RUNS + 1
+
+    with pytest.raises(CommitIdentityError, match="workflow-runs exceed safety limit"):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request(
+                _codex_positive_reaction(),
+                workflow_runs=response,
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("head_events", "error"),
+    [
+        ([None], "head-event entry is malformed"),
+        ([{"event": None}], "head-event type is malformed"),
+        (
+            [{"created_at": "not-a-date", "event": "head_ref_force_pushed"}],
+            "head-event created_at",
+        ),
+    ],
+)
+def test_codex_positive_reaction_rejects_malformed_head_events(
+    head_events: Any,
+    error: str,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+
+    with pytest.raises(CommitIdentityError, match=error):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request(
+                _codex_positive_reaction(),
+                workflow_runs=_github_actions_workflow_runs(),
+                head_events=head_events,
+            ),
+        )
+
+
+def test_codex_positive_reaction_fails_closed_at_head_event_page_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
-    monkeypatch.setattr(identity_module, "_MAX_HEAD_CHECK_SUITE_PAGES", 1)
+    monkeypatch.setattr(identity_module, "_MAX_PR_HEAD_EVENT_PAGES", 1)
+
+    with pytest.raises(CommitIdentityError, match="head-event pagination exceeded page limit"):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request(
+                _codex_positive_reaction(),
+                workflow_runs=_github_actions_workflow_runs(),
+                head_events=[{"event": "commented"} for _ in range(100)],
+            ),
+        )
+
+
+@pytest.mark.parametrize("event", ("head_ref_force_pushed", "head_ref_restored"))
+@pytest.mark.parametrize(
+    "created_at",
+    ("2026-07-15T10:59:59Z", "2026-07-15T10:59:59.500Z"),
+)
+def test_codex_positive_reaction_rejects_replayed_head_after_ref_rewrite(
+    event: str,
+    created_at: str,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+
+    with pytest.raises(CommitIdentityError, match="superseded PR head observation"):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=_codex_positive_reaction_request(
+                _codex_positive_reaction(),
+                workflow_runs=_github_actions_workflow_runs(),
+                head_events=[
+                    {
+                        "created_at": created_at,
+                        "event": event,
+                    }
+                ],
+            ),
+        )
+
+
+def test_codex_positive_reaction_fails_closed_at_workflow_run_page_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    monkeypatch.setattr(identity_module, "_MAX_HEAD_WORKFLOW_RUN_PAGES", 1)
 
     def request_json(url: str, **_kwargs: Any) -> Any:
         if "/reactions?" in url:
             return [_codex_positive_reaction()]
         if url.endswith("/pulls/42"):
             return {"head": {"sha": HEAD_SHA}}
-        if "/check-suites?" in url:
+        if "/actions/runs?" in url:
             return {
                 "total_count": 100,
-                "check_suites": [
+                "workflow_runs": [
                     {
-                        "app": {"slug": "untrusted-app"},
                         "created_at": "2026-07-15T10:59:59Z",
+                        "event": "pull_request",
                         "head_sha": HEAD_SHA,
+                        "pull_requests": [{"number": 41}],
                     }
                     for _ in range(100)
                 ],
@@ -962,18 +1111,20 @@ def test_codex_positive_reaction_fails_closed_at_check_suite_page_limit(
 
 
 @pytest.mark.parametrize(
-    ("suite_head_sha", "suite_created_at", "suite_app_slug"),
+    ("run_head_sha", "run_created_at", "run_event", "run_pr_number"),
     [
-        (FIX_SHA, "2026-07-15T10:59:59Z", "github-actions"),
-        (HEAD_SHA, "2026-07-15T11:00:00Z", "github-actions"),
-        (HEAD_SHA, "2026-07-15T11:00:01Z", "github-actions"),
-        (HEAD_SHA, "2026-07-15T10:59:59Z", "untrusted-app"),
+        (FIX_SHA, "2026-07-15T10:59:59Z", "pull_request", 42),
+        (HEAD_SHA, "2026-07-15T11:00:00Z", "pull_request", 42),
+        (HEAD_SHA, "2026-07-15T11:00:01Z", "pull_request", 42),
+        (HEAD_SHA, "2026-07-15T10:59:59Z", "push", 42),
+        (HEAD_SHA, "2026-07-15T10:59:59Z", "pull_request", 41),
     ],
 )
 def test_codex_positive_reaction_rejects_invalid_head_observation(
-    suite_head_sha: str,
-    suite_created_at: str,
-    suite_app_slug: str,
+    run_head_sha: str,
+    run_created_at: str,
+    run_event: str,
+    run_pr_number: int,
 ) -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
 
@@ -989,10 +1140,11 @@ def test_codex_positive_reaction_rejects_invalid_head_observation(
             expected_commit_ref=HEAD_SHA,
             request_json=_codex_positive_reaction_request(
                 _codex_positive_reaction(),
-                check_suites=_github_actions_check_suites(
-                    head_sha=suite_head_sha,
-                    created_at=suite_created_at,
-                    app_slug=suite_app_slug,
+                workflow_runs=_github_actions_workflow_runs(
+                    head_sha=run_head_sha,
+                    created_at=run_created_at,
+                    event=run_event,
+                    pr_number=run_pr_number,
                 ),
             ),
         )

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -834,6 +834,109 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     ]
 
 
+def test_codex_positive_reaction_accepts_approved_exact_head_review() -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+
+    evidence = verify_codex_review_reference(
+        reference,
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+        expected_commit_ref=HEAD_SHA,
+        request_json=_codex_positive_reaction_request(
+            _codex_positive_reaction(),
+            reviews=[_codex_exact_head_review(state="APPROVED")],
+        ),
+    )
+
+    assert evidence.commit_ref == HEAD_SHA
+
+
+def test_codex_positive_reaction_accepts_exact_head_review_on_second_page() -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    untrusted_page = [_codex_exact_head_review(user_id=1) for _ in range(100)]
+    requested_urls: list[str] = []
+
+    def request_json(url: str, **_kwargs: Any) -> Any:
+        requested_urls.append(url)
+        if "/reactions?" in url:
+            return [_codex_positive_reaction()]
+        if "/reviews?" in url and url.endswith("&page=1"):
+            return untrusted_page
+        if "/reviews?" in url and url.endswith("&page=2"):
+            return [_codex_exact_head_review()]
+        raise AssertionError(f"unexpected GitHub API URL: {url}")
+
+    evidence = verify_codex_review_reference(
+        reference,
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+        expected_commit_ref=HEAD_SHA,
+        request_json=request_json,
+    )
+
+    assert evidence.commit_ref == HEAD_SHA
+    assert requested_urls[-1].endswith("/reviews?per_page=100&page=2")
+
+
+@pytest.mark.parametrize(
+    ("reviews", "error"),
+    [
+        ({"unexpected": "object"}, "response is malformed"),
+        ([None], "entry is malformed"),
+        ([_codex_exact_head_review(commit_id="not-a-sha")], "review commit_id"),
+        ([_codex_exact_head_review(submitted_at="not-a-date")], "review submitted_at"),
+    ],
+)
+def test_codex_positive_reaction_rejects_malformed_review_api_data(
+    reviews: Any,
+    error: str,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+
+    def request_json(url: str, **_kwargs: Any) -> Any:
+        if "/reactions?" in url:
+            return [_codex_positive_reaction()]
+        if "/reviews?" in url:
+            return reviews
+        raise AssertionError(f"unexpected GitHub API URL: {url}")
+
+    with pytest.raises(CommitIdentityError, match=error):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=request_json,
+        )
+
+
+def test_codex_positive_reaction_fails_closed_at_review_page_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    monkeypatch.setattr(identity_module, "_MAX_PR_REVIEW_PAGES", 1)
+
+    def request_json(url: str, **_kwargs: Any) -> Any:
+        if "/reactions?" in url:
+            return [_codex_positive_reaction()]
+        if "/reviews?" in url:
+            return [_codex_exact_head_review(user_id=1) for _ in range(100)]
+        raise AssertionError(f"unexpected GitHub API URL: {url}")
+
+    with pytest.raises(CommitIdentityError, match="pagination exceeded page limit"):
+        verify_codex_review_reference(
+            reference,
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+            expected_commit_ref=HEAD_SHA,
+            request_json=request_json,
+        )
+
+
 @pytest.mark.parametrize(
     ("review_overrides",),
     [

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -2857,6 +2857,7 @@ def test_review_source_positive_response_receipt_is_nonblocking_without_review_c
         (lambda receipt: receipt.update(review_claim="approved"), "malformed or stale"),
         (lambda receipt: receipt.update(source_degraded=True), "malformed or stale"),
         (lambda receipt: receipt.update(response_content="eyes"), "malformed or stale"),
+        (lambda receipt: receipt.update(response_content=[]), "malformed or stale"),
         (
             lambda receipt: receipt.update(authority="trusted_codex_review_source_unavailability"),
             "tagged-union identity is ambiguous",

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -850,6 +850,26 @@ def test_codex_positive_reaction_is_accepted_as_exact_head_review_evidence(
     ]
 
 
+def test_codex_positive_reaction_accepts_revalidated_mapping_only_live_head() -> None:
+    reference = "https://github.com/owner/repo/pull/42#reaction-456"
+
+    evidence = verify_codex_review_reference(
+        reference,
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+        expected_commit_ref=HEAD_SHA,
+        expected_live_pr_head_ref=OUTSIDE_SHA,
+        request_json=_codex_positive_reaction_request(
+            _codex_positive_reaction(),
+            pull_head=OUTSIDE_SHA,
+            workflow_runs=_github_actions_workflow_runs(),
+        ),
+    )
+
+    assert evidence.commit_ref == HEAD_SHA
+
+
 def test_codex_positive_reaction_accepts_head_observation_on_second_page() -> None:
     reference = "https://github.com/owner/repo/pull/42#reaction-456"
     untrusted_page = [
@@ -3037,10 +3057,16 @@ def test_authenticated_closeout_validation_rejects_nonexistent_review(
         entries=(),
         digest=DIGEST,
     )
-    verifier_calls: list[tuple[str, str | None]] = []
+    verifier_calls: list[tuple[str, str | None, str | None]] = []
 
     def reject_review(reference: str, **kwargs: Any) -> Any:
-        verifier_calls.append((reference, kwargs.get("expected_commit_ref")))
+        verifier_calls.append(
+            (
+                reference,
+                kwargs.get("expected_commit_ref"),
+                kwargs.get("expected_live_pr_head_ref"),
+            )
+        )
         raise CommitIdentityError("GitHub review not found")
 
     monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: mapping)
@@ -3067,7 +3093,80 @@ def test_authenticated_closeout_validation_rejects_nonexistent_review(
             token="opaque",
         )
 
-    assert verifier_calls == [(reaction_reference, HEAD_SHA)]
+    assert verifier_calls == [(reaction_reference, HEAD_SHA, HEAD_SHA)]
+
+
+def test_authenticated_closeout_revalidates_reaction_after_mapping_only_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt = ingest_codex_security_receipt(
+        _build_scan_bundle(tmp_path / "scan"),
+        expected_base_sha=BASE_SHA,
+        expected_head_sha=HEAD_SHA,
+    )
+    reaction_reference = "https://github.com/owner/repo/pull/42#reaction-456"
+    seal = _seal(receipt)
+    seal["code_review"]["review_reference"] = reaction_reference
+    mapping = tmp_path / "PR_42_FIXED_MAPPING.md"
+    mapping.write_text(_mapping_artifact_with_seal(seal), encoding="utf-8")
+    closeout_snapshot = PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=BASE_SHA,
+        head_sha=OUTSIDE_SHA,
+        commits=(
+            PrCommitEvidence(HEAD_SHA, "2026-07-15T11:00:00Z"),
+            PrCommitEvidence(OUTSIDE_SHA, "2026-07-15T12:00:00Z"),
+        ),
+    )
+    verifier_calls: list[tuple[str, str | None, str | None]] = []
+
+    def verify_reaction(reference: str, **kwargs: Any) -> Any:
+        verifier_calls.append(
+            (
+                reference,
+                kwargs.get("expected_commit_ref"),
+                kwargs.get("expected_live_pr_head_ref"),
+            )
+        )
+        return identity_module.CodexReviewEvidence(
+            reference=reference,
+            submitted_at="2026-07-15T11:00:00Z",
+            commit_ref=HEAD_SHA,
+        )
+
+    monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: mapping)
+    monkeypatch.setattr(
+        closeout_module,
+        "fetch_pr_snapshot",
+        lambda *_a, **_k: closeout_snapshot,
+    )
+    monkeypatch.setattr(closeout_module, "_git", lambda *_a, **_k: OUTSIDE_SHA)
+    monkeypatch.setattr(
+        closeout_module,
+        "compute_material_manifest",
+        lambda *_a, **kwargs: _material_manifest(kwargs["head_ref_oid"]),
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(
+            value,
+            CommitRefKind.PR_HEAD if value == OUTSIDE_SHA else CommitRefKind.PR_COMMIT,
+        ),
+    )
+    monkeypatch.setattr(closeout_module, "verify_codex_review_reference", verify_reaction)
+    monkeypatch.setattr(closeout_module, "is_ancestor", lambda *_a, **_k: True)
+    monkeypatch.setattr(closeout_module, "assert_snapshot_unchanged", lambda *_a, **_k: None)
+
+    validated = closeout_module.validate_live_mapping(
+        repository="owner/repo",
+        pr_number=42,
+        token="opaque",
+    )
+
+    assert validated["code_review"]["review_reference"] == reaction_reference
+    assert verifier_calls == [(reaction_reference, HEAD_SHA, OUTSIDE_SHA)]
 
 
 def test_authenticated_closeout_revalidates_operator_outage_override(


### PR DESCRIPTION
# Pull Request

## Goal

Atomically align every active CodeQL Action reference with the verified `v4.37.1` commit, prevent pin drift, and record verified Codex Connector reactions as optional advisory context only.

## Business reason

Reduce CI supply-chain drift without changing workflow behavior, while preventing a reaction with no commit/run identity from blocking or weakening the real PR closeout evidence.

## Scope

- Replace exactly five `github/codeql-action/{init,analyze,upload-sarif}` references with `7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1`.
- Add the exact active-workflow CodeQL pin guard and document its command in `tests/AGENTS.md`.
- User-approved scope extension: accept verified positive Connector reactions (`+1`, `heart`, `hooray`, `rocket`) through the normal `seal --review-ref` path only as a nonblocking terminal source response with `review_claim=none`; the optional advisory rendering path remains non-authoritative.
- Preserve actual submitted-review, no-findings-comment, and official usage-limit source-unavailability evidence paths unchanged.

## Out of scope

- Lottie, SwiftPM, product/runtime behavior, APIs, OpenAPI, client behavior, backlog work, and PR #2164.
- Workflow triggers, permissions, matrices, inputs, SARIF paths/conditions, `continue-on-error`, and Trivy settings.
- Treating a Connector reaction as exact-head review, GitHub approval, Codex Security result, or thread-resolution authority.
- Branch deletion, manual Codex review retrigger, or disabling Connector/Codex Security.

## Files changed

- `.github/workflows/codeql.yml`
- `.github/workflows/build.yml`
- `.github/workflows/trivy.yml`
- `tests/test_ci_workflow_pr_size_governance_contract.py`
- `tests/AGENTS.md`
- `AGENTS.md`
- `RUNBOOK_AGENT.md`
- `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`
- `scripts/orchestration/pr_commit_identity.py`
- `scripts/orchestration/pr_review_closeout.py`
- `scripts/orchestration/pr_review_evidence.py`
- `scripts/ci/check_pr_merge_readiness.py`
- `tests/guards/test_review_source_quota_policy_guard.py`
- `tests/test_pr_merge_readiness_gate.py`
- `tests/test_pr_review_material_seal.py`
- Canonical review mapping artifact (linked below)

## Key decisions

- The official `v4.37.1` tag resolves to GitHub-verified commit `7188fc363630916deb702c7fdcf4e481b751f97a`; this PR does not claim the annotated tag object itself is signed.
- A reaction has no reviewed SHA or run id. It is live-verified for official identity, exact PR-root URL, canonical reaction ID, positive content, chronology, and unchanged sealed material digest, but never becomes exact-head review, approval, security-scan, or thread-disposition evidence.
- The terminal receipt is explicitly commitless and non-authoritative: `binding_kind=seal_context_only`, `review_claim=none`, `blocking=false`. Exact submitted-review and no-findings paths remain commit-bound.
- `build.yml:publish` and standalone `trivy.yml` do not run on `pull_request`; evidence remains the exact guard, action-pin validator, and Actionlint. Triggers remain unchanged.

## Tests / validation

### PASS — local current-head evidence

- Repo-resolved focused pytest: `tests/test_ci_workflow_pr_size_governance_contract.py`, `tests/guards/test_security_devtooling_regression_guards.py`, `tests/test_tooling_surface_guards.py`, `tests/guards/test_review_source_quota_policy_guard.py`, `tests/test_pr_review_material_seal.py`, and `tests/test_pr_merge_readiness_gate.py`.
- `python3 scripts/ci/guard_actions_pin.py --root .`
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `make validate-changed`
- `pre-commit run --all-files`
- `git diff --check`
- Repo-resolved `pytest -q tests/test_review_pattern_oracles.py`
- Apple Container Experiment Runner oracle-only review: `artifacts/orchestration/experiments/results/codeql-connector-advisory-oracle-result.json` accepted; two immutable commands passed; `mutated_paths: []`; `shared_tree_untouched: true`.
- Push hook: mypy, pip-audit, pre-push pytest, full Bandit, and Docker build test passed.

### PASS — frozen-material external evidence

- Final Codex Security diff scan `233f777e-6561-4e33-b2b4-965d41f7b373`: exact range `880753ee3d1db61c7fc8593798ade03cdb2177c2..a98dd6a330a930c37ccd49853e78a108d6cb0e6e`, 16/16 discovery rows, complete coverage, 0 reportable findings.
- Exact submitted Connector review `#pullrequestreview-4754641203` is repository-commit-bound to material head `a98dd6a330a930c37ccd49853e78a108d6cb0e6e`.
- Canonical mapping/seal is linked below; material digest `sha256:4f973a00982d13e6358c914ee6b14e9546a83f6786f54359d46670abdef0f719`.
- All 16 review threads have canonical dispositions and are resolved with evidence.

### PENDING — current-head heavy signal

- Mapping-only head `159cda598` current-head canonical CI/review cycle and strict `check_merge_ready.py --require-auth`.
- No further Codex Security scan is required or permitted for the mapping-only closeout commit.

## Security notes

This remains a privileged CI/workflow change. The five CodeQL actions are pinned to one immutable verified commit; no permissions, secrets, runtime access, suppression rules, or workflow triggers change. The advisory lookup is bounded and cannot grant authority.

## Risks / rollback

- If CodeQL/SARIF compatibility fails, revert all five workflow pins, the exact guard, and `tests/AGENTS.md` together; never partially revert the action set.
- If advisory signal handling proves incompatible, revert its verifier, closeout option, documentation, and tests together; real review/security evidence remains unchanged.

## Premortem

- A stale or delayed reaction appears after a push: it cannot prove a head and remains advisory only.
- A spoofed/non-positive reaction is supplied: strict identity, PR-root, ID, and content checks reject it.
- An advisory API lookup fails: closeout retains its real gates and logs only a warning.
- CodeQL reference drift returns: the exact active-workflow guard fails.

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/pr2169-positive-response-oracle-result-v2.json`
- The local oracle-only artifact materially informed remediation commit `3f839b4dba0af801709b55117787a44b9d735ab4`, which carries the canonical Experiment Runner trailer.

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/c4ce7a87208c.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Pre-open role order: `agent-coordinator -> security-auditor -> architecture-specialist`.
- Post-open packet for the current material completed: `qa-engineer-agent -> bug-hunter -> security-auditor`.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- Canonical artifact: [PR_2169_FIXED_MAPPING.md](docs/review/PR_2169_FIXED_MAPPING.md)
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2169#pullrequestreview-4754641203
- URL-to-SHA and disposition details belong only in that artifact after the final material review/scan cycle.

## Split justification

Operator approval: approved for the user-authorized in-PR Connector governance remediation

Privileged scope exception: approved because the five CodeQL files, bounded receipt validators and tests, governance docs, and canonical mapping must remain atomic

No separate governance PR: the advisory-only authority boundary is a user-approved narrow extension of this PR's review-evidence surface. It does not change product/runtime behavior or workflow execution.

## Deferred / Follow-ups

None.

## Merge Readiness

Pending. Frozen-material review/security evidence, canonical mapping, and thread dispositions are complete. Merge is authorized only after current-head CI and `check_merge_ready.py --require-auth` both pass; no merge-ready claim is made before that evidence.

## Next best step

Wait for current-head CI on mapping-only head `241c1c834`, run strict authenticated merge readiness, then merge, fast-forward local `main`, and run the narrow post-merge sanity bundle. Do not rerun Codex Security.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated CodeQL and Security SARIF upload workflow steps to the approved, verified action version (v4.37.1).
  * Enhanced PR closeout to support Connector “positive reactions” as optional, advisory-only signals with strict PR binding and identity checks.
* **Tests**
  * Added/extended CI governance and regression tests for pinned CodeQL action references and connector advisory reaction validation/rendering.
* **Documentation**
  * Updated agent, runbook, and orchestration docs to clarify automatic connector response handling and advisory warning/omission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
