### PR TITLE
test(orchestration): align capability mismatch telemetry fixtures

### DIFF
--- a/docs/review/PR_2173_FIXED_MAPPING.md
+++ b/docs/review/PR_2173_FIXED_MAPPING.md
@@ -1,0 +1,26 @@
+# PR 2173 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/6008b2f78da6.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/pr2144-telemetry-fixture-remediation.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: NOT-A-BUG
+Evidence: tests/test_creative_code_telemetry.py:122
+Reason: The fixture intentionally keeps a closed, local representation of the two production-contract pre-oracle classes. Importing production taxonomy would couple the independent test oracle to its implementation, and extracting a helper for this single fixture would broaden the one-file remediation without changing behavior.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2173#pullrequestreview-4759548881
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"authority":"trusted_codex_review_source_unavailability","binding_kind":"seal_context_only","blocking":false,"fallback_required":false,"material_digest":"sha256:ddbce58f345221be11799559004794a99e157bc05c172918e5252218fc937323","material_head_sha":"68ec5a06fd049b839318a22e6f2da65a3f9685e4","quota_body_sha256":"sha256:619c9f9f66a93f7e7ea60049aa147d2cf183fb706a71e11a710216ed2ba19d92","quota_created_at":"2026-07-22T23:10:40Z","quota_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2173#issuecomment-5052546530","review_claim":"none","schema_version":"pulseplate.codex-review-source-unavailability/v1","source":"codex_review","source_degraded":true,"source_status":"usage_limit_reached","status":"tooling_unavailable"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:d15772e2c7d00557757908f40a237534405513c30e3067ad50beacb7b8630d6c","findings_sha256":"sha256:fd7b090603f11cf52aeaf73de853cc1fd7cb2c7865175cbb56a1aa4e74236868","work_ledger_sha256":"sha256:38f7eabb517c7ce3be386855a5e83731e9e848783b63cc6462d5107b6f6fcc26"},"authority":"human_asserted_content_receipt","base_revision":"31c94444bb0009e08b813f02de861a5f65342582","coverage_completeness":"complete","findings_count":0,"head_revision":"68ec5a06fd049b839318a22e6f2da65a3f9685e4","manifest_sha256":"sha256:31cf8946ecdc127f76d00e710ed56b7babb111a4378d0cd12f2eedc2e83f4bba","producer":{"name":"codex-security-plugin","version":"0.1.11"},"scan_id":"86647def-8875-4324-80f6-c6972459f57a","snapshot_digest":"codex-security-snapshot/v1:sha256:46df71775048729824b50466bcda26d92826b021da6a4fee416e67bbfa05a4c8"},"material":{"base_ref_oid":"31c94444bb0009e08b813f02de861a5f65342582","digest":"sha256:ddbce58f345221be11799559004794a99e157bc05c172918e5252218fc937323","material_head_sha":"68ec5a06fd049b839318a22e6f2da65a3f9685e4","merge_base_sha":"31c94444bb0009e08b813f02de861a5f65342582","policy_version":"pulseplate.material-classification/v1"},"pr_number":2173,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/docs/review/PR_2173_FIXED_MAPPING.md
+++ b/docs/review/PR_2173_FIXED_MAPPING.md
@@ -19,6 +19,12 @@ Evidence: tests/test_creative_code_telemetry.py:122
 Reason: The fixture intentionally keeps a closed, local representation of the two production-contract pre-oracle classes. Importing production taxonomy would couple the independent test oracle to its implementation, and extracting a helper for this single fixture would broaden the one-file remediation without changing behavior.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2173#pullrequestreview-4759548881
 
+Disposition: NOT-A-BUG
+Evidence: `python -m scripts.orchestration.pr_review_closeout validate --repo Katsiarynakavaleuskaya/PulsePlate --pr-number 2173 --require-auth` returned `CONTENT_BOUND_RECEIPT_VALID sha256:ddbce58f345221be11799559004794a99e157bc05c172918e5252218fc937323` with exit code 0; the artifact contract accepts `Evidence:` anchors through `scripts/orchestration/review_mapping_artifact.py:45-51` and live content binding is enforced by `scripts/orchestration/pr_review_closeout.py:837-1054`.
+Reason: The canonical fixed-mapping artifact is a merge-blocking disposition record, not a document labelled as a verified audit. Its contract requires disposition-specific proof and a valid material seal; it does not require embedding raw logs for every check. The bounded command result above nevertheless makes the validation evidence directly reproducible. The top-level review only aggregates this inline finding and introduces no independent defect.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2173#discussion_r3635379962
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2173#pullrequestreview-4760545069
+
 ## Review Material Seal
 <!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
 <!-- pragma: allowlist nextline secret -->

--- a/tests/test_creative_code_telemetry.py
+++ b/tests/test_creative_code_telemetry.py
@@ -119,11 +119,15 @@ index 8f11111..8f22222 100644
 -    return 1
 +    return 2
 """
+    pre_oracle_rejection = not accepted and rejection_failure_class in {
+        "capability_mismatch",
+        "policy_violation",
+    }
     runner_result = {
         "experiment_id": "exp-pr4-telemetry",
         "status": "accepted" if accepted else "rejected",
         "failure_class": None if accepted else rejection_failure_class,
-        "mutated_paths": ["core/rag/orchestration.py"],
+        "mutated_paths": [] if pre_oracle_rejection else ["core/rag/orchestration.py"],
         "budget_observations": {
             "oracle_commands_configured": 1,
             "attempts": 1,
@@ -385,6 +389,9 @@ def test_capability_mismatch_telemetry_preserves_non_retryable_class(
     taxonomy_row = next(row for row in taxonomy["classes"] if row["code"] == "capability_mismatch")
 
     assert len(events) == 1
+    assert patch_result["changed_paths"] == ["core/rag/orchestration.py"]
+    assert patch_result["runner_summary"]["mutated_path_count"] == 0
+    assert patch_result["runner_summary"]["oracle_commands_executed"] == 0
     assert event["lane_stage"] == "patch_evaluation"
     assert event["status"] == "rejected"
     assert event["rejection_class"] == "capability_mismatch"


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# Pull Request

## Goal

Restore post-merge CI parity after PR #2144 by aligning the telemetry test fixture with the fail-closed pre-oracle capability/policy rejection contract.

## Business reason

The production contract correctly rejects incoherent runner evidence, but two telemetry tests still emitted post-mutation evidence for failures that occur before immutable oracles run. This narrow fix returns current `main` to deterministic Python-matrix health without weakening runtime validation.

## Scope

- Keep generated candidate `changed_paths` in the synthetic patch result.
- Emit zero runner `mutated_paths` for pre-oracle `capability_mismatch` and `policy_violation` rejections.
- Assert zero mutation and zero oracle execution for the capability-mismatch telemetry path.

## Out of scope

- No production code, schema, provider, network, workflow, OpenAPI, DB, semantic-cache, Evidence Graph, Bayes, Markov, or OCW changes.
- No weakening of the PR #2144 fail-closed contract.
- No unrelated Caddy/CD vulnerability remediation; that remains owned by its existing lane.

## Files changed

- `tests/test_creative_code_telemetry.py`

## Key decisions

- Distinguish generated candidate paths from mutations actually performed by the isolated runner.
- Limit zero-mutation fixture behavior to non-accepted capability/policy rejections.
- Preserve accepted telemetry fixtures and all production validators unchanged.

## Tests

- `python -m pytest -q tests/test_creative_code_telemetry.py` — 15 passed.
- Two contract-parity tests in `tests/test_creative_code_patch_generation.py` — 2 passed.
- `make validate-changed` — passed, selecting the telemetry suite.
- `pre-commit run --all-files` — passed.
- `check_preflight.py` and `check_agent_consistency.py` — passed.
- Apple Container Experiment Runner oracle-only review — accepted; 17 tests, one attempt, zero retries, network budget zero, shared tree untouched.

## Security notes

This PR changes test data only. It preserves the fail-closed distinction between a generated candidate and runner mutation evidence, adds no authority, and performs no network or product-runtime action.

## Risks / rollback

Risk is limited to accidentally changing accepted telemetry expectations; the conditional and focused parity tests guard against that. Rollback is a revert of the single test commit.

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/pr2144-telemetry-fixture-remediation.json`

## Lane Start Provenance

Packet: `artifacts/orchestration/task_packets/6008b2f78da6.json`

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: [review mapping](docs/review/PR_2173_FIXED_MAPPING.md)

## Split justification

- Why this PR cannot be split safely: it is already one test file and one coherent fixture correction.
- Invariant or rollout constraint requiring one PR: telemetry fixtures and their direct assertions must remain atomic.
- Follow-up PRs: none for this remediation; the separate RAG creative pilot continues from the retained handoff.

## Deferred / Follow-ups

- Resume the RAG confidence-provenance pilot from fresh `origin/main` using the retained PR #2144 handoff.
- Caddy/CD dependency remediation remains in its existing independent lane.

## Next best step

Complete one bounded post-open review/security cycle, seal the canonical mapping, merge after current-head gates, then verify the post-merge Python matrix.

<!-- markdownlint-enable MD013 -->

## Summary by Sourcery

Привести телеметрические тесты в соответствие с контрактом «fail-closed» для отклонений до запуска oracle (pre-oracle) по причине несоответствия возможностей/политик.

Исправления ошибок:
- Рассматривать отклонения из-за несоответствия возможностей и нарушений политики как pre-oracle, не создавая изменений runner в телеметрических фикстурах.

Тесты:
- Ужесточить проверки телеметрии при несоответствии возможностей, требуя неизменённых путей кандидатов с нулевыми мутациями и нулевым числом запусков oracle.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align telemetry tests with the fail-closed contract for pre-oracle capability/policy rejections.

Bug Fixes:
- Treat capability mismatch and policy violation rejections as pre-oracle, emitting no runner mutations in telemetry fixtures.

Tests:
- Tighten capability-mismatch telemetry assertions to require unchanged candidate paths with zero mutations and zero oracle executions.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align telemetry test fixture with the fail-closed pre-oracle contract so capability/policy rejections don’t report runner mutations. Restores deterministic CI after PR #2144 and seals PR 2173 closeout with documented dispositions.

- **Bug Fixes**
  - Keep candidate `changed_paths` in the patch result.
  - Set `mutated_paths` to [] for pre-oracle `capability_mismatch` and `policy_violation` rejections.
  - Assert zero mutation and zero oracle execution in the capability-mismatch test.

<sup>Written for commit d26715c6bd999530288ebffff035689486be8034. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded telemetry coverage for patch rejections triggered by capability mismatches or policy violations.
  * Improved validation for rejected patches to report changed paths, mutation counts, and oracle execution state consistently.
  * Added checks to ensure pre-oracle rejections do not incorrectly record mutated paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->