### PR TITLE
fix(ci): restore main CD Trivy and Caddy security gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,7 +383,7 @@ jobs:
           limit-severities-for-sarif: true
           exit-code: '1'
           trivyignores: .trivyignore
-          version: v0.71.2
+          version: v0.72.0
 
       - name: Check Trivy filesystem SARIF output
         id: trivy_fs_sarif
@@ -589,7 +589,7 @@ jobs:
           limit-severities-for-sarif: true
           trivyignores: .trivyignore
           exit-code: '1'
-          version: v0.71.2
+          version: v0.72.0
 
       - name: Fail when Trivy image SARIF is missing
         if: ${{ always() }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -321,7 +321,7 @@ jobs:
           timeout: 15m
           trivyignores: .trivyignore
           ignore-policy: .trivy-ignore-policy.rego
-          version: v0.71.2
+          version: v0.72.0
           cache-dir: /tmp/trivy-cache-staging-backend
 
       - name: Scan staged Caddy image
@@ -340,7 +340,7 @@ jobs:
           # Override Trivy's default root .trivyignore: it is backend/Debian-specific,
           # while the staged Caddy runtime is Alpine and must remain suppression-free.
           trivyignores: .trivyignore-caddy
-          version: v0.71.2
+          version: v0.72.0
           cache-dir: /tmp/trivy-cache-staging-caddy
 
       - name: Enforce required staging deployment policy

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -203,7 +203,7 @@ jobs:
           trivyignores: .trivyignore
           ignore-policy: .trivy-ignore-policy.rego
           exit-code: '1'
-          version: v0.71.2
+          version: v0.72.0
 
       - name: Fail when Trivy SARIF is missing
         if: ${{ always() }}

--- a/docs/review/PR_2175_FIXED_MAPPING.md
+++ b/docs/review/PR_2175_FIXED_MAPPING.md
@@ -1,0 +1,41 @@
+# PR 2175 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/f77bb9ce11d8.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/caddy-trivy-remediation-oracle-result.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 68a6069e47a1b4b82213f38aabbda7c103893d19
+Evidence: docs/security/GHSA-hrxh-6v49-42gf-grpc-go.md:21; frontend/Dockerfile.caddy-spa:33,35; focused contracts 53 passed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2175#discussion_r3642873013 -> 68a6069e47a1b4b82213f38aabbda7c103893d19
+
+Disposition: FIXED
+Commit: 68a6069e47a1b4b82213f38aabbda7c103893d19
+Evidence: docs/security/GHSA-hrxh-6v49-42gf-grpc-go.md:21; frontend/Dockerfile.caddy-spa:33,35; exact-head CodeRabbit follow-up reported no actionables
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2175#pullrequestreview-4770058194 -> 68a6069e47a1b4b82213f38aabbda7c103893d19
+
+Disposition: NOT-A-BUG
+Evidence: git diff 21ebb448..68a6069e adds no production Python functions; local and CI lint/pre-commit passed; CodeRabbit current-head status PASS
+Reason: The auto-summary docstring heuristic is advisory and has no applicable production callable in this workflow/Dockerfile/security-contract diff; required repository gates are the governing contract.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2175#issuecomment-5066051133
+
+Disposition: NOT-A-BUG
+Evidence: tests/test_ci_workflow_pr_size_governance_contract.py:1176-1314; docs/security/GHSA-hrxh-6v49-42gf-grpc-go.md:19-32
+Reason: Exact five-call enumeration and current file:line anchors are deliberate repository security-governance contracts for this bounded remediation; contract and docs gates keep drift fail closed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2175#pullrequestreview-4770036900
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"authority":"trusted_codex_review_source_unavailability","binding_kind":"seal_context_only","blocking":false,"fallback_required":false,"material_digest":"sha256:b2a21da01989717792ec96b7b547a214d299e2d6e1ab90ddb776e5f740c3e3c3","material_head_sha":"68a6069e47a1b4b82213f38aabbda7c103893d19","quota_body_sha256":"sha256:619c9f9f66a93f7e7ea60049aa147d2cf183fb706a71e11a710216ed2ba19d92","quota_created_at":"2026-07-24T04:09:25Z","quota_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2175#issuecomment-5066048775","review_claim":"none","schema_version":"pulseplate.codex-review-source-unavailability/v1","source":"codex_review","source_degraded":true,"source_status":"usage_limit_reached","status":"tooling_unavailable"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:7ca0ed566c80e395605278328eb650002574c39039afbf95f1feea7344180aa0","findings_sha256":"sha256:23c7417113906f3f2c2b8b34f83572f1a1ae0d30bceb4b7186e3d3dbca6c0feb","work_ledger_sha256":"sha256:2adda20938451b1cd0e07af08c7f01d79a34a095a556497e054b0131996d955f"},"authority":"human_asserted_content_receipt","base_revision":"21ebb448f8cba5afb1c38e581c2928f57a844a3e","coverage_completeness":"complete","findings_count":0,"head_revision":"68a6069e47a1b4b82213f38aabbda7c103893d19","manifest_sha256":"sha256:874fbd8e7fd332a92ea6ee73a5c5b18d58d4dc5f650b09de7e0a7dd28974ae17","producer":{"name":"codex-security-plugin","version":"0.1.12"},"scan_id":"99591017-013b-4719-b593-576d1c0aad11","snapshot_digest":"codex-security-snapshot/v1:sha256:6d402bd9902f72c76ffe570a7cae07063ad98be3f64657c28d51ed14800056bd"},"material":{"base_ref_oid":"21ebb448f8cba5afb1c38e581c2928f57a844a3e","digest":"sha256:b2a21da01989717792ec96b7b547a214d299e2d6e1ab90ddb776e5f740c3e3c3","material_head_sha":"68a6069e47a1b4b82213f38aabbda7c103893d19","merge_base_sha":"21ebb448f8cba5afb1c38e581c2928f57a844a3e","policy_version":"pulseplate.material-classification/v1"},"pr_number":2175,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/docs/security/GHSA-hrxh-6v49-42gf-grpc-go.md
+++ b/docs/security/GHSA-hrxh-6v49-42gf-grpc-go.md
@@ -18,8 +18,9 @@ Official sources:
 
 - `frontend/Dockerfile.caddy-spa:15` creates a temporary Go module, resolves only the exact
   Caddy and grpc-go versions, verifies the module graph, and builds with `-mod=readonly`.
-- `frontend/Dockerfile.caddy-spa:32` verifies the embedded Caddy and grpc-go module identities
-  from the completed binary before it can enter the runtime image.
+- `frontend/Dockerfile.caddy-spa:33` and `frontend/Dockerfile.caddy-spa:35` verify the
+  embedded Caddy and grpc-go module identities from the completed binary before it can enter
+  the runtime image.
 - `.github/workflows/cd.yml:324`, `.github/workflows/cd.yml:343`,
   `.github/workflows/build.yml:386`, `.github/workflows/build.yml:592`, and
   `.github/workflows/trivy.yml:206` pin the five active Trivy inputs to `v0.72.0` while the

--- a/docs/security/GHSA-hrxh-6v49-42gf-grpc-go.md
+++ b/docs/security/GHSA-hrxh-6v49-42gf-grpc-go.md
@@ -1,0 +1,35 @@
+# GHSA-hrxh-6v49-42gf: grpc-go remediation
+
+## Security decision
+
+The GitHub advisory marks `google.golang.org/grpc` versions below `1.82.1` as affected and
+`1.82.1` as patched. The failed image scan observed `v1.81.0` in the Caddy binary, so the
+repository now rebuilds Caddy `v2.11.4` with grpc-go `v1.82.1` while retaining the pinned
+builder and runtime images.
+
+Official sources:
+
+- [GitHub Advisory GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf)
+- [grpc-go v1.82.1 release](https://github.com/grpc/grpc-go/releases/tag/v1.82.1)
+- [grpc-go v1.82.1 module](https://pkg.go.dev/google.golang.org/grpc@v1.82.1)
+- [Trivy v0.72.0 release](https://github.com/aquasecurity/trivy/releases/tag/v0.72.0)
+
+## Remediation evidence
+
+- `frontend/Dockerfile.caddy-spa:15` creates a temporary Go module, resolves only the exact
+  Caddy and grpc-go versions, verifies the module graph, and builds with `-mod=readonly`.
+- `frontend/Dockerfile.caddy-spa:32` verifies the embedded Caddy and grpc-go module identities
+  from the completed binary before it can enter the runtime image.
+- `.github/workflows/cd.yml:324`, `.github/workflows/cd.yml:343`,
+  `.github/workflows/build.yml:386`, `.github/workflows/build.yml:592`, and
+  `.github/workflows/trivy.yml:206` pin the five active Trivy inputs to `v0.72.0` while the
+  action itself remains commit-pinned.
+- `tests/test_caddy_deploy_provenance.py:77` rejects unpinned, replacement-based,
+  checksum-bypassing, xcaddy, legacy `go install`, and grpc-go `v1.81.0` recipes.
+- `tests/test_ci_workflow_pr_size_governance_contract.py:1177` positively enumerates the two
+  CD, two build, and one standalone Trivy action contracts, including their exact action SHA,
+  runtime version, inputs, environment, and fail-closed behavior.
+
+No vulnerability suppression, ignore-policy expansion, workflow trigger change, permission
+change, or SSH/deploy-policy change is part of this remediation. The staged Caddy scan remains
+suppression-free through its existing empty `.trivyignore-caddy` contract.

--- a/frontend/Dockerfile.caddy-spa
+++ b/frontend/Dockerfile.caddy-spa
@@ -13,13 +13,28 @@ ENV CGO_ENABLED=0 \
     GOSUMDB=sum.golang.org
 
 RUN set -eux; \
-    go install \
+    build_dir="$(mktemp -d)"; \
+    cd "$build_dir"; \
+    go mod init pulseplate.local/caddy-build; \
+    go get github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4; \
+    go get google.golang.org/grpc@v1.82.1; \
+    go mod download all; \
+    go mod verify; \
+    test "$(go list -m -f '{{.Path}} {{.Version}}' github.com/caddyserver/caddy/v2)" = \
+      "github.com/caddyserver/caddy/v2 v2.11.4"; \
+    test "$(go list -m -f '{{.Path}} {{.Version}}' google.golang.org/grpc)" = \
+      "google.golang.org/grpc v1.82.1"; \
+    go build -mod=readonly -trimpath \
       -ldflags '-X github.com/caddyserver/caddy/v2.CustomVersion=v2.11.4' \
-      github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4; \
+      -o /go/bin/caddy \
+      github.com/caddyserver/caddy/v2/cmd/caddy; \
     /go/bin/caddy version; \
     go version -m /go/bin/caddy; \
     go version -m /go/bin/caddy \
-      | awk '$1 == "mod" && $2 == "github.com/caddyserver/caddy/v2" && $3 == "v2.11.4" { found = 1 } END { exit !found }'
+      | awk '$1 == "mod" && $2 == "github.com/caddyserver/caddy/v2" && $3 == "v2.11.4" { found = 1 } END { exit !found }'; \
+    go version -m /go/bin/caddy \
+      | awk '$1 == "dep" && $2 == "google.golang.org/grpc" && $3 == "v1.82.1" { found = 1 } END { exit !found }'; \
+    rm -rf "$build_dir"
 
 FROM node:24.16.0-bookworm-slim AS frontend-build
 

--- a/tests/test_caddy_deploy_provenance.py
+++ b/tests/test_caddy_deploy_provenance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import stat
 import subprocess
 from pathlib import Path
@@ -16,6 +17,7 @@ STAGING_COMPOSE = REPO_ROOT / "deploy" / "docker-compose.staging.yaml"
 CD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "cd.yml"
 FRONTEND_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "frontend-ci.yml"
 TRIVY_ACTION = "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25"
+TRIVY_VERSION = "v0.72.0"
 
 GO_BUILDER = (
     "golang:1.26.5-alpine3.23@"
@@ -79,10 +81,32 @@ def test_caddy_dockerfile_owns_exact_hardened_build_recipe() -> None:
     assert f"FROM {CADDY_BASE}" in text
     assert "GOTOOLCHAIN=local" in text
     assert "CGO_ENABLED=0" in text
-    assert "github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4" in text
+    assert "GOPROXY=https://proxy.golang.org,direct" in text
+    assert "GOSUMDB=sum.golang.org" in text
+    assert 'build_dir="$(mktemp -d)"' in text
+    assert "go mod init pulseplate.local/caddy-build" in text
+    caddy_get = "go get github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4"
+    grpc_get = "go get google.golang.org/grpc@v1.82.1"
+    assert caddy_get in text
+    assert grpc_get in text
+    assert text.index(caddy_get) < text.index(grpc_get)
+    assert "go mod download all" in text
+    assert "go mod verify" in text
+    assert (
+        "test \"$(go list -m -f '{{.Path}} {{.Version}}' "
+        'github.com/caddyserver/caddy/v2)" = \\\n'
+        '      "github.com/caddyserver/caddy/v2 v2.11.4"'
+    ) in text
+    assert (
+        "test \"$(go list -m -f '{{.Path}} {{.Version}}' "
+        'google.golang.org/grpc)" = \\\n'
+        '      "google.golang.org/grpc v1.82.1"'
+    ) in text
+    assert "go build -mod=readonly -trimpath" in text
     assert "github.com/caddyserver/caddy/v2.CustomVersion=v2.11.4" in text
     assert "go version -m /go/bin/caddy" in text
     assert '$2 == "github.com/caddyserver/caddy/v2" && $3 == "v2.11.4"' in text
+    assert '$2 == "google.golang.org/grpc" && $3 == "v1.82.1"' in text
     assert '"c-ares>=1.34.8-r0"' in text
     assert '"curl>=8.20.0-r0"' in text
     assert '"libcurl>=8.20.0-r0"' in text
@@ -90,10 +114,22 @@ def test_caddy_dockerfile_owns_exact_hardened_build_recipe() -> None:
     assert "caddy list-modules --packages" in text
     assert "setcap cap_net_bind_service=+ep /usr/bin/caddy" in text
     assert "getcap /usr/bin/caddy" in text
-    assert "--allow-untrusted" not in text
-    assert "GOINSECURE" not in text
-    assert "GONOSUMDB" not in text
-    assert "xcaddy" not in text
+    for forbidden in (
+        "@latest",
+        "--allow-untrusted",
+        "go install",
+        "go mod edit -replace",
+        "go mod edit --replace",
+        "GOINSECURE",
+        "GONOSUMDB",
+        "GOSUMDB=off",
+        "google.golang.org/grpc@v1.81.0",
+        "google.golang.org/grpc v1.81.0",
+        "xcaddy",
+    ):
+        assert forbidden not in text
+    assert re.search(r"(?m)^\s*replace(?:\s|=)", text) is None
+    assert 'rm -rf "$build_dir"' in text
 
 
 def test_staging_compose_requires_two_digest_references_and_preserves_caddy_state() -> None:
@@ -181,8 +217,18 @@ def test_cd_builds_attests_scans_and_deploys_both_same_job_digests() -> None:
         "severity": "CRITICAL,HIGH",
         "exit-code": "1",
         "timeout": "15m",
-        "version": "v0.71.2",
+        "version": TRIVY_VERSION,
     }
+    trivy_steps = [
+        step
+        for step in steps
+        if isinstance(step.get("uses"), str)
+        and str(step["uses"]).startswith("aquasecurity/trivy-action@")
+    ]
+    assert [step.get("name") for step in trivy_steps] == [
+        "Scan staged backend image",
+        "Scan staged Caddy image",
+    ]
     for name, digest_ref, cache_dir, policy_contract in (
         (
             "Scan staged backend image",
@@ -201,7 +247,7 @@ def test_cd_builds_attests_scans_and_deploys_both_same_job_digests() -> None:
         ),
     ):
         step = _named_step(steps, name)
-        assert step.get("continue-on-error") is not True
+        assert step.get("continue-on-error") is None
         assert step["uses"] == TRIVY_ACTION
         assert step["env"] == {
             "TRIVY_DB_REPOSITORY": "ghcr.io/aquasecurity/trivy-db",

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -174,6 +174,7 @@ TRIVY_ACTION_NODE24_CACHE_SHA = "".join(
         "6c25",
     )
 )
+TRIVY_RUNTIME_VERSION = "v0.72.0"
 CODEQL_ACTION_V4_37_1_SHA = "".join(
     (
         "7188",
@@ -1022,6 +1023,10 @@ def test_node24_checkout_and_docker_action_pins_use_verified_commit_shas() -> No
             f"aquasecurity/trivy-action@{TRIVY_ACTION_NODE24_CACHE_SHA} "
             "# v0.36.0 / Node 24 cache path": 2,
         },
+        CD_WORKFLOW_PATH: {
+            f"aquasecurity/trivy-action@{TRIVY_ACTION_NODE24_CACHE_SHA} "
+            "# v0.36.0 / Node 24 cache path": 2,
+        },
         TRIVY_WORKFLOW_PATH: {
             f"aquasecurity/trivy-action@{TRIVY_ACTION_NODE24_CACHE_SHA} "
             "# v0.36.0 / Node 24 cache path": 1,
@@ -1169,7 +1174,7 @@ def test_node24_checkout_and_docker_action_pins_use_verified_commit_shas() -> No
     ]
 
     observed_trivy_contracts = []
-    for workflow_path in (BUILD_WORKFLOW_PATH, TRIVY_WORKFLOW_PATH):
+    for workflow_path in (BUILD_WORKFLOW_PATH, CD_WORKFLOW_PATH, TRIVY_WORKFLOW_PATH):
         for job_id, step in _iter_job_steps(workflow_path):
             uses = step.get("uses")
             if isinstance(uses, str) and uses.startswith("aquasecurity/trivy-action@"):
@@ -1205,7 +1210,7 @@ def test_node24_checkout_and_docker_action_pins_use_verified_commit_shas() -> No
                 "limit-severities-for-sarif": True,
                 "exit-code": "1",
                 "trivyignores": ".trivyignore",
-                "version": "v0.71.2",
+                "version": TRIVY_RUNTIME_VERSION,
             },
             None,
             {"TRIVY_DB_REPOSITORY": "ghcr.io/aquasecurity/trivy-db"},
@@ -1228,7 +1233,52 @@ def test_node24_checkout_and_docker_action_pins_use_verified_commit_shas() -> No
                 "limit-severities-for-sarif": True,
                 "trivyignores": ".trivyignore",
                 "exit-code": "1",
-                "version": "v0.71.2",
+                "version": TRIVY_RUNTIME_VERSION,
+            },
+            None,
+            {"TRIVY_DB_REPOSITORY": "ghcr.io/aquasecurity/trivy-db"},
+            None,
+        ),
+        (
+            ".github/workflows/cd.yml",
+            "build",
+            "Scan staged backend image",
+            f"aquasecurity/trivy-action@{TRIVY_ACTION_NODE24_CACHE_SHA}",
+            {
+                "scan-type": "image",
+                "image-ref": "${{ steps.staging-image-refs.outputs.backend_ref }}",
+                "scanners": "vuln,secret",
+                "format": "table",
+                "vuln-type": "os,library",
+                "severity": "CRITICAL,HIGH",
+                "exit-code": "1",
+                "timeout": "15m",
+                "trivyignores": ".trivyignore",
+                "ignore-policy": ".trivy-ignore-policy.rego",
+                "version": TRIVY_RUNTIME_VERSION,
+                "cache-dir": "/tmp/trivy-cache-staging-backend",
+            },
+            None,
+            {"TRIVY_DB_REPOSITORY": "ghcr.io/aquasecurity/trivy-db"},
+            None,
+        ),
+        (
+            ".github/workflows/cd.yml",
+            "build",
+            "Scan staged Caddy image",
+            f"aquasecurity/trivy-action@{TRIVY_ACTION_NODE24_CACHE_SHA}",
+            {
+                "scan-type": "image",
+                "image-ref": "${{ steps.staging-image-refs.outputs.caddy_ref }}",
+                "scanners": "vuln,secret",
+                "format": "table",
+                "vuln-type": "os,library",
+                "severity": "CRITICAL,HIGH",
+                "exit-code": "1",
+                "timeout": "15m",
+                "trivyignores": ".trivyignore-caddy",
+                "version": TRIVY_RUNTIME_VERSION,
+                "cache-dir": "/tmp/trivy-cache-staging-caddy",
             },
             None,
             {"TRIVY_DB_REPOSITORY": "ghcr.io/aquasecurity/trivy-db"},
@@ -1253,13 +1303,14 @@ def test_node24_checkout_and_docker_action_pins_use_verified_commit_shas() -> No
                 "trivyignores": ".trivyignore",
                 "ignore-policy": ".trivy-ignore-policy.rego",
                 "exit-code": "1",
-                "version": "v0.71.2",
+                "version": TRIVY_RUNTIME_VERSION,
             },
             None,
             {"TRIVY_DB_REPOSITORY": "ghcr.io/aquasecurity/trivy-db"},
             None,
         ),
     ]
+    assert len(observed_trivy_contracts) == 5
 
 
 def test_build_workflow_trivy_fs_sarif_is_temp_isolated_before_upload() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# Pull Request

## Goal

Restore the main CD Caddy security gate and update the five governed Trivy runtime pins from v0.71.2 to v0.72.0.

## Business reason

Main CD run 29930860579 failed twice on GHSA-hrxh-6v49-42gf because the Caddy v2.11.4 binary embedded grpc-go v1.81.0. Re-running the unchanged image cannot restore the production security gate; the image dependency and scanner runtime must be remediated in code.

## Scope

- Pin the two CD, two image-build, and one standalone Trivy runtime invocations to v0.72.0.
- Keep `aquasecurity/trivy-action` v0.36.0 at SHA `ed142fd0673e97e23eac54620cfb913e5ce36c25`.
- Keep Caddy v2.11.4 and build it through a temporary Go module with `google.golang.org/grpc` v1.82.1.
- Verify exact requested and embedded Caddy/gRPC versions, module parity, runtime capabilities, and fail-closed Trivy inputs.
- Add positive contract coverage and a security evidence note.

## Scope approval

Operator approval: approved for the single main CD scanner-runtime and Caddy dependency remediation scope.
Frontend/backend mix approval: approved because the frontend path is the Caddy runtime image build that the privileged CD scan deploys.

## Out of scope

- No suppression, ignore-policy, severity, SARIF, permission, trigger, concurrency, SSH-gate, or deployment-variable change.
- No Caddy CLI/deploy-interface, public API, OpenAPI, client-type, or migration change.
- The separate unversioned `frontend-ci.yml` Trivy action remains unchanged.
- The existing `ledger-p2-trivy-cli-0-72-0` item is not edited in this remediation PR.

## Files changed

- `.github/workflows/cd.yml`
- `.github/workflows/build.yml`
- `.github/workflows/trivy.yml`
- `frontend/Dockerfile.caddy-spa`
- `tests/test_caddy_deploy_provenance.py`
- `tests/test_ci_workflow_pr_size_governance_contract.py`
- `docs/security/GHSA-hrxh-6v49-42gf-grpc-go.md`

## Key decisions

- Upgrade only the five already explicit governed scanner-runtime pins; do not change the verified action implementation SHA.
- Use sequential versioned `go get` operations so the Caddy request is followed by an explicit grpc-go security-floor override.
- Keep checksum verification, `GOTOOLCHAIN=local`, `GOSUMDB`, read-only module build, exact embedded-version assertions, capabilities, and runtime checks.
- Preserve empty Caddy ignore policy and fail closed instead of suppressing the advisory.

## Tests / validation

Local required bundle passed on material commit `787ee258509aa458d1d601c10150e1d715ac6972`:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- focused contract tests: 53 passed
- `python3 scripts/ci/guard_actions_pin.py --root .`
- Phase 1 docs gate for `docs/security/GHSA-hrxh-6v49-42gf-grpc-go.md`
- `make validate-changed`
- `pre-commit run --all-files`
- pre-push YAML, secrets, workflow, pip-audit, backend-test, and Bandit hooks

Apple Container evidence:

- Caddy image index: `sha256:166b8d3dd3e668aea0fbd0430c3cde4a89e639d00c4810acfb8eca69fc0e3af9`
- Runtime: Caddy v2.11.4 with grpc-go v1.82.1 and preserved build-info/capability contracts
- Unsuppressed Trivy v0.72.0 scan: zero HIGH/CRITICAL vulnerabilities and zero secrets
- Trivy report SHA-256: `37edfd5ff4745ae68b83a94c483a2f48d6112405eea7f1a8639680466facd2b4`

Current-head GitHub CI, review inventory, final Codex Security diff scan, and strict authenticated merge-readiness are pending.

## Security notes

The remediation raises grpc-go from the vulnerable v1.81.0 to the advisory's v1.82.1 fixed floor while preserving Caddy v2.11.4. No ignore entry, VEX input, `replace`, checksum bypass, `@latest`, `xcaddy`, downgrade, or fail-open behavior was added.

References:

- [Failed CD run 29930860579](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/29930860579)
- [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf)
- [Trivy v0.72.0](https://github.com/aquasecurity/trivy/releases/tag/v0.72.0)
- [trivy-action v0.36.0](https://github.com/aquasecurity/trivy-action/releases/tag/v0.36.0)
- [Caddy v2.11.4](https://github.com/caddyserver/caddy/releases/tag/v2.11.4)

## Risks / rollback

Upstream module unavailability, changed module selection, embedded-version drift, or scanner findings fail closed before deployment. Keep rollout gates closed on regression. A revert is containment only and may leave CD red; recovery must fix forward without restoring grpc-go v1.81.0, downgrading Trivy, or adding ignores.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- [Canonical review mapping](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/codex/fix-main-cd-trivy-grpc/docs/review/PR_2175_FIXED_MAPPING.md)

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/caddy-trivy-remediation-oracle-result.json`

## Lane Start Provenance

Packet: `artifacts/orchestration/task_packets/16e2afada27e.json`

## Split justification

- Why this PR cannot be split safely: Not applicable; the diff is below the privileged 800 changed-LoC threshold.
- Invariant or rollout constraint requiring one PR: The scanner-runtime pins, Caddy dependency remediation, and positive contracts jointly restore one fail-closed main CD security gate.
- Follow-up PRs: One docs-only ledger closeout after merged-main evidence.

## Deferred / Follow-ups

- Close [`ledger-p2-trivy-cli-0-72-0`](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/main/docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-trivy-cli-0-72-0) in a docs-only PR after merge and successful automatic main workflows.

## Next best step

Publish the sole mapping/seal closeout commit, then complete strict current-head CI and authenticated merge validation.

Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>

<!-- markdownlint-enable MD013 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated vulnerability scanning to the latest Trivy release.
  * Rebuilt the Caddy component with updated grpc-go security remediation and reproducible version pinning.

* **Documentation**
  * Added security advisory and remediation evidence.
  * Added review governance records.

* **Tests**
  * Strengthened validation for build provenance, scan configuration, version pinning, and CI security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->