### PR TITLE
fix(frontend): upgrade React Router for security advisories

### DIFF
--- a/docs/review/PR_2177_FIXED_MAPPING.md
+++ b/docs/review/PR_2177_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+# PR 2177 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/b7ca2dd91439.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/f0-react-router-security-oracle.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"authority":"trusted_codex_review_source_unavailability","binding_kind":"seal_context_only","blocking":false,"fallback_required":false,"material_digest":"sha256:543ab5f059a6f1858fc88079ee7a67aa72e9b722d2009ba7149156f22ba9ae6a","material_head_sha":"4b2509ebfa00edae647448f3aa6689fee5d67d7c","quota_body_sha256":"sha256:619c9f9f66a93f7e7ea60049aa147d2cf183fb706a71e11a710216ed2ba19d92","quota_created_at":"2026-07-24T12:12:05Z","quota_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2177#issuecomment-5069712731","review_claim":"none","schema_version":"pulseplate.codex-review-source-unavailability/v1","source":"codex_review","source_degraded":true,"source_status":"usage_limit_reached","status":"tooling_unavailable"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:5f8fe4aa553d20e7f5b6654ef90d33ce59fea31096b88602e0fb497e6ce14bea","findings_sha256":"sha256:d324066673e3232563438b93d55145ae5e4c1152f98d10336472f7f0ec8e1510","work_ledger_sha256":"sha256:faccd2a503c5c0e79a1808ad37f2e34306b25d1a2b3016834e733eb220ebb6ef"},"authority":"human_asserted_content_receipt","base_revision":"cb73faa7a6c869b4451f80ffe310fea9dde296f8","coverage_completeness":"complete","findings_count":0,"head_revision":"4b2509ebfa00edae647448f3aa6689fee5d67d7c","manifest_sha256":"sha256:539a229e58fefc69ef7f00ba5e23b3b61f6fce696c7421ef73c656b6d838de1c","producer":{"name":"codex-security-plugin","version":"0.1.12"},"scan_id":"620f414d-f2d5-4db3-9755-3de430cc5676","snapshot_digest":"codex-security-snapshot/v1:sha256:543ab5f059a6f1858fc88079ee7a67aa72e9b722d2009ba7149156f22ba9ae6a"},"material":{"base_ref_oid":"cb73faa7a6c869b4451f80ffe310fea9dde296f8","digest":"sha256:543ab5f059a6f1858fc88079ee7a67aa72e9b722d2009ba7149156f22ba9ae6a","material_head_sha":"4b2509ebfa00edae647448f3aa6689fee5d67d7c","merge_base_sha":"cb73faa7a6c869b4451f80ffe310fea9dde296f8","policy_version":"pulseplate.material-classification/v1"},"pr_number":2177,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,7 @@
         "react-hot-toast": "^2.4.1",
         "react-i18next": "^16.0.0",
         "react-is": "^18.3.1",
-        "react-router-dom": "7.16.0",
+        "react-router-dom": "7.18.1",
         "recharts": "^3.2.1",
         "tailwind-merge": "^2.4.0",
         "wicg-inert": "^3.1.2",
@@ -9166,9 +9166,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -9188,12 +9188,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "react-hot-toast": "^2.4.1",
     "react-i18next": "^16.0.0",
     "react-is": "^18.3.1",
-    "react-router-dom": "7.16.0",
+    "react-router-dom": "7.18.1",
     "recharts": "^3.2.1",
     "tailwind-merge": "^2.4.0",
     "wicg-inert": "^3.1.2",


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# Pull Request

## Goal

Replace the failing raw Dependabot PR #2176 with a governed React Router security hotfix that moves `react-router-dom` and `react-router` from 7.16.0 to 7.18.1.

## Business reason

React Router 7.16.0 is affected by repository alerts #236–#238. Version 7.18.0 is the first patched release; 7.18.1 is the current tested patch selected by Dependabot. This replacement keeps the security repair narrow while satisfying the repository's operator-owned PR lifecycle.

Supersedes #2176.

## Scope

- Pin `react-router-dom` to 7.18.1 in `frontend/package.json`.
- Update only the corresponding `react-router-dom` and `react-router` lock nodes and integrity data.
- Validate the unchanged SPA source against the new router packages under Node 24.

## Out of scope

- No application-source, route, API, OpenAPI, runtime-schema, product-logic, or UI change.
- No unrelated dependency update or lock-graph movement.
- No dismissal or suppression of Dependabot alerts.
- No remediation of base-equivalent audit findings outside the React Router graph.

## Files changed

- `frontend/package.json`
- `frontend/package-lock.json`

## Key decisions

- Use 7.18.1; do not return to a vulnerable version.
- Preserve exact byte-equivalence with the bounded dependency delta from #2176 while replacing its failed governance lifecycle.
- Keep alerts #236–#238 open until GitHub closes them automatically after the patched version reaches `main`.

## Tests

Local evidence on commit `4b2509ebf`:

- Node 24.16.0 / npm 11.13.0.
- `npm ci` — PASS.
- `npm run test:ci` — PASS: 91 files, 765 passed, 1 pre-existing unrelated skip.
- Real-router focused subset — PASS: 8 files, 63 tests.
- `npm run build` — PASS: 2,053 modules transformed; only existing chunk/dynamic-import warnings.
- `python scripts/orchestration/check_preflight.py --mode analyze --path frontend/package.json --path frontend/package-lock.json` — PASS.
- `python scripts/orchestration/check_agent_consistency.py` — PASS.
- `make validate-changed` — PASS: 128 focused tests.
- `pre-commit run --all-files` — PASS with no hook modifications.
- Patch SHA-256: `240021ee541d6057b25f4d5288c3f72fcc4368bf3b0fbde306b4d04b005dff67`.

Final review inventory and the single Codex Security diff scan are complete on frozen material head `4b2509ebf`. Current-head CI and strict authenticated merge readiness are now running on the mapping-only descendant `04c11b434`.

## Security notes

This PR addresses:

- [GHSA-337j-9hxr-rhxg / CVE-2026-53666](https://github.com/advisories/GHSA-337j-9hxr-rhxg)
- [GHSA-h8fp-f39c-q6mh / CVE-2026-53667](https://github.com/advisories/GHSA-h8fp-f39c-q6mh)
- [GHSA-wrjc-x8rr-h8h6 / CVE-2026-53669](https://github.com/advisories/GHSA-wrjc-x8rr-h8h6)

All three advisories have a fixed floor of 7.18.0. The installed and locked graph resolves `react-router-dom@7.18.1 -> react-router@7.18.1`. No alert is dismissed or suppressed.

An additional diagnostic `npm audit` reports eight base-equivalent findings outside the React Router graph: six high-severity dev-tooling findings through ESLint/OpenAPI tooling and two low-severity findings in the separate `jspdf -> dompurify` production branch. This PR does not claim the full frontend graph is security-clean.

## Premortem evidence

`pulseplate-premortem-risk-review` ran on the actual two-file diff.

- PM-F0-001 — `FIXED`: router compatibility regression is covered by the full frontend suite, 63 real-router tests, package export inspection, and production build.
- PM-F0-002 — `FIXED`: unrelated graph or source movement is excluded by the two-file diff, coherent lock assertions, and exact patch hash.
- PM-F0-003 — `NOT-A-BUG`: base-equivalent audit findings outside the React Router graph are not caused or changed by this dependency delta; evidence is the recursive lock comparison against exact `main`. They are disclosed without making a global security-clean claim.
- PM-F0-004 — `FIXED`: stale-base risk is closed by requiring terminal-success canonical CI on exact base `cb73faa7a6c869b4451f80ffe310fea9dde296f8` before push/PR open.

Decision: proceed with the bounded replacement after all four dispositions and the exact-main gate are satisfied.

## Risks / rollback

The remaining risk is a routing behavior change not represented in unit tests. The unchanged source, real-router coverage, exact engine/peer compatibility, and production build make this residual risk proportionate.

If current-head CI or later review finds a compatibility regression, stop rollout and fix forward to a separately verified patched React Router version. Do not restore 7.16.0 or dismiss the alerts. A plain revert is containment only because it restores the vulnerable dependency.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- [Canonical review mapping](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/codex/fix-react-router-security-advisories/docs/review/PR_2177_FIXED_MAPPING.md)

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/f0-react-router-security-oracle.json`

## Lane Start Provenance

Planning packet: `artifacts/orchestration/task_packets/5d29aab533e4.json`

Packet: `artifacts/orchestration/task_packets/b7ca2dd91439.json`

Starter: `scripts/orchestration/start_pr_lane.sh`

## Split justification

- Why this PR cannot be split safely: the manifest pin and its generated lock nodes form one atomic dependency update.
- Invariant or rollout constraint requiring one PR: the direct and transitive router versions must resolve to the same patched release.
- Follow-up PRs: none inside F0.

## Deferred / Follow-ups

- No F0 follow-up is deferred. Base-equivalent non-router audit findings require a separately authorized remediation scope.

## AGENTS.md / process updates

None. Existing governance is sufficient.

## Next best step

Pass current-head CI and strict authenticated merge readiness on mapping-only descendant `04c11b434`, observe the mandatory final review cycle, then merge and verify alerts #236–#238 on exact `main`.

<!-- markdownlint-enable MD013 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the app’s routing dependency to a newer version for improved compatibility and maintenance.
* **Documentation**
  * Added a new internal PR review governance document, including review checklist and status/seal information for the referenced change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->