### PR TITLE
chore(ci): run Anchore SBOM action on Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -638,7 +638,7 @@ jobs:
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ steps.image-ref.outputs.ref }}
           format: spdx-json

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Generate staged backend image SBOM
         id: generate-staged-sbom
-        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}@${{ steps.build.outputs.digest }}
           format: spdx-json
@@ -225,7 +225,7 @@ jobs:
 
       - name: Generate staged Caddy image SBOM
         id: generate-staged-caddy-sbom
-        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}@${{ steps.build-caddy.outputs.digest }}
           format: spdx-json
@@ -807,7 +807,7 @@ jobs:
 
       - name: Generate production image SBOM
         id: generate-production-sbom
-        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}@${{ steps.build.outputs.digest }}
           format: spdx-json

--- a/docs/review/PR_2179_FIXED_MAPPING.md
+++ b/docs/review/PR_2179_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+# PR 2179 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/9162f5a22bd1.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/sbom_action_node24_exact_41cd.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"authority":"trusted_codex_review_source_unavailability","binding_kind":"seal_context_only","blocking":false,"fallback_required":false,"material_digest":"sha256:3ba9789547eeed2b80b4f19a5aee2a69520755fc0631587f3ea2368089fac59a","material_head_sha":"41cd69120aedc82420d0c20889cfa1cf5be05f95","quota_body_sha256":"sha256:619c9f9f66a93f7e7ea60049aa147d2cf183fb706a71e11a710216ed2ba19d92","quota_created_at":"2026-07-24T14:26:18Z","quota_reference":"https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2179#issuecomment-5070927391","review_claim":"none","schema_version":"pulseplate.codex-review-source-unavailability/v1","source":"codex_review","source_degraded":true,"source_status":"usage_limit_reached","status":"tooling_unavailable"},"codex_security":{"artifacts":{"coverage_sha256":"sha256:ba40426eb73e3bf4cfc42386bc7fa53b2320e50901bf8642a93d45f162503398","findings_sha256":"sha256:3cdb112e945b4a76afb5efaf669894a874c0a1f6b25a973a378406e825cbce73","work_ledger_sha256":"sha256:171ce2fc7c535fb22d4f1922673dbf80b1295e86cbeb41aa183d3e266ab84d8f"},"authority":"human_asserted_content_receipt","base_revision":"2b5943ab355f2b8a5ecdbb075c3e1361c54b317f","coverage_completeness":"complete","findings_count":0,"head_revision":"41cd69120aedc82420d0c20889cfa1cf5be05f95","manifest_sha256":"sha256:f7b2918ec444fa0a52f360600358826d805f0b62c59285ad65615c93fbe0add4","producer":{"name":"codex-security-plugin","version":"0.1.12"},"scan_id":"8cc29a01-f85b-46ef-8d06-db64f60571ae","snapshot_digest":"codex-security-snapshot/v1:sha256:19b306010c38de4be3711df59f24d76b1b689031e9a0626e6f9064f92e66dbb8"},"material":{"base_ref_oid":"2b5943ab355f2b8a5ecdbb075c3e1361c54b317f","digest":"sha256:3ba9789547eeed2b80b4f19a5aee2a69520755fc0631587f3ea2368089fac59a","material_head_sha":"41cd69120aedc82420d0c20889cfa1cf5be05f95","merge_base_sha":"2b5943ab355f2b8a5ecdbb075c3e1361c54b317f","policy_version":"pulseplate.material-classification/v1"},"pr_number":2179,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1"}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -217,6 +217,20 @@ UPLOAD_ARTIFACT_NODE24_SHA = "".join(
         "6a0a",
     )
 )
+SBOM_ACTION_NODE24_SHA = "".join(
+    (
+        "e22c",
+        "3899",
+        "0414",
+        "9dbc",
+        "22b5",
+        "8101",
+        "8060",
+        "40fa",
+        "8d37",
+        "a610",
+    )
+)
 PYTHON_TEST_JOB_NAMES = ("test-pr", "test-feature", "test-main")
 OLD_CHECKOUT_NODE20_SHA = "".join(
     (
@@ -398,6 +412,20 @@ OLD_UPLOAD_ARTIFACT_V7_SHA = "".join(
         "ad77",
         "386f",
         "024f",
+    )
+)
+OLD_SBOM_ACTION_SHA = "".join(
+    (
+        "da16",
+        "7eac",
+        "915b",
+        "4e86",
+        "f08b",
+        "264d",
+        "bdbc",
+        "867b",
+        "61be",
+        "6f0c",
     )
 )
 GITHUB_SCRIPT_V9_TAG_OBJECT_SHA = "".join(
@@ -1387,6 +1415,116 @@ def test_active_upload_artifact_refs_all_use_node24_sha() -> None:
             assert workflow_text.count(expected_line) == workflow_upload_count
 
     assert observed_upload_steps
+
+
+def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts() -> None:
+    """Guard every active SBOM action use and its fail-closed generation contract."""
+
+    expected_uses = f"anchore/sbom-action@{SBOM_ACTION_NODE24_SHA}"
+    expected_line = f"{expected_uses} # v0.24.0"
+    expected_counts = {
+        ".github/workflows/build.yml": 1,
+        ".github/workflows/cd.yml": 3,
+    }
+    observed_counts: dict[str, int] = {}
+    observed_contracts: list[tuple[str, str, object, str, object, object, object]] = []
+
+    for workflow_path in _active_workflow_paths():
+        workflow_relative_path = str(workflow_path.relative_to(REPO_ROOT))
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        assert OLD_SBOM_ACTION_SHA not in workflow_text
+
+        workflow_sbom_count = 0
+        for job_id, step in _iter_job_steps(workflow_path):
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not uses.casefold().startswith("anchore/sbom-action@"):
+                continue
+
+            workflow_sbom_count += 1
+            assert uses == expected_uses
+            assert "if" not in step
+            assert "continue-on-error" not in step
+            observed_contracts.append(
+                (
+                    workflow_relative_path,
+                    job_id,
+                    step.get("name"),
+                    uses,
+                    step.get("with"),
+                    step.get("if"),
+                    step.get("continue-on-error"),
+                )
+            )
+
+        if workflow_sbom_count:
+            assert workflow_relative_path in expected_counts
+            assert workflow_text.count(expected_line) == workflow_sbom_count
+            observed_counts[workflow_relative_path] = workflow_sbom_count
+
+    assert observed_counts == expected_counts
+    assert observed_contracts == [
+        (
+            ".github/workflows/build.yml",
+            "publish",
+            "Generate SBOM",
+            expected_uses,
+            {
+                "image": "${{ steps.image-ref.outputs.ref }}",
+                "format": "spdx-json",
+                "output-file": "sbom.spdx.json",
+            },
+            None,
+            None,
+        ),
+        (
+            ".github/workflows/cd.yml",
+            "build",
+            "Generate staged backend image SBOM",
+            expected_uses,
+            {
+                "image": (
+                    "${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}"
+                    "@${{ steps.build.outputs.digest }}"
+                ),
+                "format": "spdx-json",
+                "output-file": "backend-image-sbom.spdx.json",
+            },
+            None,
+            None,
+        ),
+        (
+            ".github/workflows/cd.yml",
+            "build",
+            "Generate staged Caddy image SBOM",
+            expected_uses,
+            {
+                "image": (
+                    "${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}"
+                    "@${{ steps.build-caddy.outputs.digest }}"
+                ),
+                "format": "spdx-json",
+                "output-file": "caddy-image-sbom.spdx.json",
+            },
+            None,
+            None,
+        ),
+        (
+            ".github/workflows/cd.yml",
+            "build-production",
+            "Generate production image SBOM",
+            expected_uses,
+            {
+                "image": (
+                    "${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}"
+                    "@${{ steps.build.outputs.digest }}"
+                ),
+                "format": "spdx-json",
+                "output-file": "docker-image-sbom.spdx.json",
+            },
+            None,
+            None,
+        ),
+    ]
 
 
 def test_active_codeql_action_refs_use_verified_v4_37_1_sha() -> None:

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -1420,6 +1420,17 @@ def test_active_upload_artifact_refs_all_use_node24_sha() -> None:
 def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts() -> None:
     """Guard every active SBOM action use and its fail-closed generation contract."""
 
+    def iter_uses_source_mappings(node: Node) -> Iterator[tuple[ScalarNode, ScalarNode]]:
+        if isinstance(node, MappingNode):
+            for key_node, value_node in node.value:
+                if isinstance(key_node, ScalarNode) and key_node.value == "uses":
+                    if isinstance(value_node, ScalarNode):
+                        yield key_node, value_node
+                yield from iter_uses_source_mappings(value_node)
+        elif isinstance(node, SequenceNode):
+            for value_node in node.value:
+                yield from iter_uses_source_mappings(value_node)
+
     expected_uses = f"anchore/sbom-action@{SBOM_ACTION_NODE24_SHA}"
     expected_line = f"{expected_uses} # v0.24.0"
     expected_counts = {
@@ -1432,7 +1443,21 @@ def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts
     for workflow_path in _active_workflow_paths():
         workflow_relative_path = str(workflow_path.relative_to(REPO_ROOT))
         workflow_text = workflow_path.read_text(encoding="utf-8")
+        workflow_lines = workflow_text.splitlines()
         assert OLD_SBOM_ACTION_SHA not in workflow_text
+        workflow_document = yaml.compose(workflow_text)
+        assert isinstance(workflow_document, Node)
+        sbom_source_node_count = 0
+        for uses_key_node, uses_value_node in iter_uses_source_mappings(workflow_document):
+            uses = uses_value_node.value
+            if not uses.casefold().startswith("anchore/sbom-action@"):
+                continue
+
+            sbom_source_node_count += 1
+            assert uses == expected_uses
+            assert workflow_lines[uses_key_node.start_mark.line].strip() == (
+                f"uses: {expected_line}"
+            )
 
         workflow_sbom_count = 0
         for job_id, step in _iter_job_steps(workflow_path):
@@ -1456,9 +1481,9 @@ def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts
                 )
             )
 
+        assert sbom_source_node_count == workflow_sbom_count
         if workflow_sbom_count:
             assert workflow_relative_path in expected_counts
-            assert workflow_text.count(expected_line) == workflow_sbom_count
             observed_counts[workflow_relative_path] = workflow_sbom_count
 
     assert observed_counts == expected_counts

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -1438,12 +1438,17 @@ def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts
         ".github/workflows/cd.yml": 3,
     }
     observed_counts: dict[str, int] = {}
-    observed_contracts: list[tuple[str, str, object, str, object, object, object]] = []
+    observed_contracts: list[
+        tuple[str, str, object, str, object, object, object, object, object]
+    ] = []
 
     for workflow_path in _active_workflow_paths():
         workflow_relative_path = str(workflow_path.relative_to(REPO_ROOT))
         workflow_text = workflow_path.read_text(encoding="utf-8")
         workflow_lines = workflow_text.splitlines()
+        workflow = _load_workflow(workflow_path)
+        jobs = workflow["jobs"]
+        assert isinstance(jobs, dict)
         assert OLD_SBOM_ACTION_SHA not in workflow_text
         workflow_document = yaml.compose(workflow_text)
         assert isinstance(workflow_document, Node)
@@ -1465,8 +1470,11 @@ def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts
             if not isinstance(uses, str) or not uses.casefold().startswith("anchore/sbom-action@"):
                 continue
 
+            job = jobs[job_id]
+            assert isinstance(job, dict)
             workflow_sbom_count += 1
             assert uses == expected_uses
+            assert "continue-on-error" not in job
             assert "if" not in step
             assert "continue-on-error" not in step
             observed_contracts.append(
@@ -1476,6 +1484,8 @@ def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts
                     step.get("name"),
                     uses,
                     step.get("with"),
+                    job.get("if"),
+                    job.get("continue-on-error"),
                     step.get("if"),
                     step.get("continue-on-error"),
                 )
@@ -1498,6 +1508,8 @@ def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts
                 "format": "spdx-json",
                 "output-file": "sbom.spdx.json",
             },
+            "github.event_name != 'pull_request'",
+            None,
             None,
             None,
         ),
@@ -1514,6 +1526,8 @@ def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts
                 "format": "spdx-json",
                 "output-file": "backend-image-sbom.spdx.json",
             },
+            "github.ref == 'refs/heads/main'",
+            None,
             None,
             None,
         ),
@@ -1530,6 +1544,8 @@ def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts
                 "format": "spdx-json",
                 "output-file": "caddy-image-sbom.spdx.json",
             },
+            "github.ref == 'refs/heads/main'",
+            None,
             None,
             None,
         ),
@@ -1546,6 +1562,8 @@ def test_active_sbom_action_refs_use_verified_v0_24_0_sha_and_preserve_contracts
                 "format": "spdx-json",
                 "output-file": "docker-image-sbom.spdx.json",
             },
+            "startsWith(github.ref, 'refs/tags/v')",
+            None,
             None,
             None,
         ),


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# Pull Request

## Goal

Move every active Anchore SBOM generation step from the deprecated Node 20 action runtime to the verified Node 24 release.

## Business reason

GitHub runners warn that the pinned `anchore/sbom-action` v0.20.5 executes on deprecated Node 20. Updating the exact action implementation removes that release-pipeline warning while preserving the existing SBOM and attestation behavior.

## Scope

- Replace all four active `anchore/sbom-action` v0.20.5 pins with the verified v0.24.0 commit `e22c389904149dbc22b58101806040fa8d37a610`.
- Preserve the existing image, SPDX JSON, output-file, job, digest, attestation, verification, and fail-closed contracts.
- Positively enumerate all four executable SBOM action occurrences, their exact SHA/version annotation, expected locations, inputs, step policy, and owning-job policy.

## Out of scope

- No trigger, permission, concurrency, deployment gate, image build, attestation, registry, signing, Trivy, Syft configuration, or artifact-name change.
- No application runtime dependency, public API, OpenAPI, migration, or client change.
- No workflow dispatch, issue-comment trigger, manual rerun, suppression, or ignore.

## Files changed

- `.github/workflows/build.yml`
- `.github/workflows/cd.yml`
- `tests/test_ci_workflow_pr_size_governance_contract.py`

## Key decisions

- Pin the immutable upstream commit rather than a mutable release tag.
- Bind the governance test to parsed executable YAML and exact source lines, including owning-job `if` and `continue-on-error`.
- Keep the existing build/CD SBOM and attestation topology unchanged.

## Tests / validation

The local required bundle passed on material head `41cd69120aedc82420d0c20889cfa1cf5be05f95`:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- focused and complete workflow-contract selection: 33 passed
- `python3 scripts/ci/guard_actions_pin.py --root .`
- `make validate-changed`
- `pre-commit run --all-files`
- pre-push YAML, secrets, workflow, pip-audit, backend-test, and Bandit hooks
- Apple Container exact-head evidence: `artifacts/orchestration/experiments/results/sbom_action_node24_exact_41cd.json`

GitHub material-head run `30121499810` is the canonical pre-closeout run. The mapping-only descendant must complete fresh exact-head required CI before merge.

## Security notes

Upstream tag `v0.24.0` resolves to commit `e22c389904149dbc22b58101806040fa8d37a610`; its `action.yml` declares `runs.using: node24` and preserves the used `image`, `format`, and `output-file` inputs.

Final Codex Security diff scan `8cc29a01-f85b-46ef-8d06-db64f60571ae` is sealed to material digest `sha256:3ba9789547eeed2b80b4f19a5aee2a69520755fc0631587f3ea2368089fac59a` with zero reportable findings. A proposed remote tag-retarget path was rejected because Syft resolves the already loaded runner-local Docker image before registry fallback and the pushed digest is derived from that same local image.

No suppression, mutable action ref, checksum bypass, secret change, permission expansion, or fail-open behavior is introduced.

Reference: [anchore/sbom-action v0.24.0](https://github.com/anchore/sbom-action/releases/tag/v0.24.0)

## Risks / rollback

The remaining integration risk is upstream action behavior on hosted runners. Current-head Actionlint, workflow governance, required CI, and strict authenticated merge-readiness must pass before merge. If the action fails at runtime, keep publish/deploy gates closed and fix forward to a verified Node 24-compatible implementation; do not restore deprecated Node 20 execution as a release workaround.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- [Canonical review mapping](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/codex/chore-sbom-action-node24/docs/review/PR_2179_FIXED_MAPPING.md)

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/sbom_action_node24_exact_41cd.json`

## Lane Start Provenance

Packet: `artifacts/orchestration/task_packets/9162f5a22bd1.json`

## Split justification

- Why this PR cannot be split safely: Not applicable; the diff is below the privileged 800 changed-LoC threshold.
- Invariant or rollout constraint requiring one PR: The four action pins and their complete positive contract are one atomic runtime migration.
- Follow-up PRs: None.

## Deferred / Follow-ups

None.

## Next best step

Publish the sole mapping/seal closeout commit, wait for exact-head required CI and the mandatory review cycle, run strict authenticated merge-readiness, then squash-merge.

Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>

<!-- markdownlint-enable MD013 -->
