### PR TITLE
fix(governance): make Codex capability sources advisory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,9 +204,9 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    PR head. Reviewer execution SHAs are opaque until the Commit API proves
    them repository-addressable; unavailable/API-unknown refs must never enter
    ancestry checks.
-9. **Material identity:** one completed Codex review or one trusted terminal
-   Connector response/unavailability receipt, plus one completed final Codex
-   Security diff scan, bind to one material digest. A verified official Codex
+9. **Material identity:** Under **Legacy-v1-only**, one completed Codex review
+   or one trusted terminal Connector response/unavailability receipt, plus one
+   completed final Codex Security diff scan, bind to one material digest. A verified official Codex
    Connector PR-root reaction (`+1`, `heart`, `hooray`, or `rocket`) may satisfy
    the normal `--review-ref` path as a nonblocking terminal source response only
    when its canonical reaction ID, immutable
@@ -271,7 +271,28 @@ Backlog: docs/roadmap/BACKLOG_LEDGER.md#agent-consistency-preflight
    synthetic execution ref is never review proof. Every path is material except the exact
    current-PR mapping artifact. PR-body edits are outside Git. Any later code,
    test, workflow, dependency, policy, contract, or other docs change invalidates
-   the seal and reopens review/final scan.
+   the seal and reopens the applicable Legacy-v1-only review/final scan or
+   activated advisory closeout.
+   After the canonical bytes and blob OID are stored as exactly one regular
+   `100644 blob` at
+   `docs/orchestration/contracts/advisory_capability_sources.v1.json` in both
+   the authenticated base SHA and unique merge-base,
+   `seal --capability-sources-advisory` may instead emit two closed receipts:
+   Connector `review_claim=none` and Codex Security `scan_claim=none`. This
+   makes only those two capability outputs optional. Do not invoke, restart,
+   or retry either provider; after freeze, exact-head self-review, and the
+   required trusted substitute security checks, run the advisory seal command
+   directly. It never claims review,
+   scan, approval, PASS, or no findings, and strict validation still requires
+   the existing trusted exact-head substitute security-check bundle plus every
+   mapping, thread, bot, required-check, and current-head gate. Pre-closeout
+   requires the live head to equal the material head; final validation permits
+   exactly one direct child changing only the current PR mapping artifact.
+   The complete operator-outage trust boundary applies without the PR `#2142`
+   bootstrap exception, including workflows/actions, `scripts/ci/`, security
+   policy/config, dependency manifests, tests/guards, and `trivy/`, plus the
+   advisory marker and merge gate. Such changes deny self-use and close under
+   legacy v1 evidence.
 10. **One closeout commit:** author dispositions and the content-bound human
     receipt locally with `pr_review_closeout.py`, then publish mapping and seal
     once. A repeated trusted Codex unavailable-ref ancestry finding on the same
@@ -611,11 +632,57 @@ Rules:
 
 **Final-material Codex Security budget invariant (hard):**
 - The repeatable post-open pass is role-only: `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- After fixes, required local gates, current-head CI, and material freeze, run the repo-native exact-head `pulseplate-pr-review` as the local self-review. It does not itself satisfy the trusted review-evidence slot. Satisfy that slot with exactly one of a completed trusted exact-head GitHub Codex Connector review or an unedited trusted terminal Connector rate/usage-limit receipt with `review_claim=none`; the terminal unavailable path requires no retry or substitute review. Then request exactly one final manual Codex Security scan for that frozen material.
-- Lifecycle metadata records `scope=per_pr`, `automatic_budget=1`, `automatic_retries=0`, `requires_frozen_material=true`, and `additional_invocation=trusted_operator_approval`. Because `repository_invokes_plugin=false`, `automatic_budget=1` is the single operational request ceiling, not repository dispatch authority.
-- `pr_review_closeout.py prepare-final-security` requires exactly one matching evidence input: `--review-ref <exact-head-review-URL>` or `--review-source-unavailable-ref <trusted-terminal-comment-URL>`. It persists the tagged evidence without turning source unavailability into a review claim and performs no plugin call or GitHub mutation. Its atomic state is checkout-local advisory duplicate prevention only; it cannot grant authority or prove global cross-machine consumption. After the operator-issued request, `record-final-security-outcome` records `completed`, `timeout`, `safety_block`, or `incomplete`; every outcome consumes the operational request. Every additional preparation or request requires a fresh, unedited GitHub comment from an `OWNER` or `MEMBER`, created after the prior terminal outcome and bound to the exact repository, PR, full head SHA, and material digest.
-- Any material change invalidates the freeze, exact-head review, and scan evidence; merge evidence still requires one real completed scan on the exact final digest. A PR that changes security-governance, seal, merge-gate, current-head authority, CI/security workflow or action authority, or substitute-security policy inputs must not use the outage override to authorize itself.
-- GitHub Codex Connector review is separate from the locally invoked Codex Security plugin. Leave the Connector automatic: do not disable or manually retrigger it, and do not wait indefinitely when silence means no receipt. A trusted terminal rate/usage-limit receipt follows the non-review evidence mode above. The expensive Codex Security plugin is invoked manually exactly once only after final material freeze and final review-evidence validation, with no automatic retry.
+- After fixes, required local gates, current-head CI, and material freeze, run
+  the repo-native exact-head `pulseplate-pr-review` as the local self-review.
+- **Legacy-v1-only:** The local self-review does not satisfy the trusted
+  review-evidence slot. Satisfy that slot with exactly one completed trusted
+  exact-head GitHub Codex Connector review or one unedited trusted terminal
+  Connector rate/usage-limit receipt with `review_claim=none`; the terminal
+  unavailable path requires no retry or substitute review. Then request
+  exactly one final manual Codex Security scan for that frozen material.
+- **Legacy-v1-only:** Lifecycle metadata records `scope=per_pr`,
+  `automatic_budget=1`, `automatic_retries=0`,
+  `requires_frozen_material=true`, and
+  `additional_invocation=trusted_operator_approval`. Because
+  `repository_invokes_plugin=false`, `automatic_budget=1` is the single
+  operational request ceiling, not repository dispatch authority.
+- **Legacy-v1-only:** `pr_review_closeout.py prepare-final-security` requires
+  exactly one matching evidence input:
+  `--review-ref <exact-head-review-URL>` or
+  `--review-source-unavailable-ref <trusted-terminal-comment-URL>`. It
+  persists the tagged evidence without
+  turning source unavailability into a review claim and performs no plugin
+  call or GitHub mutation. Its atomic state is checkout-local advisory
+  duplicate prevention only; it cannot grant authority or prove global
+  cross-machine consumption. After the operator-issued request,
+  `record-final-security-outcome` records `completed`, `timeout`,
+  `safety_block`, or `incomplete`; every outcome consumes the operational
+  request. Every additional preparation or request requires a fresh, unedited
+  GitHub comment from an `OWNER` or `MEMBER`, created after the prior terminal
+  outcome and bound to the exact repository, PR, full head SHA, and material
+  digest.
+- **Legacy-v1-only:** GitHub Codex Connector review is separate from the
+  locally invoked Codex Security plugin. Leave the Connector automatic: do not
+  disable or manually retrigger it, and do not wait indefinitely when silence
+  means no receipt. A trusted terminal rate/usage-limit receipt follows the
+  non-review evidence mode above. Invoke the expensive Codex Security plugin
+  manually exactly once only after final material freeze and final
+  review-evidence validation, with no automatic retry.
+- **Activated advisory:** Only after the canonical marker is present with
+  byte-exact identity in the authenticated base and unique merge-base, do not
+  invoke, restart, or retry either provider. After freeze, exact-head
+  self-review, and the required trusted exact-head substitute security checks,
+  run `seal --capability-sources-advisory` directly. The no-claim receipts make
+  only the provider outputs optional: actionable findings, mapping/thread/bot
+  dispositions, the substitute security bundle, required current-head
+  CI/security checks, and strict current-head merge validation remain hard.
+- Any material change invalidates the freeze and applicable seal/evidence.
+  Legacy v1 still requires one real completed scan on the exact final digest;
+  activated advisory requires resealing the new digest and rerunning its
+  substitute-security and current-head gates. A PR that changes
+  security-governance, seal, merge-gate, current-head authority, CI/security
+  workflow or action authority, or substitute-security policy inputs must not
+  use either the outage override or activated advisory to authorize itself.
 
 ### Mandatory PR Orchestration Gates
 

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -60,14 +60,37 @@ Source of truth: the active lane packet or runbook at the canonical packet path 
 lane, which contains the enforced role-agent sequence for that task or PR.
 
 The global final-material Codex Security budget invariant is defined only in
-root `AGENTS.md`. Operationally, this runbook orders the final gates as
+root `AGENTS.md`. **Legacy-v1-only:** this runbook orders the final gates as
 freeze → exact-head `pulseplate-pr-review` self-review → trusted exact-head
 GitHub Codex Connector review evidence → local `prepare-final-security` →
 one operator-issued manual scan. The preparation command never invokes the
 plugin, and no timeout, safety block, or incomplete result is retried without
 fresh exact-material `OWNER`/`MEMBER` approval.
 
-GitHub Codex Connector review is separate from the locally invoked Codex Security plugin. Leave the Connector automatic: do not disable or manually retrigger it, and do not wait indefinitely when silence or rate limiting means no receipt. The expensive Codex Security plugin is invoked manually exactly once only after final material freeze and trusted exact-head Connector review, with no automatic retry.
+**Legacy-v1-only:** GitHub Codex Connector review is separate from the locally
+invoked Codex Security plugin. Leave the Connector automatic: do not disable
+or manually retrigger it, and do not wait indefinitely when silence or rate
+limiting means no receipt. Invoke the expensive Codex Security plugin manually
+exactly once after final material freeze and trusted exact-head Connector
+review, with no automatic retry.
+
+Once the canonical bytes and blob OID are stored as exactly one regular
+`100644 blob` at
+`docs/orchestration/contracts/advisory_capability_sources.v1.json` in the
+authenticated base SHA and unique merge-base, the operator may
+use `seal --capability-sources-advisory`. It records Connector
+`review_claim=none` and Codex Security `scan_claim=none`; only those provider
+outputs become optional. Do not invoke, restart, or retry either provider.
+After freeze, exact-head self-review, and the required trusted substitute
+security checks, run `seal --capability-sources-advisory` directly. The strict
+merge validator still requires the trusted
+exact-head substitute security-check bundle and all mapping, thread, bot,
+required-check, and current-head gates. Final validation accepts only one
+direct mapping-only child of the material head. The full operator-outage trust
+boundary applies with no PR `#2142` exception: workflows/actions, `scripts/ci/`,
+security policy/config, dependency manifests, tests/guards, and `trivy/`, plus
+the advisory marker and merge gate, are self-use denied. Such prerequisites
+close through legacy v1.
 
 **Usage:**
 ```text
@@ -519,38 +542,50 @@ Use this as the canonical operating loop from branch creation to merge window:
    - Read `AGENTS.md`, `RUNBOOK_AGENT.md`, and the nearest scoped `AGENTS.md`
    - Decide scope, risk, and which sub-agents or helpers are needed before edits
 2. **Open non-draft by default**
-   - Keep the automatic GitHub Codex Connector configuration unchanged; do not
-     manually retrigger it or hold the lane open indefinitely for a rate-limited
-     or silent Connector response.
+   - **Legacy-v1-only:** Keep the automatic GitHub Codex Connector
+     configuration unchanged; do not manually retrigger it or hold the lane
+     open indefinitely for a rate-limited or silent Connector response.
    - Open the PR ready-for-review once scope, artifact strategy, and initial local gates are coherent so bots and current-head checks run
-   - Let the configured review bots react automatically to the opened or
-     synchronized diff. Do not post manual bot-review commands or disable their
-     automatic review setting.
+   - Let configured non-capability review bots react automatically to the
+     opened or synchronized diff. Do not post manual bot-review commands or
+     disable their automatic review setting.
    - Use draft only with an explicit operator exception when review/check suppression is intentional
    - Create or confirm the canonical artifact path `docs/review/PR_<N>_FIXED_MAPPING.md`
 3. **Post-open review entry**
    - Once the PR exists, run the mandatory post-open reviewer path declared by the lane packet/runbook before calling the lane stable
    - When the lane declares `qa-engineer-agent -> bug-hunter -> security-auditor`, that pass happens after PR open, not as a substitute for pre-PR local gates
-   - Let the automatic GitHub Codex Connector observe each published diff; its
-     trusted exact-head response is the final-review evidence and remains
-     separate from the role-only pass and manually invoked Codex Security
-     plugin; do not trigger or retrigger it manually.
+   - **Legacy-v1-only:** Let the automatic GitHub Codex Connector observe each
+     published diff; its trusted exact-head response is the final-review
+     evidence and remains separate from the role-only pass and manually invoked
+     Codex Security plugin; do not trigger or retrigger it manually.
    - Fix every finding, run the required local gates and current-head CI, then
      freeze the material digest with `pr_review_closeout.py freeze`
    - Run the repo-native exact-head `pulseplate-pr-review` as the local
-     self-review; it does not itself satisfy the trusted review-evidence slot
-   - Satisfy that slot with exactly one of a completed
+     self-review; it does not itself satisfy the Legacy-v1-only trusted
+     review-evidence slot
+   - **Legacy-v1-only:** Satisfy that slot with exactly one of a completed
      trusted exact-head GitHub Codex Connector review or an unedited trusted
      terminal Connector rate/usage-limit receipt with `review_claim=none`; do not
      retry or obtain a substitute review for the terminal unavailable path
-   - Run `pr_review_closeout.py prepare-final-security --repo <owner/name>
-     --pr-number <N>` with the matching `--review-ref <exact-head-review-URL>`
-     or `--review-source-unavailable-ref <trusted-terminal-comment-URL>`, then
+   - **Legacy-v1-only:** Run `pr_review_closeout.py prepare-final-security`
+     with `--repo <owner/name> --pr-number <N>` and the matching
+     `--review-ref <exact-head-review-URL>` or
+     `--review-source-unavailable-ref <trusted-terminal-comment-URL>`, then
      have the operator make the one final manual Codex Security request; the
      command itself never invokes the plugin
-   - Record its terminal state with `record-final-security-outcome --outcome
-     <completed|timeout|safety_block|incomplete> --evidence-ref <ref>`. A later
-     approval comment must be newer than this terminal record.
+   - **Legacy-v1-only:** Record its terminal state with
+     `record-final-security-outcome` and
+     `--outcome <completed|timeout|safety_block|incomplete>` plus
+     `--evidence-ref <ref>`. A later approval comment must be newer than this
+     terminal record.
+   - **Activated advisory:** After byte-exact marker activation in the
+     authenticated base and unique merge-base, do not invoke, restart, or retry
+     either provider. After freeze, exact-head self-review, and the required
+     trusted exact-head substitute security checks, run
+     `seal --capability-sources-advisory` directly. Actionable findings,
+     mapping/thread/bot dispositions, the substitute-security bundle, required
+     current-head CI/security checks, and strict current-head merge validation
+     remain hard.
 4. **Before each push**
    - Run `pre-commit run --all-files`
    - Run the required local narrow gates for the touched scope:
@@ -670,17 +705,18 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
 
 1. `pr_review_closeout.py init` creates/resumes the gitignored local draft.
 2. Publish the coherent material diff, then `freeze` proves local HEAD equals
-   the live PR head and records its digest. Observe the configured automatic
-   Codex response; do not post a manual bot-review command. If the trusted
-   connector returns its exact review-credit exhaustion response, keep that
-   immutable same-PR comment URL as terminal source-unavailability evidence. Do
-   not retrigger the review.
+   the live PR head and records its digest. **Legacy-v1-only:** observe the
+   configured automatic Codex response; do not post a manual bot-review
+   command. If the trusted Connector returns its exact review-credit exhaustion
+   response, keep that immutable same-PR comment URL as terminal
+   source-unavailability evidence. Do not retrigger the review.
+   **Activated advisory:** do not invoke, restart, or retry either provider.
 3. Apply actionable fixes. Any material change returns to step 2; governance
    draft/body activity does not.
 4. After the final role pass, current-head gates, and material freeze, run the
    repo-native exact-head `pulseplate-pr-review` as the local self-review; it
-   does not itself satisfy the trusted review-evidence slot. Satisfy that slot
-   with exactly one of a completed trusted
+   does not itself satisfy the Legacy-v1-only trusted review-evidence slot.
+   **Legacy-v1-only:** satisfy that slot with exactly one completed trusted
    exact-head GitHub Codex Connector review or an unedited trusted terminal Connector
    rate/usage-limit receipt with `review_claim=none`; the unavailable path
    requires no retry or substitute review. Run `prepare-final-security` with
@@ -692,10 +728,14 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    do not retry without a fresh, later exact-material
    `OWNER`/`MEMBER` approval. A self-modifying security-governance PR must not
    use the bounded operator-outage path to authorize itself.
-5. Record dispositions with `add-disposition`, then run `seal` with exactly one
-   review-evidence mode: `--review-ref ...` for a completed trusted review or a
-   canonical official Connector PR-root `+1`, `heart`, `hooray`, or `rocket`
-   reaction as a nonblocking terminal positive response, or
+   **Activated advisory:** after the required trusted exact-head substitute
+   security checks, proceed directly to the advisory disposition-and-seal step;
+   do not enter, invoke, restart, or retry either legacy provider stage.
+   Actionable findings and current-head CI/security failures remain blocking.
+5. Record dispositions with `add-disposition`. **Legacy-v1-only:** run `seal`
+   with exactly one review-evidence mode: `--review-ref ...` for a completed
+   trusted review or a canonical official Connector PR-root `+1`, `heart`,
+   `hooray`, or `rocket` reaction as a nonblocking terminal positive response, or
    `--review-source-unavailable-ref ...` for an exact trusted Codex
    rate-limit / usage-limit comment. A reaction supplied through `--review-ref`
    is live-verified by exact PR-root URL and immutable Connector account identity,
@@ -734,6 +774,12 @@ Before merge: `unresolved` must be `0`. Resolve all threads in GitHub UI (Conver
    Historical PR `#2142` review-credit override receipts remain readable
    everywhere but are live-authenticated only for PR `#2142`; their old
    multi-reference authoring flags are not active CLI options for later PRs.
+   **Activated advisory:** run `seal --capability-sources-advisory` directly
+   without any Legacy-v1-only review or security evidence flags. The closed
+   receipts claim neither review nor scan and make only provider outputs
+   optional. The trusted exact-head substitute-security bundle,
+   mapping/thread/bot dispositions, required current-head CI/security checks,
+   and strict current-head merge validation remain hard.
 6. Update the live PR body with exactly one real same-repository Markdown link
    through
    `https://github.com/<owner>/<repo>/blob/<exact-live-head-ref>/docs/review/PR_<N>_FIXED_MAPPING.md`.

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -142,7 +142,8 @@ JSON block `PULSEPLATE_PR_REVIEW_SEAL_V1`. The activation boundary is the
 governance PR number + 1; the governance PR may opt in with
 `Review-Seal-Version: v1`.
 
-Root `AGENTS.md` owns the global final-material scan budget. This matrix owns
+Root `AGENTS.md` owns the global final-material scan budget.
+**Legacy-v1-only:** this matrix owns
 the field-level projection: `scope=per_pr`, `automatic_budget=1`,
 `automatic_retries=0`, `requires_frozen_material=true`,
 `additional_invocation=trusted_operator_approval`, and
@@ -155,7 +156,29 @@ rate/usage-limit receipt with `review_claim=none`; the terminal unavailable
 path requires no retry or substitute review. One operator-issued scan follows;
 the local preparation state is advisory and cannot prove global consumption.
 
-GitHub Codex Connector review is separate from the locally invoked Codex Security plugin. Leave the Connector automatic: do not disable or manually retrigger it, and do not wait indefinitely when silence means no receipt. The expensive Codex Security plugin is invoked manually exactly once only after final review-evidence validation, with no automatic retry.
+**Legacy-v1-only:** GitHub Codex Connector review is separate from the locally
+invoked Codex Security plugin. Leave the Connector automatic: do not disable
+or manually retrigger it, and do not wait indefinitely when silence means no
+receipt. Invoke the expensive Codex Security plugin manually exactly once
+after final review-evidence validation, with no automatic retry.
+
+The additive advisory-capability variant activates only when the canonical
+bytes and blob OID exist as exactly one regular `100644 blob` at
+`docs/orchestration/contracts/advisory_capability_sources.v1.json` in the
+authenticated base SHA and unique merge-base.
+`seal --capability-sources-advisory` then emits linked material-bound receipts
+with Connector `review_claim=none` and Codex Security `scan_claim=none`.
+Do not invoke, restart, or retry either provider. After freeze, exact-head
+self-review, and the required trusted substitute security checks, run
+`seal --capability-sources-advisory` directly. Provider outputs alone become
+optional; the trusted exact-head substitute
+security-check bundle, canonical mapping, review-thread dispositions, bot
+actionables, required checks, and live-head validation remain hard. Final live
+head must be exactly one direct mapping-only child of the material head. The
+complete operator-outage trust boundary applies without the PR `#2142`
+exception, including workflows/actions, `scripts/ci/`, security policy/config,
+dependency manifests, tests/guards, and `trivy/`, plus the advisory marker and
+merge gate. Such material is denied and uses legacy v1.
 
 ### Material review seal v1
 
@@ -168,8 +191,8 @@ GitHub Codex Connector review is separate from the locally invoked Codex Securit
 - Every path is material except the exact current-PR mapping artifact. PR-body
   edits are outside Git. Other docs, AGENTS/runbook, workflows, tests,
   dependencies, schemas, and policies remain material.
-- The trusted submitted Codex review object's real GitHub `commit_id` must be
-  the frozen material head. A direct PR-root reaction from the official Codex
+- **Legacy-v1-only:** The trusted submitted Codex review object's real GitHub
+  `commit_id` must be the frozen material head. A direct PR-root reaction from the official Codex
   Connector may instead use the normal `seal --review-ref` path as a nonblocking
   terminal source response only for `+1`,
   `heart`, `hooray`, or `rocket`, after live verification of its immutable
@@ -208,7 +231,13 @@ GitHub Codex Connector review is separate from the locally invoked Codex Securit
   The embedded scan record is a
   `human_asserted_content_receipt`: CI verifies schema, hashes, coverage, range,
   and content binding but does not claim signed/plugin attestation.
-- If the trusted connector returns an exact known rate-limit or usage-limit
+- **Activated advisory:** Do not invoke, restart, or retry either provider.
+  After frozen exact-head self-review and the required trusted exact-head
+  substitute security checks, `seal --capability-sources-advisory` emits the
+  linked no-claim receipts directly. The substitute-security bundle,
+  mapping/thread/bot dispositions, required current-head CI/security checks,
+  and strict live-head validation remain hard.
+- **Legacy-v1-only:** If the trusted connector returns an exact known rate-limit or usage-limit
   response, the seal uses the tagged
   `pulseplate.codex-review-source-unavailability/v1` variant. The canonical
   same-PR, unedited trusted Codex GitHub App comment is terminal unavailable
@@ -278,11 +307,15 @@ Artifact-only governance findings are fixed in the canonical artifact itself, bu
   `docs/review/PR_<N>_FIXED_MAPPING.md`
 - `post_open_review` is the packet-level phase where the canonical role-only
   `qa-engineer-agent -> bug-hunter -> security-auditor` lane is synthesized.
-  Final-material gates remain outside role dispatch: the exact-head
-  `pulseplate-pr-review` self-review, then a trusted exact-head GitHub Codex
-  Connector review or trusted terminal source-unavailable receipt, precede the
-  one operator-issued Codex Security scan; `merge_ready` keeps the
-  current-head merge-wrapper contract explicit without widening either lane.
+  Final-material gates remain outside role dispatch. After the exact-head
+  `pulseplate-pr-review` self-review, **Legacy-v1-only** requires a trusted
+  exact-head GitHub Codex Connector review or trusted terminal
+  source-unavailable receipt followed by one operator-issued Codex Security
+  scan. **Activated advisory** instead forbids invoking, restarting, or
+  retrying either provider and runs `seal --capability-sources-advisory`
+  directly after the required trusted exact-head substitute security checks.
+  Both paths retain actionable-finding closure and the current-head
+  merge-wrapper contract; advisory makes only provider outputs optional.
 
 Evidence:
 - `scripts/ci/check_pr_merge_readiness.py:1`
@@ -379,7 +412,7 @@ Canonical lane matrix:
 | Local / PR process | `pulseplate-agent-learning-loop` | Conditional hard gate | Required when operator-triggered or when repeated failure/successful-iteration patterns appear; use redacted `agent_learning_record.v1` with `pattern_kind`, bounded `learning_metrics`, proposal-only authority, and reviewed repo-diff promotion before canonical instruction changes |
 | Local / PR process | Experiment Runner oracle evidence | Hard gate | Every non-trivial PR must create oracle-only evidence by default; artifact load/write failures are infrastructure blockers, and material contribution requires governed attribution |
 | Post-open role review | `qa-engineer-agent -> bug-hunter -> security-auditor` | Hard gate | Run once after PR open; every actionable must be fixed or dispositioned before final material freeze |
-| Final-material review | repo-native exact-head `pulseplate-pr-review` self-review, then a trusted exact-head GitHub Codex Connector review or trusted terminal source-unavailable receipt, then one operator-issued manual Codex Security request | Hard gate | The local self-review is advisory and does not replace the trusted review receipt; trusted review evidence and scan bind to the frozen final digest; source unavailability claims no review and requires no retry/substitute, repository code makes no plugin call or automatic retry, and every additional request requires fresh exact-material `OWNER`/`MEMBER` approval |
+| Final-material review | repo-native exact-head `pulseplate-pr-review` self-review, then either Legacy-v1-only provider evidence or the activated `seal --capability-sources-advisory` path | Hard gate | Legacy v1 requires the trusted exact-head Connector review/source-unavailable receipt followed by one manual Codex Security request. Activated advisory must not invoke, restart, or retry either provider and makes only those outputs optional. Both paths retain frozen-material identity, actionable-finding closure, mapping/thread/bot dispositions, the applicable substitute-security bundle, required current-head CI/security checks, and strict current-head merge validation |
 | GitHub PR CI | Full/heavy verification signal | Hard gate | Current-head CI must be green for `lint`, required/current-head checks for the touched PR surface, relevant `test-main` matrix, `diff-coverage` ≥97%, applicable security/governance checks, and merge-readiness; this replaces default local full `make verify` on agent machines |
 | GitHub PR CI | Operator-approved machine-heavy deferral | Hard gate | PR body and fixed mapping document the deferral, the narrow local bundle passes, canonical current-head CI parity is green, relevant `test-main` matrix passes when selected, `diff-coverage` ≥97% is preserved when selected, and security/governance checks remain strict |
 | Local / CI  | `python scripts/orchestration/check_merge_ready.py ...` | Hard gate | Wrapper must pass Phase 2 + review governance + current-head required checks + disposition proof |

--- a/docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md
+++ b/docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md
@@ -33,6 +33,28 @@ fails closed. The receipt binds the immutable evidence to the current material
 head/digest as `seal_context_only`; a later material change requires resealing,
 but the same immutable comment may be reverified and reused.
 
+The trusted Connector receipt followed by a manual Codex Security request is
+**Legacy-v1-only**. Activated advisory does not enter that provider sequence.
+
+An independent, additive mode is available only after the canonical bytes and
+blob OID exist as exactly one regular `100644 blob` at
+`docs/orchestration/contracts/advisory_capability_sources.v1.json` in the
+authenticated base SHA and unique merge-base.
+`seal --capability-sources-advisory` emits closed material/range-bound receipts
+with Connector `review_claim=none` and Codex Security `scan_claim=none`; it
+makes those provider outputs optional and nothing else. Do not invoke, restart,
+or retry either provider. After freeze, exact-head self-review, and the
+required trusted substitute security checks, run the advisory seal command
+directly. It is not source
+unavailability, review, approval, scan, PASS, or no-findings evidence. Strict
+merge validation still requires the trusted exact-head substitute security
+bundle and every existing mapping/thread/bot/current-head gate. Final live head
+must be exactly one direct mapping-only child. The complete operator-outage
+trust boundary applies without the PR `#2142` bootstrap exception, including
+workflows/actions, `scripts/ci/`, security policy/config, dependency manifests,
+tests/guards, and `trivy/`, plus the advisory marker and merge gate. Such
+material denies self-use and uses legacy v1.
+
 Historical compatibility: the PR `#2142`
 `operator_review_credit_exhaustion_override` receipt remains parseable and
 is live-authenticated only for PR `#2142`. Its multi-reference authoring flags

--- a/docs/orchestration/contracts/advisory_capability_sources.v1.json
+++ b/docs/orchestration/contracts/advisory_capability_sources.v1.json
@@ -1,0 +1,14 @@
+{
+  "activation": "authenticated_base_and_unique_merge_base",
+  "authority": "advisory_only_no_claim",
+  "connector": {
+    "outputRequired": false,
+    "reviewClaim": "none"
+  },
+  "policyVersion": "pulseplate.advisory-capability-sources/v1",
+  "security": {
+    "outputRequired": false,
+    "scanClaim": "none",
+    "substituteSecurityBundleRequired": true
+  }
+}

--- a/scripts/ci/check_pr_merge_readiness.py
+++ b/scripts/ci/check_pr_merge_readiness.py
@@ -62,12 +62,15 @@ from scripts.orchestration.pr_review_evidence import (  # noqa: E402
     build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
+    is_advisory_capability_connector_receipt,
+    is_advisory_capability_security_receipt,
     is_review_credit_outage_receipt,
     is_mapping_only_positive_response_successor,
     is_review_source_positive_response_receipt,
     is_review_source_unavailability_receipt,
     is_security_outage_override_receipt,
     parse_embedded_review_seal,
+    validate_live_advisory_capability_receipts,
     validate_review_credit_outage_scope,
     validate_security_outage_override_scope,
     validated_duplicate_reply_urls,
@@ -841,6 +844,7 @@ def _validate_v1_seal(
     token: str,
     outage_security_wait_seconds: int = 0,
     enforce_outage_security_checks: bool = True,
+    advisory_phase: str = "final",
 ) -> dict[str, Any]:
     raw_seal = parse_embedded_review_seal(artifact_text)
     if not isinstance(raw_seal, dict):
@@ -872,7 +876,20 @@ def _validate_v1_seal(
     }:
         raise ReviewEvidenceError("material head is not a real commit in the live PR")
     code_review = seal["code_review"]
-    if is_review_source_positive_response_receipt(code_review):
+    if is_advisory_capability_connector_receipt(code_review):
+        validate_live_advisory_capability_receipts(
+            REPO_ROOT,
+            connector_receipt=code_review,
+            security_receipt=seal["codex_security"],
+            base_ref_oid=snapshot.base_sha,
+            material_head_sha=material_head.sha,
+            live_head_sha=snapshot.head_sha,
+            material_digest=material["digest"],
+            pr_number=pr_number,
+            live_material_paths=(entry.path for entry in manifest.entries),
+            phase=advisory_phase,
+        )
+    elif is_review_source_positive_response_receipt(code_review):
         response_manifest = compute_material_manifest(
             REPO_ROOT,
             base_ref_oid=snapshot.base_sha,
@@ -1053,6 +1070,18 @@ def _validate_v1_seal(
         )
         if security_receipt != expected_receipt:
             raise ReviewEvidenceError("Codex Security operator outage override receipt is stale")
+        if enforce_outage_security_checks:
+            _wait_for_operator_outage_security_checks(
+                repository=repository,
+                pr_number=pr_number,
+                token=token,
+                expected_head_sha=snapshot.head_sha,
+                security_required=_operator_outage_security_required(
+                    entry.path for entry in manifest.entries
+                ),
+                timeout_seconds=outage_security_wait_seconds,
+            )
+    elif is_advisory_capability_security_receipt(security_receipt):
         if enforce_outage_security_checks:
             _wait_for_operator_outage_security_checks(
                 repository=repository,
@@ -1308,6 +1337,7 @@ def main() -> int:
                     token=token,
                     outage_security_wait_seconds=args.outage_security_wait_seconds,
                     enforce_outage_security_checks=not args.pre_closeout,
+                    advisory_phase="pre_closeout" if args.pre_closeout else "final",
                 )
                 _prove_v1_fixed_commits(
                     mapping_entries=mapping_entries,
@@ -1436,6 +1466,8 @@ def main() -> int:
             print(f"REVIEW_SOURCE_UNAVAILABLE_VALID {seal['code_review']['source_status']}")
         elif is_review_credit_outage_receipt(seal["code_review"]):
             print(f"REVIEW_CREDIT_OUTAGE_OVERRIDE_VALID {seal['code_review']['review_commit_ref']}")
+        elif is_advisory_capability_connector_receipt(seal["code_review"]):
+            print("ADVISORY_CAPABILITY_SOURCES_VALID claims=none")
         else:
             print(f"MACHINE_BOUND_REVIEW_COMMIT {seal['code_review']['review_commit_ref']}")
     if duplicate_covered_urls:

--- a/scripts/orchestration/pr_review_closeout.py
+++ b/scripts/orchestration/pr_review_closeout.py
@@ -59,12 +59,14 @@ from scripts.orchestration.pr_review_evidence import (  # noqa: E402
     SEAL_SCHEMA_VERSION,
     UNAVAILABLE_REVIEW_REF_CAUSE,
     ReviewEvidenceError,
+    build_advisory_capability_receipts,
     build_review_credit_outage_receipt,
     build_review_source_positive_response_receipt,
     build_review_source_unavailability_receipt,
     build_security_outage_override_receipt,
     compute_material_manifest,
     ingest_codex_security_receipt,
+    is_advisory_capability_connector_receipt,
     is_review_credit_outage_receipt,
     is_mapping_only_positive_response_successor,
     is_review_source_positive_response_receipt,
@@ -73,6 +75,8 @@ from scripts.orchestration.pr_review_evidence import (  # noqa: E402
     parse_embedded_review_seal,
     render_embedded_review_seal,
     unavailable_review_ref_fingerprint,
+    validate_advisory_capability_activation,
+    validate_live_advisory_capability_receipts,
     validate_review_credit_outage_scope,
     validate_security_outage_override_scope,
 )
@@ -1411,7 +1415,39 @@ def _validate_reseal_transition(
     return str(existing_material["material_head_sha"])
 
 
+def _validate_seal_evidence_mode(args: argparse.Namespace) -> bool:
+    """Return advisory mode after enforcing its closed CLI tagged union."""
+
+    advisory = bool(getattr(args, "capability_sources_advisory", False))
+    review_ref = getattr(args, "review_ref", None)
+    unavailable_ref = getattr(args, "review_source_unavailable_ref", None)
+    scan_manifest = getattr(args, "scan_manifest", None)
+    outage_ref = getattr(args, "security_outage_override_ref", None)
+    reactions = getattr(args, "connector_advisory_reaction", None)
+    if advisory:
+        scalar_legacy_evidence_present = any(
+            value is not None for value in (review_ref, unavailable_ref, scan_manifest, outage_ref)
+        )
+        if scalar_legacy_evidence_present or reactions:
+            raise CloseoutError(
+                "--capability-sources-advisory is a closed no-output mode; "
+                "omit Connector and Codex Security evidence arguments"
+            )
+        return True
+    if (review_ref is None) == (unavailable_ref is None):
+        raise CloseoutError(
+            "legacy v1 seal requires exactly one --review-ref or " "--review-source-unavailable-ref"
+        )
+    if (scan_manifest is None) == (outage_ref is None):
+        raise CloseoutError(
+            "legacy v1 seal requires exactly one --scan-manifest or "
+            "--security-outage-override-ref"
+        )
+    return False
+
+
 def _cmd_seal(args: argparse.Namespace) -> None:
+    advisory_mode = _validate_seal_evidence_mode(args)
     state = _load_state(args.pr_number)
     if state["repository"] != args.repo:
         raise CloseoutError("--repo does not match local draft")
@@ -1436,16 +1472,37 @@ def _cmd_seal(args: argparse.Namespace) -> None:
     }
     if freeze != expected_freeze:
         raise CloseoutError("material state changed after freeze; freeze and review again")
-    connector_advisory_reactions = _optional_connector_advisory_reactions(
-        getattr(args, "connector_advisory_reaction", None),
-        repository=args.repo,
-        pr_number=args.pr_number,
-        token=token,
-    )
-    if args.review_source_unavailable_ref:
+    review_ref = getattr(args, "review_ref", None)
+    unavailable_ref = getattr(args, "review_source_unavailable_ref", None)
+    scan_manifest_arg = getattr(args, "scan_manifest", None)
+    outage_ref = getattr(args, "security_outage_override_ref", None)
+    advisory_reaction_args = getattr(args, "connector_advisory_reaction", None)
+    connector_advisory_reactions: tuple[CodexConnectorAdvisoryReactionEvidence, ...] = ()
+    if advisory_mode:
+        activated_merge_base = validate_advisory_capability_activation(
+            REPO_ROOT,
+            base_ref_oid=snapshot.base_sha,
+            head_ref_oid=snapshot.head_sha,
+            material_paths=(entry.path for entry in manifest.entries),
+        )
+        if activated_merge_base != manifest.merge_base_sha:
+            raise CloseoutError("advisory capability activation merge-base does not match material")
+        code_review_receipt, receipt = build_advisory_capability_receipts(
+            base_revision=manifest.merge_base_sha,
+            head_revision=snapshot.head_sha,
+            material_digest=manifest.digest,
+        )
+    else:
+        connector_advisory_reactions = _optional_connector_advisory_reactions(
+            advisory_reaction_args,
+            repository=args.repo,
+            pr_number=args.pr_number,
+            token=token,
+        )
+    if not advisory_mode and unavailable_ref:
         source_evidence = verify_codex_review_source_unavailability_reference(
             _required_line(
-                args.review_source_unavailable_ref,
+                unavailable_ref,
                 label="review-source-unavailable-ref",
             ),
             repository=args.repo,
@@ -1461,8 +1518,8 @@ def _cmd_seal(args: argparse.Namespace) -> None:
             source_status=source_evidence.source_status,
         )
         prepared_review_evidence = code_review_receipt
-    else:
-        review_ref = _required_line(args.review_ref, label="review-ref")
+    elif not advisory_mode:
+        review_ref = _required_line(review_ref, label="review-ref")
         review_prefix = f"https://github.com/{args.repo}/pull/{args.pr_number}#"
         if not review_ref.startswith(review_prefix):
             raise CloseoutError("review-ref must identify the requested GitHub PR")
@@ -1510,8 +1567,8 @@ def _cmd_seal(args: argparse.Namespace) -> None:
                     )
                 ),
             }
-    if args.scan_manifest:
-        scan_manifest = Path(args.scan_manifest)
+    if not advisory_mode and scan_manifest_arg:
+        scan_manifest = Path(scan_manifest_arg)
         receipt = ingest_codex_security_receipt(
             scan_manifest,
             expected_base_sha=manifest.merge_base_sha,
@@ -1525,7 +1582,7 @@ def _cmd_seal(args: argparse.Namespace) -> None:
             expected_review_evidence=prepared_review_evidence,
             scan_manifest=scan_manifest,
         )
-    else:
+    elif not advisory_mode:
         timeout_completed_at = _require_terminal_outage_final_security_preparation(
             repository=args.repo,
             pr_number=args.pr_number,
@@ -1540,7 +1597,7 @@ def _cmd_seal(args: argparse.Namespace) -> None:
         )
         outage_evidence = verify_security_outage_override_reference(
             _required_line(
-                args.security_outage_override_ref,
+                outage_ref,
                 label="security-outage-override-ref",
             ),
             repository=args.repo,
@@ -1667,7 +1724,20 @@ def validate_live_mapping(*, repository: str, pr_number: int, token: str | None)
     }:
         raise CloseoutError("sealed material head is not a real live PR commit")
     code_review = seal["code_review"]
-    if is_review_source_positive_response_receipt(code_review):
+    if is_advisory_capability_connector_receipt(code_review):
+        validate_live_advisory_capability_receipts(
+            REPO_ROOT,
+            connector_receipt=code_review,
+            security_receipt=seal["codex_security"],
+            base_ref_oid=snapshot.base_sha,
+            material_head_sha=material_head.sha,
+            live_head_sha=snapshot.head_sha,
+            material_digest=material["digest"],
+            pr_number=pr_number,
+            live_material_paths=(entry.path for entry in manifest.entries),
+            phase="final",
+        )
+    elif is_review_source_positive_response_receipt(code_review):
         response_manifest = compute_material_manifest(
             REPO_ROOT,
             base_ref_oid=snapshot.base_sha,
@@ -1906,16 +1976,50 @@ def _parser() -> argparse.ArgumentParser:
     disposition.add_argument("--verified-fix")
     disposition.set_defaults(handler=_cmd_add_disposition)
 
-    seal = subparsers.add_parser("seal")
+    seal = subparsers.add_parser(
+        "seal",
+        help="Write a content-bound review seal.",
+        description=(
+            "Write either a legacy v1 provider-evidence seal or the closed "
+            "no-provider advisory variant."
+        ),
+    )
     seal.add_argument("--repo", required=True)
     seal.add_argument("--pr-number", required=True, type=int)
-    review_evidence = seal.add_mutually_exclusive_group(required=True)
-    review_evidence.add_argument("--review-ref")
-    review_evidence.add_argument("--review-source-unavailable-ref")
-    seal.add_argument("--connector-advisory-reaction", action="append", default=[])
-    security_evidence = seal.add_mutually_exclusive_group(required=True)
-    security_evidence.add_argument("--scan-manifest")
-    security_evidence.add_argument("--security-outage-override-ref")
+    seal.add_argument(
+        "--capability-sources-advisory",
+        action="store_true",
+        help=(
+            "Use closed no-claim advisory receipts; do not pass legacy Connector "
+            "or Security evidence."
+        ),
+    )
+    legacy_review_group = seal.add_argument_group("legacy v1 Connector evidence")
+    review_evidence = legacy_review_group.add_mutually_exclusive_group(required=False)
+    review_evidence.add_argument(
+        "--review-ref",
+        help="Legacy v1: trusted exact-head Connector review or positive-response ref.",
+    )
+    review_evidence.add_argument(
+        "--review-source-unavailable-ref",
+        help="Legacy v1: trusted terminal Connector usage/rate-limit ref.",
+    )
+    legacy_review_group.add_argument(
+        "--connector-advisory-reaction",
+        action="append",
+        default=[],
+        help="Legacy v1: optional non-authoritative Connector reaction (repeatable).",
+    )
+    legacy_security_group = seal.add_argument_group("legacy v1 Codex Security evidence")
+    security_evidence = legacy_security_group.add_mutually_exclusive_group(required=False)
+    security_evidence.add_argument(
+        "--scan-manifest",
+        help="Legacy v1: completed final Codex Security scan-manifest.json path.",
+    )
+    security_evidence.add_argument(
+        "--security-outage-override-ref",
+        help="Legacy v1: authorized Codex Security outage-override ref.",
+    )
     seal.set_defaults(handler=_cmd_seal)
 
     validate = subparsers.add_parser("validate")

--- a/scripts/orchestration/pr_review_evidence.py
+++ b/scripts/orchestration/pr_review_evidence.py
@@ -50,6 +50,23 @@ REVIEW_SOURCE_POSITIVE_RESPONSE_SCHEMA_VERSION = (
 )
 REVIEW_SOURCE_POSITIVE_RESPONSE_AUTHORITY = "trusted_codex_review_source_positive_response"
 REVIEW_SOURCE_POSITIVE_RESPONSE_SOURCE = "codex_review"
+ADVISORY_CAPABILITY_SCHEMA_VERSION = "pulseplate.advisory-capability-source/v1"
+ADVISORY_CAPABILITY_AUTHORITY = "advisory_capability_source"
+ADVISORY_CAPABILITY_MARKER_PATH = "docs/orchestration/contracts/advisory_capability_sources.v1.json"
+ADVISORY_CAPABILITY_MARKER = {
+    "activation": "authenticated_base_and_unique_merge_base",
+    "authority": "advisory_only_no_claim",
+    "connector": {
+        "outputRequired": False,
+        "reviewClaim": "none",
+    },
+    "policyVersion": "pulseplate.advisory-capability-sources/v1",
+    "security": {
+        "outputRequired": False,
+        "scanClaim": "none",
+        "substituteSecurityBundleRequired": True,
+    },
+}
 OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS = frozenset(
     {
         ".bandit",
@@ -64,6 +81,7 @@ OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS = frozenset(
         "docs/orchestration/AGENTS.md",
         "docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md",
         "docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md",
+        ADVISORY_CAPABILITY_MARKER_PATH,
         "docs/orchestration/contracts/review_source_status.v1.json",
         "scripts/ci_bandit.sh",
         "scripts/ci_pip_audit.sh",
@@ -93,6 +111,16 @@ OPERATOR_OUTAGE_TRUST_BOUNDARY_PREFIXES = (
     "tests/guards/",
     "trivy/",
 )
+ADVISORY_CAPABILITY_ADDITIONAL_AUTHORIZING_PATHS = frozenset(
+    {
+        ADVISORY_CAPABILITY_MARKER_PATH,
+        "scripts/ci/check_pr_merge_readiness.py",
+    }
+)
+ADVISORY_CAPABILITY_AUTHORIZING_PATHS = (
+    OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS | ADVISORY_CAPABILITY_ADDITIONAL_AUTHORIZING_PATHS
+)
+ADVISORY_CAPABILITY_AUTHORIZING_PREFIXES = OPERATOR_OUTAGE_TRUST_BOUNDARY_PREFIXES
 REVIEW_CREDIT_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS = frozenset(
     {
         "AGENTS.md",
@@ -499,12 +527,19 @@ def _git_environment() -> dict[str, str]:
     return env
 
 
-def _run_git(repo_root: Path, args: list[str], *, timeout: int = 30) -> bytes:
+def _run_git(
+    repo_root: Path,
+    args: list[str],
+    *,
+    timeout: int = 30,
+    input_bytes: bytes | None = None,
+) -> bytes:
     git = _git_path()
     result = subprocess.run(  # nosec B603: absolute git plus validated fixed argv (remove-by: 2026-09-30, ref: PR-governance-seal)
         [git, *args],
         cwd=repo_root,
         env=_git_environment(),
+        input=input_bytes,
         capture_output=True,
         timeout=timeout,
         check=False,
@@ -529,6 +564,34 @@ def _validate_material_path(path_bytes: bytes) -> str:
     ):
         raise ReviewEvidenceError(f"Git diff contains unsafe path {path!r}")
     return path
+
+
+def _protected_material_paths(
+    material_paths: Iterable[str],
+    *,
+    exact_paths: frozenset[str],
+    prefixes: tuple[str, ...],
+    include_dependency_manifests: bool = False,
+) -> tuple[str, ...]:
+    """Return the deterministic protected subset for one authority boundary."""
+
+    return tuple(
+        sorted(
+            {
+                path
+                for path in material_paths
+                if path in exact_paths
+                or path.startswith(prefixes)
+                or (
+                    include_dependency_manifests
+                    and (
+                        PurePosixPath(path).name in _DEPENDENCY_MANIFEST_BASENAMES
+                        or _ROOT_REQUIREMENTS_MANIFEST_RE.fullmatch(PurePosixPath(path).name)
+                    )
+                )
+            }
+        )
+    )
 
 
 def _parse_raw_diff(raw: bytes, *, excluded_path: str) -> tuple[MaterialEntry, ...]:
@@ -659,6 +722,322 @@ def compute_material_manifest(
         entries=entries,
         digest=digest,
     )
+
+
+def advisory_capability_marker_bytes() -> bytes:
+    """Return the one byte-exact activation marker accepted by strict gates."""
+
+    return (
+        json.dumps(
+            ADVISORY_CAPABILITY_MARKER,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _advisory_capability_inactive(detail: str) -> ReviewEvidenceError:
+    return ReviewEvidenceError(
+        "ADVISORY_CAPABILITY_INACTIVE: "
+        f"{detail}; recovery: merge the prerequisite into the authenticated base, "
+        "refresh the PR from that base so the marker is in the unique merge-base, "
+        "then freeze and seal again"
+    )
+
+
+def _require_advisory_marker_at_revision(
+    repo_root: Path,
+    *,
+    revision: str,
+    label: str,
+    expected_bytes: bytes,
+    expected_oid: str,
+) -> None:
+    raw_entry = _run_git(
+        repo_root,
+        [
+            "ls-tree",
+            "-z",
+            "--full-tree",
+            revision,
+            "--",
+            ADVISORY_CAPABILITY_MARKER_PATH,
+        ],
+    )
+    if not raw_entry:
+        raise _advisory_capability_inactive(f"marker missing from {label}")
+    if not raw_entry.endswith(b"\0"):
+        raise _advisory_capability_inactive(f"marker tree entry is malformed in {label}")
+    records = raw_entry[:-1].split(b"\0")
+    if len(records) != 1:
+        raise _advisory_capability_inactive(f"marker must be exactly one 100644 blob in {label}")
+    try:
+        metadata, path = records[0].split(b"\t", 1)
+        mode, object_type, raw_oid = metadata.split(b" ")
+        oid = raw_oid.decode("ascii")
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise _advisory_capability_inactive(f"marker tree entry is malformed in {label}") from exc
+    if (
+        path != ADVISORY_CAPABILITY_MARKER_PATH.encode()
+        or re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", oid) is None
+    ):
+        raise _advisory_capability_inactive(f"marker tree entry is malformed in {label}")
+    if mode != b"100644" or object_type != b"blob":
+        raise _advisory_capability_inactive(f"marker must be exactly one 100644 blob in {label}")
+    if oid != expected_oid:
+        raise _advisory_capability_inactive(f"marker blob OID differs in {label}")
+    try:
+        marker = _run_git(repo_root, ["cat-file", "blob", oid])
+    except ReviewEvidenceError as exc:
+        raise _advisory_capability_inactive(f"marker blob is unavailable in {label}") from exc
+    if marker != expected_bytes:
+        raise _advisory_capability_inactive(f"marker bytes differ in {label}")
+
+
+def validate_advisory_capability_activation(
+    repo_root: Path,
+    *,
+    base_ref_oid: str,
+    head_ref_oid: str,
+    material_paths: Iterable[str],
+) -> str:
+    """Require an already-merged marker and deny changes to its authority path."""
+
+    touched = _protected_material_paths(
+        material_paths,
+        exact_paths=ADVISORY_CAPABILITY_AUTHORIZING_PATHS,
+        prefixes=ADVISORY_CAPABILITY_AUTHORIZING_PREFIXES,
+        include_dependency_manifests=True,
+    )
+    if touched:
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_SELF_USE_DENIED: current material changes "
+            "authorizing paths: " + ", ".join(touched)
+        )
+    base_sha = _require_sha(base_ref_oid, label="advisory capability base_ref_oid")
+    head_sha = _require_sha(head_ref_oid, label="advisory capability head_ref_oid")
+    root = repo_root.resolve(strict=True)
+    merge_base_raw = _run_git(root, ["merge-base", "--all", base_sha, head_sha])
+    merge_bases = [line for line in merge_base_raw.decode("ascii").splitlines() if line]
+    if len(merge_bases) != 1:
+        raise _advisory_capability_inactive("base/head must have exactly one unique merge-base")
+    merge_base_sha = _require_sha(
+        merge_bases[0],
+        label="advisory capability merge base",
+    )
+    expected = advisory_capability_marker_bytes()
+    raw_expected_oid = _run_git(
+        root,
+        ["hash-object", "--stdin"],
+        input_bytes=expected,
+    )
+    expected_oid_lines = raw_expected_oid.decode("ascii", errors="replace").splitlines()
+    if (
+        len(expected_oid_lines) != 1
+        or re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", expected_oid_lines[0]) is None
+    ):
+        raise _advisory_capability_inactive("canonical marker blob OID is malformed")
+    expected_oid = expected_oid_lines[0]
+    for label, revision in (
+        ("authenticated base", base_sha),
+        ("unique merge-base", merge_base_sha),
+    ):
+        _require_advisory_marker_at_revision(
+            root,
+            revision=revision,
+            label=label,
+            expected_bytes=expected,
+            expected_oid=expected_oid,
+        )
+    return merge_base_sha
+
+
+def _require_canonical_mapping_blob_at_revision(
+    repo_root: Path,
+    *,
+    revision: str,
+    expected_path: str,
+) -> None:
+    """Require one regular canonical mapping blob at the accepted live revision."""
+
+    raw_entry = _run_git(
+        repo_root,
+        [
+            "ls-tree",
+            "-z",
+            "--full-tree",
+            revision,
+            "--",
+            expected_path,
+        ],
+    )
+    if not raw_entry:
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: canonical mapping artifact is missing at "
+            f"{expected_path}"
+        )
+    if not raw_entry.endswith(b"\0"):
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: canonical mapping tree entry is malformed at "
+            f"{expected_path}"
+        )
+    records = raw_entry[:-1].split(b"\0")
+    if len(records) != 1:
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: canonical mapping artifact must be "
+            f"exactly one regular 100644 blob at {expected_path}"
+        )
+    try:
+        metadata, path = records[0].split(b"\t", 1)
+        mode, object_type, raw_oid = metadata.split(b" ")
+        oid = raw_oid.decode("ascii")
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: canonical mapping tree entry is malformed at "
+            f"{expected_path}"
+        ) from exc
+    if (
+        path != expected_path.encode()
+        or re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", oid) is None
+    ):
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: canonical mapping tree entry is malformed at "
+            f"{expected_path}"
+        )
+    if mode != b"100644" or object_type != b"blob":
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: canonical mapping artifact must be "
+            f"exactly one regular 100644 blob at {expected_path}"
+        )
+
+
+def validate_advisory_live_head_topology(
+    repo_root: Path,
+    *,
+    material_head_sha: str,
+    live_head_sha: str,
+    pr_number: int,
+    phase: str,
+) -> None:
+    """Require the exact pre-closeout head or one direct mapping-only child."""
+
+    material_head = _require_sha(material_head_sha, label="advisory material head")
+    live_head = _require_sha(live_head_sha, label="advisory live head")
+    if pr_number <= 0:
+        raise ReviewEvidenceError("pr_number must be positive")
+    if phase not in {"pre_closeout", "final"}:
+        raise ReviewEvidenceError("advisory live-head phase is unsupported")
+    if phase == "pre_closeout":
+        if live_head != material_head:
+            raise ReviewEvidenceError(
+                "ADVISORY_CAPABILITY_HEAD_INVALID: pre-closeout live head must equal material head"
+            )
+        return
+    if live_head == material_head:
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: final live head must be one mapping-only child"
+        )
+
+    root = repo_root.resolve(strict=True)
+    raw_parents = _run_git(root, ["rev-list", "--parents", "-n", "1", live_head])
+    try:
+        parent_lines = raw_parents.decode("ascii").splitlines()
+    except UnicodeDecodeError as exc:
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: live commit parents are malformed"
+        ) from exc
+    if len(parent_lines) != 1 or parent_lines[0].split() != [live_head, material_head]:
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: final live head must be one direct child "
+            "of material head"
+        )
+
+    expected_path = f"docs/review/PR_{pr_number}_FIXED_MAPPING.md"
+    _require_canonical_mapping_blob_at_revision(
+        root,
+        revision=live_head,
+        expected_path=expected_path,
+    )
+    raw_paths = _run_git(
+        root,
+        [
+            "diff-tree",
+            "-r",
+            "--name-only",
+            "-z",
+            "--no-commit-id",
+            "--no-renames",
+            material_head,
+            live_head,
+            "--",
+        ],
+    )
+    if raw_paths and not raw_paths.endswith(b"\0"):
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: mapping successor diff is malformed"
+        )
+    paths = tuple(
+        _validate_material_path(path) for path in (raw_paths[:-1].split(b"\0") if raw_paths else ())
+    )
+    if paths != (expected_path,):
+        raise ReviewEvidenceError(
+            "ADVISORY_CAPABILITY_HEAD_INVALID: final child must change only " f"{expected_path}"
+        )
+
+
+def validate_live_advisory_capability_receipts(
+    repo_root: Path,
+    *,
+    connector_receipt: Any,
+    security_receipt: Any,
+    base_ref_oid: str,
+    material_head_sha: str,
+    live_head_sha: str,
+    material_digest: str,
+    pr_number: int,
+    live_material_paths: Iterable[str],
+    phase: str,
+) -> None:
+    """Revalidate one linked advisory pair against live material and topology."""
+
+    if not is_advisory_capability_connector_receipt(
+        connector_receipt
+    ) or not is_advisory_capability_security_receipt(security_receipt):
+        raise ReviewEvidenceError(
+            "advisory capability mode requires linked Connector and Security receipts"
+        )
+    validate_advisory_live_head_topology(
+        repo_root,
+        material_head_sha=material_head_sha,
+        live_head_sha=live_head_sha,
+        pr_number=pr_number,
+        phase=phase,
+    )
+    material_manifest = compute_material_manifest(
+        repo_root,
+        base_ref_oid=base_ref_oid,
+        head_ref_oid=material_head_sha,
+        pr_number=pr_number,
+    )
+    if material_manifest.digest != material_digest:
+        raise ReviewEvidenceError(
+            "advisory capability material head has a different material digest"
+        )
+    activated_merge_base = validate_advisory_capability_activation(
+        repo_root,
+        base_ref_oid=base_ref_oid,
+        head_ref_oid=live_head_sha,
+        material_paths=live_material_paths,
+    )
+    expected_connector, expected_security = build_advisory_capability_receipts(
+        base_revision=activated_merge_base,
+        head_revision=material_head_sha,
+        material_digest=material_digest,
+    )
+    if connector_receipt != expected_connector or security_receipt != expected_security:
+        raise ReviewEvidenceError("advisory capability receipts are stale")
 
 
 def _safe_relative_artifact_path(value: Any) -> PurePosixPath:
@@ -1091,6 +1470,65 @@ def ingest_codex_security_receipt(
         os.close(root_descriptor)
 
 
+def build_advisory_capability_receipts(
+    *,
+    base_revision: str,
+    head_revision: str,
+    material_digest: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build two closed no-claim receipts for optional capability outputs."""
+
+    connector = {
+        "authority": ADVISORY_CAPABILITY_AUTHORITY,
+        "binding_kind": "seal_context_only",
+        "blocking": False,
+        "capability_source": "codex_connector",
+        "material_digest": material_digest,
+        "material_head_sha": head_revision,
+        "output_required": False,
+        "review_claim": "none",
+        "schema_version": ADVISORY_CAPABILITY_SCHEMA_VERSION,
+        "status": "advisory_optional",
+    }
+    security = {
+        "authority": ADVISORY_CAPABILITY_AUTHORITY,
+        "base_revision": base_revision,
+        "binding_kind": "seal_context_only",
+        "blocking": False,
+        "capability_source": "codex_security_plugin",
+        "head_revision": head_revision,
+        "material_digest": material_digest,
+        "no_findings_claim": False,
+        "output_required": False,
+        "scan_claim": "none",
+        "scan_id": None,
+        "schema_version": ADVISORY_CAPABILITY_SCHEMA_VERSION,
+        "status": "advisory_optional",
+        "substitute_security_bundle_required": True,
+    }
+    _validate_code_review_receipt(connector, material_digest=material_digest)
+    _validate_security_receipt(security)
+    return connector, security
+
+
+def is_advisory_capability_connector_receipt(receipt: Any) -> bool:
+    return (
+        isinstance(receipt, dict)
+        and receipt.get("schema_version") == ADVISORY_CAPABILITY_SCHEMA_VERSION
+        and receipt.get("authority") == ADVISORY_CAPABILITY_AUTHORITY
+        and receipt.get("capability_source") == "codex_connector"
+    )
+
+
+def is_advisory_capability_security_receipt(receipt: Any) -> bool:
+    return (
+        isinstance(receipt, dict)
+        and receipt.get("schema_version") == ADVISORY_CAPABILITY_SCHEMA_VERSION
+        and receipt.get("authority") == ADVISORY_CAPABILITY_AUTHORITY
+        and receipt.get("capability_source") == "codex_security_plugin"
+    )
+
+
 def build_security_outage_override_receipt(
     *,
     base_revision: str,
@@ -1294,13 +1732,10 @@ def validate_review_credit_outage_scope(
 ) -> None:
     """Keep the historical credit-outage receipt live-valid only for PR #2142."""
 
-    touched = sorted(
-        {
-            path
-            for path in material_paths
-            if path in REVIEW_CREDIT_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS
-            or path.startswith(REVIEW_CREDIT_OUTAGE_TRUST_BOUNDARY_PREFIXES)
-        }
+    touched = _protected_material_paths(
+        material_paths,
+        exact_paths=REVIEW_CREDIT_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS,
+        prefixes=REVIEW_CREDIT_OUTAGE_TRUST_BOUNDARY_PREFIXES,
     )
     is_bootstrap = (
         repository.casefold() == REVIEW_CREDIT_OUTAGE_BOOTSTRAP_REPOSITORY.casefold()
@@ -1328,15 +1763,11 @@ def validate_security_outage_override_scope(
 ) -> None:
     """Deny outage self-authorization outside the one reviewed bootstrap PR."""
 
-    touched = sorted(
-        {
-            path
-            for path in material_paths
-            if path in OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS
-            or path.startswith(OPERATOR_OUTAGE_TRUST_BOUNDARY_PREFIXES)
-            or PurePosixPath(path).name in _DEPENDENCY_MANIFEST_BASENAMES
-            or _ROOT_REQUIREMENTS_MANIFEST_RE.fullmatch(PurePosixPath(path).name)
-        }
+    touched = _protected_material_paths(
+        material_paths,
+        exact_paths=OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS,
+        prefixes=OPERATOR_OUTAGE_TRUST_BOUNDARY_PREFIXES,
+        include_dependency_manifests=True,
     )
     if not touched:
         return
@@ -1354,6 +1785,42 @@ def validate_security_outage_override_scope(
 def _validate_security_receipt(receipt: Any) -> None:
     if not isinstance(receipt, dict):
         raise ReviewEvidenceError("codex_security must be an object")
+    if is_advisory_capability_security_receipt(receipt):
+        _require_exact_keys(
+            receipt,
+            {
+                "authority",
+                "base_revision",
+                "binding_kind",
+                "blocking",
+                "capability_source",
+                "head_revision",
+                "material_digest",
+                "no_findings_claim",
+                "output_required",
+                "scan_claim",
+                "scan_id",
+                "schema_version",
+                "status",
+                "substitute_security_bundle_required",
+            },
+            label="codex_security advisory capability",
+        )
+        _require_sha(receipt["base_revision"], label="codex_security.base_revision")
+        _require_sha(receipt["head_revision"], label="codex_security.head_revision")
+        _require_digest(receipt["material_digest"], label="codex_security.material_digest")
+        if (
+            receipt["binding_kind"] != "seal_context_only"
+            or receipt["blocking"] is not False
+            or receipt["no_findings_claim"] is not False
+            or receipt["output_required"] is not False
+            or receipt["scan_claim"] != "none"
+            or receipt["scan_id"] is not None
+            or receipt["status"] != "advisory_optional"
+            or receipt["substitute_security_bundle_required"] is not True
+        ):
+            raise ReviewEvidenceError("Codex Security advisory capability receipt is malformed")
+        return
     if receipt.get("authority") == OPERATOR_OUTAGE_AUTHORITY:
         _require_exact_keys(
             receipt,
@@ -1453,6 +1920,43 @@ def _validate_security_receipt(receipt: Any) -> None:
 def _validate_code_review_receipt(receipt: Any, *, material_digest: str) -> None:
     if not isinstance(receipt, dict):
         raise ReviewEvidenceError("review seal code_review must be an object")
+    if is_advisory_capability_connector_receipt(receipt):
+        _require_exact_keys(
+            receipt,
+            {
+                "authority",
+                "binding_kind",
+                "blocking",
+                "capability_source",
+                "material_digest",
+                "material_head_sha",
+                "output_required",
+                "review_claim",
+                "schema_version",
+                "status",
+            },
+            label="review seal code_review advisory capability",
+        )
+        _require_sha(
+            receipt["material_head_sha"],
+            label="code_review.material_head_sha",
+        )
+        _require_digest(
+            receipt["material_digest"],
+            label="code_review.material_digest",
+        )
+        if (
+            receipt["material_digest"] != material_digest
+            or receipt["binding_kind"] != "seal_context_only"
+            or receipt["blocking"] is not False
+            or receipt["output_required"] is not False
+            or receipt["review_claim"] != "none"
+            or receipt["status"] != "advisory_optional"
+        ):
+            raise ReviewEvidenceError(
+                "review seal code_review advisory capability receipt is malformed"
+            )
+        return
     has_source_schema = receipt.get("schema_version") == REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION
     has_source_authority = receipt.get("authority") == REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY
     if has_source_schema != has_source_authority:
@@ -1713,9 +2217,16 @@ def validate_review_seal(seal: Any) -> dict[str, Any]:
         raise ReviewEvidenceError("review seal material policy version is unsupported")
     code_review = seal["code_review"]
     _validate_code_review_receipt(code_review, material_digest=material_digest)
+    advisory_connector = is_advisory_capability_connector_receipt(code_review)
+    advisory_security = is_advisory_capability_security_receipt(seal["codex_security"])
+    if advisory_connector != advisory_security:
+        raise ReviewEvidenceError(
+            "advisory capability mode requires linked Connector and Security receipts"
+        )
     if (
         is_review_source_unavailability_receipt(code_review)
         or is_review_source_positive_response_receipt(code_review)
+        or advisory_connector
     ) and (code_review["material_head_sha"] != material["material_head_sha"]):
         raise ReviewEvidenceError(
             "review-source context receipt does not match sealed material head"
@@ -1731,6 +2242,10 @@ def validate_review_seal(seal: Any) -> dict[str, Any]:
     ):
         raise ReviewEvidenceError(
             "Codex Security operator outage override does not match sealed material digest"
+        )
+    if advisory_security and seal["codex_security"]["material_digest"] != material_digest:
+        raise ReviewEvidenceError(
+            "Codex Security advisory capability receipt does not match sealed material digest"
         )
     return seal
 

--- a/scripts/run-backend-tests-pre-commit.sh
+++ b/scripts/run-backend-tests-pre-commit.sh
@@ -170,6 +170,7 @@ declare -a REVIEW_SOURCE_QUOTA_POLICY_SURFACE_FILES=(
     "RUNBOOK_AGENT.md"
     "docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md"
     "docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md"
+    "docs/orchestration/contracts/advisory_capability_sources.v1.json"
     "docs/orchestration/contracts/review_source_status.v1.json"
     "scripts/ci/check_pr_merge_readiness.py"
     "scripts/orchestration/pr_commit_identity.py"

--- a/tests/guards/test_review_source_quota_policy_guard.py
+++ b/tests/guards/test_review_source_quota_policy_guard.py
@@ -8,9 +8,16 @@ import pytest
 
 from scripts.orchestration import pr_review_closeout
 from scripts.orchestration.pr_review_evidence import (
+    ADVISORY_CAPABILITY_AUTHORIZING_PREFIXES,
+    ADVISORY_CAPABILITY_AUTHORIZING_PATHS,
+    ADVISORY_CAPABILITY_MARKER_PATH,
+    OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS,
+    OPERATOR_OUTAGE_TRUST_BOUNDARY_PREFIXES,
     REVIEW_SOURCE_UNAVAILABILITY_AUTHORITY,
     REVIEW_SOURCE_UNAVAILABILITY_SCHEMA_VERSION,
     ReviewEvidenceError,
+    advisory_capability_marker_bytes,
+    build_advisory_capability_receipts,
     build_review_source_unavailability_receipt,
     validate_review_credit_outage_scope,
 )
@@ -31,6 +38,7 @@ POLICY_SURFACE_FILES = {
     "RUNBOOK_AGENT.md",
     "docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md",
     "docs/orchestration/REVIEW_SOURCE_DEGRADATION_POLICY.md",
+    "docs/orchestration/contracts/advisory_capability_sources.v1.json",
     "docs/orchestration/contracts/review_source_status.v1.json",
     "scripts/ci/check_pr_merge_readiness.py",
     "scripts/orchestration/pr_commit_identity.py",
@@ -155,6 +163,7 @@ def test_closeout_exposes_only_current_review_authoring_modes() -> None:
     options = _seal_option_strings()
     assert {"--review-ref", "--review-source-unavailable-ref"} <= options
     assert "--connector-advisory-reaction" in options
+    assert "--capability-sources-advisory" in options
     assert not options.intersection(LEGACY_AUTHORING_OPTIONS)
     closeout_source = (REPO_ROOT / "scripts/orchestration/pr_review_closeout.py").read_text(
         encoding="utf-8"
@@ -180,6 +189,27 @@ def test_quota_receipt_authority_never_claims_review_or_blocking() -> None:
     assert receipt["blocking"] is False
     assert "review_reference" not in receipt
     assert "review_commit_ref" not in receipt
+
+
+def test_advisory_capability_contract_is_exact_no_claim_and_self_protected() -> None:
+    marker = REPO_ROOT / ADVISORY_CAPABILITY_MARKER_PATH
+    assert marker.read_bytes() == advisory_capability_marker_bytes()
+    assert ADVISORY_CAPABILITY_AUTHORIZING_PATHS.issuperset(
+        OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS
+    )
+    assert ADVISORY_CAPABILITY_AUTHORIZING_PATHS - OPERATOR_OUTAGE_TRUST_BOUNDARY_EXACT_PATHS == {
+        "scripts/ci/check_pr_merge_readiness.py"
+    }
+    assert ADVISORY_CAPABILITY_AUTHORIZING_PREFIXES == OPERATOR_OUTAGE_TRUST_BOUNDARY_PREFIXES
+    connector, security = build_advisory_capability_receipts(
+        base_revision="a" * 40,
+        head_revision="b" * 40,
+        material_digest="sha256:" + "c" * 64,
+    )
+    assert connector["review_claim"] == "none"
+    assert security["scan_claim"] == "none"
+    assert security["no_findings_claim"] is False
+    assert security["substitute_security_bundle_required"] is True
 
 
 def test_authoritative_docs_keep_terminal_warning_only_contract() -> None:
@@ -211,6 +241,9 @@ def test_authoritative_docs_keep_terminal_warning_only_contract() -> None:
             "prior_review_required=false",
             "operator_override_required=false",
             "ttl_required=false",
+            "--capability-sources-advisory",
+            "scan_claim=none",
+            "advisory_capability_sources.v1.json",
         ):
             assert anchor in document, f"{path}: missing {anchor}"
         assert any(
@@ -221,6 +254,13 @@ def test_authoritative_docs_keep_terminal_warning_only_contract() -> None:
                 "requires no retry",
             )
         ), f"{path}: missing terminal no-retry contract"
+        for anchor in (
+            "legacy-v1-only",
+            "do not invoke, restart, or retry either provider",
+            "current-head",
+            "substitute",
+        ):
+            assert anchor in normalized_casefold, f"{path}: missing final-mode split {anchor}"
     runbook = documents["RUNBOOK_AGENT.md"]
     normalized_runbook = " ".join(runbook.split())
     assert "do not trigger or retrigger it manually" in normalized_runbook

--- a/tests/test_pr_merge_readiness_gate.py
+++ b/tests/test_pr_merge_readiness_gate.py
@@ -36,6 +36,8 @@ from scripts.orchestration.pr_review_evidence import (
     MATERIAL_POLICY_VERSION,
     RECEIPT_AUTHORITY,
     ReviewEvidenceError,
+    advisory_capability_marker_bytes,
+    build_advisory_capability_receipts,
     build_review_credit_outage_receipt,
     build_review_source_positive_response_receipt,
     build_review_source_unavailability_receipt,
@@ -2413,3 +2415,141 @@ def test_fetch_pr_context_includes_exact_head_ref(monkeypatch: pytest.MonkeyPatc
         "body",
         "codex/review",
     )
+
+
+def test_ci_gate_advisory_capability_requires_live_exact_head_substitute_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    marker = repo / "docs" / "orchestration" / "contracts" / "advisory_capability_sources.v1.json"
+    marker.parent.mkdir(parents=True)
+    marker.write_bytes(advisory_capability_marker_bytes())
+    base_sha = _commit(repo, "activate advisory capability")
+    source = repo / "src" / "policy.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("ENFORCED = True\n", encoding="utf-8")
+    material_head = _commit(repo, "material")
+    material = compute_material_manifest(
+        repo,
+        base_ref_oid=base_sha,
+        head_ref_oid=material_head,
+        pr_number=42,
+    )
+    connector, security = build_advisory_capability_receipts(
+        base_revision=base_sha,
+        head_revision=material_head,
+        material_digest=material.digest,
+    )
+    seal = {
+        "authority": RECEIPT_AUTHORITY,
+        "code_review": connector,
+        "codex_security": security,
+        "material": {
+            "base_ref_oid": base_sha,
+            "digest": material.digest,
+            "material_head_sha": material_head,
+            "merge_base_sha": base_sha,
+            "policy_version": MATERIAL_POLICY_VERSION,
+        },
+        "pr_number": 42,
+        "repository": "owner/repo",
+        "schema_version": "pulseplate.pr-review-seal/v1",
+    }
+    mapping = repo / "docs" / "review" / "PR_42_FIXED_MAPPING.md"
+    mapping.parent.mkdir(parents=True)
+    mapping.write_text(_artifact_with_seal(seal), encoding="utf-8")
+    live_head = _commit(repo, "mapping-only closeout")
+    snapshot = PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=base_sha,
+        head_sha=live_head,
+        commits=(
+            PrCommitEvidence(material_head, None),
+            PrCommitEvidence(live_head, None),
+        ),
+    )
+    monkeypatch.setattr(merge_gate, "REPO_ROOT", repo)
+    monkeypatch.setattr(
+        merge_gate,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(
+            value,
+            CommitRefKind.PR_COMMIT if value == material_head else CommitRefKind.PR_HEAD,
+        ),
+    )
+    monkeypatch.setattr(merge_gate, "is_ancestor", lambda *_a, **_k: True)
+    bundle_heads: list[str] = []
+    monkeypatch.setattr(
+        merge_gate,
+        "_validate_operator_outage_security_checks",
+        lambda **kwargs: bundle_heads.append(kwargs["expected_head_sha"]),
+    )
+    monkeypatch.setattr(
+        merge_gate,
+        "verify_codex_review_reference",
+        lambda *_a, **_k: pytest.fail("advisory mode must not verify Connector output"),
+    )
+
+    artifact = _artifact_with_seal(seal)
+    monkeypatch.setenv("GITHUB_TOKEN", "opaque")
+    monkeypatch.setattr(merge_gate, "REVIEW_SEAL_REQUIRED_FROM_PR", 1)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_pr_merge_readiness.py",
+            "--pr-number",
+            "42",
+            "--repo",
+            "owner/repo",
+        ],
+    )
+    pr_context = (
+        42,
+        "owner/repo",
+        False,
+        "- [canonical artifact](https://github.com/owner/repo/blob/main/"
+        "docs/review/PR_42_FIXED_MAPPING.md)",
+        "main",
+    )
+    monkeypatch.setattr(merge_gate, "_fetch_pr_context", lambda *_a, **_k: pr_context)
+    monkeypatch.setattr(merge_gate, "fetch_pr_snapshot", lambda *_a, **_k: snapshot)
+    monkeypatch.setattr(merge_gate, "_local_head_sha", lambda: live_head)
+    monkeypatch.setattr(merge_gate, "fetch_review_threads", lambda *_a, **_k: ())
+    monkeypatch.setattr(merge_gate, "_collect_actionable_items", lambda **_k: [])
+    monkeypatch.setattr(merge_gate, "read_mapping_artifact", lambda _pr: artifact)
+    monkeypatch.setattr(merge_gate, "assert_snapshot_unchanged", lambda *_a, **_k: None)
+
+    assert merge_gate.main() == 0
+    output = capsys.readouterr().out
+    assert "ADVISORY_CAPABILITY_SOURCES_VALID claims=none" in output
+    assert "MACHINE_BOUND_REVIEW_COMMIT" not in output
+    assert bundle_heads == [live_head]
+
+    mapping.write_text(mapping.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    second_mapping_head = _commit(repo, "second mapping-only commit")
+    two_commit_snapshot = PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=base_sha,
+        head_sha=second_mapping_head,
+        commits=(
+            PrCommitEvidence(material_head, None),
+            PrCommitEvidence(live_head, None),
+            PrCommitEvidence(second_mapping_head, None),
+        ),
+    )
+    with pytest.raises(ReviewEvidenceError, match="one direct child"):
+        merge_gate._validate_v1_seal(
+            artifact_text=artifact,
+            repository="owner/repo",
+            pr_number=42,
+            snapshot=two_commit_snapshot,
+            token="opaque",
+            enforce_outage_security_checks=False,
+        )

--- a/tests/test_pr_review_material_seal.py
+++ b/tests/test_pr_review_material_seal.py
@@ -47,12 +47,16 @@ from scripts.orchestration import pr_commit_identity as identity_module
 from scripts.orchestration import pr_review_closeout as closeout_module
 from scripts.orchestration import pr_review_evidence as evidence_module
 from scripts.orchestration.pr_review_evidence import (
+    ADVISORY_CAPABILITY_AUTHORIZING_PREFIXES,
+    ADVISORY_CAPABILITY_AUTHORIZING_PATHS,
     MATERIAL_POLICY_VERSION,
     RECEIPT_AUTHORITY,
     SEAL_BEGIN,
     SEAL_END,
     MaterialManifest,
     ReviewEvidenceError,
+    advisory_capability_marker_bytes,
+    build_advisory_capability_receipts,
     build_review_credit_outage_receipt,
     build_review_source_positive_response_receipt,
     build_review_source_unavailability_receipt,
@@ -68,6 +72,8 @@ from scripts.orchestration.pr_review_evidence import (
     render_embedded_review_seal,
     unavailable_review_ref_fingerprint,
     validate_review_credit_outage_scope,
+    validate_advisory_capability_activation,
+    validate_advisory_live_head_topology,
     validate_security_outage_override_scope,
     validated_duplicate_reply_urls,
 )
@@ -6276,6 +6282,28 @@ def test_prepare_final_security_parser_keeps_seal_contract_separate() -> None:
     assert outcome_args.handler is closeout_module._cmd_record_final_security_outcome
 
 
+def test_closeout_seal_help_distinguishes_advisory_and_legacy_modes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    parser = closeout_module._parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["seal", "--help"])
+
+    assert exc_info.value.code == 0
+    help_text = capsys.readouterr().out
+    normalized_help = " ".join(help_text.split())
+    assert "closed no-provider advisory variant" in normalized_help
+    assert "closed no-claim advisory receipts" in normalized_help
+    assert "legacy v1 Connector evidence" in normalized_help
+    assert "legacy v1 Codex Security evidence" in normalized_help
+    assert "--review-ref" in normalized_help
+    assert "--review-source-unavailable-ref" in normalized_help
+    assert "--connector-advisory-reaction" in normalized_help
+    assert "--scan-manifest" in normalized_help
+    assert "--security-outage-override-ref" in normalized_help
+
+
 def test_closeout_seal_requires_exactly_one_security_evidence_input() -> None:
     parser = closeout_module._parser()
     base = [
@@ -6291,15 +6319,17 @@ def test_closeout_seal_requires_exactly_one_security_evidence_input() -> None:
         "https://github.com/owner/repo/pull/42#issuecomment-456",
     ]
 
-    with pytest.raises(SystemExit):
-        parser.parse_args(common)
-    with pytest.raises(SystemExit):
-        parser.parse_args(
-            [
-                *base,
-                "--scan-manifest",
-                "/tmp/scan-manifest.json",
-            ]
+    with pytest.raises(closeout_module.CloseoutError, match="legacy v1 seal requires"):
+        closeout_module._validate_seal_evidence_mode(parser.parse_args(common))
+    with pytest.raises(closeout_module.CloseoutError, match="legacy v1 seal requires"):
+        closeout_module._validate_seal_evidence_mode(
+            parser.parse_args(
+                [
+                    *base,
+                    "--scan-manifest",
+                    "/tmp/scan-manifest.json",
+                ]
+            )
         )
     with pytest.raises(SystemExit):
         parser.parse_args(
@@ -6357,6 +6387,57 @@ def test_closeout_seal_requires_exactly_one_security_evidence_input() -> None:
         "https://github.com/owner/repo/pull/42#reaction-456",
         "https://github.com/owner/repo/pull/42#reaction-457",
     ]
+    capability_args = parser.parse_args([*base, "--capability-sources-advisory"])
+    assert closeout_module._validate_seal_evidence_mode(capability_args) is True
+    with pytest.raises(closeout_module.CloseoutError, match="closed no-output mode"):
+        closeout_module._validate_seal_evidence_mode(
+            parser.parse_args(
+                [
+                    *base,
+                    "--capability-sources-advisory",
+                    "--scan-manifest",
+                    "/tmp/scan-manifest.json",
+                ]
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "review_ref",
+        "review_source_unavailable_ref",
+        "scan_manifest",
+        "security_outage_override_ref",
+    ),
+)
+@pytest.mark.parametrize("value", ("", "present"))
+def test_advisory_seal_rejects_empty_or_nonempty_legacy_scalar_before_io(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+) -> None:
+    values: dict[str, Any] = {
+        "capability_sources_advisory": True,
+        "connector_advisory_reaction": [],
+        "pr_number": 42,
+        "repo": "owner/repo",
+        "review_ref": None,
+        "review_source_unavailable_ref": None,
+        "scan_manifest": None,
+        "security_outage_override_ref": None,
+    }
+    values[field] = value
+    args = Namespace(**values)
+    for name in ("_load_state", "_token", "fetch_pr_snapshot"):
+        monkeypatch.setattr(
+            closeout_module,
+            name,
+            lambda *_a, **_k: pytest.fail("invalid evidence mode must precede I/O"),
+        )
+
+    with pytest.raises(closeout_module.CloseoutError, match="closed no-output mode"):
+        closeout_module._cmd_seal(args)
 
 
 def test_closeout_renders_connector_reactions_as_advisory_without_mutating_seal() -> None:
@@ -6467,3 +6548,680 @@ def test_closeout_omits_connector_advisory_transport_failure(
         "WARNING: Connector advisory reaction omitted: truncated response"
         in capsys.readouterr().err
     )
+
+
+def _advisory_seal(
+    connector: dict[str, Any],
+    security: dict[str, Any],
+    *,
+    base_sha: str = BASE_SHA,
+    head_sha: str = HEAD_SHA,
+    digest: str = DIGEST,
+) -> dict[str, Any]:
+    return {
+        "authority": RECEIPT_AUTHORITY,
+        "code_review": connector,
+        "codex_security": security,
+        "material": {
+            "base_ref_oid": base_sha,
+            "digest": digest,
+            "material_head_sha": head_sha,
+            "merge_base_sha": base_sha,
+            "policy_version": MATERIAL_POLICY_VERSION,
+        },
+        "pr_number": 42,
+        "repository": "owner/repo",
+        "schema_version": "pulseplate.pr-review-seal/v1",
+    }
+
+
+def _write_advisory_marker(repo: Path, raw: bytes | None = None) -> Path:
+    marker = repo / "docs/orchestration/contracts/advisory_capability_sources.v1.json"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_bytes(advisory_capability_marker_bytes() if raw is None else raw)
+    return marker
+
+
+def _advisory_snapshot(base_sha: str, head_sha: str, *commits: str) -> PrSnapshot:
+    return PrSnapshot(
+        repository="owner/repo",
+        pr_number=42,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        commits=tuple(PrCommitEvidence(commit, None) for commit in commits),
+    )
+
+
+def test_advisory_capability_receipts_are_closed_material_bound_no_claims() -> None:
+    connector, security = build_advisory_capability_receipts(
+        base_revision=BASE_SHA,
+        head_revision=HEAD_SHA,
+        material_digest=DIGEST,
+    )
+    seal = _advisory_seal(connector, security)
+
+    assert parse_embedded_review_seal(render_embedded_review_seal(seal)) == seal
+    assert connector["review_claim"] == "none"
+    assert connector["output_required"] is False
+    assert security["scan_claim"] == "none"
+    assert security["no_findings_claim"] is False
+    assert security["scan_id"] is None
+    assert security["substitute_security_bundle_required"] is True
+
+    tampered = json.loads(json.dumps(seal))
+    tampered["code_review"]["review_claim"] = "completed"
+    with pytest.raises(ReviewEvidenceError, match="advisory capability receipt"):
+        render_embedded_review_seal(tampered)
+
+
+def test_advisory_capability_receipts_require_linked_connector_and_security_variants() -> None:
+    connector, security = build_advisory_capability_receipts(
+        base_revision=BASE_SHA,
+        head_revision=HEAD_SHA,
+        material_digest=DIGEST,
+    )
+    seal = _advisory_seal(connector, security)
+    legacy_security = build_security_outage_override_receipt(
+        base_revision=BASE_SHA,
+        head_revision=HEAD_SHA,
+        material_digest=DIGEST,
+        override_reference="https://github.com/owner/repo/pull/42#issuecomment-789",
+        created_at="2026-07-15T11:00:00Z",
+        operator_user_id=123,
+        operator_login="owner",
+        operator_association="OWNER",
+    )
+
+    connector_only = json.loads(json.dumps(seal))
+    connector_only["codex_security"] = legacy_security
+    with pytest.raises(ReviewEvidenceError, match="requires linked Connector and Security"):
+        render_embedded_review_seal(connector_only)
+
+    security_only = _seal(security)
+    with pytest.raises(ReviewEvidenceError, match="requires linked Connector and Security"):
+        render_embedded_review_seal(security_only)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("security_result", "passed", "keys mismatch"),
+        ("scan_claim", "completed", "receipt is malformed"),
+        ("no_findings_claim", True, "receipt is malformed"),
+    ],
+)
+def test_advisory_security_receipt_rejects_unknown_or_claim_fields(
+    field: str,
+    value: Any,
+    error: str,
+) -> None:
+    connector, security = build_advisory_capability_receipts(
+        base_revision=BASE_SHA,
+        head_revision=HEAD_SHA,
+        material_digest=DIGEST,
+    )
+    security[field] = value
+    seal = _advisory_seal(connector, security)
+
+    with pytest.raises(ReviewEvidenceError, match=error):
+        render_embedded_review_seal(seal)
+
+
+def test_closeout_advisory_seal_and_authenticated_mapping_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _write_advisory_marker(repo)
+    base_sha = _commit(repo, "activate advisory capability")
+    source = repo / "src" / "policy.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("ENFORCED = True\n", encoding="utf-8")
+    material_head = _commit(repo, "material")
+    material = compute_material_manifest(
+        repo,
+        base_ref_oid=base_sha,
+        head_ref_oid=material_head,
+        pr_number=42,
+    )
+    freeze = {
+        "base_ref_oid": base_sha,
+        "digest": material.digest,
+        "material_head_sha": material_head,
+        "merge_base_sha": material.merge_base_sha,
+        "policy_version": MATERIAL_POLICY_VERSION,
+    }
+    state = {
+        "dispositions": [],
+        "experiment_result": None,
+        "freeze": freeze,
+        "packet": None,
+        "pr_number": 42,
+        "repository": "owner/repo",
+        "schema_version": closeout_module.DRAFT_SCHEMA_VERSION,
+    }
+    target = repo / "docs" / "review" / "PR_42_FIXED_MAPPING.md"
+    snapshots = [_advisory_snapshot(base_sha, material_head, material_head)]
+    real_closeout_git = closeout_module._git
+
+    def git_with_synthetic_live_head(*args: str) -> str:
+        if args == ("rev-parse", "HEAD"):
+            return snapshots[0].head_sha
+        return real_closeout_git(*args)
+
+    monkeypatch.setattr(closeout_module, "REPO_ROOT", repo)
+    monkeypatch.setattr(closeout_module, "_load_state", lambda _pr: state)
+    monkeypatch.setattr(closeout_module, "_token", lambda: "opaque")
+    monkeypatch.setattr(closeout_module, "fetch_pr_snapshot", lambda *_a, **_k: snapshots[0])
+    monkeypatch.setattr(closeout_module, "_require_clean_live_head", lambda _head: None)
+    monkeypatch.setattr(closeout_module, "_git", git_with_synthetic_live_head)
+    monkeypatch.setattr(closeout_module, "mapping_artifact_path", lambda _pr: target)
+    monkeypatch.setattr(closeout_module, "assert_snapshot_unchanged", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        closeout_module,
+        "verify_codex_review_reference",
+        lambda *_a, **_k: pytest.fail("advisory seal must not verify Connector output"),
+    )
+    monkeypatch.setattr(
+        closeout_module,
+        "ingest_codex_security_receipt",
+        lambda *_a, **_k: pytest.fail("advisory seal must not ingest plugin output"),
+    )
+
+    closeout_module._cmd_seal(
+        Namespace(
+            capability_sources_advisory=True,
+            connector_advisory_reaction=[],
+            pr_number=42,
+            repo="owner/repo",
+            review_ref=None,
+            review_source_unavailable_ref=None,
+            scan_manifest=None,
+            security_outage_override_ref=None,
+        )
+    )
+
+    authored = parse_embedded_review_seal(target.read_text(encoding="utf-8"))
+    assert authored["code_review"]["review_claim"] == "none"
+    assert authored["codex_security"]["scan_claim"] == "none"
+    mapping_head = _commit(repo, "mapping-only closeout")
+    snapshots[0] = _advisory_snapshot(base_sha, mapping_head, material_head, mapping_head)
+    monkeypatch.setattr(
+        closeout_module,
+        "classify_commit_ref",
+        lambda value, *_a, **_k: RepositoryCommitRef(
+            value,
+            CommitRefKind.PR_COMMIT if value == material_head else CommitRefKind.PR_HEAD,
+        ),
+    )
+    monkeypatch.setattr(closeout_module, "is_ancestor", lambda *_a, **_k: True)
+
+    assert (
+        closeout_module.validate_live_mapping(
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+        )
+        == authored
+    )
+
+    target.write_text(target.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    second_mapping_head = _commit(repo, "second mapping-only commit")
+    snapshots[0] = _advisory_snapshot(
+        base_sha,
+        second_mapping_head,
+        material_head,
+        mapping_head,
+        second_mapping_head,
+    )
+    with pytest.raises(ReviewEvidenceError, match="one direct child"):
+        closeout_module.validate_live_mapping(
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+        )
+
+    source.write_text("ENFORCED = False\n", encoding="utf-8")
+    material_descendant = _commit(repo, "material descendant")
+    snapshots[0] = _advisory_snapshot(
+        base_sha,
+        material_descendant,
+        material_head,
+        mapping_head,
+        second_mapping_head,
+        material_descendant,
+    )
+    with pytest.raises(closeout_module.CloseoutError, match="stale for the live material state"):
+        closeout_module.validate_live_mapping(
+            repository="owner/repo",
+            pr_number=42,
+            token="opaque",
+        )
+
+
+@pytest.mark.parametrize(
+    "authorizer_path",
+    [
+        *sorted(ADVISORY_CAPABILITY_AUTHORIZING_PATHS),
+        *(f"{prefix}authority.yml" for prefix in ADVISORY_CAPABILITY_AUTHORIZING_PREFIXES),
+    ],
+)
+def test_advisory_capability_denies_all_authority_self_use_paths(
+    tmp_path: Path,
+    authorizer_path: str,
+) -> None:
+    with pytest.raises(ReviewEvidenceError, match="SELF_USE_DENIED"):
+        validate_advisory_capability_activation(
+            tmp_path,
+            base_ref_oid=BASE_SHA,
+            head_ref_oid=HEAD_SHA,
+            material_paths=(authorizer_path,),
+        )
+
+
+@pytest.mark.parametrize(
+    "protected_path",
+    (
+        "scripts/orchestration/pr_commit_identity.py",
+        "scripts/orchestration/review_mapping_artifact.py",
+        "scripts/orchestration/check_review_threads_disposition.py",
+        "scripts/ci/check_pr_body_phase2_gates.py",
+        "scripts/ci_bandit.sh",
+        "scripts/ci_pip_audit.sh",
+        "scripts/ci/summarize_bandit_report.py",
+        "scripts/ci/check_trivy_ignore_policy_expiry.py",
+        ".bandit",
+        ".trivyignore",
+        "trivy/ignore-policy.rego",
+    ),
+)
+def test_advisory_self_use_rejects_full_outage_boundary_examples(
+    tmp_path: Path,
+    protected_path: str,
+) -> None:
+    with pytest.raises(ReviewEvidenceError, match=re.escape(protected_path)):
+        validate_advisory_capability_activation(
+            tmp_path,
+            base_ref_oid=BASE_SHA,
+            head_ref_oid=HEAD_SHA,
+            material_paths=(protected_path,),
+        )
+
+
+@pytest.mark.parametrize(
+    ("raw_entry", "error"),
+    [
+        (b"", "marker missing"),
+        (
+            f"120000 blob {'a' * 40}\t"
+            "docs/orchestration/contracts/advisory_capability_sources.v1.json\0".encode(),
+            "exactly one 100644 blob",
+        ),
+        (
+            f"100755 blob {'a' * 40}\t"
+            "docs/orchestration/contracts/advisory_capability_sources.v1.json\0".encode(),
+            "exactly one 100644 blob",
+        ),
+        (
+            f"040000 tree {'a' * 40}\t"
+            "docs/orchestration/contracts/advisory_capability_sources.v1.json\0".encode(),
+            "exactly one 100644 blob",
+        ),
+        (
+            f"160000 commit {'a' * 40}\t"
+            "docs/orchestration/contracts/advisory_capability_sources.v1.json\0".encode(),
+            "exactly one 100644 blob",
+        ),
+        (b"malformed\0", "tree entry is malformed"),
+        (
+            f"100644 blob {'b' * 40}\t"
+            "docs/orchestration/contracts/advisory_capability_sources.v1.json\0".encode(),
+            "blob OID differs",
+        ),
+        (
+            (
+                f"100644 blob {'a' * 40}\t"
+                "docs/orchestration/contracts/advisory_capability_sources.v1.json\0"
+            ).encode()
+            * 2,
+            "exactly one 100644 blob",
+        ),
+    ],
+)
+def test_advisory_marker_rejects_noncanonical_git_objects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_entry: bytes,
+    error: str,
+) -> None:
+    def run_git(_root: Path, args: list[str], **_kwargs: Any) -> bytes:
+        if args[0] == "ls-tree":
+            return raw_entry
+        pytest.fail(f"unexpected git command: {args}")
+
+    monkeypatch.setattr(evidence_module, "_run_git", run_git)
+    with pytest.raises(ReviewEvidenceError, match=error):
+        evidence_module._require_advisory_marker_at_revision(
+            tmp_path,
+            revision=BASE_SHA,
+            label="authenticated base",
+            expected_bytes=advisory_capability_marker_bytes(),
+            expected_oid="a" * 40,
+        )
+
+
+def test_advisory_marker_rejects_blob_bytes_that_do_not_match_oid_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = (
+        f"100644 blob {'a' * 40}\t"
+        "docs/orchestration/contracts/advisory_capability_sources.v1.json\0"
+    ).encode()
+
+    def run_git(_root: Path, args: list[str], **_kwargs: Any) -> bytes:
+        return entry if args[0] == "ls-tree" else b"{}\n"
+
+    monkeypatch.setattr(evidence_module, "_run_git", run_git)
+    with pytest.raises(ReviewEvidenceError, match="marker bytes differ"):
+        evidence_module._require_advisory_marker_at_revision(
+            tmp_path,
+            revision=BASE_SHA,
+            label="authenticated base",
+            expected_bytes=advisory_capability_marker_bytes(),
+            expected_oid="a" * 40,
+        )
+
+
+@pytest.mark.parametrize(
+    ("raw_entry", "error"),
+    [
+        (b"", "canonical mapping artifact is missing"),
+        (
+            f"040000 tree {'a' * 40}\t" "docs/review/PR_42_FIXED_MAPPING.md\0".encode(),
+            "exactly one regular 100644 blob",
+        ),
+        (b"malformed\0", "canonical mapping tree entry is malformed"),
+        (
+            (f"100644 blob {'a' * 40}\t" "docs/review/PR_42_FIXED_MAPPING.md\0").encode() * 2,
+            "exactly one regular 100644 blob",
+        ),
+    ],
+)
+def test_advisory_mapping_entry_rejects_missing_tree_malformed_or_duplicate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_entry: bytes,
+    error: str,
+) -> None:
+    def run_git(_root: Path, args: list[str], **_kwargs: Any) -> bytes:
+        assert args == [
+            "ls-tree",
+            "-z",
+            "--full-tree",
+            HEAD_SHA,
+            "--",
+            "docs/review/PR_42_FIXED_MAPPING.md",
+        ]
+        return raw_entry
+
+    monkeypatch.setattr(evidence_module, "_run_git", run_git)
+    with pytest.raises(ReviewEvidenceError, match=error):
+        evidence_module._require_canonical_mapping_blob_at_revision(
+            tmp_path,
+            revision=HEAD_SHA,
+            expected_path="docs/review/PR_42_FIXED_MAPPING.md",
+        )
+
+
+@pytest.mark.parametrize(
+    ("entry_kind", "expected_entry_prefix"),
+    [
+        ("symlink", "120000 blob "),
+        ("executable", "100755 blob "),
+        ("gitlink", "160000 commit "),
+    ],
+)
+def test_advisory_live_head_rejects_nonregular_mapping_entry(
+    tmp_path: Path,
+    entry_kind: str,
+    expected_entry_prefix: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "policy.txt").write_text("stable\n", encoding="utf-8")
+    material_head = _commit(repo, "material")
+    mapping = repo / "docs" / "review" / "PR_42_FIXED_MAPPING.md"
+    mapping.parent.mkdir(parents=True)
+    if entry_kind == "symlink":
+        mapping.symlink_to("noncanonical-target")
+    elif entry_kind == "executable":
+        mapping.write_text("mapping\n", encoding="utf-8")
+        mapping.chmod(0o755)
+    else:
+        mapping.mkdir()
+        _git(mapping, "init", "-q")
+        (mapping / "README.md").write_text("nested\n", encoding="utf-8")
+        _commit(mapping, "nested mapping gitlink")
+    mapping_child = _commit(repo, f"{entry_kind} mapping child")
+    mapping_path = mapping.relative_to(repo).as_posix()
+
+    assert _git(repo, "ls-tree", mapping_child, "--", mapping_path).startswith(
+        expected_entry_prefix
+    )
+    with pytest.raises(ReviewEvidenceError, match="exactly one regular 100644 blob"):
+        validate_advisory_live_head_topology(
+            repo,
+            material_head_sha=material_head,
+            live_head_sha=mapping_child,
+            pr_number=42,
+            phase="final",
+        )
+
+
+def test_advisory_live_head_requires_exact_phase_and_one_mapping_child(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    source = repo / "src" / "policy.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("stable\n", encoding="utf-8")
+    material_head = _commit(repo, "material")
+    mapping = repo / "docs" / "review" / "PR_42_FIXED_MAPPING.md"
+    mapping.parent.mkdir(parents=True)
+
+    validate_advisory_live_head_topology(
+        repo,
+        material_head_sha=material_head,
+        live_head_sha=material_head,
+        pr_number=42,
+        phase="pre_closeout",
+    )
+    with pytest.raises(ReviewEvidenceError, match="final live head must be one mapping-only child"):
+        validate_advisory_live_head_topology(
+            repo,
+            material_head_sha=material_head,
+            live_head_sha=material_head,
+            pr_number=42,
+            phase="final",
+        )
+
+    mapping.write_text("mapping\n", encoding="utf-8")
+    mapping_child = _commit(repo, "mapping child")
+    validate_advisory_live_head_topology(
+        repo,
+        material_head_sha=material_head,
+        live_head_sha=mapping_child,
+        pr_number=42,
+        phase="final",
+    )
+    with pytest.raises(ReviewEvidenceError, match="pre-closeout live head must equal"):
+        validate_advisory_live_head_topology(
+            repo,
+            material_head_sha=material_head,
+            live_head_sha=mapping_child,
+            pr_number=42,
+            phase="pre_closeout",
+        )
+
+    mapping.write_text("mapping two\n", encoding="utf-8")
+    second_child = _commit(repo, "second mapping commit")
+    with pytest.raises(ReviewEvidenceError, match="one direct child"):
+        validate_advisory_live_head_topology(
+            repo,
+            material_head_sha=material_head,
+            live_head_sha=second_child,
+            pr_number=42,
+            phase="final",
+        )
+
+    _git(repo, "checkout", "-q", material_head)
+    mapping.parent.mkdir(parents=True)
+    mapping.write_text("mapping with material\n", encoding="utf-8")
+    source.write_text("changed\n", encoding="utf-8")
+    material_child = _commit(repo, "mapping and material child")
+    with pytest.raises(ReviewEvidenceError, match="must change only"):
+        validate_advisory_live_head_topology(
+            repo,
+            material_head_sha=material_head,
+            live_head_sha=material_child,
+            pr_number=42,
+            phase="final",
+        )
+
+    source.write_text("stable\n", encoding="utf-8")
+    mapping.write_text("mapping after revert\n", encoding="utf-8")
+    reverted_head = _commit(repo, "revert material change")
+    with pytest.raises(ReviewEvidenceError, match="one direct child"):
+        validate_advisory_live_head_topology(
+            repo,
+            material_head_sha=material_head,
+            live_head_sha=reverted_head,
+            pr_number=42,
+            phase="final",
+        )
+
+
+def test_advisory_capability_checks_distinct_base_and_merge_base_marker_bytes(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    marker = _write_advisory_marker(repo)
+    merge_base = _commit(repo, "marker at shared ancestor")
+    base_branch = _git(repo, "branch", "--show-current")
+    _git(repo, "checkout", "-q", "-b", "feature", merge_base)
+    (repo / "feature.txt").write_text("material\n", encoding="utf-8")
+    head_sha = _commit(repo, "feature material")
+    _git(repo, "checkout", "-q", base_branch)
+    (repo / "base.txt").write_text("base advance\n", encoding="utf-8")
+    base_sha = _commit(repo, "authenticated base advance")
+
+    assert (
+        validate_advisory_capability_activation(
+            repo,
+            base_ref_oid=base_sha,
+            head_ref_oid=head_sha,
+            material_paths=("feature.txt",),
+        )
+        == merge_base
+    )
+
+    marker.write_text("{}\n", encoding="utf-8")
+    drifted_base = _commit(repo, "drift marker on authenticated base")
+    with pytest.raises(ReviewEvidenceError, match="blob OID differs in authenticated base"):
+        validate_advisory_capability_activation(
+            repo,
+            base_ref_oid=drifted_base,
+            head_ref_oid=head_sha,
+            material_paths=("feature.txt",),
+        )
+
+
+@pytest.mark.parametrize(
+    ("merge_marker", "error"),
+    [
+        (b"{}\n", "blob OID differs in unique merge-base"),
+        (None, "marker missing from unique merge-base"),
+    ],
+)
+def test_advisory_capability_rejects_bad_marker_at_distinct_merge_base(
+    tmp_path: Path,
+    merge_marker: bytes | None,
+    error: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    marker = (
+        _write_advisory_marker(repo, merge_marker)
+        if merge_marker is not None
+        else repo / "docs/orchestration/contracts/advisory_capability_sources.v1.json"
+    )
+    if merge_marker is None:
+        (repo / "README.md").write_text("base without marker\n", encoding="utf-8")
+    merge_base = _commit(repo, "drifted marker at shared ancestor")
+    base_branch = _git(repo, "branch", "--show-current")
+    _git(repo, "checkout", "-q", "-b", "feature", merge_base)
+    (repo / "feature.txt").write_text("material\n", encoding="utf-8")
+    head_sha = _commit(repo, "feature material")
+    _git(repo, "checkout", "-q", base_branch)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_bytes(advisory_capability_marker_bytes())
+    base_sha = _commit(repo, "fix marker only on authenticated base")
+
+    with pytest.raises(ReviewEvidenceError, match=error) as exc_info:
+        validate_advisory_capability_activation(
+            repo,
+            base_ref_oid=base_sha,
+            head_ref_oid=head_sha,
+            material_paths=("feature.txt",),
+        )
+    assert str(exc_info.value).startswith("ADVISORY_CAPABILITY_INACTIVE:")
+    assert "refresh the PR from that base" in str(exc_info.value)
+
+
+def test_advisory_capability_rejects_missing_marker(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    base_sha = _commit(repo, "base without marker")
+    (repo / "README.md").write_text("material\n", encoding="utf-8")
+    head_sha = _commit(repo, "material")
+
+    with pytest.raises(
+        ReviewEvidenceError, match="marker missing from authenticated base"
+    ) as exc_info:
+        validate_advisory_capability_activation(
+            repo,
+            base_ref_oid=base_sha,
+            head_ref_oid=head_sha,
+            material_paths=("README.md",),
+        )
+    assert "merge the prerequisite into the authenticated base" in str(exc_info.value)
+
+
+def test_advisory_capability_rejects_non_unique_merge_base(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        evidence_module,
+        "_run_git",
+        lambda *_a, **_k: f"{BASE_SHA}\n{HEAD_SHA}\n".encode(),
+    )
+
+    with pytest.raises(ReviewEvidenceError, match="exactly one unique merge-base"):
+        validate_advisory_capability_activation(
+            tmp_path,
+            base_ref_oid=BASE_SHA,
+            head_ref_oid=HEAD_SHA,
+            material_paths=(),
+        )


### PR DESCRIPTION
## Goal

Remove mandatory final GitHub Codex Connector and Codex Security plugin output when those capabilities are unavailable, without weakening repository-owned merge gates.

## Business reason

Prevent physically unavailable or rate-limited Codex-only providers from deadlocking normal PR work in other IDEs and models, while preserving trusted exact-head security and review governance.

## Scope

- Add one activated advisory seal mode: `seal --capability-sources-advisory`.
- Emit closed Connector and Codex Security receipts with `review_claim=none`, `scan_claim=none`, and no no-findings claim.
- Require the exact activation marker in authenticated base and unique merge-base.
- Deny advisory self-use for governance, workflow, action, dependency, and substitute-security authority changes.
- Keep exact-head substitute security checks, actionables, threads, dispositions, canonical mapping, and strict merge readiness hard.
- Preserve all legacy v1 evidence modes.

## Out of scope

- No Connector inventory, retry, restart, manual trigger, OWNER receipt, TTL, or pagination system.
- No Codex Security plugin invocation or automatic retry.
- No workflow, dependency, product-runtime, or PR #2184 material change.
- No claim that provider silence is a review, scan, approval, PASS, or no-findings result.

## Files changed

- Review seal and closeout validators.
- Strict merge-readiness advisory validation.
- Activation contract and normative governance docs.
- Pre-commit selection and deterministic regression coverage.

## Key decisions

- The provider-free mode is dormant until this prerequisite is merged and present in both the downstream PR base and merge-base.
- This prerequisite cannot use the mode it introduces and must close under the existing legacy v1 contract.
- Activated advisory operators must not invoke, restart, or retry either provider.
- A final mapping successor must be exactly one direct commit containing one canonical `100644 blob` mapping artifact.
- Protected security/governance material cannot authorize itself with advisory receipts.

## Tests / validation

Local passed on commit `8c6c34a6e`:

- `python scripts/orchestration/check_preflight.py`
- `python scripts/orchestration/check_agent_consistency.py`
- focused governance pytest: 506 tests
- `make validate-changed`: 517 tests
- `pre-commit run --all-files`
- pre-push MyPy, pip-audit, backend pytest, full-repo Bandit, and Docker build hook
- offline review-pattern oracle: 4 tests
- trusted Apple-container Experiment Runner oracle: accepted, 506 tests, network disabled

Current-head GitHub CI is pending after PR open.

## Security notes

This PR changes privileged review-governance code. Advisory mode removes only external provider availability as authority. It still fails closed on missing or noncanonical activation, material drift, protected-path self-use, malformed or linked receipt drift, wrong mapping topology, missing/failed/untrusted exact-head substitute security checks, unresolved threads, and actionable bot findings.

## Risks / rollback

- Bootstrap risk: this prerequisite remains subject to legacy v1 evidence. Do not manually trigger or retry Connector; only an automatic trusted terminal rate-limit receipt or real trusted response can satisfy that legacy slot.
- Downstream limitation: PR #2184 is not eligible for advisory mode while its material changes protected workflow/security-authority surfaces. It still needs legacy v1 evidence or a separately merged cleanup of those protected inputs.
- Rollback: merge a legacy-v1 PR that removes or disables the activation marker. Existing historical seals remain readable; future advisory seals fail closed.

## Premortem Evidence

Decision: proceed with the explicit bootstrap and protected-path limitations above.

Closed failure modes:

- advisory self-authorizes changed workflows/security inputs: FIXED by canonical trust-boundary superset and tests;
- marker or mapping artifact is a symlink/executable/gitlink: FIXED by exact `100644 blob` validation and tests;
- multiple or change-revert closeout commits pass: FIXED by direct one-child mapping-only topology;
- docs still tell unavailable providers to run/retry: FIXED by enforced Legacy-v1-only versus activated-advisory split;
- successful advisory main path crashes or mixed CLI flags bypass validation: FIXED by end-to-end and empty-value regressions.

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/6d9e72905f0a.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Branch: `codex/owner-capability-advisory-evidence`

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/exp-2a92f7a7814f.json`
- Status: accepted
- Backend: Apple Container 1.1.0, `linux_arm64`, network isolated
- Contribution: oracle review; canonical co-author trailer is present on the material commit

## Pre-open role evidence

- agent-coordinator: scope and hard-gate contract approved
- security-auditor: implementation owner; focused and all-files gates passed
- qa-engineer-agent: actionables fixed
- bug-hunter: PASS after trust-boundary and topology remediation
- cursor-specialist-agent: PASS after impossible-provider documentation cleanup
- architecture-specialist: PASS after canonical mapping blob hardening

## Discussion Thread Pass

- [ ] Discussion-thread pass completed
- [ ] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_<N>_FIXED_MAPPING.md`
- URL to SHA and disposition details belong only in the canonical artifact.

## Split justification

- Why this PR cannot be split safely: the marker, authoring path, strict validator, normative contract, and negative tests must land atomically. A marker-only or validator-only split would either be inert, expected-red, or create a self-authorization gap.
- Invariant or rollout constraint requiring one PR: advisory acceptance must remain dormant until the exact marker and all fail-closed validators are simultaneously present in merged base ancestry.
- Follow-up PRs: refresh eligible downstream PR bases after merge; protected trust-boundary PRs continue using legacy v1 evidence.

## Deferred / Follow-ups

- None inside this prerequisite. PR #2184 remains a separate lane.

## Next best step

Run the mandatory post-open QA, bug-hunter, and security pass on the exact PR head, then close legacy v1 review/security evidence without manual Connector retry.

## Summary by Sourcery

Введение консультативного режима «capability-sources seal», который позволяет закрывать PR без выводов Codex Connector или Codex Security, при этом сохраняя строгие гарантии управляемости (governance) и готовности к слиянию (merge-readiness).

Новые возможности:
- Добавить консультативный режим sealing для источников возможностей (capability-sources) и флаг CLI для формирования закрытых квитанций Connector и Codex Security без претензий (no-claim), когда провайдеры недоступны.

Улучшения:
- Обеспечить активацию консультативного режима через канонический маркер-артефакт, присутствующий как в аутентифицированной базовой ветке, так и в уникальной merge-base, со строгой проверкой git-объектов и топологии.
- Расширить проверку готовности к слиянию (merge-readiness), чтобы поддерживать консультативные seal’ы, требуя для этого:
  - точных substitute security bundles на текущей голове ветки (exact-head),
  - коммитов закрытия, содержащих только отображения (mapping-only closeout commits),
  - неизменённых материальных дайджестов (material digests).
- Усилить границы политик управляемости (governance) и квот, чтобы консультативная capability не могла самостоятельно авторизовывать изменения в workflow, CI, политиках безопасности, манифестах зависимостей или входных данных substitute-security.
- Обновить документацию по оркестрации и управляемости, чтобы различать устаревшие потоки доказательств от провайдеров (legacy v1 provider-evidence flows) и новый консультативный режим, а также описать его поведение «fail-closed».

Тесты:
- Добавить комплексные тесты для поведения CLI в консультативном режиме seal, активации маркера, топологии отображений, проверки актуальных квитанций (live receipt validation) и запрета самоприменения на защищённых путях.
- Расширить защиту готовности к слиянию и политик квот, чтобы они охватывали маркер консультативной capability, квитанции и инварианты документации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an advisory capability-sources seal mode that allows PRs to close without Codex Connector or Codex Security outputs while preserving strict governance and merge-readiness guarantees.

New Features:
- Add an advisory capability-sources sealing mode and CLI flag to emit closed no-claim Connector and Codex Security receipts when providers are unavailable.

Enhancements:
- Enforce advisory activation via a canonical marker artifact present in both authenticated base and unique merge-base, with strict git-object and topology validation.
- Extend merge-readiness validation to support advisory seals, requiring exact-head substitute security bundles, mapping-only closeout commits, and unchanged material digests.
- Harden governance and quota policy boundaries so advisory capability cannot self-authorize changes to workflows, CI, security policies, dependency manifests, or substitute-security inputs.
- Update orchestration and governance documentation to distinguish legacy v1 provider-evidence flows from the new advisory mode and describe its fail-closed behavior.

Tests:
- Add comprehensive tests for advisory seal CLI behavior, marker activation, mapping topology, live receipt validation, and self-use denial on protected paths.
- Extend merge-readiness and quota policy guards to cover the advisory capability marker, receipts, and documentation invariants.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Введение консультативного режима «capability-sources seal», который позволяет закрывать PR без выводов Codex Connector или Codex Security, при этом сохраняя строгие гарантии управляемости (governance) и готовности к слиянию (merge-readiness).

Новые возможности:
- Добавить консультативный режим sealing для источников возможностей (capability-sources) и флаг CLI для формирования закрытых квитанций Connector и Codex Security без претензий (no-claim), когда провайдеры недоступны.

Улучшения:
- Обеспечить активацию консультативного режима через канонический маркер-артефакт, присутствующий как в аутентифицированной базовой ветке, так и в уникальной merge-base, со строгой проверкой git-объектов и топологии.
- Расширить проверку готовности к слиянию (merge-readiness), чтобы поддерживать консультативные seal’ы, требуя для этого:
  - точных substitute security bundles на текущей голове ветки (exact-head),
  - коммитов закрытия, содержащих только отображения (mapping-only closeout commits),
  - неизменённых материальных дайджестов (material digests).
- Усилить границы политик управляемости (governance) и квот, чтобы консультативная capability не могла самостоятельно авторизовывать изменения в workflow, CI, политиках безопасности, манифестах зависимостей или входных данных substitute-security.
- Обновить документацию по оркестрации и управляемости, чтобы различать устаревшие потоки доказательств от провайдеров (legacy v1 provider-evidence flows) и новый консультативный режим, а также описать его поведение «fail-closed».

Тесты:
- Добавить комплексные тесты для поведения CLI в консультативном режиме seal, активации маркера, топологии отображений, проверки актуальных квитанций (live receipt validation) и запрета самоприменения на защищённых путях.
- Расширить защиту готовности к слиянию и политик квот, чтобы они охватывали маркер консультативной capability, квитанции и инварианты документации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an advisory capability-sources seal mode that allows PRs to close without Codex Connector or Codex Security outputs while preserving strict governance and merge-readiness guarantees.

New Features:
- Add an advisory capability-sources sealing mode and CLI flag to emit closed no-claim Connector and Codex Security receipts when providers are unavailable.

Enhancements:
- Enforce advisory activation via a canonical marker artifact present in both authenticated base and unique merge-base, with strict git-object and topology validation.
- Extend merge-readiness validation to support advisory seals, requiring exact-head substitute security bundles, mapping-only closeout commits, and unchanged material digests.
- Harden governance and quota policy boundaries so advisory capability cannot self-authorize changes to workflows, CI, security policies, dependency manifests, or substitute-security inputs.
- Update orchestration and governance documentation to distinguish legacy v1 provider-evidence flows from the new advisory mode and describe its fail-closed behavior.

Tests:
- Add comprehensive tests for advisory seal CLI behavior, marker activation, mapping topology, live receipt validation, and self-use denial on protected paths.
- Extend merge-readiness and quota policy guards to cover the advisory capability marker, receipts, and documentation invariants.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Введение консультативного режима «capability-sources seal», который позволяет закрывать PR без выводов Codex Connector или Codex Security, при этом сохраняя строгие гарантии управляемости (governance) и готовности к слиянию (merge-readiness).

Новые возможности:
- Добавить консультативный режим sealing для источников возможностей (capability-sources) и флаг CLI для формирования закрытых квитанций Connector и Codex Security без претензий (no-claim), когда провайдеры недоступны.

Улучшения:
- Обеспечить активацию консультативного режима через канонический маркер-артефакт, присутствующий как в аутентифицированной базовой ветке, так и в уникальной merge-base, со строгой проверкой git-объектов и топологии.
- Расширить проверку готовности к слиянию (merge-readiness), чтобы поддерживать консультативные seal’ы, требуя для этого:
  - точных substitute security bundles на текущей голове ветки (exact-head),
  - коммитов закрытия, содержащих только отображения (mapping-only closeout commits),
  - неизменённых материальных дайджестов (material digests).
- Усилить границы политик управляемости (governance) и квот, чтобы консультативная capability не могла самостоятельно авторизовывать изменения в workflow, CI, политиках безопасности, манифестах зависимостей или входных данных substitute-security.
- Обновить документацию по оркестрации и управляемости, чтобы различать устаревшие потоки доказательств от провайдеров (legacy v1 provider-evidence flows) и новый консультативный режим, а также описать его поведение «fail-closed».

Тесты:
- Добавить комплексные тесты для поведения CLI в консультативном режиме seal, активации маркера, топологии отображений, проверки актуальных квитанций (live receipt validation) и запрета самоприменения на защищённых путях.
- Расширить защиту готовности к слиянию и политик квот, чтобы они охватывали маркер консультативной capability, квитанции и инварианты документации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an advisory capability-sources seal mode that allows PRs to close without Codex Connector or Codex Security outputs while preserving strict governance and merge-readiness guarantees.

New Features:
- Add an advisory capability-sources sealing mode and CLI flag to emit closed no-claim Connector and Codex Security receipts when providers are unavailable.

Enhancements:
- Enforce advisory activation via a canonical marker artifact present in both authenticated base and unique merge-base, with strict git-object and topology validation.
- Extend merge-readiness validation to support advisory seals, requiring exact-head substitute security bundles, mapping-only closeout commits, and unchanged material digests.
- Harden governance and quota policy boundaries so advisory capability cannot self-authorize changes to workflows, CI, security policies, dependency manifests, or substitute-security inputs.
- Update orchestration and governance documentation to distinguish legacy v1 provider-evidence flows from the new advisory mode and describe its fail-closed behavior.

Tests:
- Add comprehensive tests for advisory seal CLI behavior, marker activation, mapping topology, live receipt validation, and self-use denial on protected paths.
- Extend merge-readiness and quota policy guards to cover the advisory capability marker, receipts, and documentation invariants.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Введение консультативного режима «capability-sources seal», который позволяет закрывать PR без выводов Codex Connector или Codex Security, при этом сохраняя строгие гарантии управляемости (governance) и готовности к слиянию (merge-readiness).

Новые возможности:
- Добавить консультативный режим sealing для источников возможностей (capability-sources) и флаг CLI для формирования закрытых квитанций Connector и Codex Security без претензий (no-claim), когда провайдеры недоступны.

Улучшения:
- Обеспечить активацию консультативного режима через канонический маркер-артефакт, присутствующий как в аутентифицированной базовой ветке, так и в уникальной merge-base, со строгой проверкой git-объектов и топологии.
- Расширить проверку готовности к слиянию (merge-readiness), чтобы поддерживать консультативные seal’ы, требуя для этого:
  - точных substitute security bundles на текущей голове ветки (exact-head),
  - коммитов закрытия, содержащих только отображения (mapping-only closeout commits),
  - неизменённых материальных дайджестов (material digests).
- Усилить границы политик управляемости (governance) и квот, чтобы консультативная capability не могла самостоятельно авторизовывать изменения в workflow, CI, политиках безопасности, манифестах зависимостей или входных данных substitute-security.
- Обновить документацию по оркестрации и управляемости, чтобы различать устаревшие потоки доказательств от провайдеров (legacy v1 provider-evidence flows) и новый консультативный режим, а также описать его поведение «fail-closed».

Тесты:
- Добавить комплексные тесты для поведения CLI в консультативном режиме seal, активации маркера, топологии отображений, проверки актуальных квитанций (live receipt validation) и запрета самоприменения на защищённых путях.
- Расширить защиту готовности к слиянию и политик квот, чтобы они охватывали маркер консультативной capability, квитанции и инварианты документации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an advisory capability-sources seal mode that allows PRs to close without Codex Connector or Codex Security outputs while preserving strict governance and merge-readiness guarantees.

New Features:
- Add an advisory capability-sources sealing mode and CLI flag to emit closed no-claim Connector and Codex Security receipts when providers are unavailable.

Enhancements:
- Enforce advisory activation via a canonical marker artifact present in both authenticated base and unique merge-base, with strict git-object and topology validation.
- Extend merge-readiness validation to support advisory seals, requiring exact-head substitute security bundles, mapping-only closeout commits, and unchanged material digests.
- Harden governance and quota policy boundaries so advisory capability cannot self-authorize changes to workflows, CI, security policies, dependency manifests, or substitute-security inputs.
- Update orchestration and governance documentation to distinguish legacy v1 provider-evidence flows from the new advisory mode and describe its fail-closed behavior.

Tests:
- Add comprehensive tests for advisory seal CLI behavior, marker activation, mapping topology, live receipt validation, and self-use denial on protected paths.
- Extend merge-readiness and quota policy guards to cover the advisory capability marker, receipts, and documentation invariants.

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Codex Connector and Codex Security outputs optional behind an explicit activation to prevent PR deadlocks when providers are unavailable, while keeping strict merge governance intact. Adds an advisory receipts path and validators that require exact-head substitute security and preserve all hard gates.

- **New Features**
  - Added `seal --capability-sources-advisory`; emits closed receipts with `review_claim=none` and `scan_claim=none`.
  - Activation requires the canonical `100644 blob` at `docs/orchestration/contracts/advisory_capability_sources.v1.json` in the authenticated base and unique merge-base.
  - Enforces live exact-head substitute security; preserves dispositions, threads, canonical mapping, and strict merge-readiness checks.
  - Blocks advisory self-authorization for governance, workflows, actions, dependencies, and substitute-security authority changes; legacy v1 evidence remains unchanged.

- **Migration**
  - Do not invoke, restart, or retry Connector or Codex Security in advisory mode.
  - Add the marker file, then run `seal --capability-sources-advisory`.
  - Advisory cannot be used when protected governance/security surfaces change; use legacy v1 evidence.
  - Advisory stays dormant until the marker exists in both base and merge-base; legacy modes continue to work.

<sup>Written for commit 8c6c34a6e01bca667d19fedb9a8f71d1fa95aa50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an activated advisory review mode for final security and merge-readiness workflows.
  * Advisory mode supports closed, no-claim receipts while preserving required substitute security checks and live-head validation.

* **Documentation**
  * Clarified Legacy-v1-only and advisory-mode procedures, evidence requirements, provider invocation rules, and material-change handling.
  * Added an advisory capability contract and updated orchestration guidance.

* **Bug Fixes**
  * Strengthened validation against stale evidence, unauthorized self-approval, mismatched material, and invalid repository topology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->