### PR TITLE
fix(security): remediate Caddy x/text CVE-2026-56852

### DIFF
--- a/docs/review/PR_2195_FIXED_MAPPING.md
+++ b/docs/review/PR_2195_FIXED_MAPPING.md
@@ -1,0 +1,51 @@
+# PR 2195 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/b394bf41d54c.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/caddy-cve-2026-56852-oracle-result.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: a43a7bce9923dc322060e067f7e637425f3ae339
+Evidence: docs/security/CVE-2026-56852-golang-x-text.md:40-47 now carries exact Dockerfile, workflow, and provenance-test anchors and removes the broad unanchored absence claims; CodeRabbit marked the thread addressed in a43a7bc.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2195#discussion_r3676603820 -> a43a7bce9923dc322060e067f7e637425f3ae339
+
+Disposition: FIXED
+Commit: a43a7bce9923dc322060e067f7e637425f3ae339
+Evidence: docs/security/CVE-2026-56852-golang-x-text.md:40-47 addresses the follow-up by embedding canonical evidence anchors and deleting the broad no-VEX/parser/runtime claims; CodeRabbit marked the root finding addressed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2195#discussion_r3676636321 -> a43a7bce9923dc322060e067f7e637425f3ae339
+
+Disposition: FIXED
+Commit: a43a7bce9923dc322060e067f7e637425f3ae339
+Evidence: docs/security/CVE-2026-56852-golang-x-text.md:40-47 adds the requested in-document file:line evidence and removes claims that were not directly anchored; CodeRabbit completed the refreshed material review with no actionables.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2195#pullrequestreview-4811115408 -> a43a7bce9923dc322060e067f7e637425f3ae339
+
+Disposition: NOT-A-BUG
+Evidence: GitHub Commit API returns HTTP 422 for reviewer ref 574bc5172f1a08ab177eb208030ff75feff72f83; the historical sealed material ab78451e7323b6381bee7d5ac486632fbdc5eb63 was the direct parent of its mapping-only successor.
+Reason: The cited SHA was an unavailable reviewer execution ref, not a repository-addressable PR head. The historical material chain was reachable; the current branch was rebuilt only to inherit fresh main and incorporate the later review fix before this exact-material seal.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2195#discussion_r3675183750
+
+Disposition: NOT-A-BUG
+Evidence: GitHub Commit API returns HTTP 422 for reviewer ref 9fa662718c5050614e0c9a80364c64025b4d3deb; the historical PR head 635d1a4a494f8f3b68162a637704fcadbfd861f2 was a mapping-only successor of material commit ab78451e7323b6381bee7d5ac486632fbdc5eb63.
+Reason: The cited SHA was an unavailable reviewer execution ref, not repository ancestry truth. The current material commit replays the bounded Caddy remediation on fresh main and binds the accepted documentation fix without treating the unavailable ref as a commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2195#discussion_r3675360527
+
+Disposition: NOT-A-BUG
+Evidence: tests/test_caddy_deploy_provenance.py:143,202-215,244-274; .github/workflows/cd.yml:298-307,340-342
+Reason: read_text() intentionally fails closed if the canonical root ignore file disappears; the workflow independently requires that file and uses a separately verified empty non-symlink .trivyignore-caddy for the Caddy scan. Keeping the bounded assertion in the existing Caddy provenance/scan-policy owner avoids a softened existence guard or unnecessary helper.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2195#pullrequestreview-4809129896
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"blocking":false,"material_digest":"sha256:84ab0382e547772afab26032d379cfa1dbbd82af75e594535c8863e70f95b556","material_head_sha":"a43a7bce9923dc322060e067f7e637425f3ae339","output_required":false,"review_claim":"none"},"codex_security":{"base_revision":"9cfbcd38aaecc7bf3efcd7315bcd6c15d19f695b","blocking":false,"head_revision":"a43a7bce9923dc322060e067f7e637425f3ae339","material_digest":"sha256:84ab0382e547772afab26032d379cfa1dbbd82af75e594535c8863e70f95b556","no_findings_claim":false,"output_required":false,"scan_claim":"none"},"material":{"base_ref_oid":"9cfbcd38aaecc7bf3efcd7315bcd6c15d19f695b","digest":"sha256:84ab0382e547772afab26032d379cfa1dbbd82af75e594535c8863e70f95b556","material_head_sha":"a43a7bce9923dc322060e067f7e637425f3ae339","merge_base_sha":"9cfbcd38aaecc7bf3efcd7315bcd6c15d19f695b","policy_version":"pulseplate.material-classification/v1"},"pr_number":2195,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1","self_review":{"actionable_findings_count":0,"authority":"repo_native_pulseplate_pr_review_advisory","blocking":false,"findings_count":0,"material_digest":"sha256:84ab0382e547772afab26032d379cfa1dbbd82af75e594535c8863e70f95b556","material_head_sha":"a43a7bce9923dc322060e067f7e637425f3ae339","report_payload":{"actionable_findings_count":0,"base_ref_oid":"9cfbcd38aaecc7bf3efcd7315bcd6c15d19f695b","calibration":{"case_labels":["clean-context","review-source-degraded"],"false_positive_controls":["clean context must produce zero findings","benign fixed-mapping presence must not become a governance finding","warnings and governance uncertainty remain actionable findings, not diagnostic notes","review-source degradation is status/warning only unless an explicit blocking source finding exists","large diff risk is review-planning evidence, not a merge-readiness claim"],"posting_eligible":false,"posting_gate":"GitHub posting remains out of scope until a dedicated calibrated posting PR.","rubric_version":"pr4-2026-04-28"},"coordinator_packet":{"path":"artifacts/orchestration/task_packets/b394bf41d54c.json","role_order":["agent-coordinator","architecture-specialist","security-auditor","qa-engineer-agent","bug-hunter","data-scientist-agent"],"task_packet_id":"b394bf41d54c"},"decision_log":["This report is advisory and side-effect free.","This report does not post GitHub comments, resolve review threads, merge PRs, or claim merge readiness.","External CodeRabbit, Sourcery, and Cubic statuses remain separate PR governance signals."],"deferred_followups":[],"findings":[],"findings_count":0,"gate_plan":["python3 scripts/orchestration/check_preflight.py","python3 scripts/orchestration/check_agent_consistency.py","python3 -m pytest tests/test_pr_review_report.py tests/test_pr_review_context.py -q","Add and fill docs/review/PR_<N>_FIXED_MAPPING.md before merge-ready loop","make test-fast"],"generated_at_utc":"2026-07-29T17:32:16Z","material_digest":"sha256:84ab0382e547772afab26032d379cfa1dbbd82af75e594535c8863e70f95b556","material_head_sha":"a43a7bce9923dc322060e067f7e637425f3ae339","merge_base_sha":"9cfbcd38aaecc7bf3efcd7315bcd6c15d19f695b","mode":"dry-run-report","review_source_status":[{"blocking":false,"evidence":"gh api repos/<repo>/pulls/<pr>","fallback_required":false,"reason":"","source":"github_pr_metadata","source_degraded":false,"status":"available"},{"blocking":false,"evidence":"9cfbcd38aaecc7bf3efcd7315bcd6c15d19f695b..a43a7bce9923dc322060e067f7e637425f3ae339","fallback_required":false,"reason":"","source":"git_diff","source_degraded":false,"status":"available"},{"blocking":false,"evidence":"docs/review/PR_2195_FIXED_MAPPING.md","fallback_required":true,"reason":"Fixed-mapping artifact unavailable","source":"fixed_mapping_artifact","source_degraded":true,"status":"unavailable"}],"role_review":[{"role_agent":"agent-coordinator","summary":"agent-coordinator has no deterministic findings from the supplied context."},{"role_agent":"architecture-specialist","summary":"architecture-specialist has no deterministic findings from the supplied context."},{"role_agent":"security-auditor","summary":"security-auditor has no deterministic findings from the supplied context."},{"role_agent":"qa-engineer-agent","summary":"qa-engineer-agent has no deterministic findings from the supplied context."},{"role_agent":"bug-hunter","summary":"bug-hunter has no deterministic findings from the supplied context."},{"role_agent":"data-scientist-agent","summary":"data-scientist-agent has no scoring calibration changes in this dry-run report."}],"schema_version":"2.0.0","scope_reviewed":{"changed_files":["docs/security/CVE-2026-56852-golang-x-text.md","frontend/Dockerfile.caddy-spa","tests/test_caddy_deploy_provenance.py"],"diff_summary":{"additions":84,"changed_lines":85,"deletions":1,"files":3},"fixed_mapping_errors":[],"omitted_surfaces":["GitHub posting","PR thread resolution","merge readiness claims"],"pr_metadata_available":true,"scoped_agents_md":["AGENTS.md","frontend/AGENTS.md","tests/AGENTS.md"]},"warnings":[]},"report_sha256":"sha256:96bf3c40856971f55f0dc71fd24f9100d761fc73bffcb9517578cf05cef0f9ab","review_claim":"none","review_tool":"pulseplate-pr-review","schema_version":"pulseplate.self-review-advisory/v1","status":"advisory_report_attached"}}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/docs/security/CVE-2026-56852-golang-x-text.md
+++ b/docs/security/CVE-2026-56852-golang-x-text.md
@@ -1,0 +1,66 @@
+# CVE-2026-56852: Caddy `golang.org/x/text` remediation
+
+## Security decision
+
+The Go project reports that `golang.org/x/text/unicode/norm` can enter an infinite loop
+when processing invalid UTF-8. Versions below `v0.39.0` are affected. PulsePlate does not
+claim a confirmed request path to the vulnerable routines, but the network-facing Caddy
+binary shipped the affected module, so the existing fail-closed HIGH/CRITICAL image policy
+requires remediation.
+
+Official sources:
+
+- [Go issue 80142](https://go.dev/issue/80142)
+- [Go vulnerability GO-2026-5970](https://pkg.go.dev/vuln/GO-2026-5970)
+- [NVD CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852)
+- [`golang.org/x/text` v0.39.0 module](https://pkg.go.dev/golang.org/x/text@v0.39.0)
+
+## Observed evidence
+
+Main CD run
+[30455163231](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/30455163231),
+job
+[90586762124](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/30455163231/job/90586762124),
+scanned the immutable staged Caddy image
+`ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:3335a65543fb338e03df18a4103b88efac4d62b2f73ff6c994ba9505a51fae21`.
+Trivy found `golang.org/x/text v0.37.0` in `usr/bin/caddy`, classified
+`CVE-2026-56852` as HIGH, reported fixed version `0.39.0`, and exited `1`.
+
+## Remediation
+
+- `frontend/Dockerfile.caddy-spa:21` selects `golang.org/x/text v0.39.0` in the real
+  temporary Caddy module graph.
+- `frontend/Dockerfile.caddy-spa:28` fails the build unless the resolved module is exactly
+  `v0.39.0`.
+- `frontend/Dockerfile.caddy-spa:40` fails the build unless the completed Caddy binary
+  embeds exactly `golang.org/x/text v0.39.0`.
+- `tests/test_caddy_deploy_provenance.py:77` keeps these finite known-module assertions
+  fail-closed and rejects the observed vulnerable `v0.37.0` literals.
+
+Unchanged container invariants remain explicit in their canonical owner:
+
+- Caddy `v2.11.4`, Go `1.26.5`, grpc-go `v1.82.1`, and both OCI base digests are
+  pinned and verified at `frontend/Dockerfile.caddy-spa:8,19-20,24-27,59,62,79-80`.
+- The Caddy image scan remains suppression-free: `.github/workflows/cd.yml:295-307,327-344`
+  creates a dedicated empty `.trivyignore-caddy`, while
+  `tests/test_caddy_deploy_provenance.py:143,202-215,244-274` rejects this CVE in the
+  backend ignore file and locks the empty Caddy policy plus fail-closed scan contract.
+
+## Validation and rollback
+
+Required validation:
+
+- focused Caddy provenance tests;
+- a real build of `frontend/Dockerfile.caddy-spa`;
+- runtime Caddy version, build-info, capability, module-parity, and Caddyfile checks;
+- a suppression-free Trivy `v0.72.0` HIGH/CRITICAL image scan;
+- the repository local narrow bundle and current-head specialized CI.
+
+Before merge, rollback is a revert of this three-file technical change, which intentionally
+restores the CD block and must not be paired with a Trivy suppression. A runtime rollback
+may use only a separately verified immutable digest whose Caddy binary embeds
+`golang.org/x/text v0.39.0` or later and passes the current Trivy policy. An older clean scan
+does not approve its image for rollback after the vulnerability database changes; this PR
+does not assert an approved pre-existing rollback digest.
+Caddy release readiness requires a fresh successful post-merge main CD scan of the newly
+built immutable image digest.

--- a/frontend/Dockerfile.caddy-spa
+++ b/frontend/Dockerfile.caddy-spa
@@ -18,12 +18,15 @@ RUN set -eux; \
     go mod init pulseplate.local/caddy-build; \
     go get github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4; \
     go get google.golang.org/grpc@v1.82.1; \
+    go get golang.org/x/text@v0.39.0; \
     go mod download all; \
     go mod verify; \
     test "$(go list -m -f '{{.Path}} {{.Version}}' github.com/caddyserver/caddy/v2)" = \
       "github.com/caddyserver/caddy/v2 v2.11.4"; \
     test "$(go list -m -f '{{.Path}} {{.Version}}' google.golang.org/grpc)" = \
       "google.golang.org/grpc v1.82.1"; \
+    test "$(go list -m -f '{{.Path}} {{.Version}}' golang.org/x/text)" = \
+      "golang.org/x/text v0.39.0"; \
     go build -mod=readonly -trimpath \
       -ldflags '-X github.com/caddyserver/caddy/v2.CustomVersion=v2.11.4' \
       -o /go/bin/caddy \
@@ -34,6 +37,8 @@ RUN set -eux; \
       | awk '$1 == "mod" && $2 == "github.com/caddyserver/caddy/v2" && $3 == "v2.11.4" { found = 1 } END { exit !found }'; \
     go version -m /go/bin/caddy \
       | awk '$1 == "dep" && $2 == "google.golang.org/grpc" && $3 == "v1.82.1" { found = 1 } END { exit !found }'; \
+    go version -m /go/bin/caddy \
+      | awk '$1 == "dep" && $2 == "golang.org/x/text" && $3 == "v0.39.0" { found = 1 } END { exit !found }'; \
     rm -rf "$build_dir"
 
 FROM node:24.16.0-bookworm-slim AS frontend-build

--- a/tests/test_caddy_deploy_provenance.py
+++ b/tests/test_caddy_deploy_provenance.py
@@ -87,9 +87,12 @@ def test_caddy_dockerfile_owns_exact_hardened_build_recipe() -> None:
     assert "go mod init pulseplate.local/caddy-build" in text
     caddy_get = "go get github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4"
     grpc_get = "go get google.golang.org/grpc@v1.82.1"
+    text_get = "go get golang.org/x/text@v0.39.0"
     assert caddy_get in text
     assert grpc_get in text
-    assert text.index(caddy_get) < text.index(grpc_get)
+    assert text_get in text
+    assert text.index(caddy_get) < text.index(grpc_get) < text.index(text_get)
+    assert text.index(text_get) < text.index("go mod download all")
     assert "go mod download all" in text
     assert "go mod verify" in text
     assert (
@@ -102,11 +105,17 @@ def test_caddy_dockerfile_owns_exact_hardened_build_recipe() -> None:
         'google.golang.org/grpc)" = \\\n'
         '      "google.golang.org/grpc v1.82.1"'
     ) in text
+    assert (
+        "test \"$(go list -m -f '{{.Path}} {{.Version}}' "
+        'golang.org/x/text)" = \\\n'
+        '      "golang.org/x/text v0.39.0"'
+    ) in text
     assert "go build -mod=readonly -trimpath" in text
     assert "github.com/caddyserver/caddy/v2.CustomVersion=v2.11.4" in text
     assert "go version -m /go/bin/caddy" in text
     assert '$2 == "github.com/caddyserver/caddy/v2" && $3 == "v2.11.4"' in text
     assert '$2 == "google.golang.org/grpc" && $3 == "v1.82.1"' in text
+    assert '$2 == "golang.org/x/text" && $3 == "v0.39.0"' in text
     assert '"c-ares>=1.34.8-r0"' in text
     assert '"curl>=8.20.0-r0"' in text
     assert '"libcurl>=8.20.0-r0"' in text
@@ -125,10 +134,13 @@ def test_caddy_dockerfile_owns_exact_hardened_build_recipe() -> None:
         "GOSUMDB=off",
         "google.golang.org/grpc@v1.81.0",
         "google.golang.org/grpc v1.81.0",
+        "golang.org/x/text@v0.37.0",
+        "golang.org/x/text v0.37.0",
         "xcaddy",
     ):
         assert forbidden not in text
     assert re.search(r"(?m)^\s*replace(?:\s|=)", text) is None
+    assert "CVE-2026-56852" not in (REPO_ROOT / ".trivyignore").read_text(encoding="utf-8")
     assert 'rm -rf "$build_dir"' in text
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# Pull Request

## Goal

Remove the current main CD Trivy block by ensuring the existing Caddy `v2.11.4` build embeds `golang.org/x/text v0.39.0`, the fixed version for CVE-2026-56852.

## Business reason

The staged network-facing Caddy image currently fails the repository's fail-closed HIGH/CRITICAL policy. This narrow remediation restores the trusted delivery lane without weakening Trivy, changing the Caddy release, or mixing security work into PR #2193.

## Scope

- Select `golang.org/x/text v0.39.0` in the real temporary Caddy module graph.
- Fail the build unless both `go list -m` and `go version -m /go/bin/caddy` prove the exact fixed version.
- Extend the existing finite Caddy provenance guard to reject the observed vulnerable version and any CVE suppression.
- Record official advisory, scanner, validation, and fail-closed rollback evidence.

## Out of scope

- Caddy, Go, grpc-go, Node, Alpine, or OCI base-image version/digest upgrades.
- Trivy workflow, severity, VEX, ignore, allowlist, or suppression changes.
- Generic Go/container dependency parsers or simulated build objects.
- PR #2193 Python convergence, product runtime, OpenAPI, schema, Swift/iOS, or dependency lock refreshes.

## Files changed

- `frontend/Dockerfile.caddy-spa`
- `tests/test_caddy_deploy_provenance.py`
- `docs/security/CVE-2026-56852-golang-x-text.md`

## Key decisions

- Keep Caddy `v2.11.4`, Go `1.26.5`, grpc-go `v1.82.1`, Node `24.16.0`, existing Caddy capabilities, SumDB policy, module parity, and every base digest unchanged.
- Pin only the vulnerable transitive module after the existing Caddy/grpc pins.
- Inspect the completed real binary rather than modeling or simulating module objects.
- Do not claim a confirmed PulsePlate request path to the vulnerable routines; remediate because the shipped network-facing binary contains the affected module and the repository policy blocks it.

## Tests / validation

Passed locally on material commit `ab78451e7323b6381bee7d5ac486632fbdc5eb63`:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- focused Caddy provenance and docs tests — `68 passed`
- `make validate-changed` — selected the committed Caddy provenance surface, `21 passed`
- `pre-commit run --all-files`
- `git diff --check`
- pre-push hooks, including `pip-audit`, backend tests, and full-repo Bandit
- real Apple Container build of `frontend/Dockerfile.caddy-spa`
- runtime checks: Caddy `v2.11.4`, Go `1.26.5`, grpc-go `v1.82.1`, `golang.org/x/text v0.39.0`, and `cap_net_bind_service=ep`
- `caddy validate` for `deploy/Caddyfile` and `deploy/Caddyfile.production`
- suppression-free Trivy `v0.72.0` scan of the built OCI image with HIGH/CRITICAL exit-code enforcement — `0` Alpine findings and `0` `usr/bin/caddy` findings

Docker Desktop was unavailable, so the real build and scan used Apple Container. Current-head specialized Docker/CD on GitHub remains required to build and scan the immutable `linux/amd64` image before readiness. Full local `make verify` was not run per repository machine-budget policy.

## Security notes

Main CD run `30455163231`, job `90586762124`, found `golang.org/x/text v0.37.0` and HIGH `CVE-2026-56852` in immutable staged image digest `sha256:3335a65543fb338e03df18a4103b88efac4d62b2f73ff6c994ba9505a51fae21`. The fixed module version is `v0.39.0`. This PR adds no secret, permission, workflow, network-runtime, suppression, VEX, or fail-open behavior.

## Premortem

- `PM-CADDY-1 — FIXED`: the module graph could resolve `v0.39.0` while the binary retained `v0.37.0`; the build now checks both graph and embedded build metadata.
- `PM-CADDY-2 — FIXED`: the transitive override could drift Caddy or grpc-go; their exact pins and existing official/rebuilt module parity remain enforced.
- `PM-CADDY-3 — FIXED`: the alert could be hidden instead of remediated; the finite guard rejects the vulnerable literals and the CVE in `.trivyignore`.
- `PM-CADDY-4 — FIXED`: an older scanner-clean digest could be mistaken for a safe rollback after the DB changed; rollback now requires fresh embedded-version and current-policy proof and asserts no approved pre-existing digest.
- `PM-CADDY-5 — NOT-A-BUG`: local arm64 evidence is not `linux/amd64` release proof; current-head GitHub Docker/CD remains a hard gate and no readiness claim is made before it passes.
- Decision: `proceed`; no premortem finding remains unclosed.

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/caddy-cve-2026-56852-oracle-result.json`

Accepted in `oracle_only_governance_reviewer` mode on the final three-file diff. The exact Apple Container runner digest `sha256:ee233e13a3663e86bcf8922fe0944e183c9220e600e2f33447e8acf483fa8940` proved strict nested network isolation, applied all three source diff paths in an isolated checkout, ran both immutable oracles successfully, and left the shared tree untouched. This is advisory local evidence and grants no merge authority.

## Lane Start Provenance

Packet: `artifacts/orchestration/task_packets/19e6028a8a85.json`

Pre-open role order: `agent-coordinator` → `security-auditor` → `architecture-specialist`. All returned GO/APPROVE with no P0–P2 findings after the final implementation review.

## Risks / rollback

The bounded compatibility risk is a transitive `x/text` change inside the existing Caddy build. Real build, module graph, embedded metadata, Caddyfile, capability, and Trivy checks passed locally. Before merge, rollback is a revert of `ab78451e7323b6381bee7d5ac486632fbdc5eb63`, which intentionally restores the CD block and must not be paired with a suppression. After deployment, rollback may use only a separately verified immutable image whose binary embeds `x/text v0.39.0` or later and passes the current Trivy policy.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- [Canonical review mapping](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/codex/fix-caddy-trivy-cve-2026-56852/docs/review/PR_2195_FIXED_MAPPING.md)

## Split justification

- Why this PR cannot be split safely: Not applicable; the three files form one bounded security invariant below the Tier 1 threshold.
- Invariant or rollout constraint requiring one PR: selection, real-binary assertion, regression guard, and security decision must agree atomically.

Operator approval: approved for the requested Caddy CVE-2026-56852 remediation.
Privileged scope exception: approved because the Caddy image builder and its security evidence form one atomic invariant.
Frontend/backend mix approval: approved because the only frontend path is the security-owned Caddy image builder.

- Follow-up PRs: none inside this CVE lane.

## Deferred / Follow-ups

- Resume PR #2193 only after this security lane is independently merged and main is healthy.
- Any future Caddy/Go/base-image upgrades remain separate dependency/security lanes.
- AGENTS/instruction update: not applicable; no process or architecture rule changes.

## Next best step

Run the mandatory post-open QA → bug-hunter → security review chain, then require current-head Docker/CD Trivy evidence before the one closeout commit.

<!-- markdownlint-enable MD013 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added a security decision/remediation record for **CVE-2026-56852**.
  * Updated the Caddy-based build to pin and verify **golang.org/x/text v0.39.0** to prevent an infinite-loop risk on invalid UTF-8.
  * Enhanced binary verification to ensure the built/deployed Caddy artifact contains the fixed module version.

* **Tests**
  * Hardened provenance checks to require the **v0.39.0** module be fetched in the expected build sequence.
  * Tightened forbidden-artifact validation to reject **v0.37.0** and ensured the CVE is not listed in scan suppressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->