### PR TITLE
test: make conftest restoration order-independent

### DIFF
--- a/docs/review/PR_2210_FIXED_MAPPING.md
+++ b/docs/review/PR_2210_FIXED_MAPPING.md
@@ -1,0 +1,56 @@
+# PR 2210 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/e3571ec31b05.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/exp-42dc7ffbee73-result.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 67c31ac63e579c06eeeebcc8d37406ea28e68fd4
+Evidence: tests/test_conftest_final_coverage.py:82 proves the replacement module is installed before teardown; isolated present/absent cases and both 38-test execution orders pass.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2210#discussion_r3686859204 -> 67c31ac63e579c06eeeebcc8d37406ea28e68fd4
+
+Disposition: FIXED
+Commit: 67c31ac63e579c06eeeebcc8d37406ea28e68fd4
+Evidence: The linked actionable now asserts the replacement binding at tests/test_conftest_final_coverage.py:82; both execution orders pass 38 tests each, and the general alternatives were evaluated without widening fixture lifecycle scope.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2210#pullrequestreview-4823958784 -> 67c31ac63e579c06eeeebcc8d37406ea28e68fd4
+
+Disposition: NOT-A-BUG
+Evidence: Cursor issue comment states Bugbot is not enabled and contains no code finding.
+Reason: Provider unavailability is not a review or approval; the comment requests no repository change.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2210#issuecomment-5137173518
+
+Disposition: NOT-A-BUG
+Evidence: Codex Connector issue comment reports exhausted usage limits and contains no code finding.
+Reason: Provider absence is not success and requires no retry; the comment requests no repository change.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2210#issuecomment-5137173582
+
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit reports a temporary review limit and provides no substantive review or requested code change.
+Reason: Rate-limit unavailability is not a review or PASS and requires no retry for this frozen material digest.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2210#issuecomment-5137174068
+
+Disposition: NOT-A-BUG
+Evidence: Sourcery review guide accurately summarizes the one-file fixture-lifecycle test change and contains no separate requested fix.
+Reason: This is descriptive reviewer guidance; the linked actionable review is dispositioned separately.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2210#issuecomment-5137174437
+
+Disposition: NOT-A-BUG
+Evidence: Codecov reports all modified and coverable lines are covered and contains no requested fix.
+Reason: This is a positive coverage report, not an actionable defect.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2210#issuecomment-5137291890
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"blocking":false,"material_digest":"sha256:10f84effe2b4c60afde76ce1a95cbb49aab1e4a596a9f8929098080f004c4faf","material_head_sha":"67c31ac63e579c06eeeebcc8d37406ea28e68fd4","output_required":false,"review_claim":"none"},"codex_security":{"base_revision":"eba51489574e6eee200144b8fed723af54078217","blocking":false,"head_revision":"67c31ac63e579c06eeeebcc8d37406ea28e68fd4","material_digest":"sha256:10f84effe2b4c60afde76ce1a95cbb49aab1e4a596a9f8929098080f004c4faf","no_findings_claim":false,"output_required":false,"scan_claim":"none"},"material":{"base_ref_oid":"eba51489574e6eee200144b8fed723af54078217","digest":"sha256:10f84effe2b4c60afde76ce1a95cbb49aab1e4a596a9f8929098080f004c4faf","material_head_sha":"67c31ac63e579c06eeeebcc8d37406ea28e68fd4","merge_base_sha":"eba51489574e6eee200144b8fed723af54078217","policy_version":"pulseplate.material-classification/v1"},"pr_number":2210,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1","self_review":{"actionable_findings_count":0,"authority":"repo_native_pulseplate_pr_review_advisory","blocking":false,"findings_count":0,"material_digest":"sha256:10f84effe2b4c60afde76ce1a95cbb49aab1e4a596a9f8929098080f004c4faf","material_head_sha":"67c31ac63e579c06eeeebcc8d37406ea28e68fd4","report_payload":{"actionable_findings_count":0,"base_ref_oid":"eba51489574e6eee200144b8fed723af54078217","calibration":{"case_labels":["clean-context","review-source-degraded"],"false_positive_controls":["clean context must produce zero findings","benign fixed-mapping presence must not become a governance finding","warnings and governance uncertainty remain actionable findings, not diagnostic notes","review-source degradation is status/warning only unless an explicit blocking source finding exists","large diff risk is review-planning evidence, not a merge-readiness claim"],"posting_eligible":false,"posting_gate":"GitHub posting remains out of scope until a dedicated calibrated posting PR.","rubric_version":"pr4-2026-04-28"},"coordinator_packet":{"path":"artifacts/orchestration/task_packets/e3571ec31b05.json","role_order":["agent-coordinator","architecture-specialist","security-auditor","qa-engineer-agent","bug-hunter","data-scientist-agent"],"task_packet_id":"e3571ec31b05"},"decision_log":["This report is advisory and side-effect free.","This report does not post GitHub comments, resolve review threads, merge PRs, or claim merge readiness.","External CodeRabbit, Sourcery, and Cubic statuses remain separate PR governance signals."],"deferred_followups":[],"findings":[],"findings_count":0,"gate_plan":["python3 scripts/orchestration/check_preflight.py","python3 scripts/orchestration/check_agent_consistency.py","python3 -m pytest tests/test_pr_review_report.py tests/test_pr_review_context.py -q","Add and fill docs/review/PR_<N>_FIXED_MAPPING.md before merge-ready loop","make test-fast"],"generated_at_utc":"2026-07-30T23:22:50Z","material_digest":"sha256:10f84effe2b4c60afde76ce1a95cbb49aab1e4a596a9f8929098080f004c4faf","material_head_sha":"67c31ac63e579c06eeeebcc8d37406ea28e68fd4","merge_base_sha":"eba51489574e6eee200144b8fed723af54078217","mode":"dry-run-report","review_source_status":[{"blocking":false,"evidence":"gh api repos/<repo>/pulls/<pr>","fallback_required":false,"reason":"","source":"github_pr_metadata","source_degraded":false,"status":"available"},{"blocking":false,"evidence":"eba51489574e6eee200144b8fed723af54078217..67c31ac63e579c06eeeebcc8d37406ea28e68fd4","fallback_required":false,"reason":"","source":"git_diff","source_degraded":false,"status":"available"},{"blocking":false,"evidence":"docs/review/PR_2210_FIXED_MAPPING.md","fallback_required":true,"reason":"Fixed-mapping artifact unavailable","source":"fixed_mapping_artifact","source_degraded":true,"status":"unavailable"}],"role_review":[{"role_agent":"agent-coordinator","summary":"agent-coordinator has no deterministic findings from the supplied context."},{"role_agent":"architecture-specialist","summary":"architecture-specialist has no deterministic findings from the supplied context."},{"role_agent":"security-auditor","summary":"security-auditor has no deterministic findings from the supplied context."},{"role_agent":"qa-engineer-agent","summary":"qa-engineer-agent has no deterministic findings from the supplied context."},{"role_agent":"bug-hunter","summary":"bug-hunter has no deterministic findings from the supplied context."},{"role_agent":"data-scientist-agent","summary":"data-scientist-agent has no scoring calibration changes in this dry-run report."}],"schema_version":"2.0.0","scope_reviewed":{"changed_files":["tests/test_conftest_final_coverage.py"],"diff_summary":{"additions":11,"changed_lines":22,"deletions":11,"files":1},"fixed_mapping_errors":[],"omitted_surfaces":["GitHub posting","PR thread resolution","merge readiness claims"],"pr_metadata_available":true,"scoped_agents_md":["AGENTS.md","tests/AGENTS.md"]},"warnings":[]},"report_sha256":"sha256:ae186d33b1624388b302c64e67429da8195e11eaa604fbe74db6ffa3ee86c3a4","review_claim":"none","review_tool":"pulseplate-pr-review","schema_version":"pulseplate.self-review-advisory/v1","status":"advisory_report_attached"}}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/tests/test_conftest_final_coverage.py
+++ b/tests/test_conftest_final_coverage.py
@@ -79,6 +79,7 @@ class TestConftestFinalCoverage:
         request.addfinalizer(assert_original_binding_restored)
         assert request.getfixturevalue("reset_sys_modules") is None
         monkeypatch.setitem(sys.modules, module_name, replacement_module)
+        assert sys.modules[module_name] is replacement_module
 
     def test_conftest_all_environments_fixture(
         self, production_environment, test_environment, premium_disabled_environment

--- a/tests/test_conftest_final_coverage.py
+++ b/tests/test_conftest_final_coverage.py
@@ -6,7 +6,6 @@ import os
 import sys
 from types import ModuleType
 
-import conftest as root_conftest
 import pytest
 from fastapi.testclient import TestClient
 
@@ -57,6 +56,7 @@ class TestConftestFinalCoverage:
     def test_reset_sys_modules_restores_exact_opt_in_binding(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
         original_present: bool,
     ) -> None:
         """The opt-in compatibility fixture must not leak a replacement module."""
@@ -69,17 +69,16 @@ class TestConftestFinalCoverage:
         else:
             monkeypatch.delitem(sys.modules, module_name, raising=False)
 
-        fixture_generator = root_conftest.reset_sys_modules.__wrapped__()
-        assert next(fixture_generator) is None
+        def assert_original_binding_restored() -> None:
+            if original_present:
+                assert sys.modules[module_name] is original_module
+            else:
+                assert module_name not in sys.modules
+
+        # Register before dynamic setup so pytest's LIFO teardown restores first.
+        request.addfinalizer(assert_original_binding_restored)
+        assert request.getfixturevalue("reset_sys_modules") is None
         monkeypatch.setitem(sys.modules, module_name, replacement_module)
-
-        with pytest.raises(StopIteration):
-            next(fixture_generator)
-
-        if original_present:
-            assert sys.modules[module_name] is original_module
-        else:
-            assert module_name not in sys.modules
 
     def test_conftest_all_environments_fixture(
         self, production_environment, test_environment, premium_disabled_environment


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# Pull Request

## Goal

Make the exact `reset_sys_modules` restoration regression independent of pytest
collection order by resolving the fixture through pytest instead of importing an
ambiguous bare `conftest` module.

## Business reason

The collection-order collision blocks the shared Python main matrix and therefore
slows every backend contributor. This one-file prerequisite removes the confirmed
`conftest` failure without coupling the separate VIP environment failure or
expanding TC1b.

## Scope

- Remove the bare `import conftest` from the restoration regression.
- Acquire `reset_sys_modules` through canonical pytest fixture resolution.
- Assert exact present/absent restoration after fixture teardown and before
  `monkeypatch` restores process-global state.
- Preserve the existing opt-in VIP binding contract.

## Out of scope

- `conftest.py`, `tests/conftest.py`, and `tests/evals/conftest.py`.
- Package markers, import configuration, `sys.path`, reload, module aliases,
  custom loaders, or broader `sys.modules` cleanup.
- The separate VIP production/test environment failures.
- Production runtime, auth, database, scheduler, Insight, app factory, TC1b, or
  TC2 changes.
- Mapping/seal work before post-open actionables are fixed and material content
  is frozen.

## Files changed

- `tests/test_conftest_final_coverage.py`

## Key decisions

- Use public pytest fixture resolution rather than identifying a conftest module
  by import name or file path.
- Register the assertion finalizer before dynamic fixture setup so pytest LIFO
  teardown is deterministic: reset fixture, exact-state assertion, then
  `monkeypatch` cleanup.
- Keep present and absent original bindings as separate parameterized oracles.
- Keep the conftest and VIP main-failure classes in separate prerequisite PRs.

## Tests

Current material head: `67c31ac63e579c06eeeebcc8d37406ea28e68fd4`.

Observed on exact `main=eba51489574e6eee200144b8fed723af54078217`:

- Isolated execution passed because bare `conftest` resolved to the repository
  root.
- Combined collection with
  `tests/evals/test_judgment_validity_sidecar.py` reproduced both failures:
  `AttributeError: module 'conftest' has no attribute 'reset_sys_modules'`.
- Main CI run `30587607976` completed with only the separate VIP
  production/test environment startup error across the completed Python jobs;
  that failure remains outside this one-file prerequisite.

Passed locally on the material commit:

- Isolated absent/present regression: 2 passed.
- Eval-first combined regression: 2 passed.
- Target-first combined regression: 2 passed.
- Complete two-file bundle in both orders: 38 passed per order.
- Focused lifecycle plus both sys.modules policy guards under
  `-W error::ResourceWarning`: 60 passed.
- Sourcery follow-up assertion proves the replacement binding is installed
  before teardown; the isolated pair and both complete execution orders still
  pass on the exact material head.
- `python scripts/orchestration/check_preflight.py --mode execute ...`.
- `python scripts/orchestration/check_agent_consistency.py`.
- Canonical branch-diff backend hook: 10 passed.
- `make validate-changed`: 10 passed.
- `git diff --check`.
- `pre-commit run --all-files`: every hook passed without modifications.
- Push hooks: detect-secrets, Black, Ruff, pip-audit, backend tests, full-repo
  Bandit, and the remaining applicable hooks passed.

Not run: local `make verify`, per the repository machine-budget hard rule.

Hosted material checks passed on exact head `67c31ac63e579c06eeeebcc8d37406ea28e68fd4`:
`lint`, `test-pr (3.13)`, `security`, and `diff-coverage`. The initial Phase 2
and merge-readiness jobs failed only because the canonical closeout was not yet
published.

Pending: publication of the single canonical mapping/seal commit, current-head
closeout CI, strict merge-readiness validation, and the mandatory review wait
window.

## Experiment Runner Evidence

Artifact: artifacts/orchestration/experiments/results/exp-42dc7ffbee73-result.json

- Accepted oracle-only result under strict Apple Container isolation.
- Current-head oracles passed 10/10 and 38/38 tests plus `git diff --check`.
- `mutated_paths` is empty, `shared_tree_untouched=true`, network budget is zero,
  and `promotion_ready=false`.
- No provider review, provider scan, approval, or no-findings claim is made.

## Lane Start Provenance

Packet: artifacts/orchestration/task_packets/e3571ec31b05.json

Starter: coordinator-first preflight and `task_bootstrap.py`.

## Premortem closures

- `PM-C1` — FIXED: ambiguous bare conftest import was removed; both collection
  orders pass.
- `PM-C2` — NOT-A-BUG: finalizer ordering is reset fixture, assertion, then
  monkeypatch; isolated and combined oracles prove both states.
- `PM-C3` — NOT-A-BUG: `request.getfixturevalue("reset_sys_modules")` exercises
  the actual fixture instead of a copied implementation.
- `PM-C4` — FIXED: exact present identity and exact absence are verified after
  fixture teardown.
- `PM-C5` — NOT-A-BUG: no loader, reload, plugin-manager, `sys.path`, or
  conftest-name `sys.modules` workaround was introduced.

## Post-open review status

- Required post-open `QA -> bug-hunter -> security` passes completed on exact
  head `67c31ac63e579c06eeeebcc8d37406ea28e68fd4` with no remaining actionables.
- Sourcery requested proof that the replacement binding exists before teardown;
  commit `67c31ac63e579c06eeeebcc8d37406ea28e68fd4` added the assertion and all
  order-parity oracles passed again.
- Sourcery's general fixture/helper alternatives were evaluated without
  widening the lifecycle-sensitive one-test scope.
- Codecov reports all modified and coverable lines are covered.
- Cursor Bugbot, Codex Connector, and CodeRabbit did not perform substantive
  reviews because of account or usage limits. Their absence is not a review,
  approval, PASS, or no-findings claim and was not retried.

## Security notes

- No production, auth, secret, workflow, dependency, database, or deployment
  surface changes.
- Existing module mutation remains scoped to the opt-in
  `app.routers.vip` compatibility fixture.
- No import-identity surgery or new process-global cleanup was introduced.
- Detect-secrets, Ruff, Bandit, pip-audit, policy guards, and all pre-commit
  security surfaces passed locally.

## Risks / rollback

- Risk: the assertion observes state after `monkeypatch` cleanup. Mitigation:
  registration order plus both exact-state oracles proves the opposite LIFO
  order.
- Risk: combined collection still selects the eval conftest. Mitigation: the
  test no longer imports by module identity, and both complete file orders pass.
- Rollback: revert PR #2210 (both material commits); there is no production
  deploy, migration, or persistent data change.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- [Canonical review mapping](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/codex/conftest-import-identity-isolation/docs/review/PR_2210_FIXED_MAPPING.md)
- URL→SHA and disposition details belong only in the canonical artifact.

## Deferred / Follow-ups

- Separate prerequisite: repair VIP production/test environment isolation while
  preserving fail-closed startup guards.
- After stable post-merge main, resume TC1b opt-in SQLite isolation, then S1,
  TC2, Insight cutover, and AF1.

## Next best step

Run strict pre-closeout validation against the live inventory, publish the one
mapping/seal commit, then wait for current-head CI and the review window before
the final authenticated merge-readiness check.

<!-- markdownlint-enable MD013 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for restoring module state after temporary changes.
  * Updated fixture handling to use pytest lifecycle management for more reliable cleanup verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->