### PR TITLE
test(scheduler): restore persisted rollback fixture parity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -635,14 +635,14 @@
         "filename": "tests/test_app_coverage_missing_lines.py",
         "hashed_secret": "172ce43af039f34e03db145738088d0addc715d9",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 44
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_app_coverage_missing_lines.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 59
+        "line_number": 64
       }
     ],
     "tests/test_app_coverage_optimized.py": [
@@ -1493,5 +1493,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T04:52:51Z"
+  "generated_at": "2026-08-02T16:14:14Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -863,7 +863,7 @@
         "filename": "tests/test_coverage_improvement.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 23
       }
     ],
     "tests/test_daily_plate_coverage_96.py": [
@@ -1493,5 +1493,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-02T16:14:14Z"
+  "generated_at": "2026-08-02T16:30:51Z"
 }

--- a/docs/review/PR_2230_FIXED_MAPPING.md
+++ b/docs/review/PR_2230_FIXED_MAPPING.md
@@ -1,0 +1,51 @@
+# PR 2230 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/b9a0ade907a9.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/main-scheduler-fixture-final-oracle-result.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 8dbdfc7cdb9ce0616c2871326a1f7a556dfd47b5
+Evidence: tests/test_comprehensive_coverage.py: all modified fake_scheduler callables now carry explicit SimpleNamespace return annotations; focused rollback/admin tests and full pre-commit passed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2230#discussion_r3699768978 -> 8dbdfc7cdb9ce0616c2871326a1f7a556dfd47b5
+
+Disposition: FIXED
+Commit: b00b72a0387da23c47841a50f1ee82eb9fad7224
+Evidence: All 19 changed helper and fixture definitions now have behavioral docstrings, clearing the reported 78.57 percent docstring warning; the live PR description was also restored and retains its incident and run references.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2230#issuecomment-5159319358 -> b00b72a0387da23c47841a50f1ee82eb9fad7224
+
+Disposition: FIXED
+Commit: 8dbdfc7cdb9ce0616c2871326a1f7a556dfd47b5
+Evidence: tests/helpers/fast_update_stubs.py: typed TypeVar preserves the injected manager type and _load_versions returns the same shared versions mapping; focused persisted-store tests passed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2230#pullrequestreview-4839217365 -> 8dbdfc7cdb9ce0616c2871326a1f7a556dfd47b5
+
+Disposition: FIXED
+Commit: 8dbdfc7cdb9ce0616c2871326a1f7a556dfd47b5
+Evidence: tests/test_comprehensive_coverage.py: the actionable return-annotation finding summarized by this review was fixed on every listed scheduler stub and validated by focused tests plus pre-commit.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2230#pullrequestreview-4839220553 -> 8dbdfc7cdb9ce0616c2871326a1f7a556dfd47b5
+
+Disposition: NOT-A-BUG
+Evidence: The bot comment explicitly states that Bugbot was not enabled and that no review was performed.
+Reason: No code or governance finding was asserted, so there is no actionable defect to fix.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2230#issuecomment-5159317102
+
+Disposition: NOT-A-BUG
+Evidence: The comment is an auto-generated reviewer guide summarizing scope and usage; it contains no review finding or requested code change.
+Reason: Informational review guidance is not an actionable defect; the separate Sourcery review findings are dispositioned independently.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2230#issuecomment-5159317792
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"blocking":false,"material_digest":"sha256:d07f1c31d437be52a00116259fb71792a2b5b97e850b319c388f211ae8bf8710","material_head_sha":"656f3fc111647b3d6fe8db7771bcf81f20ae5824","output_required":false,"review_claim":"none"},"codex_security":{"base_revision":"be6f93e3113c84fa241b949b0b2b72aabaa2bc2e","blocking":false,"head_revision":"656f3fc111647b3d6fe8db7771bcf81f20ae5824","material_digest":"sha256:d07f1c31d437be52a00116259fb71792a2b5b97e850b319c388f211ae8bf8710","no_findings_claim":false,"output_required":false,"scan_claim":"none"},"material":{"base_ref_oid":"be6f93e3113c84fa241b949b0b2b72aabaa2bc2e","digest":"sha256:d07f1c31d437be52a00116259fb71792a2b5b97e850b319c388f211ae8bf8710","material_head_sha":"656f3fc111647b3d6fe8db7771bcf81f20ae5824","merge_base_sha":"be6f93e3113c84fa241b949b0b2b72aabaa2bc2e","policy_version":"pulseplate.material-classification/v1"},"pr_number":2230,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1","self_review":{"actionable_findings_count":0,"authority":"repo_native_pulseplate_pr_review_advisory","blocking":false,"findings_count":0,"material_digest":"sha256:d07f1c31d437be52a00116259fb71792a2b5b97e850b319c388f211ae8bf8710","material_head_sha":"656f3fc111647b3d6fe8db7771bcf81f20ae5824","report_payload":{"actionable_findings_count":0,"base_ref_oid":"be6f93e3113c84fa241b949b0b2b72aabaa2bc2e","calibration":{"case_labels":["clean-context","review-source-degraded"],"false_positive_controls":["clean context must produce zero findings","benign fixed-mapping presence must not become a governance finding","warnings and governance uncertainty remain actionable findings, not diagnostic notes","review-source degradation is status/warning only unless an explicit blocking source finding exists","large diff risk is review-planning evidence, not a merge-readiness claim"],"posting_eligible":false,"posting_gate":"GitHub posting remains out of scope until a dedicated calibrated posting PR.","rubric_version":"pr4-2026-04-28"},"coordinator_packet":{"path":"artifacts/orchestration/task_packets/b9a0ade907a9.json","role_order":["agent-coordinator","architecture-specialist","security-auditor","qa-engineer-agent","bug-hunter","data-scientist-agent"],"task_packet_id":"b9a0ade907a9"},"decision_log":["This report is advisory and side-effect free.","This report does not post GitHub comments, resolve review threads, merge PRs, or claim merge readiness.","External CodeRabbit, Sourcery, and Cubic statuses remain separate PR governance signals."],"deferred_followups":[],"findings":[],"findings_count":0,"gate_plan":["python3 scripts/orchestration/check_preflight.py","python3 scripts/orchestration/check_agent_consistency.py","python3 -m pytest tests/test_pr_review_report.py tests/test_pr_review_context.py -q","Add and fill docs/review/PR_<N>_FIXED_MAPPING.md before merge-ready loop","make test-fast"],"generated_at_utc":"2026-08-02T17:31:29Z","material_digest":"sha256:d07f1c31d437be52a00116259fb71792a2b5b97e850b319c388f211ae8bf8710","material_head_sha":"656f3fc111647b3d6fe8db7771bcf81f20ae5824","merge_base_sha":"be6f93e3113c84fa241b949b0b2b72aabaa2bc2e","mode":"dry-run-report","review_source_status":[{"blocking":false,"evidence":"gh api repos/<repo>/pulls/<pr>","fallback_required":false,"reason":"","source":"github_pr_metadata","source_degraded":false,"status":"available"},{"blocking":false,"evidence":"be6f93e3113c84fa241b949b0b2b72aabaa2bc2e..656f3fc111647b3d6fe8db7771bcf81f20ae5824","fallback_required":false,"reason":"","source":"git_diff","source_degraded":false,"status":"available"},{"blocking":false,"evidence":"docs/review/PR_2230_FIXED_MAPPING.md","fallback_required":true,"reason":"Fixed-mapping artifact unavailable","source":"fixed_mapping_artifact","source_degraded":true,"status":"unavailable"}],"role_review":[{"role_agent":"agent-coordinator","summary":"agent-coordinator has no deterministic findings from the supplied context."},{"role_agent":"architecture-specialist","summary":"architecture-specialist has no deterministic findings from the supplied context."},{"role_agent":"security-auditor","summary":"security-auditor has no deterministic findings from the supplied context."},{"role_agent":"qa-engineer-agent","summary":"qa-engineer-agent has no deterministic findings from the supplied context."},{"role_agent":"bug-hunter","summary":"bug-hunter has no deterministic findings from the supplied context."},{"role_agent":"data-scientist-agent","summary":"data-scientist-agent has no scoring calibration changes in this dry-run report."}],"schema_version":"2.0.0","scope_reviewed":{"changed_files":[".secrets.baseline","tests/helpers/fast_update_stubs.py","tests/test_admin_endpoints_97.py","tests/test_app_coverage_missing_lines.py","tests/test_app_endpoints_combined.py","tests/test_app_rollback_paths.py","tests/test_comprehensive_coverage.py","tests/test_coverage_improvement.py","tests/test_update_manager_endpoints.py"],"diff_summary":{"additions":161,"changed_lines":222,"deletions":61,"files":9},"fixed_mapping_errors":[],"omitted_surfaces":["GitHub posting","PR thread resolution","merge readiness claims"],"pr_metadata_available":true,"scoped_agents_md":["AGENTS.md","tests/AGENTS.md"]},"warnings":[]},"report_sha256":"sha256:8006e649f74417cffcd4c3789ff39b89204ec3d5ac972e71c98794856d616a0b","review_claim":"none","review_tool":"pulseplate-pr-review","schema_version":"pulseplate.self-review-advisory/v1","status":"advisory_report_attached"}}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/tests/helpers/fast_update_stubs.py
+++ b/tests/helpers/fast_update_stubs.py
@@ -5,7 +5,7 @@ import importlib
 from pathlib import Path
 import sys
 from types import ModuleType, SimpleNamespace
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar, cast
 
 
 class SchedulerLike(Protocol):
@@ -13,22 +13,27 @@ class SchedulerLike(Protocol):
 
 
 BackgroundUpdateCallable = Callable[..., Any]
+PersistedVersionStoreTarget = TypeVar("PersistedVersionStoreTarget")
 
 
-def add_persisted_version_store_stub(update_manager: Any, tmp_path: Path) -> Any:
+def add_persisted_version_store_stub(
+    update_manager: PersistedVersionStoreTarget,
+    tmp_path: Path,
+) -> PersistedVersionStoreTarget:
     """Add the persisted-version surface required by leased rollback tests."""
 
     versions_file = tmp_path / "database_versions.json"
     assert not versions_file.exists()
 
     versions: dict[str, Any] = {}
-    update_manager.versions_file = versions_file
-    update_manager.versions = versions
+    persisted_store = cast(Any, update_manager)
+    persisted_store.versions_file = versions_file
+    persisted_store.versions = versions
 
     def _load_versions() -> dict[str, Any]:
-        return {}
+        return versions
 
-    update_manager._load_versions = _load_versions
+    persisted_store._load_versions = _load_versions
     return update_manager
 
 

--- a/tests/helpers/fast_update_stubs.py
+++ b/tests/helpers/fast_update_stubs.py
@@ -31,6 +31,8 @@ def add_persisted_version_store_stub(
     persisted_store.versions = versions
 
     def _load_versions() -> dict[str, Any]:
+        """Return the stable in-memory versions mapping for this fixture."""
+
         return versions
 
     persisted_store._load_versions = _load_versions

--- a/tests/helpers/fast_update_stubs.py
+++ b/tests/helpers/fast_update_stubs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import importlib
+from pathlib import Path
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import Any, Protocol
@@ -12,6 +13,23 @@ class SchedulerLike(Protocol):
 
 
 BackgroundUpdateCallable = Callable[..., Any]
+
+
+def add_persisted_version_store_stub(update_manager: Any, tmp_path: Path) -> Any:
+    """Add the persisted-version surface required by leased rollback tests."""
+
+    versions_file = tmp_path / "database_versions.json"
+    assert not versions_file.exists()
+
+    versions: dict[str, Any] = {}
+    update_manager.versions_file = versions_file
+    update_manager.versions = versions
+
+    def _load_versions() -> dict[str, Any]:
+        return {}
+
+    update_manager._load_versions = _load_versions
+    return update_manager
 
 
 def make_scheduler_stub(usda_result: Any = None) -> SchedulerLike:

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -74,6 +74,8 @@ class TestAdminEndpoints:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
+        """Exercise authenticated admin routes with a persisted-store-aware scheduler."""
+
         monkeypatch.setenv("API_KEY", "test_key")
 
         class _UpdateManager:
@@ -296,6 +298,8 @@ class TestAdminEndpoints:
         )
 
         async def get_scheduler() -> object:
+            """Return the rollback scheduler fixture for this request."""
+
             return SimpleNamespace(update_manager=persisted_update_manager)
 
         monkeypatch.setattr(

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -11,6 +11,7 @@
 """
 
 import os
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock
@@ -20,6 +21,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from app.services import admin_operations as admin_operations_service
 from starlette.types import ASGIApp
+from tests.helpers.fast_update_stubs import add_persisted_version_store_stub
 
 
 @pytest.fixture
@@ -70,6 +72,7 @@ class TestAdminEndpoints:
         self,
         client: TestClient,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -80,8 +83,13 @@ class TestAdminEndpoints:
             def rollback_database(self, source: str, target_version: str) -> bool:
                 return source == "usda" and target_version == "1.0.0"
 
+        persisted_update_manager = add_persisted_version_store_stub(
+            _UpdateManager(),
+            tmp_path,
+        )
+
         class _Scheduler:
-            update_manager = _UpdateManager()
+            update_manager = persisted_update_manager
 
             def get_status(self) -> dict[str, str]:
                 return {"status": "ok"}
@@ -269,7 +277,12 @@ class TestAdminEndpoints:
         assert response.status_code == 200
         assert response.json()["total_sources_with_updates"] == 1
 
-    def test_rollback_endpoint(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rollback_endpoint(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
         """Тест /api/v1/admin/rollback (блок 1640-1662)"""
         monkeypatch.setenv("API_KEY", "test_key")
 
@@ -277,8 +290,13 @@ class TestAdminEndpoints:
             def rollback_database(self, source: str, target_version: str) -> bool:
                 return source == "usda" and target_version == "1.0.0"
 
+        persisted_update_manager = add_persisted_version_store_stub(
+            _UpdateManager(),
+            tmp_path,
+        )
+
         async def get_scheduler() -> object:
-            return SimpleNamespace(update_manager=_UpdateManager())
+            return SimpleNamespace(update_manager=persisted_update_manager)
 
         monkeypatch.setattr(
             admin_operations_service,

--- a/tests/test_app_coverage_missing_lines.py
+++ b/tests/test_app_coverage_missing_lines.py
@@ -3,13 +3,18 @@ Test coverage for missing lines in app.py to improve coverage to 97%.
 """
 
 import os
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import app as app_mod
 from app.services import admin_operations
 from fastapi.testclient import TestClient
-from tests.helpers.fast_update_stubs import make_scheduler_stub, patch_admin_get_update_scheduler
+from tests.helpers.fast_update_stubs import (
+    add_persisted_version_store_stub,
+    make_scheduler_stub,
+    patch_admin_get_update_scheduler,
+)
 
 
 class TestAppMissingLinesCoverage:
@@ -288,12 +293,16 @@ class TestAppMissingLinesCoverage:
         assert response.status_code == 200
 
     def test_rollback_database_endpoint(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         """Test rollback database endpoint."""
         client = client
 
         scheduler = MagicMock()
+        scheduler.update_manager = add_persisted_version_store_stub(MagicMock(), tmp_path)
         scheduler.update_manager.rollback_database = AsyncMock(return_value=True)
         patch_admin_get_update_scheduler(monkeypatch, scheduler)
         response = client.post(

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -710,6 +710,8 @@ class TestAdminOperationsService:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
+        """Exercise persisted rollback success and explicit error outcomes."""
+
         raising_rollback_calls: list[tuple[str, str]] = []
 
         class _VersionedRollbackManager:
@@ -730,6 +732,8 @@ class TestAdminOperationsService:
 
         class _RaisingRollbackManager(_VersionedRollbackManager):
             def rollback_database(self, source: str, target_version: str) -> bool:
+                """Record the attempted rollback before raising the fixture error."""
+
                 raising_rollback_calls.append((source, target_version))
                 raise RuntimeError("rollback boom")
 

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -710,6 +710,8 @@ class TestAdminOperationsService:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
+        raising_rollback_calls: list[tuple[str, str]] = []
+
         class _VersionedRollbackManager:
             versions_file = tmp_path / "database-versions.json"
             versions: dict[str, object] = {}
@@ -728,6 +730,7 @@ class TestAdminOperationsService:
 
         class _RaisingRollbackManager(_VersionedRollbackManager):
             def rollback_database(self, source: str, target_version: str) -> bool:
+                raising_rollback_calls.append((source, target_version))
                 raise RuntimeError("rollback boom")
 
         class _AwaitableRollbackManager(_VersionedRollbackManager):
@@ -802,6 +805,7 @@ class TestAdminOperationsService:
             asyncio.run(admin_operations_service.rollback_database("usda", "1.0.0"))
         assert exc_info.value.status_code == 500
         assert "Rollback failed" in str(exc_info.value.detail)
+        assert raising_rollback_calls == [("usda", "1.0.0")]
 
         monkeypatch.setattr(
             admin_operations_service,

--- a/tests/test_app_rollback_paths.py
+++ b/tests/test_app_rollback_paths.py
@@ -81,6 +81,8 @@ def test_rollback_raises_inside_method(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """Preserve the endpoint error contract when the rollback callable raises."""
+
     rollback_database = AsyncMock(side_effect=RuntimeError("boom"))
 
     class DummyScheduler:

--- a/tests/test_app_rollback_paths.py
+++ b/tests/test_app_rollback_paths.py
@@ -9,12 +9,15 @@ Covers:
 """
 
 import asyncio
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
 from unittest.mock import AsyncMock
 
 from app.services import admin_operations
+from tests.helpers.fast_update_stubs import add_persisted_version_store_stub
 
 
 def test_rollback_scheduler_failure(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -74,13 +77,17 @@ def test_rollback_no_rollback_fn(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Rollback operation not supported" in exc.value.detail
 
 
-def test_rollback_raises_inside_method(monkeypatch: pytest.MonkeyPatch) -> None:
-    class DummyManager:
-        async def rollback_database(self, source: str, target_version: str) -> None:
-            raise RuntimeError("boom")
+def test_rollback_raises_inside_method(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    rollback_database = AsyncMock(side_effect=RuntimeError("boom"))
 
     class DummyScheduler:
-        update_manager = DummyManager()
+        update_manager = add_persisted_version_store_stub(
+            SimpleNamespace(rollback_database=rollback_database),
+            tmp_path,
+        )
 
     mock_get_update_scheduler = AsyncMock(return_value=DummyScheduler())
     monkeypatch.setattr(
@@ -93,5 +100,6 @@ def test_rollback_raises_inside_method(monkeypatch: pytest.MonkeyPatch) -> None:
         asyncio.run(admin_operations.rollback_database("usda", "v1"))
 
     mock_get_update_scheduler.assert_awaited_once()
+    rollback_database.assert_awaited_once_with("usda", "v1")
     assert exc.value.status_code == 500
     assert "Rollback operation failed" in exc.value.detail

--- a/tests/test_comprehensive_coverage.py
+++ b/tests/test_comprehensive_coverage.py
@@ -306,7 +306,7 @@ class TestComprehensiveCoverage:
         rollback_database = AsyncMock(side_effect=Exception("Rollback failed"))
 
         # Patch get_update_scheduler to return a scheduler with failing rollback
-        async def fake_scheduler():
+        async def fake_scheduler() -> SimpleNamespace:
             # Return a scheduler whose rollback_database raises an exception
             mock_update_manager = add_persisted_version_store_stub(
                 SimpleNamespace(rollback_database=rollback_database),
@@ -340,7 +340,7 @@ class TestComprehensiveCoverage:
         """Test rollback when rollback_database returns False."""
 
         # Patch get_update_scheduler to return a scheduler with rollback returning False
-        async def fake_scheduler():
+        async def fake_scheduler() -> SimpleNamespace:
             # Return a scheduler whose rollback_database returns False
             mock_update_manager = add_persisted_version_store_stub(
                 SimpleNamespace(rollback_database=AsyncMock(return_value=False)),

--- a/tests/test_comprehensive_coverage.py
+++ b/tests/test_comprehensive_coverage.py
@@ -4,6 +4,7 @@ Comprehensive tests to improve coverage to 97%+.
 
 import asyncio
 import os
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, Iterator, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -17,6 +18,7 @@ import app as app_mod
 from app import app
 from app.services import admin_operations, pro_nutrition_plate
 from tests.helpers.fast_update_stubs import (
+    add_persisted_version_store_stub,
     make_scheduler_stub,
     patch_admin_get_update_scheduler,
 )
@@ -204,13 +206,20 @@ class TestComprehensiveCoverage:
             assert response.json() == {"detail": "Update check failed"}
 
     @pytest.mark.serial
-    def test_rollback_endpoint_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rollback_endpoint_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
         """Test rollback endpoint success case."""
         # Use monkeypatch.setattr to patch module-level function for FastAPI endpoints
 
         async def fake_scheduler() -> SimpleNamespace:
             # Return a scheduler with update_manager.rollback_database that returns True
-            mock_update_manager = SimpleNamespace(rollback_database=AsyncMock(return_value=True))
+            mock_update_manager = add_persisted_version_store_stub(
+                SimpleNamespace(rollback_database=AsyncMock(return_value=True)),
+                tmp_path,
+            )
             return SimpleNamespace(update_manager=mock_update_manager)
 
         monkeypatch.setattr(admin_operations, "get_update_scheduler", fake_scheduler)
@@ -288,17 +297,21 @@ class TestComprehensiveCoverage:
 
     @pytest.mark.serial
     def test_rollback_endpoint_rollback_function_exception(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         """Test rollback when rollback_database raises exception."""
+
+        rollback_database = AsyncMock(side_effect=Exception("Rollback failed"))
 
         # Patch get_update_scheduler to return a scheduler with failing rollback
         async def fake_scheduler():
             # Return a scheduler whose rollback_database raises an exception
-            async def failing_rollback(source, target_version):
-                raise Exception("Rollback failed")
-
-            mock_update_manager = SimpleNamespace(rollback_database=failing_rollback)
+            mock_update_manager = add_persisted_version_store_stub(
+                SimpleNamespace(rollback_database=rollback_database),
+                tmp_path,
+            )
             return SimpleNamespace(update_manager=mock_update_manager)
 
         # Patch both the module attribute and globals to ensure the endpoint sees it
@@ -316,15 +329,23 @@ class TestComprehensiveCoverage:
         assert "detail" in data
         assert "Rollback operation failed" in data["detail"]
         assert "Rollback failed" in data["detail"]
+        rollback_database.assert_awaited_once_with("usda", "1.0")
 
     @pytest.mark.serial
-    def test_rollback_endpoint_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rollback_endpoint_returns_false(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
         """Test rollback when rollback_database returns False."""
 
         # Patch get_update_scheduler to return a scheduler with rollback returning False
         async def fake_scheduler():
             # Return a scheduler whose rollback_database returns False
-            mock_update_manager = SimpleNamespace(rollback_database=AsyncMock(return_value=False))
+            mock_update_manager = add_persisted_version_store_stub(
+                SimpleNamespace(rollback_database=AsyncMock(return_value=False)),
+                tmp_path,
+            )
             return SimpleNamespace(update_manager=mock_update_manager)
 
         # Patch both the module attribute and globals to ensure the endpoint sees it

--- a/tests/test_comprehensive_coverage.py
+++ b/tests/test_comprehensive_coverage.py
@@ -343,13 +343,15 @@ class TestComprehensiveCoverage:
     ) -> None:
         """Test rollback when rollback_database returns False."""
 
+        rollback_database = AsyncMock(return_value=False)
+
         # Patch get_update_scheduler to return a scheduler with rollback returning False
         async def fake_scheduler() -> SimpleNamespace:
             """Return a persisted-store-aware scheduler for a false rollback result."""
 
             # Return a scheduler whose rollback_database returns False
             mock_update_manager = add_persisted_version_store_stub(
-                SimpleNamespace(rollback_database=AsyncMock(return_value=False)),
+                SimpleNamespace(rollback_database=rollback_database),
                 tmp_path,
             )
             return SimpleNamespace(update_manager=mock_update_manager)
@@ -365,11 +367,8 @@ class TestComprehensiveCoverage:
 
         # Assert deterministic 500 error response when rollback returns False
         assert response.status_code == 500
-        data = response.json()
-        assert "detail" in data
-        assert "Rollback operation failed" in data["detail"]
-        assert "usda" in data["detail"]
-        assert "1.0" in data["detail"]
+        assert response.json() == {"detail": "Rollback operation failed for usda to version 1.0"}
+        rollback_database.assert_awaited_once_with("usda", "1.0")
 
     def test_premium_plate_endpoint_success(
         self,

--- a/tests/test_comprehensive_coverage.py
+++ b/tests/test_comprehensive_coverage.py
@@ -215,6 +215,8 @@ class TestComprehensiveCoverage:
         # Use monkeypatch.setattr to patch module-level function for FastAPI endpoints
 
         async def fake_scheduler() -> SimpleNamespace:
+            """Return a persisted-store-aware scheduler for rollback success."""
+
             # Return a scheduler with update_manager.rollback_database that returns True
             mock_update_manager = add_persisted_version_store_stub(
                 SimpleNamespace(rollback_database=AsyncMock(return_value=True)),
@@ -307,6 +309,8 @@ class TestComprehensiveCoverage:
 
         # Patch get_update_scheduler to return a scheduler with failing rollback
         async def fake_scheduler() -> SimpleNamespace:
+            """Return a persisted-store-aware scheduler whose rollback raises."""
+
             # Return a scheduler whose rollback_database raises an exception
             mock_update_manager = add_persisted_version_store_stub(
                 SimpleNamespace(rollback_database=rollback_database),
@@ -341,6 +345,8 @@ class TestComprehensiveCoverage:
 
         # Patch get_update_scheduler to return a scheduler with rollback returning False
         async def fake_scheduler() -> SimpleNamespace:
+            """Return a persisted-store-aware scheduler for a false rollback result."""
+
             # Return a scheduler whose rollback_database returns False
             mock_update_manager = add_persisted_version_store_stub(
                 SimpleNamespace(rollback_database=AsyncMock(return_value=False)),

--- a/tests/test_coverage_improvement.py
+++ b/tests/test_coverage_improvement.py
@@ -3,6 +3,7 @@ Additional tests to improve coverage to 97%+.
 """
 
 import os
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,6 +12,7 @@ from fastapi.testclient import TestClient
 # Import the FastAPI app from app.py file
 from app import app
 from app.middleware.api_tiers import TEST_KEY_VIP
+from tests.helpers.fast_update_stubs import add_persisted_version_store_stub
 
 
 class TestCoverageImprovement:
@@ -117,31 +119,28 @@ class TestCoverageImprovement:
             # Exception is expected, but the code should handle it gracefully
             pass
 
-    def test_update_manager_uncovered_lines(self) -> None:
+    def test_update_manager_uncovered_lines(self, tmp_path: Path) -> None:
         """Test uncovered lines in update_manager.py."""
-        # Test rollback database error handling - fix the class name
-        try:
-            with patch(
-                "core.food_apis.update_manager.DatabaseUpdateManager._load_backup",
-                side_effect=Exception("Test error"),
-            ):
-                with patch(
-                    "app.services.admin_operations.get_update_scheduler",
-                    new_callable=AsyncMock,
-                ) as mock_get_scheduler:
-                    mock_scheduler = AsyncMock()
-                    mock_scheduler.update_manager.rollback_database = AsyncMock(return_value=False)
-                    mock_get_scheduler.return_value = mock_scheduler
+        with patch(
+            "app.services.admin_operations.get_update_scheduler",
+            new_callable=AsyncMock,
+        ) as mock_get_scheduler:
+            rollback_database = AsyncMock(return_value=False)
+            update_manager = add_persisted_version_store_stub(
+                MagicMock(rollback_database=rollback_database),
+                tmp_path,
+            )
+            mock_get_scheduler.return_value = MagicMock(update_manager=update_manager)
 
-                    _ = self.client.post(
-                        "/api/v1/admin/rollback",
-                        params={"source": "usda", "target_version": "1.0"},
-                        headers={"X-API-Key": "test_key"},
-                    )
-                    # Should handle gracefully
-        except Exception:
-            # Exception is expected, but the code should handle it gracefully
-            pass
+            response = self.client.post(
+                "/api/v1/admin/rollback",
+                params={"source": "usda", "target_version": "1.0"},
+                headers={"X-API-Key": "test_key"},
+            )
+
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Rollback operation failed for usda to version 1.0"}
+        rollback_database.assert_awaited_once_with("usda", "1.0")
 
     def test_menu_engine_uncovered_lines(self) -> None:
         """Test uncovered lines in menu_engine.py."""

--- a/tests/test_update_manager_endpoints.py
+++ b/tests/test_update_manager_endpoints.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
+from tests.helpers.fast_update_stubs import add_persisted_version_store_stub
 
 
 class TestUpdateManagerEndpoints:
@@ -73,10 +74,10 @@ class TestUpdateManagerEndpoints:
         assert response.json() == {"detail": "Update check failed"}
         assert "secret-token" not in response.text
 
-    def test_rollback_success(self, client: TestClient) -> None:
+    def test_rollback_success(self, client: TestClient, tmp_path: Path) -> None:
         """Test successful database rollback."""
         mock_scheduler = MagicMock()
-        mock_update_manager = MagicMock()
+        mock_update_manager = add_persisted_version_store_stub(MagicMock(), tmp_path)
         mock_update_manager.rollback_database = AsyncMock(return_value=True)
         mock_scheduler.update_manager = mock_update_manager
         mock_get_scheduler = AsyncMock(return_value=mock_scheduler)
@@ -97,10 +98,10 @@ class TestUpdateManagerEndpoints:
         mock_get_scheduler.assert_awaited_once()
         mock_update_manager.rollback_database.assert_awaited_once()
 
-    def test_rollback_failure(self, client: TestClient) -> None:
+    def test_rollback_failure(self, client: TestClient, tmp_path: Path) -> None:
         """Test failed database rollback."""
         mock_scheduler = MagicMock()
-        mock_update_manager = MagicMock()
+        mock_update_manager = add_persisted_version_store_stub(MagicMock(), tmp_path)
         mock_update_manager.rollback_database = AsyncMock(return_value=False)
         mock_scheduler.update_manager = mock_update_manager
         mock_get_scheduler = AsyncMock(return_value=mock_scheduler)
@@ -119,10 +120,10 @@ class TestUpdateManagerEndpoints:
         mock_get_scheduler.assert_awaited_once()
         mock_update_manager.rollback_database.assert_awaited_once()
 
-    def test_rollback_exception(self, client: TestClient) -> None:
+    def test_rollback_exception(self, client: TestClient, tmp_path: Path) -> None:
         """Test rollback with exception."""
         mock_scheduler = MagicMock()
-        mock_update_manager = MagicMock()
+        mock_update_manager = add_persisted_version_store_stub(MagicMock(), tmp_path)
         mock_update_manager.rollback_database = AsyncMock(side_effect=ValueError("Invalid version"))
         mock_scheduler.update_manager = mock_update_manager
         mock_get_scheduler = AsyncMock(return_value=mock_scheduler)


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# Pull Request

## Goal

Restore canonical current-main CI after PR #2217 by bringing every admin rollback test fixture into parity with the production `PersistedVersionStore` contract and by closing rollback error-path false positives.

## Business reason

Canonical push run `30754025259` failed in all Python 3.11, 3.12, and 3.13 `test-main` matrices at exact main SHA `be6f93e3113c84fa241b949b0b2b72aabaa2bc2e`. The failures blocked colleagues from safely basing new work on `main`. This PR repairs the test contract without weakening the production fail-closed scheduler refresh that prevents stale persisted version state from being mutated.

## Scope

- Add one explicit shared test helper that provides the required persisted-version surface: an absent `tmp_path` file, a stable in-memory versions dictionary, and synchronous `_load_versions() -> {}`.
- Update all nine originally failing rollback/admin tests across Python 3.11, 3.12, and 3.13.
- Preserve synchronous, asynchronous, success, false-result, and exception callback behavior.
- Require exception paths to prove the intended rollback callable was actually reached.
- Remove a broad `try/except Exception: pass` false green from the same admin rollback path.
- Update only generated `.secrets.baseline` line-number metadata and timestamp as required by pre-commit.

## Out of scope

- No production, scheduler runtime, lease, auth, route, workflow, dependency, deploy, OpenAPI, frontend, iOS, or RAG behavior changes.
- No weakening or bypass of `refresh_update_version_state()`, `_load_versions_fail_closed()`, or `run_with_update_lease()`.
- No Codex Security/provider scan and no provider retry.
- No changes to PR #2229 or any creative experiment/code artifact.

## Files changed

- `.secrets.baseline`
- `tests/helpers/fast_update_stubs.py`
- `tests/test_admin_endpoints_97.py`
- `tests/test_app_coverage_missing_lines.py`
- `tests/test_app_endpoints_combined.py`
- `tests/test_app_rollback_paths.py`
- `tests/test_comprehensive_coverage.py`
- `tests/test_coverage_improvement.py`
- `tests/test_update_manager_endpoints.py`

Exact material scope: nine paths, all test/generated evidence; zero production paths.

## Key decisions

- Keep the production fail-closed persisted-state invariant unchanged and repair stale fixtures instead.
- Use a real absent `Path` under pytest `tmp_path`; do not rely on permissive `MagicMock` behavior for `Path.exists()` or JSON state.
- Keep the loader synchronous because `PersistedVersionStore` is synchronously consumed inside the existing worker-thread refresh boundary.
- Retain observable `AsyncMock` or event evidence for raising callbacks so a generic sanitized `500` cannot hide an earlier refresh failure.
- Commit generated detect-secrets updates separately from functional test changes.

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/b9a0ade907a9.json`
- Base / merge-base: `be6f93e3113c84fa241b949b0b2b72aabaa2bc2e`
- Exact material head: `656f3fc111647b3d6fe8db7771bcf81f20ae5824`
- Dispatch manifest: coordinator read-only, QA sole implementation owner, bug-hunter read-only after QA, security-auditor read-only after bug-hunter.

## Role-agent evidence

- Agent coordinator: GO for exact nine-path test/generated scope; no production weakening.
- QA engineer: PASS on exact head; 19 focused rollback nodes passed.
- Bug hunter: PASS on exact head after scanning all admin rollback fixtures; no remaining P0/P1/P2 false-green or protocol defect.
- Security auditor: PASS on exact head; zero security actionables and no provider scan.

## Premortem closure

- Stale fixtures fail before rollback because they omit persisted-state fields.
  - Disposition: FIXED.
  - Evidence: shared explicit persisted-store helper and all original 3.11/3.12/3.13 failure fixtures updated in `e3bd80a33778922112d7e14898fbc4f95694fb69`.
- Generic `500` assertions pass even when the intended raising rollback callable is never reached.
  - Disposition: FIXED.
  - Evidence: exact `AsyncMock.assert_awaited_once_with(...)` and raising-call event assertions in `e3bd80a33778922112d7e14898fbc4f95694fb69` and `8053bfc05416b4bcb7cf7edd2ade9ac47aa7bfe7`.
- A broad exception swallow hides the same main regression.
  - Disposition: FIXED.
  - Evidence: `tests/test_coverage_improvement.py` now asserts the exact false-result response and callback arguments in `8053bfc05416b4bcb7cf7edd2ade9ac47aa7bfe7`.
- Shared persisted-state test data leaks between tests.
  - Disposition: FIXED.
  - Evidence: each fixture uses an asserted-absent file under per-test `tmp_path`.
- Detect-secrets baseline changes hide a secret inventory change.
  - Disposition: NOT-A-BUG.
  - Evidence: only three line numbers and `generated_at` changed; base/head inventory remains 27 plugins, 122 result-bearing files, and 158 findings, with normalized document SHA-256 `06464b1d68ab9bf789681ceedb53a91b0af1467551e57b2b4a44996b0d47efce`.

No premortem finding remains open.

## Tests

Exact material head: `656f3fc111647b3d6fe8db7771bcf81f20ae5824`.

- Canonical preflight: PASS; clean worktree.
- Agent consistency: PASS.
- Expanded rollback/admin/fail-closed local bundle: 199 passed; only two existing SQLAlchemy sqlite date-adapter deprecation warnings.
- `make validate-changed`: PASS; selected all eight changed Python test/helper modules, 126 tests.
- `git diff --check origin/main...HEAD`: PASS.
- `pre-commit run --all-files`: PASS with no final modifications.
- Commit and pre-push hooks: PASS, including MyPy, pip-audit, backend tests, full-repo Bandit, and applicable Docker hook routing.
- Local full `make verify` was not run per repository machine-budget policy.
- Canonical current-head PR CI: the final mapping-head run will start after the sole closeout commit is pushed.

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/main-scheduler-fixture-final-oracle-result.json`
- Experiment: `exp-5163ca1e48f7`
- Status: accepted.
- Mode: `oracle_only_governance_reviewer`; no candidate patch, no provider call, no mutation, no promotion authority.
- Strict Apple Container 1.1.0 image digest: `sha256:5b3abbad998dc1b23f9d99e72a8fde931558401b81a2aec8c5eeeff90b128a70`; network budget 0.
- Oracles: 2/2 passed — 126 changed rollback/admin tests and 11 canonical persisted/refresh tests.
- `mutated_paths=[]`, `shared_tree_untouched=true`, `promotion_ready=false`, `coauthor_required=false`.

## Security notes

- Production auth, lease, refresh, stable-file revalidation, sanitized-error, and rollback ordering remain unchanged.
- The helper cannot accept corrupt or non-empty persisted JSON; unchanged production code and canonical tests retain those fail-closed checks.
- `.secrets.baseline` detector types, filenames, hashes, verification flags, plugins, and finding inventory are unchanged.
- No new secret, suppression, allowlist, privileged scope, or external execution surface is introduced.

## Risks / rollback

- Risk: a future production persisted-store contract change can make tests stale again. Mitigation: one shared explicit helper plus callback-reachability assertions make such drift fail visibly.
- Risk: a test-only fix could accidentally codify a permissive production fallback. Mitigation: zero production diff and unchanged canonical fail-closed tests.
- Rollback: revert the eventual PR merge commit. That restores the known-red main fixtures, so rollback should be followed immediately by a corrected fixture-forward fix rather than production invariant weakening.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- [Canonical review mapping and material seal](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/codex/scheduler-version-fixture-main-fix/docs/review/PR_2230_FIXED_MAPPING.md)
- URL-to-SHA and disposition details live only in that canonical artifact.

## Split justification

- Why this PR cannot be split safely: the fixture helper and every rollback consumer must move together so Python-version-specific shards do not retain a different persisted-store contract.
- Invariant or rollout constraint requiring one PR: all affected fixtures consume the same fail-closed production refresh seam and collectively restore one canonical main run.
- Follow-up PRs: none inside this remediation; PR #2229 may synchronize only after terminal-green main.

## Deferred / Follow-ups

None.

## Next best step

Run authenticated pre-closeout, publish the sole mapping/seal closeout commit, wait for terminal exact-head CI with diff coverage at or above 97%, complete the review quiet window, and pass strict authenticated readiness before a normal merge.

<!-- markdownlint-enable MD013 -->

## Summary by Sourcery

Привести тестовые фикстуры, связанные с откатом (rollback), в соответствие с контрактом хранилища сохранённых версий и усилить утверждения (assertions), касающиеся поведения админского отката и путей обработки ошибок, без изменения продукционного кода.

Enhancements:
- Ввести общий вспомогательный хелпер для стаббинга интерфейса хранилища сохранённых версий для экземпляров менеджера обновлений, связанных с откатом, в тестах.

Tests:
- Обновить несколько тестов админских и rollback-эндпоинтов для использования общего стабба хранилища сохранённых версий и для более точной проверки rollback-callback’ов, ответов и путей выброса исключений, чтобы исключить ложноположительные срабатывания.
- Убедиться, что тесты путей ошибок при откате проверяют, что нужный rollback-callable действительно вызывается и ожидается (awaited), включая сценарии с ошибками и исключениями в разных наборах покрытия.

Chores:
- Обновить метаданные baseline-файла для detect-secrets, чтобы отразить текущие номера строк и временные метки, не изменяя сам инвентарь секретов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align rollback-related test fixtures with the persisted version store contract and strengthen assertions around admin rollback behavior and error paths without changing production code.

Enhancements:
- Introduce a shared helper to stub the persisted version store surface for rollback-related update manager instances in tests.

Tests:
- Update multiple admin and rollback endpoint tests to use the shared persisted-version stub and to assert rollback callbacks, responses, and exception paths more precisely, eliminating false positives.
- Ensure rollback error-path tests verify that the intended rollback callable is reached and awaited, including failure and exception scenarios across different coverage suites.

Chores:
- Refresh the detect-secrets baseline metadata to reflect current line numbers and timestamps without altering the secret inventory.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded rollback endpoint coverage for successful, failed, and exceptional operations.
  * Added verification that rollback requests use the expected source and target versions.
  * Improved test isolation with temporary persisted-version storage.
* **Chores**
  * Updated security baseline references and refreshed the baseline timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->