### PR TITLE
fix(ci): require immutable docker@sha256 digest pins for docker:// action refs

### DIFF
--- a/docs/security/TOOLING_SURFACE_POLICY.md
+++ b/docs/security/TOOLING_SURFACE_POLICY.md
@@ -21,8 +21,8 @@ Keep developer tooling, CI actions, and workspace recommendations pinned and rev
   other executable carriers or YAML-semantic forms.
 - Recognized references are classified in this order:
   - local `./` references are repo-local and do not require an external SHA pin
-  - `docker://` references are excluded from this classifier; exclusion is not
-    a safety, provenance, or immutability claim
+  - `docker://` references must use an immutable lowercase 64-hex
+    `@sha256:<digest>` pin; mutable tags are forbidden
   - other references must satisfy the exact lowercase 40-hex SHA predicate
 - On `pull_request`, `jobs.pr_scope_guard` executes the bounded guard against
   the live checkout as the first validation command after `set -euo pipefail`

--- a/scripts/ci/guard_actions_pin.py
+++ b/scripts/ci/guard_actions_pin.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 USES_RE = re.compile(r"^\s*-?\s*uses:\s*(?P<action>\S+?)(?:\s+#.*)?\s*$")
 PINNED_SHA_RE = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+PINNED_DOCKER_DIGEST_RE = re.compile(r"^docker://[^@]+@sha256:[0-9a-f]{64}$")
 
 
 def _workflow_paths(workflows_dir: Path) -> list[Path]:
@@ -45,6 +46,12 @@ def find_unpinned_actions(root: Path) -> list[str]:
             if action.startswith("./"):
                 continue
             if action.startswith("docker://"):
+                if PINNED_DOCKER_DIGEST_RE.match(action):
+                    continue
+                violations.append(
+                    f"{action_source_path.relative_to(root)}:{line_number}: "
+                    f"Docker action '{action}' must pin a sha256 digest"
+                )
                 continue
             if PINNED_SHA_RE.match(action):
                 continue

--- a/tests/test_tooling_surface_guards.py
+++ b/tests/test_tooling_surface_guards.py
@@ -176,11 +176,29 @@ def test_actions_pin_guard_allows_local_composite_action(tmp_path: Path) -> None
     assert PIN_GUARD_OK in result.stdout
 
 
-def test_actions_pin_guard_excludes_docker_references(tmp_path: Path) -> None:
+def test_actions_pin_guard_rejects_mutable_docker_references(tmp_path: Path) -> None:
     action_dir = tmp_path / ".github" / "actions" / "nested" / "container"
     action_dir.mkdir(parents=True)
     (action_dir / "action.yaml").write_text(
-        "runs:\n  using: composite\n  steps:\n    - uses: docker://alpine:3.20\n",
+        "runs:\n  using: composite\n  steps:\n    - uses: docker://alpine:latest\n",
+        encoding="utf-8",
+    )
+
+    result = _run(GUARD_ACTIONS, tmp_path)
+
+    assert result.returncode == 1
+    assert (
+        "Docker action 'docker://alpine:latest' must pin a sha256 digest"
+        in result.stdout
+    )
+
+
+def test_actions_pin_guard_allows_docker_digest_references(tmp_path: Path) -> None:
+    action_dir = tmp_path / ".github" / "actions" / "nested" / "container"
+    action_dir.mkdir(parents=True)
+    digest = "a" * 64
+    (action_dir / "action.yaml").write_text(
+        f"runs:\n  using: composite\n  steps:\n    - uses: docker://alpine@sha256:{digest}\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
### Motivation

- Close a supply-chain bypass where the actions pin guard previously skipped all `docker://` references, allowing mutable tags to pass the pre-merge check.

### Description

- Add `PINNED_DOCKER_DIGEST_RE` and enforce that `docker://` action references must be pinned to a lowercase 64-hex `@sha256:<digest>`; mutable tags now produce a violation.
- Emit a clear violation message for unpinned Docker actions and preserve existing 40-hex commit-SHA checks for non-docker action refs.
- Add regression tests that assert mutable Docker tags (e.g. `docker://alpine:latest`) are rejected and that digest-pinned Docker refs are accepted.
- Update `docs/security/TOOLING_SURFACE_POLICY.md` to require immutable Docker digest pins and forbid mutable tags in the policy text.

### Testing

- Ran `python3 scripts/orchestration/check_preflight.py` and `python3 scripts/orchestration/check_agent_consistency.py`, both passed.
- Executed `python3 scripts/ci/guard_actions_pin.py --root .` and direct Python assertions exercising `find_unpinned_actions()` which confirmed mutable Docker tags are rejected and sha256 digest pins accepted.
- Ran `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/TOOLING_SURFACE_POLICY.md` and `python3 -m py_compile scripts/ci/guard_actions_pin.py`, both passed and no diff/check issues were reported.
- Focused pytest file could not be executed in this environment due to missing virtualenv / dependencies (`fastapi` and repo `.venv` were not available), and `pre-commit` / `make validate-changed` could not be run for the same reason; those CI-style local gates must be re-run in a fully provisioned dev/CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f0b0fd2b0832cb16cc14b7731aab9)

## Summary by Sourcery

Принудительно использовать неизменяемые sha256-хэши (digest pins) для Docker-основанных ссылок на GitHub Actions и обновить соответствующим образом политику инструментов и тесты.

Bug Fixes:
- Обрабатывать ссылки на действия вида `docker://` так же, как и другие actions, отклоняя изменяемые теги и требуя пины с sha256-диджестом, чтобы закрыть обход цепочки поставок.

Enhancements:
- Добавить отдельный валидатор для ссылок `docker://`, который принимает только строчные 64‑значные шестнадцатеричные sha256-диджесты и выдаёт понятные сообщения о нарушениях при отсутствии пина.
- Согласовать документацию по политике поверхности security-инструментов с новым требованием об использовании неизменяемых Docker-диджестов и запретом изменяемых тегов.

Tests:
- Расширить набор тестов actions pin guard, чтобы проверять отклонение изменяемых Docker-тегов и принятие Docker-ссылок, закреплённых (pinned) с помощью sha256-диджестов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce immutable sha256 digest pins for Docker-based GitHub Action references and update tooling policy and tests accordingly.

Bug Fixes:
- Treat docker:// action references like other actions by rejecting mutable tags and requiring sha256 digest pins to close a supply-chain bypass.

Enhancements:
- Add a specific validator for docker:// references that accepts only lowercase 64-hex sha256 digests and surfaces clear violation messages when unpinned.
- Align the security tooling surface policy documentation with the new requirement for immutable Docker digest pins and the prohibition of mutable tags.

Tests:
- Extend the actions pin guard test suite to assert rejection of mutable Docker tags and acceptance of sha256 digest-pinned Docker references.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the CI actions pin guard to require `docker://` refs to use immutable `@sha256:<64-hex>` digests, blocking mutable tags like `:latest`. Adds clear violations, tests, and updates the security policy.

- **Bug Fixes**
  - Enforce `PINNED_DOCKER_DIGEST_RE` so only `docker://...@sha256:<64-hex>` is allowed; reject mutable tags.
  - Preserve 40-hex commit SHA checks for non-docker refs and emit a clear message for unpinned Docker actions.
  - Add regression tests for rejecting tags and accepting digest pins; update `docs/security/TOOLING_SURFACE_POLICY.md`.

<sup>Written for commit c29059119f96f2ca8e2b50d05c72934dcef46b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Docker-based GitHub Actions must now use immutable, lowercase 64-character SHA-256 digest references.
  * Mutable Docker tags and unpinned references are rejected by validation checks.
* **Documentation**
  * Updated tooling security guidance to include Docker references in pinning requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->