### PR TITLE
fix(deps): restore live compiled lock replay binding to reject live lockfile drift

### DIFF
--- a/docs/security/CRYPTOGRAPHY_50_0_0_ADVISORY_CLUSTER.md
+++ b/docs/security/CRYPTOGRAPHY_50_0_0_ADVISORY_CLUSTER.md
@@ -107,7 +107,9 @@ rejects non-cryptography semantic transitions, requires all `I_R` carriers to
 match frozen S_head, and compares all five replay `C_R` lock byte streams with
 frozen S_head. It also binds all ten frozen semantic digests to the owner
 snapshot and never reads mutable live requirement files as historical
-admission evidence. The separate live schema and
+admission evidence. In addition, it hashes every current compiled lockfile and
+requires its bytes to match the frozen replay receipt, so unrelated live lock
+drift fails closed. The separate live schema and
 `REQUIREMENT_SURFACES` floor guard continue to enforce current repository truth
 and may rotate independently after this bounded admission.
 

--- a/tests/test_dependency_security_guard.py
+++ b/tests/test_dependency_security_guard.py
@@ -681,6 +681,15 @@ def _assert_snapshot_receipts(snapshot: dict, head_texts: dict[str, str]) -> Non
             assert file_hash == record["file_sha256"], f"{name}: compiled replay receipt mismatch"
 
 
+def _assert_live_compiled_replay_receipts(snapshot: dict) -> None:
+    """Bind every current compiled lock byte stream to the frozen replay receipt."""
+    for name in sorted(CRYPTOGRAPHY_COMPILED_SURFACES):
+        live_hash = hashlib.sha256((REPO_ROOT / name).read_bytes()).hexdigest()
+        assert (
+            live_hash == snapshot["surfaces"][name]["file_sha256"]
+        ), f"{name}: live compiled replay receipt mismatch"
+
+
 def _historical_admission_inputs() -> tuple[
     dict,
     dict[str, Version],
@@ -699,6 +708,7 @@ def _historical_admission_inputs() -> tuple[
     assert base_surfaces | head_surfaces == declared_surfaces, "S_base/S_head union drifted"
     assert not base_surfaces ^ head_surfaces, "S_base/S_head topology deltas are forbidden"
     _assert_snapshot_receipts(snapshot, head_texts)
+    _assert_live_compiled_replay_receipts(snapshot)
     parent_record, merge_base, replay_texts = _immutable_replay_witness_evidence()
     _assert_immutable_replay_witness(
         parent_record=parent_record,
@@ -1138,6 +1148,24 @@ def test_cryptography_50_admission_rejects_unreplayable_compiled_lock() -> None:
     snapshot["surfaces"]["requirements.txt"]["file_sha256"] = "0" * 64
     with pytest.raises(AssertionError, match="compiled replay receipt mismatch"):
         _assert_snapshot_receipts(snapshot, head_texts)
+
+
+def test_cryptography_50_admission_rejects_live_compiled_lock_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot, _, _ = _historical_snapshot_evidence()
+    for name in CRYPTOGRAPHY_COMPILED_SURFACES:
+        shutil.copyfile(REPO_ROOT / name, tmp_path / name)
+    drifted_lock = tmp_path / "requirements.txt"
+    drifted_lock.write_bytes(drifted_lock.read_bytes() + b"zipp==3.99.0\n")
+    monkeypatch.setitem(_assert_live_compiled_replay_receipts.__globals__, "REPO_ROOT", tmp_path)
+
+    with pytest.raises(
+        AssertionError,
+        match="requirements.txt: live compiled replay receipt mismatch",
+    ):
+        _assert_live_compiled_replay_receipts(snapshot)
 
 
 def test_cryptography_50_admission_rejects_current_owner_snapshot_drift(


### PR DESCRIPTION
### Motivation

- The cryptography remediation admission test was weakened by reconstructing `S_head` from historical snapshot text and not hashing live compiled lockfiles, which allowed unrelated lockfile changes to evade the guard.

### Description

- Add `_assert_live_compiled_replay_receipts(snapshot)` which computes SHA-256 over the live compiled lockfiles and compares them to the frozen `file_sha256` receipts in the admission snapshot.
- Call `_assert_live_compiled_replay_receipts(snapshot)` from `_historical_admission_inputs()` to enforce the live-lock binding as part of admission inputs validation in `tests/test_dependency_security_guard.py`.
- Add regression test `test_cryptography_50_admission_rejects_live_compiled_lock_drift` that mutates a copied `requirements.txt` and asserts admission fails when live compiled lock bytes diverge from the frozen replay receipt.
- Update documentation in `docs/security/CRYPTOGRAPHY_50_0_0_ADVISORY_CLUSTER.md` to state that current compiled lockfile bytes are hashed and required to match frozen replay receipts.

### Testing

- Ran `python3 scripts/orchestration/check_preflight.py` which passed.
- Ran `python3 scripts/orchestration/check_agent_consistency.py` which passed.
- Ran `git diff --check` and `python3 -m py_compile tests/test_dependency_security_guard.py` which passed (no syntax errors detected).
- Verified live compiled lockfile hashes against the snapshot using a small Python check that read files and compared SHA-256 digests (matched existing frozen receipts in this worktree).
- Attempted to run `pytest`/`make validate-changed`/`pre-commit run --all-files` but those commands were blocked in this environment because the repository shared `.venv`, `pytest`, and `pre-commit` are not available here; those focused test hook runs should be executed in CI or a local dev environment with the repo `.venv` set up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c1052cc8832c8249c1363ff5b511)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores live compiled lock replay binding to reject any drift in current lockfiles for the cryptography admission guard. Adds a regression test and updates docs to reflect the stricter check.

- **Bug Fixes**
  - Added `_assert_live_compiled_replay_receipts(snapshot)` to hash current compiled lockfiles (SHA‑256) and compare against frozen replay receipts.
  - Enforced the check by calling it from `_historical_admission_inputs()` during admission input validation.
  - Added `test_cryptography_50_admission_rejects_live_compiled_lock_drift`, which mutates `requirements.txt` and asserts failure on mismatch.
  - Updated `docs/security/CRYPTOGRAPHY_50_0_0_ADVISORY_CLUSTER.md` to document the live lock hash requirement.

<sup>Written for commit ae7edf5e10e828b1d12ee485a0339fa248f2bcec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security admission checks by detecting changes to compiled dependency lockfiles.
  * Prevents admission when live lockfile contents differ from the recorded replay receipt.

* **Tests**
  * Added regression coverage confirming that modified compiled lockfiles are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->