### PR TITLE
fix(dependabot): forbid external code execution that can expose private registry credentials

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     directory: "/"
     registries:
       - "python-index"
-    insecure-external-code-execution: "allow"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 4

--- a/docs/DEPENDENCY_MANAGEMENT.md
+++ b/docs/DEPENDENCY_MANAGEMENT.md
@@ -463,40 +463,17 @@ single root `pip` block resolves exclusively through the private
 `python-index` registry, keeps automatic transitive security-update eligibility,
 and limits routine version-update traffic with owner groups, cooldowns, and a
 four-PR cap. Security updates are not grouped, suppressed, or counted against
-that version-update cap. The same sole updater carries the exact
-`insecure-external-code-execution: allow` capability required for Python
-manifest evaluation. This is a bounded authority grant, not a claim that
-executed dependency code is safe.
+that version-update cap. External code execution is forbidden because the
+updater receives private `python-index` credentials; allowing package or
+manifest code to execute could expose those credentials to compromised code.
 
-GitHub can expose the associated registry credentials to manifest or package
-code under this capability. Compromised code can copy and replay the dedicated
-Dependabot read credentials. The required non-root principal, effective
-write-denied ACL, zero index ownership, and separation from `DEVPI_CI_*` limit
-integrity impact but do not preserve credential confidentiality or prevent
-unauthorized reads. Before relying on this updater, recheck the two Dependabot
-secret names without retrieving their values and retain a redacted receipt for
-the principal's effective write denial and zero index ownership. Those secret
-and ACL observations are mutable external evidence, not durable or canonical
-repository truth.
-
-The policy checker admits this capability only as literal `allow` on the one
-`pip` updater at `/`, with `registries: [python-index]`, the exact
-`DEVPI_DEPENDABOT_USER` / `DEVPI_DEPENDABOT_PASSWORD` references, and
-`replaces-base: true`. It rejects the key everywhere else, all other values,
-additional updater or registry shapes, dependency filters, target-branch
-changes, and public fallback.
-
-Rollback is structural: remove the capability from `.github/dependabot.yml`,
-restore its blanket forbidden-key guard and negative test, and retain
-`replaces-base: true`. When exposure is suspected, remove the capability or
-disable the updater before rotating only the dedicated Dependabot credentials.
-Setting the version-update pull-request limit to zero is not containment:
-security updates are exempt from that cap and can still evaluate manifests.
-The post-merge oracle is an exact-main Dependabot run that advances beyond the
-external-code refusal while remaining private-registry-only; that run still
-does not prove credential confidentiality, dependency-graph or artifact
-equivalence, D0 acceptance, merge readiness, or authority to merge generated
-changes.
+The policy checker rejects `insecure-external-code-execution` at every mapping
+position and retains `replaces-base: true`, the exact
+`DEVPI_DEPENDABOT_USER` / `DEVPI_DEPENDABOT_PASSWORD` references, a single
+private registry, and a single root updater. It also rejects additional updater
+or registry shapes, dependency filters, target-branch changes, and public
+fallback. If Dependabot cannot evaluate a manifest without external code, it
+must fail closed rather than grant package code access to registry credentials.
 
 Run `python scripts/ci/check_dependabot_python_policy.py --repo-root .` after
 changing the config, any root or one-directory-deep `.in`/`.txt` file,

--- a/scripts/ci/check_dependabot_python_policy.py
+++ b/scripts/ci/check_dependabot_python_policy.py
@@ -143,6 +143,7 @@ FORBIDDEN_UPDATE_KEYS = {
     "allow",
     "ignore",
     "exclude-paths",
+    "insecure-external-code-execution",
     "target-branch",
 }
 EXTERNAL_CODE_EXECUTION_KEY = "insecure-external-code-execution"
@@ -150,7 +151,6 @@ EXPECTED_UPDATE_EXACT_VALUES: dict[str, object] = {
     "package-ecosystem": "pip",
     "directory": "/",
     "registries": [REGISTRY_NAME],
-    EXTERNAL_CODE_EXECUTION_KEY: "allow",
     "schedule": {"interval": "weekly"},
     "open-pull-requests-limit": 4,
     "commit-message": {"prefix": "deps", "include": "scope"},
@@ -814,11 +814,12 @@ def validate_repo(repo_root: Path) -> list[str]:
         errors.append(_error(update_path, "must be a mapping"))
         return errors
     for mapping_path, mapping in _walk_mapping(config, "$"):
-        if EXTERNAL_CODE_EXECUTION_KEY in mapping and mapping is not update:
+        if EXTERNAL_CODE_EXECUTION_KEY in mapping:
             errors.append(
                 _error(
                     f"{mapping_path}.{EXTERNAL_CODE_EXECUTION_KEY}",
-                    f"key is allowed only at {update_path}",
+                    "key is forbidden because external code must not receive "
+                    "private registry credentials",
                 )
             )
     if set(update) != EXPECTED_UPDATE_KEYS:
@@ -845,7 +846,8 @@ def validate_repo(repo_root: Path) -> list[str]:
         errors=errors,
     )
     for mapping_path, mapping in _walk_mapping(update, update_path):
-        for forbidden_key in sorted(FORBIDDEN_UPDATE_KEYS.intersection(mapping)):
+        forbidden_update_keys = FORBIDDEN_UPDATE_KEYS - {EXTERNAL_CODE_EXECUTION_KEY}
+        for forbidden_key in sorted(forbidden_update_keys.intersection(mapping)):
             errors.append(
                 _error(
                     f"{mapping_path}.{forbidden_key}",

--- a/tests/test_check_dependabot_python_policy.py
+++ b/tests/test_check_dependabot_python_policy.py
@@ -901,12 +901,12 @@ def test_mode_a_rejects_update_suppression(
     assert any("updates[0].exclude-paths:key is forbidden" in error for error in errors)
 
 
-def test_external_code_execution_is_bound_to_exact_private_pip_updater() -> None:
+def test_external_code_execution_is_absent_from_private_pip_updater() -> None:
     config = _load_config(REPO_ROOT)
     update = _pip_update(config)
     registries = config["registries"]
 
-    assert update[policy.EXTERNAL_CODE_EXECUTION_KEY] == "allow"
+    assert policy.EXTERNAL_CODE_EXECUTION_KEY not in update
     assert update["package-ecosystem"] == "pip"
     assert update["directory"] == "/"
     assert update["registries"] == [policy.REGISTRY_NAME]
@@ -914,55 +914,11 @@ def test_external_code_execution_is_bound_to_exact_private_pip_updater() -> None
     assert policy.validate_repo(REPO_ROOT) == []
 
 
-@pytest.mark.parametrize(
-    "invalid_value",
-    [None, "", "deny", "ALLOW", True, False, 1, 0, [], {}, ["allow"]],
-)
-def test_external_code_execution_requires_literal_allow(
-    tmp_path: Path,
-    invalid_value: object,
-) -> None:
-    repo = _copy_policy_repo(tmp_path)
-    config = _load_config(repo)
-    _pip_update(config)[policy.EXTERNAL_CODE_EXECUTION_KEY] = invalid_value
-    _write_config(repo, config)
-
-    errors = policy.validate_repo(repo)
-
-    assert any(
-        "updates[0].insecure-external-code-execution:must be exactly 'allow'" in error
-        for error in errors
-    )
-
-
-def test_external_code_execution_is_mandatory(tmp_path: Path) -> None:
-    repo = _copy_policy_repo(tmp_path)
-    config = _load_config(repo)
-    _pip_update(config).pop(policy.EXTERNAL_CODE_EXECUTION_KEY)
-    _write_config(repo, config)
-
-    errors = policy.validate_repo(repo)
-
-    assert any(
-        error.startswith(".github/dependabot.yml:updates[0]:keys must be exactly")
-        for error in errors
-    )
-    assert any(
-        "updates[0].insecure-external-code-execution:must be exactly 'allow'" in error
-        for error in errors
-    )
-
-
-def test_external_code_execution_is_rejected_at_every_other_mapping_position(
+def test_external_code_execution_is_rejected_at_every_mapping_position(
     tmp_path: Path,
 ) -> None:
     canonical_config = _load_config(REPO_ROOT)
-    authorized_selector: MappingSelector = ("updates", 0)
-    forbidden_selectors = [
-        selector
-        for selector in _iter_mapping_selectors(canonical_config)
-        if selector != authorized_selector
-    ]
+    forbidden_selectors = list(_iter_mapping_selectors(canonical_config))
 
     assert {
         (),
@@ -988,7 +944,8 @@ def test_external_code_execution_is_rejected_at_every_other_mapping_position(
 
         expected_error = (
             f".github/dependabot.yml:{_selector_path(selector)}."
-            "insecure-external-code-execution:key is allowed only at updates[0]"
+            "insecure-external-code-execution:key is forbidden because external code "
+            "must not receive private registry credentials"
         )
         assert expected_error in errors
 
@@ -1014,7 +971,10 @@ def test_external_code_execution_rejects_recursively_nested_unknown_container(
     errors = policy.validate_repo(repo)
 
     assert any(
-        error.endswith(".insecure-external-code-execution:key is allowed only at updates[0]")
+        error.endswith(
+            ".insecure-external-code-execution:key is forbidden because external code "
+            "must not receive private registry credentials"
+        )
         for error in errors
     )
 


### PR DESCRIPTION
### Motivation

- A Dependabot pip updater was configured with `insecure-external-code-execution: "allow"` while bound to a private `python-index` using `DEVPI_DEPENDABOT_*` secrets, which allows evaluated package/manifest code to access those credentials.
- The change restores a fail-closed posture so manifest/package evaluation cannot receive repository/registry credentials and prevents credential exfiltration via Dependabot-run code.

### Description

- Removed the unsafe `insecure-external-code-execution: "allow"` entry from the root `pip` updater in `/.github/dependabot.yml` while preserving the private registry, schedule, groups, cooldown, and PR limits.
- Updated the policy validator in `scripts/ci/check_dependabot_python_policy.py` to treat `insecure-external-code-execution` as forbidden across the config tree and to forbid reintroduction or nested placement of the key.  The validator now includes the key in forbidden keys and reports an explicit forbidden-message when found.
- Adjusted the test suite in `tests/test_check_dependabot_python_policy.py` to assert the capability is absent and to verify the validator rejects the key at every mapping position (including nested containers).
- Revised `docs/DEPENDENCY_MANAGEMENT.md` to document the fail-closed policy: external code execution is forbidden for the private pip updater and Dependabot must not be granted access to private registry credentials for manifest evaluation.

### Testing

- Ran the validator against HEAD with `python3 scripts/ci/check_dependabot_python_policy.py --repo-root .` and it returned `PASS` for the repository config. (success)
- Ran governance sanity scripts `python3 scripts/orchestration/check_preflight.py` and `python3 scripts/orchestration/check_agent_consistency.py` which completed without errors. (success)
- Verified Python files compile with `python3 -m py_compile scripts/ci/check_dependabot_python_policy.py tests/test_check_dependabot_python_policy.py`. (success)
- Attempted `pytest` for the modified test module but the environment lacks `pytest` so `python3 -m pytest -q tests/test_check_dependabot_python_policy.py` could not run here; tests in CI should run normally where `pytest` and the repo venv are available. (not run in this environment)
- `make validate-changed` and `pre-commit run --all-files` were not executed to completion in this environment due to missing local `.venv`/tools; CI must still run the full narrow bundle and canonical current-head checks as required by repo policy. (not completed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c3363c34832ca1cf91a27cfdb47b)

## Summary by Sourcery

Ужесточение политики обновления pip в Dependabot за счёт запрета небезопасного выполнения внешнего кода и обеспечения того, что учётные данные приватных реестров не будут раскрыты коду, который выполняется.

Bug Fixes:
- Предотвратить предоставление конфигурацией Dependabot доступа к выполнению внешнего кода с учётными данными приватного python-index путём запрета ключа `insecure-external-code-execution`.

Enhancements:
- Обновить валидатор политики Dependabot, чтобы он рассматривал `insecure-external-code-execution` как глобально запрещённый ключ и выдавал понятное сообщение об ошибке, сфокусированное на безопасности, при его обнаружении.
- Уточнить тесты, чтобы проверять, что `insecure-external-code-execution` отсутствует в каноническом pip updater и отклоняется на всех позициях сопоставления, включая вложенные контейнеры.

Documentation:
- Задокументировать политику «fail-closed», согласно которой выполнение внешнего кода запрещено для приватного pip updater, а Dependabot не должен получать учётные данные реестра для оценки манифестов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten Dependabot pip updater policy by forbidding insecure external code execution and ensuring private registry credentials are not exposed to evaluated code.

Bug Fixes:
- Prevent Dependabot configuration from granting external code execution access to private python-index credentials by disallowing the insecure-external-code-execution key.

Enhancements:
- Update the Dependabot policy validator to treat insecure-external-code-execution as a globally forbidden key and to emit a clear security-focused error message when encountered.
- Refine tests to assert that insecure-external-code-execution is absent from the canonical pip updater and rejected at all mapping positions, including nested containers.

Documentation:
- Document the fail-closed policy that external code execution is forbidden for the private pip updater and that Dependabot must not receive registry credentials for manifest evaluation.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block external code execution in Dependabot `pip` updates to protect private `python-index` credentials. Removes the `insecure-external-code-execution` allowance and enforces a fail-closed policy to prevent exposure of `DEVPI_DEPENDABOT_*` secrets.

- **Bug Fixes**
  - Removed `insecure-external-code-execution: "allow"` from the root `pip` updater in `.github/dependabot.yml` while keeping the private `python-index`, schedule, and PR limits.
  - Updated `scripts/ci/check_dependabot_python_policy.py` to forbid `insecure-external-code-execution` anywhere and to keep a single root private updater with no public fallback.
  - Adjusted tests to assert the key is absent and rejected at every mapping position.

<sup>Written for commit dc622b21a6253df61335a935642ff7f360cf4ee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Dependabot Python updates now fail closed by rejecting external code execution settings.
  * Private registry credentials are protected from exposure during dependency evaluation.

* **Documentation**
  * Updated dependency-management guidance to reflect the stricter security policy.

* **Tests**
  * Added coverage confirming the restricted setting is rejected wherever it appears in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->