### PR TITLE
Prevent ReDoS in Dependabot requirement classifier by hardening whitespace quantifiers

### DIFF
--- a/scripts/ci/dependabot_requirement_carriers.py
+++ b/scripts/ci/dependabot_requirement_carriers.py
@@ -86,14 +86,23 @@ _UPSTREAM_MARKER_EXPRESSION_ONE = (
 _UPSTREAM_MARKER_EXPRESSION = (
     rf"(?:{_UPSTREAM_MARKER_EXPRESSION_ONE}|\(\s*|\s*\)|" rf"\s+and\s+|\s+or\s+)+"
 )
-_UPSTREAM_VALID_REQUIREMENT_LINE_RE = re.compile(
+_UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN = (
     rf"^\s*\\?\s*{_UPSTREAM_NAME}"
     rf"\s*\\?\s*(?:\[\s*{_UPSTREAM_EXTRA}"
     rf"(?:\s*,\s*{_UPSTREAM_EXTRA})*\s*\])?"
     rf"\s*\\?\s*\(?(?:{_UPSTREAM_REQUIREMENTS})?\)?"
     rf"\s*\\?\s*(?:;\s*{_UPSTREAM_MARKER_EXPRESSION})?"
     rf"\s*\\?\s*(?:{_UPSTREAM_HASHES})?"
-    r"\s*(?:#+\s*.*)?$",
+    r"\s*(?:#+\s*.*)?$"
+)
+# Whitespace in this grammar only separates tokens; no following token can
+# consume it.  Make every whitespace repetition possessive so invalid
+# near-matches cannot redistribute the same run across adjacent optional
+# sections and trigger catastrophic backtracking.
+_UPSTREAM_VALID_REQUIREMENT_LINE_RE = re.compile(
+    _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN.replace(r"\s*", r"\s*+").replace(
+        r"\s+", r"\s++"
+    ),
     flags=re.ASCII,
 )
 RepoPath = str | PurePath

--- a/tests/test_check_dependabot_python_policy.py
+++ b/tests/test_check_dependabot_python_policy.py
@@ -203,6 +203,15 @@ def test_frozen_upstream_requirement_grammar_accepts_valid_lines(content: str) -
     assert carriers.is_dependabot_requirement_carrier_text("extra.txt", content)
 
 
+@pytest.mark.parametrize("suffix", ("!", "@", "="))
+def test_frozen_upstream_requirement_grammar_rejects_long_invalid_near_match(
+    suffix: str,
+) -> None:
+    content = f"package{' ' * 100_000}{suffix}\n"
+
+    assert not carriers.is_dependabot_requirement_carrier_text("extra.txt", content)
+
+
 def test_requirement_carrier_upstream_snapshot_is_immutable_and_documented() -> None:
     snapshot = carriers.DEPENDABOT_REQUIREMENT_CARRIER_UPSTREAM_SNAPSHOT
     assert asdict(snapshot) == {


### PR DESCRIPTION
### Motivation

- Fix a ReDoS/C I-availability risk in the Dependabot requirement carrier classifier where adjacent optional whitespace groups in the requirement regex allowed catastrophic backtracking on attacker-controlled files.

### Description

- Replace the in-place compiled regex with a pattern string and compile a hardened variant that converts `\s*`/`\s+` runs into possessive-like forms to prevent redistribution of long whitespace runs across adjacent optional sections. 
- Preserve the original upstream requirement grammar tokens so valid requirement lines continue to match. 
- Add a regression test that injects very long whitespace runs followed by an invalid suffix and asserts the classifier rejects the line. 
- Changes touch `scripts/ci/dependabot_requirement_carriers.py` (regex hardening) and `tests/test_check_dependabot_python_policy.py` (regression test). 

### Testing

- `python3 scripts/orchestration/check_preflight.py` passed. 
- `python3 scripts/orchestration/check_agent_consistency.py` passed. 
- `python -m py_compile` on the modified modules passed. 
- Manual adversarial benchmark executed the new classifier against long-space inputs and showed the classifier now rejects adversarial inputs quickly (example run: elapsed ~0.0018s for three large cases). 
- `git diff --check` reported no whitespace/patch issues. 
- Local `pytest`/`make validate-changed` could not be completed in this environment because the shared `.venv` and test dependencies (e.g. `fastapi`) are not available and `pre-commit` is not installed; these environment limitations prevented a full local test run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c3377c28832c9c3b214398e02c32)

## Summary by Sourcery

Усилить регулярное выражение классификатора строк требований Dependabot, чтобы предотвратить ReDoS, при этом сохранив исходную грамматику требований, и добавить регрессионное покрытие для некорректных входных данных с длинными последовательностями пробелов.

Bug Fixes:
- Предотвратить катастрофический перебор в классификаторе требований Dependabot за счёт придания квантификаторам для пробельных символов поведения, аналогичного possessive-квантификаторам.

Tests:
- Добавить регрессионный тест, который гарантирует, что строки требований с очень длинными последовательностями пробелов, за которыми следуют недопустимые суффиксы, быстро отклоняются.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the Dependabot requirement line classifier regex to prevent ReDoS while preserving the upstream requirement grammar, and add regression coverage for long-whitespace invalid inputs.

Bug Fixes:
- Prevent catastrophic backtracking in the Dependabot requirement classifier by making whitespace quantifiers possessive-like.

Tests:
- Add a regression test ensuring requirement lines with very long whitespace runs followed by invalid suffixes are rejected quickly.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Dependabot requirement classifier regex to prevent catastrophic backtracking on long whitespace runs in requirement lines. Preserves the upstream grammar so valid lines still match.

- **Bug Fixes**
  - Switched to a pattern string and compile a hardened variant that makes `\s*`/`\s+` possessive (`\s*+`, `\s++`) to stop whitespace redistribution across optional sections.
  - Added a regression test that feeds 100k-space near-matches with invalid suffixes and asserts fast rejection.

<sup>Written for commit 4ea154754aff0b69da20f63c83227ff37a87bfdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

