### PR TITLE
fix(ci): isolate startup probe from runtime paths

### DIFF
--- a/scripts/ci/check_python_startup_hooks.py
+++ b/scripts/ci/check_python_startup_hooks.py
@@ -23,9 +23,7 @@ ALLOWED_EXECUTABLE_PTH_FILENAMES: tuple[str, ...] = (
 EXECUTABLE_IMPORT_PATTERN = re.compile(r"^\s*import\b")
 STARTUP_PROBE_PYTHON_ENV_ALLOWLIST = frozenset(
     {
-        "PYTHONHOME",
         "PYTHONNOUSERSITE",
-        "PYTHONPLATLIBDIR",
         "PYTHONUSERBASE",
     }
 )
@@ -203,7 +201,7 @@ def _revalidate_python_executable(executable: ResolvedPythonExecutable) -> None:
 
 
 def _startup_probe_environment() -> dict[str, str]:
-    """Preserve site-layout semantics while excluding Python code-injection controls."""
+    """Preserve user-site semantics while excluding Python code-loading controls."""
     return {
         key: value
         for key, value in os.environ.items()

--- a/tests/test_check_python_startup_hooks.py
+++ b/tests/test_check_python_startup_hooks.py
@@ -289,10 +289,10 @@ def test_external_interpreter_site_packages_uses_startup_safe_probe(
     assert observed_kwargs.get("capture_output") is True
     observed_env = observed_kwargs.get("env")
     assert isinstance(observed_env, dict)
-    assert observed_env["PYTHONHOME"] == "/tmp/runtime-home"
     assert observed_env["PYTHONUSERBASE"] == "relative-userbase"
     assert observed_env["PYTHONNOUSERSITE"] == "1"
-    assert observed_env["PYTHONPLATLIBDIR"] == "runtime-lib"
+    assert "PYTHONHOME" not in observed_env
+    assert "PYTHONPLATLIBDIR" not in observed_env
     assert "PYTHONPATH" not in observed_env
     assert "PYTHONINSPECT" not in observed_env
     assert observed_kwargs.get("text") is True
@@ -358,7 +358,7 @@ def test_startup_safe_probe_normalizes_relative_site_paths(
     assert payload["site_packages"] == [str(tmp_path / relative_site_packages)]
 
 
-def test_external_interpreter_preserves_pythonhome_semantics(
+def test_external_interpreter_ignores_pythonhome_code_loading_control(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -366,8 +366,9 @@ def test_external_interpreter_preserves_pythonhome_semantics(
     empty_python_home.mkdir()
     monkeypatch.setenv("PYTHONHOME", str(empty_python_home))
 
-    with pytest.raises(RuntimeError, match="Unable to probe site-packages"):
-        hook_guard.external_interpreter_site_packages(sys.executable)
+    discovered = hook_guard.external_interpreter_site_packages(sys.executable)
+
+    assert discovered
 
 
 def test_external_interpreter_normalizes_relative_pythonuserbase_safely(


### PR DESCRIPTION
### Motivation

- A startup-probe change exposed a security regression by forwarding `PYTHONHOME` and `PYTHONPLATLIBDIR` into the probe environment while invoking a non-isolated probe (`-P -S`), allowing attacker-controlled stdlib modules to run before probe validation.
- The intent is to keep user-site semantics (e.g. `PYTHONUSERBASE` / `PYTHONNOUSERSITE`) while preventing environment-controlled standard-library redirection that can execute code during the probe.

### Description

- Remove `PYTHONHOME` and `PYTHONPLATLIBDIR` from `STARTUP_PROBE_PYTHON_ENV_ALLOWLIST` in `scripts/ci/check_python_startup_hooks.py` so the probe no longer inherits these code-loading controls. 
- Clarify the probe-environment docstring to reflect excluding code-loading controls while preserving user-site semantics. 
- Update `tests/test_check_python_startup_hooks.py` expectations to assert that `PYTHONHOME` and `PYTHONPLATLIBDIR` are not forwarded and that the probe still discovers site-packages via permitted user-site variables. 
- Commit message: `fix(ci): isolate startup probe from runtime paths`.

### Testing

- Ran `python scripts/orchestration/check_preflight.py` which passed locally. 
- Ran `python scripts/orchestration/check_agent_consistency.py` which passed locally. 
- Byte-compiled the guard and tests with `python -m py_compile scripts/ci/check_python_startup_hooks.py tests/test_check_python_startup_hooks.py` which succeeded. 
- Executed the startup-hook test file in an isolated venv with `python -m pytest -q /tmp/test_check_python_startup_hooks.py` which reported `32 passed`. 

Note: some repo-wide gates could not be executed in this environment: `make validate-changed` failed due to a missing repo `.venv`, `pre-commit run --all-files` is unavailable because `pre-commit` is not installed here, and `gh pr create` could not complete because GitHub CLI authentication was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c3363378832cb657667124a49ab9)

## Summary by Sourcery

Изолировать стартовый probe Python в CI от конфигурации runtime-пути, чтобы избежать загружаемого кода, контролируемого окружением, при этом сохранив поведение user-site.

Исправления ошибок:
- Прекратить прокидывание `PYTHONHOME` и `PYTHONPLATLIBDIR` в окружение стартового probe, чтобы предотвратить выполнение контролируемого злоумышленником кода стандартной библиотеки во время CI-проверок.

Тесты:
- Обновить тесты startup-hook так, чтобы они проверяли, что `PYTHONHOME` и `PYTHONPLATLIBDIR` исключены из окружения probe, при этом обнаружение user-site по‑прежнему работает, а также чтобы `PYTHONHOME` считался нефатальным при проверке внешнего интерпретатора.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Isolate the CI Python startup probe from runtime path configuration to avoid environment-controlled code loading while preserving user-site behavior.

Bug Fixes:
- Stop forwarding PYTHONHOME and PYTHONPLATLIBDIR into the startup probe environment to prevent attacker-controlled stdlib code from running during CI checks.

Tests:
- Update startup-hook tests to assert PYTHONHOME and PYTHONPLATLIBDIR are excluded from the probe environment while user-site discovery still works, and to treat PYTHONHOME as non-fatal for external interpreter probing.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python startup checks to prevent environment settings from affecting code-loading behavior.
  * Preserved user-site package behavior during startup validation.
  * Updated checks to ensure site-package discovery succeeds even when `PYTHONHOME` is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->