### PR TITLE
fix(dependabot): restore fail-closed private-index update boundary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     directory: "/"
     registries:
       - "python-index"
-    insecure-external-code-execution: "allow"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 4

--- a/docs/DEPENDENCY_MANAGEMENT.md
+++ b/docs/DEPENDENCY_MANAGEMENT.md
@@ -463,40 +463,19 @@ single root `pip` block resolves exclusively through the private
 `python-index` registry, keeps automatic transitive security-update eligibility,
 and limits routine version-update traffic with owner groups, cooldowns, and a
 four-PR cap. Security updates are not grouped, suppressed, or counted against
-that version-update cap. The same sole updater carries the exact
-`insecure-external-code-execution: allow` capability required for Python
-manifest evaluation. This is a bounded authority grant, not a claim that
-executed dependency code is safe.
+that version-update cap. External code execution is forbidden because the
+updater receives private registry credentials. The policy checker rejects
+`insecure-external-code-execution` at every mapping position while retaining
+the single private index and `replaces-base: true`. If Dependabot has no safe
+update path without executing manifest code, it must fail closed; use the
+reviewed manual dependency-update lane rather than restoring `allow`.
 
-GitHub can expose the associated registry credentials to manifest or package
-code under this capability. Compromised code can copy and replay the dedicated
-Dependabot read credentials. The required non-root principal, effective
-write-denied ACL, zero index ownership, and separation from `DEVPI_CI_*` limit
-integrity impact but do not preserve credential confidentiality or prevent
-unauthorized reads. Before relying on this updater, recheck the two Dependabot
-secret names without retrieving their values and retain a redacted receipt for
-the principal's effective write denial and zero index ownership. Those secret
-and ACL observations are mutable external evidence, not durable or canonical
-repository truth.
-
-The policy checker admits this capability only as literal `allow` on the one
-`pip` updater at `/`, with `registries: [python-index]`, the exact
-`DEVPI_DEPENDABOT_USER` / `DEVPI_DEPENDABOT_PASSWORD` references, and
-`replaces-base: true`. It rejects the key everywhere else, all other values,
-additional updater or registry shapes, dependency filters, target-branch
-changes, and public fallback.
-
-Rollback is structural: remove the capability from `.github/dependabot.yml`,
-restore its blanket forbidden-key guard and negative test, and retain
-`replaces-base: true`. When exposure is suspected, remove the capability or
-disable the updater before rotating only the dedicated Dependabot credentials.
-Setting the version-update pull-request limit to zero is not containment:
-security updates are exempt from that cap and can still evaluate manifests.
-The post-merge oracle is an exact-main Dependabot run that advances beyond the
-external-code refusal while remaining private-registry-only; that run still
-does not prove credential confidentiality, dependency-graph or artifact
-equivalence, D0 acceptance, merge readiness, or authority to merge generated
-changes.
+Candidate admission remains review-controlled. Before accepting an update,
+confirm the approved source and version, provenance, hashes or mirror lineage,
+explicit yanked and prerelease status, approved lock replay, absence of
+unrelated lock drift, and the targeted security and runtime gates. A successful
+Dependabot attempt is intake evidence only, not proof of candidate integrity or
+merge readiness.
 
 Run `python scripts/ci/check_dependabot_python_policy.py --repo-root .` after
 changing the config, any root or one-directory-deep `.in`/`.txt` file,

--- a/docs/review/PR_2251_FIXED_MAPPING.md
+++ b/docs/review/PR_2251_FIXED_MAPPING.md
@@ -1,0 +1,41 @@
+# PR 2251 — Review Governance
+
+Review-Seal-Version: v1
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/5dfca669304e.json`
+
+## Experiment Runner Evidence
+Artifact: `artifacts/orchestration/experiments/results/exp-1a1f3f0d9c83-3767773b-result.json`
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: b0efc2d3cb2f40477b084c76b81b5ba55841058c
+Evidence: scripts/ci/dependabot_requirement_carriers.py:98-108; tests/test_check_dependabot_python_policy.py:229; owning suite 121 PASS; exact-head CI run 31367525279 test-pr PASS
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2251#discussion_r3746816733 -> b0efc2d3cb2f40477b084c76b81b5ba55841058c
+
+Disposition: FIXED
+Commit: b0efc2d3cb2f40477b084c76b81b5ba55841058c
+Evidence: scripts/ci/dependabot_requirement_carriers.py:98-108; tests/test_check_dependabot_python_policy.py:229; exact-head CI run 31367525279 test-pr PASS
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2251#pullrequestreview-4893871345 -> b0efc2d3cb2f40477b084c76b81b5ba55841058c
+
+Disposition: NOT-A-BUG
+Evidence: .github/workflows/ci.yml:8,611-613; scripts/ci/dependabot_requirement_carriers.py:101-109; Python 3.13.14 import and 121-test owning suite PASS; exact-head CI run 31367525279 lint/test-pr PASS
+Reason: Standard re supports possessive quantifiers on the repository Python 3.11+ floor; compilation and current-head execution prove the review claim false.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2251#discussion_r3746801498
+
+Disposition: NOT-A-BUG
+Evidence: scripts/ci/dependabot_requirement_carriers.py:56-109; tests/test_check_dependabot_python_policy.py:26,198-243; exact-head CI run 31367525279 lint/test-pr PASS
+Reason: The frozen plan requires one mechanical compile-time transform and one test-local diagnostic suffix constant; a helper, generalized pattern owner, or production test-message export would widen the design without fixing a defect.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2251#pullrequestreview-4893856948
+
+## Review Material Seal
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_BEGIN -->
+<!-- pragma: allowlist nextline secret -->
+{"authority":"human_asserted_content_receipt","code_review":{"blocking":false,"material_digest":"sha256:c782e736e5a3e7ea74481ef63d8de8501760fb02ffe929aa88f829a896dc7ee5","material_head_sha":"3767773bec2a87a1f4ef5815a91cc1ac403e0568","output_required":false,"review_claim":"none"},"codex_security":{"base_revision":"48b04c2267aa7ff8708feb348c64bdf68ac52ba7","blocking":false,"head_revision":"3767773bec2a87a1f4ef5815a91cc1ac403e0568","material_digest":"sha256:c782e736e5a3e7ea74481ef63d8de8501760fb02ffe929aa88f829a896dc7ee5","no_findings_claim":false,"output_required":false,"scan_claim":"none"},"material":{"base_ref_oid":"48b04c2267aa7ff8708feb348c64bdf68ac52ba7","digest":"sha256:c782e736e5a3e7ea74481ef63d8de8501760fb02ffe929aa88f829a896dc7ee5","material_head_sha":"3767773bec2a87a1f4ef5815a91cc1ac403e0568","merge_base_sha":"48b04c2267aa7ff8708feb348c64bdf68ac52ba7","policy_version":"pulseplate.material-classification/v1"},"pr_number":2251,"repository":"Katsiarynakavaleuskaya/PulsePlate","schema_version":"pulseplate.pr-review-seal/v1","self_review":{"actionable_findings_count":0,"authority":"repo_native_pulseplate_pr_review_advisory","blocking":false,"findings_count":0,"material_digest":"sha256:c782e736e5a3e7ea74481ef63d8de8501760fb02ffe929aa88f829a896dc7ee5","material_head_sha":"3767773bec2a87a1f4ef5815a91cc1ac403e0568","report_payload":{"actionable_findings_count":0,"base_ref_oid":"48b04c2267aa7ff8708feb348c64bdf68ac52ba7","calibration":{"case_labels":["clean-context","review-source-degraded"],"false_positive_controls":["clean context must produce zero findings","benign fixed-mapping presence must not become a governance finding","warnings and governance uncertainty remain actionable findings, not diagnostic notes","review-source degradation is status/warning only unless an explicit blocking source finding exists","large diff risk is review-planning evidence, not a merge-readiness claim"],"posting_eligible":false,"posting_gate":"GitHub posting remains out of scope until a dedicated calibrated posting PR.","rubric_version":"pr4-2026-04-28"},"coordinator_packet":{"path":"artifacts/orchestration/task_packets/420100aecf85.json","role_order":["agent-coordinator","architecture-specialist","security-auditor","qa-engineer-agent","bug-hunter","data-scientist-agent"],"task_packet_id":"420100aecf85"},"decision_log":["This report is advisory and side-effect free.","This report does not post GitHub comments, resolve review threads, merge PRs, or claim merge readiness.","External CodeRabbit, Sourcery, and Cubic statuses remain separate PR governance signals."],"deferred_followups":[],"findings":[],"findings_count":0,"gate_plan":["python3 scripts/orchestration/check_preflight.py","python3 scripts/orchestration/check_agent_consistency.py","python3 -m pytest tests/test_pr_review_report.py tests/test_pr_review_context.py -q","Add and fill docs/review/PR_<N>_FIXED_MAPPING.md before merge-ready loop","make test-fast"],"generated_at_utc":"2026-08-10T08:28:29Z","material_digest":"sha256:c782e736e5a3e7ea74481ef63d8de8501760fb02ffe929aa88f829a896dc7ee5","material_head_sha":"3767773bec2a87a1f4ef5815a91cc1ac403e0568","merge_base_sha":"48b04c2267aa7ff8708feb348c64bdf68ac52ba7","mode":"dry-run-report","review_source_status":[{"blocking":false,"evidence":"gh api repos/<repo>/pulls/<pr>","fallback_required":false,"reason":"","source":"github_pr_metadata","source_degraded":false,"status":"available"},{"blocking":false,"evidence":"48b04c2267aa7ff8708feb348c64bdf68ac52ba7..3767773bec2a87a1f4ef5815a91cc1ac403e0568","fallback_required":false,"reason":"","source":"git_diff","source_degraded":false,"status":"available"},{"blocking":false,"evidence":"docs/review/PR_2251_FIXED_MAPPING.md","fallback_required":true,"reason":"Fixed-mapping artifact unavailable","source":"fixed_mapping_artifact","source_degraded":true,"status":"unavailable"}],"role_review":[{"role_agent":"agent-coordinator","summary":"agent-coordinator has no deterministic findings from the supplied context."},{"role_agent":"architecture-specialist","summary":"architecture-specialist has no deterministic findings from the supplied context."},{"role_agent":"security-auditor","summary":"security-auditor has no deterministic findings from the supplied context."},{"role_agent":"qa-engineer-agent","summary":"qa-engineer-agent has no deterministic findings from the supplied context."},{"role_agent":"bug-hunter","summary":"bug-hunter has no deterministic findings from the supplied context."},{"role_agent":"data-scientist-agent","summary":"data-scientist-agent has no scoring calibration changes in this dry-run report."}],"schema_version":"2.0.0","scope_reviewed":{"changed_files":[".github/dependabot.yml","docs/DEPENDENCY_MANAGEMENT.md","scripts/ci/check_dependabot_python_policy.py","scripts/ci/dependabot_requirement_carriers.py","tests/test_check_dependabot_python_policy.py"],"diff_summary":{"additions":114,"changed_lines":202,"deletions":88,"files":5},"fixed_mapping_errors":[],"omitted_surfaces":["GitHub posting","PR thread resolution","merge readiness claims"],"pr_metadata_available":true,"scoped_agents_md":["AGENTS.md","scripts/AGENTS.md","tests/AGENTS.md"]},"warnings":[]},"report_sha256":"sha256:c184721496a31e932865f859818c64ffe545a7dccc7f500811eb0791bbb0eb01","review_claim":"none","review_tool":"pulseplate-pr-review","schema_version":"pulseplate.self-review-advisory/v1","status":"advisory_report_attached"}}
+<!-- PULSEPLATE_PR_REVIEW_SEAL_V1_END -->

--- a/scripts/ci/check_dependabot_python_policy.py
+++ b/scripts/ci/check_dependabot_python_policy.py
@@ -150,7 +150,6 @@ EXPECTED_UPDATE_EXACT_VALUES: dict[str, object] = {
     "package-ecosystem": "pip",
     "directory": "/",
     "registries": [REGISTRY_NAME],
-    EXTERNAL_CODE_EXECUTION_KEY: "allow",
     "schedule": {"interval": "weekly"},
     "open-pull-requests-limit": 4,
     "commit-message": {"prefix": "deps", "include": "scope"},
@@ -750,6 +749,16 @@ def validate_repo(repo_root: Path) -> list[str]:
         errors.append(_error("$", "root must be a mapping"))
         return errors
 
+    for mapping_path, mapping in _walk_mapping(config, "$"):
+        if EXTERNAL_CODE_EXECUTION_KEY in mapping:
+            errors.append(
+                _error(
+                    f"{mapping_path}.{EXTERNAL_CODE_EXECUTION_KEY}",
+                    "key is forbidden because external code must not receive "
+                    "private registry credentials",
+                )
+            )
+
     try:
         unknown_carriers = _unknown_dependabot_requirement_carriers(repo_root)
     except DependabotRequirementDiscoveryError:
@@ -813,14 +822,6 @@ def validate_repo(repo_root: Path) -> list[str]:
     if not isinstance(update, Mapping):
         errors.append(_error(update_path, "must be a mapping"))
         return errors
-    for mapping_path, mapping in _walk_mapping(config, "$"):
-        if EXTERNAL_CODE_EXECUTION_KEY in mapping and mapping is not update:
-            errors.append(
-                _error(
-                    f"{mapping_path}.{EXTERNAL_CODE_EXECUTION_KEY}",
-                    f"key is allowed only at {update_path}",
-                )
-            )
     if set(update) != EXPECTED_UPDATE_KEYS:
         errors.append(
             _error(

--- a/scripts/ci/dependabot_requirement_carriers.py
+++ b/scripts/ci/dependabot_requirement_carriers.py
@@ -95,10 +95,16 @@ _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN = (
     rf"\s*\\?\s*(?:{_UPSTREAM_HASHES})?"
     r"\s*(?:#+\s*.*)?$"
 )
-# Whitespace in this grammar separates tokens. Possessive repetitions prevent
-# adjacent optional branches from redistributing the same whitespace run.
+# The release prefix and its following version class both accept digits, while
+# whitespace separates tokens. Possessive repetitions prevent either shared
+# run from being redistributed across adjacent grammar components.
 _UPSTREAM_VALID_REQUIREMENT_LINE_RE = re.compile(
-    _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN.replace(r"\s*", r"\s*+").replace(r"\s+", r"\s++"),
+    _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN.replace(
+        r"[0-9]+[A-Za-z0-9_.*-]*",
+        r"[0-9]++[A-Za-z0-9_.*-]*",
+    )
+    .replace(r"\s*", r"\s*+")
+    .replace(r"\s+", r"\s++"),
     flags=re.ASCII,
 )
 RepoPath = str | PurePath

--- a/scripts/ci/dependabot_requirement_carriers.py
+++ b/scripts/ci/dependabot_requirement_carriers.py
@@ -86,14 +86,19 @@ _UPSTREAM_MARKER_EXPRESSION_ONE = (
 _UPSTREAM_MARKER_EXPRESSION = (
     rf"(?:{_UPSTREAM_MARKER_EXPRESSION_ONE}|\(\s*|\s*\)|" rf"\s+and\s+|\s+or\s+)+"
 )
-_UPSTREAM_VALID_REQUIREMENT_LINE_RE = re.compile(
+_UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN = (
     rf"^\s*\\?\s*{_UPSTREAM_NAME}"
     rf"\s*\\?\s*(?:\[\s*{_UPSTREAM_EXTRA}"
     rf"(?:\s*,\s*{_UPSTREAM_EXTRA})*\s*\])?"
     rf"\s*\\?\s*\(?(?:{_UPSTREAM_REQUIREMENTS})?\)?"
     rf"\s*\\?\s*(?:;\s*{_UPSTREAM_MARKER_EXPRESSION})?"
     rf"\s*\\?\s*(?:{_UPSTREAM_HASHES})?"
-    r"\s*(?:#+\s*.*)?$",
+    r"\s*(?:#+\s*.*)?$"
+)
+# Whitespace in this grammar separates tokens. Possessive repetitions prevent
+# adjacent optional branches from redistributing the same whitespace run.
+_UPSTREAM_VALID_REQUIREMENT_LINE_RE = re.compile(
+    _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN.replace(r"\s*", r"\s*+").replace(r"\s+", r"\s++"),
     flags=re.ASCII,
 )
 RepoPath = str | PurePath

--- a/tests/test_check_dependabot_python_policy.py
+++ b/tests/test_check_dependabot_python_policy.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 
 import pytest
 import yaml
@@ -205,6 +206,24 @@ def test_non_requirement_text_file_is_not_misclassified_as_carrier(
 )
 def test_frozen_upstream_requirement_grammar_accepts_valid_lines(content: str) -> None:
     assert carriers.is_dependabot_requirement_carrier_text("extra.txt", content)
+
+
+def test_frozen_upstream_requirement_grammar_rejects_long_invalid_near_matches() -> None:
+    probe = (
+        "from scripts.ci.dependabot_requirement_carriers import "
+        "is_dependabot_requirement_carrier_text\n"
+        "for suffix in ('!', '@', '='):\n"
+        "    content = f\"package{' ' * 1000}{suffix}\\n\"\n"
+        "    assert not is_dependabot_requirement_carrier_text('extra.txt', content)\n"
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", probe],
+        check=True,
+        cwd=REPO_ROOT,
+        shell=False,
+        timeout=5,
+    )
 
 
 def test_requirement_carrier_upstream_snapshot_is_immutable_and_documented() -> None:

--- a/tests/test_check_dependabot_python_policy.py
+++ b/tests/test_check_dependabot_python_policy.py
@@ -17,6 +17,10 @@ from scripts.ci import dependabot_requirement_carriers as carriers
 from scripts.ci.check_python_dependency_surfaces import DEPENDENCY_SURFACES
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX = (
+    ".insecure-external-code-execution:key is forbidden because external code "
+    "must not receive private registry credentials"
+)
 
 
 def _run_fixture_git(repo: Path, *args: str) -> None:
@@ -901,12 +905,12 @@ def test_mode_a_rejects_update_suppression(
     assert any("updates[0].exclude-paths:key is forbidden" in error for error in errors)
 
 
-def test_external_code_execution_is_bound_to_exact_private_pip_updater() -> None:
+def test_external_code_execution_is_absent_from_private_pip_updater() -> None:
     config = _load_config(REPO_ROOT)
     update = _pip_update(config)
     registries = config["registries"]
 
-    assert update[policy.EXTERNAL_CODE_EXECUTION_KEY] == "allow"
+    assert policy.EXTERNAL_CODE_EXECUTION_KEY not in update
     assert update["package-ecosystem"] == "pip"
     assert update["directory"] == "/"
     assert update["registries"] == [policy.REGISTRY_NAME]
@@ -915,54 +919,31 @@ def test_external_code_execution_is_bound_to_exact_private_pip_updater() -> None
 
 
 @pytest.mark.parametrize(
-    "invalid_value",
-    [None, "", "deny", "ALLOW", True, False, 1, 0, [], {}, ["allow"]],
+    "present_value",
+    ["allow", "deny", False, None, {}],
 )
-def test_external_code_execution_requires_literal_allow(
+def test_external_code_execution_is_forbidden_independent_of_value(
     tmp_path: Path,
-    invalid_value: object,
+    present_value: object,
 ) -> None:
     repo = _copy_policy_repo(tmp_path)
     config = _load_config(repo)
-    _pip_update(config)[policy.EXTERNAL_CODE_EXECUTION_KEY] = invalid_value
+    _pip_update(config)[policy.EXTERNAL_CODE_EXECUTION_KEY] = present_value
     _write_config(repo, config)
 
     errors = policy.validate_repo(repo)
 
-    assert any(
-        "updates[0].insecure-external-code-execution:must be exactly 'allow'" in error
-        for error in errors
+    expected_error = (
+        ".github/dependabot.yml:$.updates[0]" f"{EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX}"
     )
+    assert errors.count(expected_error) == 1
 
 
-def test_external_code_execution_is_mandatory(tmp_path: Path) -> None:
-    repo = _copy_policy_repo(tmp_path)
-    config = _load_config(repo)
-    _pip_update(config).pop(policy.EXTERNAL_CODE_EXECUTION_KEY)
-    _write_config(repo, config)
-
-    errors = policy.validate_repo(repo)
-
-    assert any(
-        error.startswith(".github/dependabot.yml:updates[0]:keys must be exactly")
-        for error in errors
-    )
-    assert any(
-        "updates[0].insecure-external-code-execution:must be exactly 'allow'" in error
-        for error in errors
-    )
-
-
-def test_external_code_execution_is_rejected_at_every_other_mapping_position(
+def test_external_code_execution_is_rejected_at_every_mapping_position(
     tmp_path: Path,
 ) -> None:
     canonical_config = _load_config(REPO_ROOT)
-    authorized_selector: MappingSelector = ("updates", 0)
-    forbidden_selectors = [
-        selector
-        for selector in _iter_mapping_selectors(canonical_config)
-        if selector != authorized_selector
-    ]
+    forbidden_selectors = list(_iter_mapping_selectors(canonical_config))
 
     assert {
         (),
@@ -987,10 +968,10 @@ def test_external_code_execution_is_rejected_at_every_other_mapping_position(
         errors = policy.validate_repo(repo)
 
         expected_error = (
-            f".github/dependabot.yml:{_selector_path(selector)}."
-            "insecure-external-code-execution:key is allowed only at updates[0]"
+            f".github/dependabot.yml:{_selector_path(selector)}"
+            f"{EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX}"
         )
-        assert expected_error in errors
+        assert errors.count(expected_error) == 1
 
 
 @pytest.mark.parametrize(
@@ -1013,10 +994,29 @@ def test_external_code_execution_rejects_recursively_nested_unknown_container(
 
     errors = policy.validate_repo(repo)
 
-    assert any(
-        error.endswith(".insecure-external-code-execution:key is allowed only at updates[0]")
-        for error in errors
-    )
+    matching_errors = [
+        error for error in errors if error.endswith(EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX)
+    ]
+    assert len(matching_errors) == 1
+
+
+@pytest.mark.parametrize("invalid_updates", [None, [], ["not-a-mapping"]])
+def test_external_code_execution_is_reported_before_invalid_update_shape_returns(
+    tmp_path: Path,
+    invalid_updates: object,
+) -> None:
+    repo = _copy_policy_repo(tmp_path)
+    config = _load_config(repo)
+    sentinel = "DO_NOT_RENDER_THIS_VALUE"
+    config[policy.EXTERNAL_CODE_EXECUTION_KEY] = sentinel
+    config["updates"] = invalid_updates
+    _write_config(repo, config)
+
+    errors = policy.validate_repo(repo)
+
+    expected_error = ".github/dependabot.yml:$" f"{EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX}"
+    assert errors.count(expected_error) == 1
+    assert sentinel not in "\n".join(errors)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_check_dependabot_python_policy.py
+++ b/tests/test_check_dependabot_python_policy.py
@@ -226,6 +226,23 @@ def test_frozen_upstream_requirement_grammar_rejects_long_invalid_near_matches()
     )
 
 
+def test_frozen_upstream_requirement_grammar_rejects_long_invalid_version_near_match() -> None:
+    probe = (
+        "from scripts.ci.dependabot_requirement_carriers import "
+        "is_dependabot_requirement_carrier_text\n"
+        "content = f\"package=={'1' * 10000}!\\n\"\n"
+        "assert not is_dependabot_requirement_carrier_text('extra.txt', content)\n"
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", probe],
+        check=True,
+        cwd=REPO_ROOT,
+        shell=False,
+        timeout=5,
+    )
+
+
 def test_requirement_carrier_upstream_snapshot_is_immutable_and_documented() -> None:
     snapshot = carriers.DEPENDABOT_REQUIREMENT_CARRIER_UPSTREAM_SNAPSHOT
     assert asdict(snapshot) == {


### PR DESCRIPTION
## Goal

Restore the fail-closed Dependabot private-index boundary by removing external manifest-code execution authority and bounding the existing pinned requirement-carrier regex without changing its accepted grammar.

## Business reason

The private Python updater receives registry credentials. Allowing manifest code to execute expands the credential trust boundary, while the current translated requirement-line regex has a reproducible catastrophic-backtracking near-match. This PR removes that capability and closes the bounded denial-of-service path without widening dependency intake or creating a new parser.

## Scope

- Remove `insecure-external-code-execution: allow` from the sole root `pip` updater.
- Reject the key by presence in every mapping traversed by the existing bounded YAML checker, independently of its value.
- Preserve one exact private `python-index`, secret references, and `replaces-base: true`.
- Make only the overlapping whitespace repetitions and the specific overlapping numeric version repetition possessive under standard Python 3.11+ `re`.
- Add deterministic owning tests and align dependency-management prose.

## Out of scope

- No requirements, constraints, lock, workflow, private proxy, credential, Docker, RAG, frontend, iOS, OpenAPI, `AGENTS.md`, or backlog change.
- No public PyPI fallback, new carrier family, parser, tokenizer, regex dependency, policy framework, schema, API, service, crawler, suppression, skip, or contract-version bump.
- No claim that private routing proves candidate provenance, integrity, or merge readiness.

## Files changed

Exactly five material paths:

- `.github/dependabot.yml`
- `scripts/ci/check_dependabot_python_policy.py`
- `scripts/ci/dependabot_requirement_carriers.py`
- `tests/test_check_dependabot_python_policy.py`
- `docs/DEPENDENCY_MANAGEMENT.md`

## Key decisions

- Authority is reduced: absence of a safe automatic update path is `FAIL_CLOSED` and routes to the reviewed manual-update lane; restoring `allow` is not rollback.
- `FORBIDDEN_UPDATE_KEYS` remains unchanged. The existing full mapping walk is the sole owner of the static sanitized diagnostic.
- The traversal runs before semantic updater-shape early returns so every reachable mapping occurrence is reported without rendering its value or source YAML.
- `dependabot-python-requirement-carriers/v1`, its pinned upstream identity, limits, suffixes, and grammar source remain unchanged.
- Post-open validation found one distinct overlapping numeric version repetition; the operator authorized only that possessive rewrite plus one child-process regression, with no parser/framework/carrier-branch expansion.
- Any golden acceptance delta, newly admitted invalid case, second materially novel carrier, or need for a sixth material path is a stop/rescope condition.

## Tests / validation

- Red-first policy/config failures reproduced against the old `allow` contract.
- Red-first regex regressions reproduced as `subprocess.TimeoutExpired` after five seconds for the 1,000-space family and, after the authorized post-open rescope, the 10,000-digit version family.
- `check_preflight.py`: PASS.
- `check_agent_consistency.py`: PASS.
- Dependabot policy CLI: PASS.
- Owning module: PASS, 121 tests.
- Focused dependency, supply-chain, repository-policy, nosec, and absolute-subprocess guards: PASS.
- `tests/test_review_pattern_oracles.py`: PASS.
- `tests/test_agent_learning_loop.py`: PASS.
- `py_compile`: PASS.
- `make validate-changed`: PASS on the committed branch diff.
- `pre-commit run --all-files`: PASS after Black applied its normal formatting and the full bundle was rerun.
- Commit and pre-push hooks: PASS, including mypy, pip-audit, backend tests, full-repo Bandit, and Docker build test.
- `git diff --check`: PASS.
- GitHub material-head CI run 31367525279: all technical jobs PASS; the pre-closeout Merge readiness gate failed as expected before mapping publication.

## Security notes

- The forbidden diagnostic is static and contains no configured value, secret reference, arbitrary nested scalar, or source YAML.
- Representative values `allow`, `deny`, `false`, `null`, and an empty mapping are rejected by presence.
- Canonical, known nested, unknown nested dict/list, and malformed-updater early-return shapes are covered.
- One isolated `sys.executable` child rejects `!`, `@`, and `=` after 1,000 spaces; one second child rejects the authorized 10,000-digit version near-match. Both use `shell=False`, `check=True`, repository cwd, and a five-second timeout.
- Private-index routing and a successful Dependabot attempt remain intake evidence only; candidate source, version, provenance, hashes/mirror lineage, yanked/prerelease status, lock replay, drift, and targeted security/runtime gates remain review-controlled.

## Risks / rollback

- Dependabot may be unable to evaluate a dynamic manifest after authority removal. That is the intended fail-closed outcome; use the reviewed manual dependency-update lane.
- Possessive quantifiers require Python 3.11+, matching the repository 3.11/3.12/3.13 lanes. Current-head CI remains required to prove matrix compatibility.
- Rollback is a normal revert only if policy review identifies a defect; restoring external-code execution is not an acceptable operational rollback.
- No database, runtime API, dependency, lock, or migration state is involved.

## Deferred / follow-ups

- After merge, observe the next Dependabot attempt and classify only as `SUCCESS`, `FAIL_CLOSED`, or `CONFIG_ERROR`.
- A `FAIL_CLOSED` result uses the reviewed manual update lane. Candidate provenance/integrity is never inferred from this PR or an automated attempt.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- [Canonical PR 2251 review mapping](https://github.com/Katsiarynakavaleuskaya/PulsePlate/blob/fix/dependabot-private-index-trust-boundary/docs/review/PR_2251_FIXED_MAPPING.md)

## Experiment Runner Evidence

- Artifact: artifacts/orchestration/experiments/results/exp-1a1f3f0d9c83-3767773b-result.json
- Apple Container oracle-only result was accepted with `mutated_paths=[]`, network isolation, and three immutable oracle commands returning zero.
- This local artifact has no review, security-provider, approval, merge, or readiness authority and did not materially shape the implementation decision.

## Lane Start Provenance

- Packet: artifacts/orchestration/task_packets/5dfca669304e.json
- Starter: scripts/orchestration/start_pr_lane.sh

## Next best step

Publish the sole mapping-only closeout commit, wait for terminal current-head checks and one review cycle, then run the strict authenticated merge-readiness wrapper before merge.

Supersedes #2242 and #2243.

## Summary by Sourcery

Запретить небезопасное выполнение внешнего кода в приватном обновляторе pip для Dependabot и усилить проверку строк с требованиями, чтобы избежать катастрофического бэктрекинга регулярных выражений, сохранив при этом неизменной допустимую грамматику.

New Features:
- Добавить проверку политики репозитория, которая сообщает о любом наличии ключа `insecure-external-code-execution` в конфиге Dependabot, независимо от его значения.
- Ввести тестовый стенд с ограничением по тайм-ауту, который прогоняет валидатор строк требований на длинных некорректных входных данных, чтобы гарантировать детерминированный отказ.

Bug Fixes:
- Предотвратить катастрофический бэктрекинг в регулярном выражении строки требований Dependabot, сделав квантификаторы пробелов обладающими свойством «possessive» в семантике `re` Python 3.11+.

Enhancements:
- Ужесточить проверку политики Dependabot, чтобы в случае необходимости выполнения внешнего кода для динамических манифестов проверка завершалась в режиме «fail closed», перенаправляя такие обновления в поток ручного рассмотрения.
- Уточнить документацию по управлению зависимостями, описав удаление полномочий на выполнение внешнего кода и подтвердив, что успешные запуски Dependabot являются лишь свидетельством принятия артефактов, а не доказательством их целостности или готовности.

Documentation:
- Обновить документацию по управлению зависимостями, чтобы отразить запрет на выполнение внешнего кода для приватного обновлятора pip и подчеркнуть необходимость ручной проверки для принятых обновлений.

Tests:
- Добавить тесты, гарантирующие, что приватный обновлятор pip больше не объявляет `insecure-external-code-execution`, что этот ключ запрещён во всех позициях отображения конфига, и что его диагностические сообщения не раскрывают настроенные значения.
- Добавить регрессионные тесты, подтверждающие, что обновлённое регулярное выражение для строк требований отклоняет длинные почти совпадающие строки с избытком пробелов за ограниченное время выполнения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disallow insecure external code execution in the private pip Dependabot updater and strengthen requirement-line validation to avoid catastrophic regex backtracking while keeping the accepted grammar unchanged.

New Features:
- Add a repository policy check that reports any presence of the insecure-external-code-execution key anywhere in the Dependabot config, independently of its value.
- Introduce a timeout-guarded test harness that exercises the requirement-line validator under long invalid inputs to ensure deterministic rejection.

Bug Fixes:
- Prevent catastrophic backtracking in the Dependabot requirement-line regex by making whitespace quantifiers possessive under Python 3.11+ re semantics.

Enhancements:
- Tighten Dependabot policy validation to fail closed when external code execution would be required for dynamic manifests, directing such updates to the manual-review lane.
- Clarify dependency-management documentation to describe the removal of external code execution authority and reaffirm that successful Dependabot runs are intake evidence only, not proof of integrity or readiness.

Documentation:
- Update dependency management documentation to reflect that external code execution is now forbidden for the private pip updater and to reinforce manual review requirements for accepted updates.

Tests:
- Add tests ensuring the private pip updater no longer declares insecure-external-code-execution, that the key is forbidden at all config mapping positions, and that its diagnostic does not leak configured values.
- Add regression tests that verify the updated requirement-line regex rejects long whitespace-heavy near-matches within a bounded execution time.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened dependency update policies by prohibiting external code execution for private Python registry updates.
  * Added fail-closed validation to prevent credential exposure through unsupported configuration settings.

* **Documentation**
  * Updated dependency management guidance with manual verification requirements for candidate updates and validation results.

* **Bug Fixes**
  * Improved requirement parsing to handle whitespace reliably and prevent ambiguous matches.

* **Tests**
  * Expanded coverage for detecting forbidden settings at all configuration levels, including nested entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the fail-closed Dependabot policy for the private Python index by forbidding external manifest code execution and bounding the requirement-line regex to prevent catastrophic backtracking. Dependabot now fails closed if a manifest requires execution.

- **Bug Fixes**
  - Reject `insecure-external-code-execution` at any mapping in `.github/dependabot.yml`; keep a single private `python-index` and `replaces-base: true`. Errors surface before shape checks and never echo values.
  - Make whitespace and numeric version runs possessive in the requirement-line regex (Python 3.11+) to block long-space and long-version near-match backtracking. Add timeout-guarded tests.

- **Documentation**
  - Update dependency policy for the fail-closed stance and bounded regex behavior.
  - Add `docs/review/PR_2251_FIXED_MAPPING.md` with review-seal dispositions.

<sup>Written for commit 964bdcbad110b5f2da8fa979ddf4a1f2e6dd4a84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

