### PR TITLE
fix(dependabot): restore fail-closed private-index update boundary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     directory: "/"
     registries:
       - "python-index"
-    insecure-external-code-execution: "allow"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 4

--- a/docs/DEPENDENCY_MANAGEMENT.md
+++ b/docs/DEPENDENCY_MANAGEMENT.md
@@ -463,40 +463,23 @@ single root `pip` block resolves exclusively through the private
 `python-index` registry, keeps automatic transitive security-update eligibility,
 and limits routine version-update traffic with owner groups, cooldowns, and a
 four-PR cap. Security updates are not grouped, suppressed, or counted against
-that version-update cap. The same sole updater carries the exact
-`insecure-external-code-execution: allow` capability required for Python
-manifest evaluation. This is a bounded authority grant, not a claim that
-executed dependency code is safe.
+that version-update cap. PulsePlate's canonical Dependabot policy forbids the
+`insecure-external-code-execution` opt-in for this single root updater because
+it is configured with private registry credentials. The policy checker rejects
+that key at every mapping position. The single private `python-index` and
+`replaces-base: true` are a repository routing and checker contract, not proof
+of live service behavior, registry provenance, or candidate integrity. If
+Dependabot has no update path without executing manifest code, it must fail
+closed. Use an operator-owned manual dependency-update lane with independently
+evidenced admission and merge gates rather than restoring the opt-in; manual
+operation is not intrinsically safe.
 
-GitHub can expose the associated registry credentials to manifest or package
-code under this capability. Compromised code can copy and replay the dedicated
-Dependabot read credentials. The required non-root principal, effective
-write-denied ACL, zero index ownership, and separation from `DEVPI_CI_*` limit
-integrity impact but do not preserve credential confidentiality or prevent
-unauthorized reads. Before relying on this updater, recheck the two Dependabot
-secret names without retrieving their values and retain a redacted receipt for
-the principal's effective write denial and zero index ownership. Those secret
-and ACL observations are mutable external evidence, not durable or canonical
-repository truth.
-
-The policy checker admits this capability only as literal `allow` on the one
-`pip` updater at `/`, with `registries: [python-index]`, the exact
-`DEVPI_DEPENDABOT_USER` / `DEVPI_DEPENDABOT_PASSWORD` references, and
-`replaces-base: true`. It rejects the key everywhere else, all other values,
-additional updater or registry shapes, dependency filters, target-branch
-changes, and public fallback.
-
-Rollback is structural: remove the capability from `.github/dependabot.yml`,
-restore its blanket forbidden-key guard and negative test, and retain
-`replaces-base: true`. When exposure is suspected, remove the capability or
-disable the updater before rotating only the dedicated Dependabot credentials.
-Setting the version-update pull-request limit to zero is not containment:
-security updates are exempt from that cap and can still evaluate manifests.
-The post-merge oracle is an exact-main Dependabot run that advances beyond the
-external-code refusal while remaining private-registry-only; that run still
-does not prove credential confidentiality, dependency-graph or artifact
-equivalence, D0 acceptance, merge readiness, or authority to merge generated
-changes.
+Candidate admission remains review-controlled. Before accepting an update,
+confirm the approved source and version, provenance, hashes or mirror lineage,
+explicit yanked and prerelease status, approved lock replay, absence of
+unrelated lock drift, and the targeted security and runtime gates. A successful
+Dependabot attempt is intake evidence only, not proof of candidate integrity or
+merge readiness.
 
 Run `python scripts/ci/check_dependabot_python_policy.py --repo-root .` after
 changing the config, any root or one-directory-deep `.in`/`.txt` file,

--- a/scripts/ci/check_dependabot_python_policy.py
+++ b/scripts/ci/check_dependabot_python_policy.py
@@ -589,10 +589,15 @@ def _validate_exact_mapping(
         )
     for key, expected_value in expected.items():
         if key in actual and not _exact_value_matches(actual[key], expected_value):
+            expected_description = (
+                "configured secret reference"
+                if key_path == f"registries.{REGISTRY_NAME}" and key in {"username", "password"}
+                else repr(expected_value)
+            )
             errors.append(
                 _error(
                     f"{key_path}.{key}",
-                    f"must be {expected_value!r}; got {_value_shape(actual[key])}",
+                    f"must be {expected_description}; got {_value_shape(actual[key])}",
                 )
             )
 

--- a/scripts/ci/check_dependabot_python_policy.py
+++ b/scripts/ci/check_dependabot_python_policy.py
@@ -150,7 +150,6 @@ EXPECTED_UPDATE_EXACT_VALUES: dict[str, object] = {
     "package-ecosystem": "pip",
     "directory": "/",
     "registries": [REGISTRY_NAME],
-    EXTERNAL_CODE_EXECUTION_KEY: "allow",
     "schedule": {"interval": "weekly"},
     "open-pull-requests-limit": 4,
     "commit-message": {"prefix": "deps", "include": "scope"},
@@ -750,6 +749,16 @@ def validate_repo(repo_root: Path) -> list[str]:
         errors.append(_error("$", "root must be a mapping"))
         return errors
 
+    for mapping_path, mapping in _walk_mapping(config, "$"):
+        if EXTERNAL_CODE_EXECUTION_KEY in mapping:
+            errors.append(
+                _error(
+                    f"{mapping_path}.{EXTERNAL_CODE_EXECUTION_KEY}",
+                    "key is forbidden because external code must not receive "
+                    "private registry credentials",
+                )
+            )
+
     try:
         unknown_carriers = _unknown_dependabot_requirement_carriers(repo_root)
     except DependabotRequirementDiscoveryError:
@@ -813,14 +822,6 @@ def validate_repo(repo_root: Path) -> list[str]:
     if not isinstance(update, Mapping):
         errors.append(_error(update_path, "must be a mapping"))
         return errors
-    for mapping_path, mapping in _walk_mapping(config, "$"):
-        if EXTERNAL_CODE_EXECUTION_KEY in mapping and mapping is not update:
-            errors.append(
-                _error(
-                    f"{mapping_path}.{EXTERNAL_CODE_EXECUTION_KEY}",
-                    f"key is allowed only at {update_path}",
-                )
-            )
     if set(update) != EXPECTED_UPDATE_KEYS:
         errors.append(
             _error(

--- a/scripts/ci/dependabot_requirement_carriers.py
+++ b/scripts/ci/dependabot_requirement_carriers.py
@@ -96,15 +96,17 @@ _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN = (
     r"\s*(?:#+\s*.*)?$"
 )
 # The release prefix and its following version class both accept digits, while
-# whitespace separates tokens. Possessive repetitions prevent either shared
-# run from being redistributed across adjacent grammar components.
+# the top-level continuation boundaries can redistribute long whitespace runs
+# across adjacent optional components. Keep marker-clause whitespace identical
+# to the frozen raw pattern because that accepted language relies on backtracking.
 _UPSTREAM_VALID_REQUIREMENT_LINE_RE = re.compile(
     _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN.replace(
         r"[0-9]+[A-Za-z0-9_.*-]*",
         r"[0-9]++[A-Za-z0-9_.*-]*",
-    )
-    .replace(r"\s*", r"\s*+")
-    .replace(r"\s+", r"\s++"),
+    ).replace(
+        r"\s*\\?\s*",
+        r"\s*+\\?\s*+",
+    ),
     flags=re.ASCII,
 )
 RepoPath = str | PurePath

--- a/scripts/ci/dependabot_requirement_carriers.py
+++ b/scripts/ci/dependabot_requirement_carriers.py
@@ -95,10 +95,16 @@ _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN = (
     rf"\s*\\?\s*(?:{_UPSTREAM_HASHES})?"
     r"\s*(?:#+\s*.*)?$"
 )
-# Whitespace in this grammar separates tokens. Possessive repetitions prevent
-# adjacent optional branches from redistributing the same whitespace run.
+# The release prefix and its following version class both accept digits, while
+# whitespace separates tokens. Possessive repetitions prevent either shared
+# run from being redistributed across adjacent grammar components.
 _UPSTREAM_VALID_REQUIREMENT_LINE_RE = re.compile(
-    _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN.replace(r"\s*", r"\s*+").replace(r"\s+", r"\s++"),
+    _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN.replace(
+        r"[0-9]+[A-Za-z0-9_.*-]*",
+        r"[0-9]++[A-Za-z0-9_.*-]*",
+    )
+    .replace(r"\s*", r"\s*+")
+    .replace(r"\s+", r"\s++"),
     flags=re.ASCII,
 )
 RepoPath = str | PurePath

--- a/scripts/ci/dependabot_requirement_carriers.py
+++ b/scripts/ci/dependabot_requirement_carriers.py
@@ -86,14 +86,19 @@ _UPSTREAM_MARKER_EXPRESSION_ONE = (
 _UPSTREAM_MARKER_EXPRESSION = (
     rf"(?:{_UPSTREAM_MARKER_EXPRESSION_ONE}|\(\s*|\s*\)|" rf"\s+and\s+|\s+or\s+)+"
 )
-_UPSTREAM_VALID_REQUIREMENT_LINE_RE = re.compile(
+_UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN = (
     rf"^\s*\\?\s*{_UPSTREAM_NAME}"
     rf"\s*\\?\s*(?:\[\s*{_UPSTREAM_EXTRA}"
     rf"(?:\s*,\s*{_UPSTREAM_EXTRA})*\s*\])?"
     rf"\s*\\?\s*\(?(?:{_UPSTREAM_REQUIREMENTS})?\)?"
     rf"\s*\\?\s*(?:;\s*{_UPSTREAM_MARKER_EXPRESSION})?"
     rf"\s*\\?\s*(?:{_UPSTREAM_HASHES})?"
-    r"\s*(?:#+\s*.*)?$",
+    r"\s*(?:#+\s*.*)?$"
+)
+# Whitespace in this grammar separates tokens. Possessive repetitions prevent
+# adjacent optional branches from redistributing the same whitespace run.
+_UPSTREAM_VALID_REQUIREMENT_LINE_RE = re.compile(
+    _UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN.replace(r"\s*", r"\s*+").replace(r"\s+", r"\s++"),
     flags=re.ASCII,
 )
 RepoPath = str | PurePath

--- a/tests/test_check_dependabot_python_policy.py
+++ b/tests/test_check_dependabot_python_policy.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 
 import pytest
 import yaml
@@ -205,6 +206,24 @@ def test_non_requirement_text_file_is_not_misclassified_as_carrier(
 )
 def test_frozen_upstream_requirement_grammar_accepts_valid_lines(content: str) -> None:
     assert carriers.is_dependabot_requirement_carrier_text("extra.txt", content)
+
+
+def test_frozen_upstream_requirement_grammar_rejects_long_invalid_near_matches() -> None:
+    probe = (
+        "from scripts.ci.dependabot_requirement_carriers import "
+        "is_dependabot_requirement_carrier_text\n"
+        "for suffix in ('!', '@', '='):\n"
+        "    content = f\"package{' ' * 1000}{suffix}\\n\"\n"
+        "    assert not is_dependabot_requirement_carrier_text('extra.txt', content)\n"
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", probe],
+        check=True,
+        cwd=REPO_ROOT,
+        shell=False,
+        timeout=5,
+    )
 
 
 def test_requirement_carrier_upstream_snapshot_is_immutable_and_documented() -> None:

--- a/tests/test_check_dependabot_python_policy.py
+++ b/tests/test_check_dependabot_python_policy.py
@@ -17,6 +17,10 @@ from scripts.ci import dependabot_requirement_carriers as carriers
 from scripts.ci.check_python_dependency_surfaces import DEPENDENCY_SURFACES
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX = (
+    ".insecure-external-code-execution:key is forbidden because external code "
+    "must not receive private registry credentials"
+)
 
 
 def _run_fixture_git(repo: Path, *args: str) -> None:
@@ -901,12 +905,12 @@ def test_mode_a_rejects_update_suppression(
     assert any("updates[0].exclude-paths:key is forbidden" in error for error in errors)
 
 
-def test_external_code_execution_is_bound_to_exact_private_pip_updater() -> None:
+def test_external_code_execution_is_absent_from_private_pip_updater() -> None:
     config = _load_config(REPO_ROOT)
     update = _pip_update(config)
     registries = config["registries"]
 
-    assert update[policy.EXTERNAL_CODE_EXECUTION_KEY] == "allow"
+    assert policy.EXTERNAL_CODE_EXECUTION_KEY not in update
     assert update["package-ecosystem"] == "pip"
     assert update["directory"] == "/"
     assert update["registries"] == [policy.REGISTRY_NAME]
@@ -915,54 +919,31 @@ def test_external_code_execution_is_bound_to_exact_private_pip_updater() -> None
 
 
 @pytest.mark.parametrize(
-    "invalid_value",
-    [None, "", "deny", "ALLOW", True, False, 1, 0, [], {}, ["allow"]],
+    "present_value",
+    ["allow", "deny", False, None, {}],
 )
-def test_external_code_execution_requires_literal_allow(
+def test_external_code_execution_is_forbidden_independent_of_value(
     tmp_path: Path,
-    invalid_value: object,
+    present_value: object,
 ) -> None:
     repo = _copy_policy_repo(tmp_path)
     config = _load_config(repo)
-    _pip_update(config)[policy.EXTERNAL_CODE_EXECUTION_KEY] = invalid_value
+    _pip_update(config)[policy.EXTERNAL_CODE_EXECUTION_KEY] = present_value
     _write_config(repo, config)
 
     errors = policy.validate_repo(repo)
 
-    assert any(
-        "updates[0].insecure-external-code-execution:must be exactly 'allow'" in error
-        for error in errors
+    expected_error = (
+        ".github/dependabot.yml:$.updates[0]" f"{EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX}"
     )
+    assert errors.count(expected_error) == 1
 
 
-def test_external_code_execution_is_mandatory(tmp_path: Path) -> None:
-    repo = _copy_policy_repo(tmp_path)
-    config = _load_config(repo)
-    _pip_update(config).pop(policy.EXTERNAL_CODE_EXECUTION_KEY)
-    _write_config(repo, config)
-
-    errors = policy.validate_repo(repo)
-
-    assert any(
-        error.startswith(".github/dependabot.yml:updates[0]:keys must be exactly")
-        for error in errors
-    )
-    assert any(
-        "updates[0].insecure-external-code-execution:must be exactly 'allow'" in error
-        for error in errors
-    )
-
-
-def test_external_code_execution_is_rejected_at_every_other_mapping_position(
+def test_external_code_execution_is_rejected_at_every_mapping_position(
     tmp_path: Path,
 ) -> None:
     canonical_config = _load_config(REPO_ROOT)
-    authorized_selector: MappingSelector = ("updates", 0)
-    forbidden_selectors = [
-        selector
-        for selector in _iter_mapping_selectors(canonical_config)
-        if selector != authorized_selector
-    ]
+    forbidden_selectors = list(_iter_mapping_selectors(canonical_config))
 
     assert {
         (),
@@ -987,10 +968,10 @@ def test_external_code_execution_is_rejected_at_every_other_mapping_position(
         errors = policy.validate_repo(repo)
 
         expected_error = (
-            f".github/dependabot.yml:{_selector_path(selector)}."
-            "insecure-external-code-execution:key is allowed only at updates[0]"
+            f".github/dependabot.yml:{_selector_path(selector)}"
+            f"{EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX}"
         )
-        assert expected_error in errors
+        assert errors.count(expected_error) == 1
 
 
 @pytest.mark.parametrize(
@@ -1013,10 +994,29 @@ def test_external_code_execution_rejects_recursively_nested_unknown_container(
 
     errors = policy.validate_repo(repo)
 
-    assert any(
-        error.endswith(".insecure-external-code-execution:key is allowed only at updates[0]")
-        for error in errors
-    )
+    matching_errors = [
+        error for error in errors if error.endswith(EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX)
+    ]
+    assert len(matching_errors) == 1
+
+
+@pytest.mark.parametrize("invalid_updates", [None, [], ["not-a-mapping"]])
+def test_external_code_execution_is_reported_before_invalid_update_shape_returns(
+    tmp_path: Path,
+    invalid_updates: object,
+) -> None:
+    repo = _copy_policy_repo(tmp_path)
+    config = _load_config(repo)
+    sentinel = "DO_NOT_RENDER_THIS_VALUE"
+    config[policy.EXTERNAL_CODE_EXECUTION_KEY] = sentinel
+    config["updates"] = invalid_updates
+    _write_config(repo, config)
+
+    errors = policy.validate_repo(repo)
+
+    expected_error = ".github/dependabot.yml:$" f"{EXTERNAL_CODE_EXECUTION_FORBIDDEN_ERROR_SUFFIX}"
+    assert errors.count(expected_error) == 1
+    assert sentinel not in "\n".join(errors)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_check_dependabot_python_policy.py
+++ b/tests/test_check_dependabot_python_policy.py
@@ -226,6 +226,23 @@ def test_frozen_upstream_requirement_grammar_rejects_long_invalid_near_matches()
     )
 
 
+def test_frozen_upstream_requirement_grammar_rejects_long_invalid_version_near_match() -> None:
+    probe = (
+        "from scripts.ci.dependabot_requirement_carriers import "
+        "is_dependabot_requirement_carrier_text\n"
+        "content = f\"package=={'1' * 10000}!\\n\"\n"
+        "assert not is_dependabot_requirement_carrier_text('extra.txt', content)\n"
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", probe],
+        check=True,
+        cwd=REPO_ROOT,
+        shell=False,
+        timeout=5,
+    )
+
+
 def test_requirement_carrier_upstream_snapshot_is_immutable_and_documented() -> None:
     snapshot = carriers.DEPENDABOT_REQUIREMENT_CARRIER_UPSTREAM_SNAPSHOT
     assert asdict(snapshot) == {

--- a/tests/test_check_dependabot_python_policy.py
+++ b/tests/test_check_dependabot_python_policy.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from dataclasses import FrozenInstanceError, asdict
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
@@ -206,6 +207,23 @@ def test_non_requirement_text_file_is_not_misclassified_as_carrier(
 )
 def test_frozen_upstream_requirement_grammar_accepts_valid_lines(content: str) -> None:
     assert carriers.is_dependabot_requirement_carrier_text("extra.txt", content)
+
+
+def test_frozen_upstream_marker_language_matches_raw_pattern() -> None:
+    raw_pattern = re.compile(
+        carriers._UPSTREAM_VALID_REQUIREMENT_LINE_PATTERN,
+        flags=re.ASCII,
+    )
+    marker_lines = (
+        "package; (  and ",
+        "package; (  or ",
+        'package; python_version == "3" and  or ',
+        'package; python_version == "3" or  and ',
+    )
+
+    for marker_line in marker_lines:
+        assert raw_pattern.fullmatch(marker_line) is not None
+        assert carriers._UPSTREAM_VALID_REQUIREMENT_LINE_RE.fullmatch(marker_line) is not None
 
 
 def test_frozen_upstream_requirement_grammar_rejects_long_invalid_near_matches() -> None:
@@ -806,6 +824,52 @@ def test_registry_credential_literals_are_redacted_from_errors_and_cli_output(
     assert exit_code == 1
     assert sentinel not in captured.out
     assert sentinel not in captured.err
+
+
+@pytest.mark.parametrize("credential_key", ["username", "password"])
+def test_registry_credential_mapping_diagnostics_are_redacted(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    credential_key: str,
+) -> None:
+    repo = _copy_policy_repo(tmp_path)
+    config = _load_config(repo)
+    registries = config["registries"]
+    assert isinstance(registries, dict)
+    registry = registries[policy.REGISTRY_NAME]
+    assert isinstance(registry, dict)
+    sentinel = f"mapping-{credential_key}-must-not-leak"
+    registry[credential_key] = {
+        policy.EXTERNAL_CODE_EXECUTION_KEY: sentinel,
+    }
+    _write_config(repo, config)
+
+    errors = policy.validate_repo(repo)
+    forbidden_error = (
+        f".github/dependabot.yml:$.registries.{policy.REGISTRY_NAME}.{credential_key}."
+        f"{policy.EXTERNAL_CODE_EXECUTION_KEY}:key is forbidden because external code "
+        "must not receive private registry credentials"
+    )
+    exact_mapping_error = (
+        f".github/dependabot.yml:registries.{policy.REGISTRY_NAME}.{credential_key}:"
+        "must be configured secret reference; got mapping(len=1)"
+    )
+    rendered_errors = "\n".join(errors)
+
+    assert errors.count(forbidden_error) == 1
+    assert exact_mapping_error in errors
+    assert sentinel not in rendered_errors
+    assert "${{secrets." not in rendered_errors
+
+    exit_code = policy.main(["--repo-root", str(repo)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out.count(forbidden_error) == 1
+    assert sentinel not in captured.out
+    assert sentinel not in captured.err
+    assert "${{secrets." not in captured.out
+    assert "${{secrets." not in captured.err
 
 
 def test_registry_url_userinfo_is_redacted_from_errors_and_cli_output(


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# Pull Request

## Goal

Restore the fail-closed Dependabot private-index boundary: remove the external manifest-code opt-in, reject that key in every mapping of the bounded canonical YAML, and bound the two reviewed requirement-line backtracking families without changing the frozen v1 accepted grammar.

Supersedes #2251, which carried the same material corrections but already had a mapping-only successor. The old mapping commit is intentionally excluded. PRs #2242 and #2243 remain historical inputs only and are not rebased or merged here.

## Business reason

Reduce dependency-intake credential exposure and prevent a crafted tracked requirement carrier from stalling the required policy guard, while preserving private-only routing and a review-controlled manual fallback.

## Scope

- Remove only `insecure-external-code-execution: "allow"` from the sole root pip updater.
- Reject presence of that key in every reachable mapping, independent of value, with one static sanitized diagnostic per occurrence.
- Preserve the exact one-private-index, `replaces-base: true`, updater schedule, cooldown, grouping, PR-limit, and commit-message contract.
- Preserve `dependabot-python-requirement-carriers/v1`, its pinned upstream source and accepted grammar; make only whitespace repetitions and the reviewed overlapping numeric release repetition possessive.
- Add bounded child-process regressions for 1,000-space `!`/`@`/`=` near-matches and the 10,000-digit invalid version near-match.
- Align dependency-management prose with the fail-closed/manual admission boundary.

## Out of scope

Requirements, constraints, locks, workflows, registry credentials or proxy configuration, Docker, RAG, frontend, iOS, OpenAPI, new parsers/tokenizers/frameworks, carrier branches/exceptions, `AGENTS.md`, and `BACKLOG_LEDGER.md`.

## Files changed

- `.github/dependabot.yml`
- `scripts/ci/check_dependabot_python_policy.py`
- `scripts/ci/dependabot_requirement_carriers.py`
- `tests/test_check_dependabot_python_policy.py`
- `docs/DEPENDENCY_MANAGEMENT.md`

## Key decisions

- Repository policy forbids configuring the external-code opt-in for this updater; it does not claim control over every possible external runtime.
- One private index plus `replaces-base: true` is a routing/checker contract, not candidate provenance or integrity proof.
- If automated intake cannot proceed without manifest-code execution, it fails closed and uses the independently reviewed operator-owned manual lane; the manual lane is not intrinsically safe.
- Historical suggestions for a new parser/helper or production diagnostic framework are rejected as scope expansion. Standard-library possessive quantifiers are supported on the repository Python 3.11+ floor.

## Tests

Local material head `c265e8051388fed867d0d57712065a2b91ef8d94`:

- `scripts/orchestration/check_preflight.py` — PASS
- `scripts/orchestration/check_agent_consistency.py` — PASS
- `scripts/ci/check_dependabot_python_policy.py --repo-root .` — PASS
- `pytest -q tests/test_check_dependabot_python_policy.py` — 121 PASS
- focused dependency-surface, supply-chain, repo-policy, nosec, and subprocess guards — PASS
- `python -m py_compile` for the two CI modules and owning test — PASS
- `make validate-changed` — PASS
- `pre-commit run --all-files` — PASS; no hook-generated changes
- review-pattern and learning-loop oracles — 28 PASS
- explicit Apple Container oracle-only run — accepted; all three immutable commands exit 0; `mutated_paths=[]`; network budget 0
- GitHub current-head CI — pending after PR open

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/5dfca669304e.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Pre-open role order completed: `agent-coordinator -> logic-agent -> philosophy-agent -> security-auditor -> architecture-specialist`

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/dependabot-private-index-clean-replacement-result.json`
- Backend: explicit `apple-container`
- Immutable image digest: `sha256:5b3abbad998dc1b23f9d99e72a8fde931558401b81a2aec8c5eeeff90b128a70`
- Result: accepted, strict isolation, no mutation, no network

Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>

## Security notes

This PR removes a credential-adjacent capability and adds no new authority. Diagnostics do not render values, secret references, arbitrary nested scalars, or source YAML. Private-only routing and a successful Dependabot attempt do not prove mirror contents, candidate provenance, credential confidentiality, integrity, or merge readiness.

## Risks / rollback

The bounded regex evidence does not prove universal linear complexity or live GitHub parser parity. Any accepted-language delta, second materially novel carrier/performance family, or need for another parser branch is a stop/rescope condition. If automated updates cannot proceed after merge, classify the outcome as `FAIL_CLOSED` and use the reviewed manual lane; do not restore the external-code opt-in as rollback. If the local recognizer itself regresses, hold automated intake and correct the bounded recognizer under a fresh invariant review while retaining the fail-closed config.

<!-- phase2-pre-closeout: final-security-pending -->

## Discussion Thread Pass

- [ ] Discussion-thread pass completed
- [ ] Fixed in commit mapping completed

### Fixed in Commit Mapping

- Pending final clean scan and the single mapping/closeout commit.
- canonical artifact: `docs/review/PR_<N>_FIXED_MAPPING.md`
- URL→SHA and disposition details belong only in the canonical artifact.

## Split justification

Not required: the diff is below the Tier 1 changed-LoC threshold and the five paths form one closed policy/recognizer/test/documentation boundary.

## Deferred / Follow-ups

None. Post-merge observation is acceptance verification, not deferred implementation.

## Next best step

Run the single post-open role chain, close every actual finding on the material head, wait for terminal exact-head technical CI, and then publish one canonical mapping/seal commit.

<!-- markdownlint-enable MD013 -->

## Summary by Sourcery

Ужесточить политику Dependabot для Python, чтобы запретить выполнение внешнего кода для приватного обновлятора pip, усилить распознавание строк требований и обновить тесты и документацию в соответствии с «fail‑closed» границей.

Bug Fixes:
- Гарантировать, что распознаватель носителя требований Dependabot отклоняет чрезвычайно длинные недопустимые строки‑псевдосовпадения, чтобы избежать патологического поведения при разборе.

Enhancements:
- Удалить параметр opt‑in для небезопасного выполнения внешнего кода из приватного обновлятора pip Dependabot и внедрить на уровне репозитория правило запрещённого ключа, связанное с учётными данными приватного реестра.
- Уточнить исходный regex для строк требований с помощью присваивающих (possessive) квантификаторов, чтобы ограничить повторения пробелов и числовых релизов без изменения допустимой грамматики.

Documentation:
- Привести документацию по управлению зависимостями в соответствие с «fail‑closed» политикой Dependabot для приватного индекса, разъяснив, что выполнение внешнего кода остаётся отключённым, а ручной приём изменений контролируется ревью.

Tests:
- Расширить тесты политики и грамматики, чтобы покрыть глобальное отклонение ключа external‑code‑execution, порядок диагностик при некорректных обновлениях и регрессии, связанные с длинными недопустимыми строками‑псевдосовпадениями требований.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten Dependabot Python policy to forbid external code execution for the private pip updater, harden requirement-line recognition, and update tests and documentation to reflect the fail-closed boundary.

Bug Fixes:
- Ensure the Dependabot requirement carrier recognizer rejects extremely long invalid near-match lines to avoid pathological parsing behavior.

Enhancements:
- Remove the insecure-external-code-execution opt-in from the private pip Dependabot updater and enforce a repository-wide forbidden-key rule tied to private registry credentials.
- Refine the upstream requirement-line regex with possessive quantifiers to bound whitespace and numeric release repetitions without changing the accepted grammar.

Documentation:
- Align dependency-management documentation with the fail-closed Dependabot private-index policy, clarifying that external code execution remains disabled and manual intake is review-controlled.

Tests:
- Extend policy and grammar tests to cover global rejection of the external-code-execution key, ordering of diagnostics with malformed updates, and long invalid requirement-line near-match regressions.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a fail-closed Dependabot policy for the private Python index by removing manifest-code execution and tightening requirement parsing. Diagnostics are redacted, and the requirement recognizer preserves upstream grammar while bounding backtracking.

- **Bug Fixes**
  - Removed `insecure-external-code-execution` from the root `pip` updater and now forbid this key anywhere in the config with a single sanitized diagnostic.
  - Redacted secret references and registry-credential mapping diagnostics; preserved the single private `python-index` and `replaces-base: true`.
  - Bounded the requirement-line regex with possessive quantifiers while keeping upstream marker grammar identical; added explicit parity tests.
  - Expanded tests to reject long invalid near-matches, report the forbidden key even on malformed update shapes, and ensure CLI/output redaction.
  - Updated `docs/DEPENDENCY_MANAGEMENT.md` to document the fail-closed stance and the operator-owned manual admission lane.

<sup>Written for commit 8bda326cae2e5ddbdf52b716ce26d280d7953489. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/2260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened dependency update safeguards by prohibiting insecure external code execution, including in nested configuration entries.
  * Added fail-closed checks to prevent private registry credentials from being exposed.

* **Bug Fixes**
  * Improved validation of dependency requirements, including long invalid inputs and malformed configurations.

* **Documentation**
  * Updated dependency management guidance with stricter provenance, integrity, locking, and review requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->